### PR TITLE
Rasie limit on container shutdown for addons 

### DIFF
--- a/supervisor/addons/validate.py
+++ b/supervisor/addons/validate.py
@@ -261,7 +261,7 @@ SCHEMA_ADDON_CONFIG = vol.Schema(
         ),
         vol.Optional(ATTR_IMAGE): vol.Match(RE_DOCKER_IMAGE),
         vol.Optional(ATTR_TIMEOUT, default=10): vol.All(
-            vol.Coerce(int), vol.Range(min=10, max=120)
+            vol.Coerce(int), vol.Range(min=10, max=300)
         ),
     },
     extra=vol.REMOVE_EXTRA,


### PR DESCRIPTION
use case tmpfs based mariadb for recorder taking over 2 mins for dump to stable storage on Pi4.
I can't see why this can't be raised it seems an arbitrary limit? Discuss.

Phill.
