### PR TITLE
Handle new API / Frontend early boot

### DIFF
--- a/supervisor/api/proxy.py
+++ b/supervisor/api/proxy.py
@@ -75,6 +75,8 @@ class APIProxy(CoreSysAttributes):
     async def stream(self, request: web.Request):
         """Proxy HomeAssistant EventStream Requests."""
         self._check_access(request)
+        if not await self.sys_homeassistant.check_api_state():
+            raise HTTPBadGateway()
 
         _LOGGER.info("Home Assistant EventStream start")
         async with self._api_client(request, "stream", timeout=None) as client:
@@ -94,6 +96,8 @@ class APIProxy(CoreSysAttributes):
     async def api(self, request: web.Request):
         """Proxy Home Assistant API Requests."""
         self._check_access(request)
+        if not await self.sys_homeassistant.check_api_state():
+            raise HTTPBadGateway()
 
         # Normal request
         path = request.match_info.get("path", "")
@@ -153,6 +157,8 @@ class APIProxy(CoreSysAttributes):
 
     async def websocket(self, request: web.Request):
         """Initialize a WebSocket API connection."""
+        if not await self.sys_homeassistant.check_api_state():
+            raise HTTPBadGateway()
         _LOGGER.info("Home Assistant WebSocket API request initialize")
 
         # init server

--- a/supervisor/homeassistant.py
+++ b/supervisor/homeassistant.py
@@ -274,7 +274,7 @@ class HomeAssistant(JsonConfig, CoreSysAttributes):
 
         # Start landingpage
         _LOGGER.info("Start HomeAssistant landingpage")
-        with suppress(HomeAssistantError):
+        with suppress(DockerAPIError):
             await self.instance.run()
 
     @process_lock

--- a/supervisor/homeassistant.py
+++ b/supervisor/homeassistant.py
@@ -275,7 +275,7 @@ class HomeAssistant(JsonConfig, CoreSysAttributes):
         # Start landingpage
         _LOGGER.info("Start HomeAssistant landingpage")
         with suppress(HomeAssistantError):
-            await self._start()
+            await self.instance.run()
 
     @process_lock
     async def install(self) -> None:

--- a/supervisor/homeassistant.py
+++ b/supervisor/homeassistant.py
@@ -274,8 +274,8 @@ class HomeAssistant(JsonConfig, CoreSysAttributes):
 
         # Start landingpage
         _LOGGER.info("Start HomeAssistant landingpage")
-        with suppress(DockerAPIError):
-            await self.instance.run()
+        with suppress(HomeAssistantError):
+            await self._start()
 
     @process_lock
     async def install(self) -> None:
@@ -374,6 +374,10 @@ class HomeAssistant(JsonConfig, CoreSysAttributes):
             await self.instance.run()
         except DockerAPIError:
             raise HomeAssistantError() from None
+
+        # Don't block for landingpage
+        if self.version == "landingpage":
+            return
         await self._block_till_run()
 
     @process_lock

--- a/supervisor/homeassistant.py
+++ b/supervisor/homeassistant.py
@@ -567,10 +567,13 @@ class HomeAssistant(JsonConfig, CoreSysAttributes):
 
         # Check if API is up
         with suppress(HomeAssistantAPIError):
-            async with self.make_request("get", "api/") as resp:
+            async with self.make_request("get", "api/config") as resp:
                 if resp.status in (200, 201):
-                    return True
-                _LOGGER.debug("Home Assistant API return: %d", resp.status)
+                    data = await resp.json()
+                    if data.get("state", "RUNNING") == "RUNNING":
+                        return True
+                else:
+                    _LOGGER.debug("Home Assistant API return: %d", resp.status)
 
         return False
 


### PR DESCRIPTION
Avoid also log flooding because we restart Core.

90% of the code is for P2 and the other 10% for P1. Since we need anyway touch the code and change the logic. The P1 adds the 503 for API which makes this PR a lot simpler.