### PR TITLE
Remove Azure CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://dev.azure.com/home-assistant/supervisor/_apis/build/status/Release?branchName=dev)](https://dev.azure.com/home-assistant/supervisor/_build/latest?definitionId=60&branchName=dev)
-
 # Home Assistant Supervisor
 
 ## First private cloud solution for home automation

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://dev.azure.com/home-assistant/Hass.io/_apis/build/status/hassio?branchName=dev)](https://dev.azure.com/home-assistant/Hass.io/_build/latest?definitionId=2&branchName=dev)
+[![Build Status](https://dev.azure.com/home-assistant/supervisor/_apis/build/status/Release?branchName=dev)](https://dev.azure.com/home-assistant/supervisor/_build/latest?definitionId=60&branchName=dev)
 
 # Home Assistant Supervisor
 


### PR DESCRIPTION
Noticed this points to the old pipeline.

Not sure what badge you want to show so chose `Release`