### PR TITLE
Fix wrong last boot

### DIFF
--- a/hassio/const.py
+++ b/hassio/const.py
@@ -342,3 +342,12 @@ class UpdateChannels(str, Enum):
     STABLE = "stable"
     BETA = "beta"
     DEV = "dev"
+
+
+class CoreState(str, Enum):
+    """Represent current loading state."""
+
+    INITIALIZE = "initialize"
+    STARTUP = "startup"
+    RUNNING = "running"
+    FREEZE = "freeze"

--- a/hassio/const.py
+++ b/hassio/const.py
@@ -344,7 +344,7 @@ class UpdateChannels(str, Enum):
     DEV = "dev"
 
 
-class CoreState(str, Enum):
+class CoreStates(str, Enum):
     """Represent current loading state."""
 
     INITIALIZE = "initialize"

--- a/hassio/coresys.py
+++ b/hassio/coresys.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Optional
 import aiohttp
 
 from .config import CoreConfig
-from .const import UpdateChannels, CoreState
+from .const import UpdateChannels, CoreStates
 from .docker import DockerAPI
 from .misc.hardware import Hardware
 from .misc.scheduler import Scheduler
@@ -40,7 +40,7 @@ class CoreSys:
         """Initialize coresys."""
         # Static attributes
         self.machine_id: Optional[str] = None
-        self.state: Optional[CoreState] = None
+        self.state: Optional[CoreStates] = None
 
         # External objects
         self._loop: asyncio.BaseEventLoop = asyncio.get_running_loop()

--- a/hassio/coresys.py
+++ b/hassio/coresys.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Optional
 import aiohttp
 
 from .config import CoreConfig
-from .const import UpdateChannels
+from .const import UpdateChannels, CoreState
 from .docker import DockerAPI
 from .misc.hardware import Hardware
 from .misc.scheduler import Scheduler
@@ -39,7 +39,8 @@ class CoreSys:
     def __init__(self):
         """Initialize coresys."""
         # Static attributes
-        self.machine_id: str = None
+        self.machine_id: Optional[str] = None
+        self.state: Optional[CoreState] = None
 
         # External objects
         self._loop: asyncio.BaseEventLoop = asyncio.get_running_loop()


### PR DESCRIPTION
The update of the supervisor can end up in write the last boot time while he restarts itself. Because we never process a full boot, we end up in a bad state. It only happens, for instance, they were a bit down.