### PR TITLE
Remove passing in deprecated loop arguments

### DIFF
--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -23,7 +23,7 @@ class DockerInterface(CoreSysAttributes):
         """Initialize Docker base wrapper."""
         self.coresys: CoreSys = coresys
         self._meta: Optional[Dict[str, Any]] = None
-        self.lock: asyncio.Lock = asyncio.Lock(loop=coresys.loop)
+        self.lock: asyncio.Lock = asyncio.Lock()
 
     @property
     def timeout(self) -> str:

--- a/supervisor/homeassistant.py
+++ b/supervisor/homeassistant.py
@@ -67,7 +67,7 @@ class HomeAssistant(JsonConfig, CoreSysAttributes):
         super().__init__(FILE_HASSIO_HOMEASSISTANT, SCHEMA_HASS_CONFIG)
         self.coresys: CoreSys = coresys
         self.instance: DockerHomeAssistant = DockerHomeAssistant(coresys)
-        self.lock: asyncio.Lock = asyncio.Lock(loop=coresys.loop)
+        self.lock: asyncio.Lock = asyncio.Lock()
         self._error_state: bool = False
 
         # We don't persist access tokens. Instead we fetch new ones when needed

--- a/supervisor/snapshots/__init__.py
+++ b/supervisor/snapshots/__init__.py
@@ -19,7 +19,7 @@ class SnapshotManager(CoreSysAttributes):
         """Initialize a snapshot manager."""
         self.coresys = coresys
         self.snapshots_obj = {}
-        self.lock = asyncio.Lock(loop=coresys.loop)
+        self.lock = asyncio.Lock()
 
     @property
     def list_snapshots(self):

--- a/supervisor/store/git.py
+++ b/supervisor/store/git.py
@@ -23,7 +23,7 @@ class GitRepo(CoreSysAttributes):
         self.coresys = coresys
         self.repo = None
         self.path = path
-        self.lock = asyncio.Lock(loop=coresys.loop)
+        self.lock = asyncio.Lock()
 
         self.data = RE_REPOSITORY.match(url).groupdict()
 


### PR DESCRIPTION
Removes the passing along of the loop, as it is deprecated in Python 3.8

```
/home/frenck/code/supervisor/supervisor/docker/interface.py:26: DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
    self.lock: asyncio.Lock = asyncio.Lock(loop=coresys.loop)
```