### PR TITLE
Update Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,15 +1,15 @@
 <!-- READ THIS FIRST:
 - If you need additional help with this template please refer to https://www.home-assistant.io/help/reporting_issues/
-- Make sure you are running the latest version of Home Assistant before reporting an issue: https://github.com/home-assistant/home-assistant/releases
-- Do not report issues for components here, plaese refer to https://github.com/home-assistant/home-assistant/issues
+- Make sure you are running the latest version of Home Assistant before reporting an issue: https://github.com/home-assistant/core/releases
+- Do not report issues for integrations here, please refer to https://github.com/home-assistant/core/issues
 - This is for bugs only. Feature and enhancement requests should go in our community forum: https://community.home-assistant.io/c/feature-requests
 - Provide as many details as possible. Paste logs, configuration sample and code into the backticks. Do not delete any text from this template!
-- If you have a problem with a Add-on, make a issue on there repository.
+- If you have a problem with an add-on, make an issue in their repository.
 -->
 
 **Home Assistant release with the issue:**
 <!--
-- Frontend -> Developer tools -> Info
+- Frontend -> Configuration -> Info
 - Or use this command: hass --version
 -->
 
@@ -20,8 +20,8 @@ Please provide details about your environment.
 
 **Supervisor logs:**
 <!--
-- Frontend -> Hass.io -> System
-- Or use this command: hassio su logs
+- Frontend -> Supervisor -> System
+- Or use this command: ha supervisor logs
 -->
 
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@
 - Do not report issues for integrations here, please refer to https://github.com/home-assistant/core/issues
 - This is for bugs only. Feature and enhancement requests should go in our community forum: https://community.home-assistant.io/c/feature-requests
 - Provide as many details as possible. Paste logs, configuration sample and code into the backticks. Do not delete any text from this template!
-- If you have a problem with an add-on, make an issue in their repository.
+- If you have a problem with an add-on, make an issue in its repository.
 -->
 
 **Home Assistant release with the issue:**
@@ -26,4 +26,3 @@ Please provide details about your environment.
 
 
 **Description of problem:**
-


### PR DESCRIPTION
Issue template was bit out of date.

* Updated some outdated wording (Hass.io in sidebar = Supervisor now)
* Updated location of Info panel (moved from Dev Tools to Configuration > Info in 0.112)
* Updated names of some repos
* Minor typos / grammar fixes