### PR TITLE
Replace Logger.fatal by Logger.critical

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -380,7 +380,7 @@ class RestAPI(CoreSysAttributes):
         try:
             await self._site.start()
         except OSError as err:
-            _LOGGER.fatal("Failed to create HTTP server at 0.0.0.0:80 -> %s", err)
+            _LOGGER.critical("Failed to create HTTP server at 0.0.0.0:80 -> %s", err)
         else:
             _LOGGER.info("Start API on %s", self.sys_docker.network.supervisor)
 

--- a/supervisor/bootstrap.py
+++ b/supervisor/bootstrap.py
@@ -214,27 +214,27 @@ def check_environment() -> None:
         try:
             os.environ[key]
         except KeyError:
-            _LOGGER.fatal("Can't find %s in env!", key)
+            _LOGGER.critical("Can't find %s in env!", key)
 
     # Check Machine info
     if not os.environ.get(ENV_HOMEASSISTANT_REPOSITORY) and not os.environ.get(
         ENV_SUPERVISOR_MACHINE
     ):
-        _LOGGER.fatal("Can't find any kind of machine/homeassistant details!")
+        _LOGGER.critical("Can't find any kind of machine/homeassistant details!")
     elif not os.environ.get(ENV_SUPERVISOR_MACHINE):
         _LOGGER.info("Use the old homeassistant repository for machine extraction")
 
     # check docker socket
     if not SOCKET_DOCKER.is_socket():
-        _LOGGER.fatal("Can't find Docker socket!")
+        _LOGGER.critical("Can't find Docker socket!")
 
     # check socat exec
     if not shutil.which("socat"):
-        _LOGGER.fatal("Can't find socat!")
+        _LOGGER.critical("Can't find socat!")
 
     # check socat exec
     if not shutil.which("gdbus"):
-        _LOGGER.fatal("Can't find gdbus!")
+        _LOGGER.critical("Can't find gdbus!")
 
 
 def reg_signal(loop):

--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -39,7 +39,9 @@ class Core(CoreSysAttributes):
             and self.sys_config.version != self.sys_supervisor.version
         ):
             self.healthy = False
-            _LOGGER.fatal("System running in a unhealthy state. Please update you OS!")
+            _LOGGER.critical(
+                "System running in a unhealthy state. Please update you OS!"
+            )
 
     async def setup(self):
         """Setup supervisor orchestration."""
@@ -106,7 +108,7 @@ class Core(CoreSysAttributes):
                 else:
                     await self.sys_supervisor.update()
             except SupervisorUpdateError:
-                _LOGGER.fatal(
+                _LOGGER.critical(
                     "Can't update supervisor! This will break some Add-ons or affect "
                     "future version of Home Assistant!"
                 )

--- a/supervisor/homeassistant.py
+++ b/supervisor/homeassistant.py
@@ -356,7 +356,7 @@ class HomeAssistant(JsonConfig, CoreSysAttributes):
 
         # Update going wrong, revert it
         if self.error_state and rollback:
-            _LOGGER.fatal("HomeAssistant update fails -> rollback!")
+            _LOGGER.critical("HomeAssistant update fails -> rollback!")
             await _update(rollback)
         else:
             raise HomeAssistantUpdateError()

--- a/supervisor/hwmon.py
+++ b/supervisor/hwmon.py
@@ -28,7 +28,7 @@ class HwMonitor(CoreSysAttributes):
             self.monitor = pyudev.Monitor.from_netlink(self.context)
             self.observer = pyudev.MonitorObserver(self.monitor, self._udev_events)
         except OSError:
-            _LOGGER.fatal("Not privileged to run udev monitor!")
+            _LOGGER.critical("Not privileged to run udev monitor!")
         else:
             self.observer.start()
             _LOGGER.info("Started Supervisor hardware monitor")

--- a/supervisor/misc/scheduler.py
+++ b/supervisor/misc/scheduler.py
@@ -64,7 +64,7 @@ class Scheduler:
 
             job = self.loop.call_at(calc.timestamp(), self._run_task, task_id)
         else:
-            _LOGGER.fatal(
+            _LOGGER.critical(
                 "Unknown interval %s (type: %s) for scheduler %s",
                 interval,
                 type(interval),

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -36,7 +36,7 @@ class Supervisor(CoreSysAttributes):
         try:
             await self.instance.attach(tag="latest")
         except DockerAPIError:
-            _LOGGER.fatal("Can't setup Supervisor Docker container!")
+            _LOGGER.critical("Can't setup Supervisor Docker container!")
 
         with suppress(DockerAPIError):
             await self.instance.cleanup()


### PR DESCRIPTION
Python actually does not have a fatal. Fatal is an alias to critical (see PEP-282).

This PR removes the use of the alias.