### PR TITLE
Don't reuse venv cache when Python version changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
             ${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
-            ${{ runner.os }}-venv-
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
The cache restore of the venvs allowed for restoring cache from different Python versions. This is not good as the Python version itself is part of the venv.

This PR removes the cache key that allowed restoring a venv cache that doesn't match the Python version.