### PR TITLE
Make a copy of the logfile before rollback

### DIFF
--- a/supervisor/homeassistant.py
+++ b/supervisor/homeassistant.py
@@ -360,12 +360,16 @@ class HomeAssistant(JsonConfig, CoreSysAttributes):
         if self.error_state and rollback:
             _LOGGER.critical("HomeAssistant update fails -> rollback!")
             # Make a copy of the current log file if it exsist
-            logfile = Path(self.sys_config.path_homeassistant, "home-assistant.log")
+            logfile = self.sys_config.path_homeassistant / "home-assistant.log"
             if logfile.exists():
-                backup = Path(
-                    self.sys_config.path_homeassistant, "home-assistant-rollback.log"
+                backup = (
+                    self.sys_config.path_homeassistant / "home-assistant-rollback.log"
                 )
-                shutil.copy(logfile.as_posix(), backup.as_posix())
+
+                shutil.copy(logfile, backup)
+                _LOGGER.info(
+                    "A backup of the logfile is stored in /config/home-assistant-rollback.log"
+                )
             await _update(rollback)
         else:
             raise HomeAssistantUpdateError()

--- a/supervisor/homeassistant.py
+++ b/supervisor/homeassistant.py
@@ -359,6 +359,13 @@ class HomeAssistant(JsonConfig, CoreSysAttributes):
         # Update going wrong, revert it
         if self.error_state and rollback:
             _LOGGER.critical("HomeAssistant update fails -> rollback!")
+            # Make a copy of the current log file if it exsist
+            logfile = Path(self.sys_config.path_homeassistant, "home-assistant.log")
+            if logfile.exists():
+                backup = Path(
+                    self.sys_config.path_homeassistant, "home-assistant-rollback.log"
+                )
+                shutil.copy(logfile.as_posix(), backup.as_posix())
             await _update(rollback)
         else:
             raise HomeAssistantUpdateError()


### PR DESCRIPTION
Creates `home-assistant-rollback.log` from `home-assistant.log` before rollback, so the reason for rollback is not lost