### PR TITLE
Cleanup and speedup pylint

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,27 +1,28 @@
 [MASTER]
 reports=no
+jobs=2
 
 # Reasons disabled:
+# format - handled by black
 # locally-disabled - it spams too much
 # duplicate-code - unavoidable
 # cyclic-import - doesn't test if both import on load
 # abstract-class-little-used - prevents from setting right foundation
 # abstract-class-not-used - is flaky, should not show up but does
 # unused-argument - generic callbacks and setup methods create a lot of warnings
-# global-statement - used for the on-demand requirement installation
 # redefined-variable-type - this is Python, we're duck typing!
 # too-many-* - are not enforced for the sake of readability
 # too-few-* - same as too-many-*
 # abstract-method - with intro of async there are always methods missing
-
 disable=
+  format,
   abstract-class-little-used,
-  abstract-class-not-used,
   abstract-method,
   cyclic-import,
   duplicate-code,
-  global-statement,
   locally-disabled,
+  no-else-return,
+  no-self-use,
   not-context-manager,
   redefined-variable-type,
   too-few-public-methods,
@@ -34,14 +35,6 @@ disable=
   too-many-return-statements,
   too-many-statements,
   unused-argument,
-  line-too-long,
-  bad-continuation,
-  too-few-public-methods,
-  no-self-use,
-  not-async-context-manager,
-  too-many-locals,
-  too-many-branches,
-  no-else-return
 
 [EXCEPTIONS]
 overgeneral-exceptions=Exception


### PR DESCRIPTION
Cleans up the Pylint configuration, more in line with the core repository.
This PR does not change any code.

- Sets jobs to 2, make Pylint around 40% quicker.
- Remove duplicate disabled rules.
- Disables formatting rules in Pylint (handled by Black).
- Removed disabled rules that currently had no offenders in the codebase.

