### PR TITLE
Add video devices to video mapping

### DIFF
--- a/hassio/misc/hardware.py
+++ b/hassio/misc/hardware.py
@@ -28,7 +28,7 @@ GPIO_DEVICES: Path = Path("/sys/class/gpio")
 SOC_DEVICES: Path = Path("/sys/devices/platform/soc")
 RE_TTY: re.Pattern = re.compile(r"tty[A-Z]+")
 
-RE_VIDEO_DEVICES = re.compile(r"^(?:vchiq|cec)")
+RE_VIDEO_DEVICES = re.compile(r"^(?:vchiq|cec|video\d+)")
 
 
 @attr.s(frozen=True)


### PR DESCRIPTION
Allow to pass video* devices to containers. Should allow to use usb webcams / uvc tuners.