### PR TITLE
Fix YAML & JSON styling

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,3 @@
-// See https://aka.ms/vscode-remote/devcontainer.json for format details.
 {
   "name": "Supervisor dev",
   "context": "..",

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -24,4 +24,4 @@ only: pulls
 
 # Optionally, specify configuration settings just for `issues` or `pulls`
 issues:
-   daysUntilLock: 30
+  daysUntilLock: 30


### PR DESCRIPTION
2 small changes:

- Removed a comment from the devcontainer.json, making the `json` valid for validating, as the JSON format natively doesn't support comments.
- Indenting was off in .github/lock.yaml