### PR TITLE
Fix S6 supervisor not listening in finish script

### DIFF
--- a/rootfs/etc/services.d/supervisor/finish
+++ b/rootfs/etc/services.d/supervisor/finish
@@ -1,5 +1,8 @@
-#!/usr/bin/execlineb -S0
+#!/usr/bin/execlineb -S1
 # ==============================================================================
 # Take down the S6 supervision tree when Supervisor fails
 # ==============================================================================
+if { s6-test ${1} -ne 0 }
+if { s6-test ${1} -ne 256 }
+
 s6-svscanctl -t /var/run/s6/services

--- a/rootfs/etc/services.d/supervisor/finish
+++ b/rootfs/etc/services.d/supervisor/finish
@@ -1,8 +1,5 @@
-#!/usr/bin/execlineb -S1
+#!/usr/bin/execlineb -S0
 # ==============================================================================
 # Take down the S6 supervision tree when Supervisor fails
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
-
-s6-svscanctl -t /var/run/s6/services
+redirfd -w 2 /dev/null s6-svscanctl -t /var/run/s6/services


### PR DESCRIPTION
Noticed during shutdown of the supervisor in my dev environment:

```
20-05-21 10:02:19 INFO (MainThread) [__main__] Close Supervisor
[cont-finish.d] executing container finish scripts...
[cont-finish.d] done.
[s6-finish] waiting for services.
s6-svscanctl: fatal: unable to control /var/run/s6/services: supervisor not listening
[s6-finish] sending all processes the TERM signal.
[s6-finish] sending all processes the KILL signal and exiting.
```

This PR addressed that, by adjusting the S6 Overlay service finish script for the Supervisor.