### PR TITLE
Allow all addons to access /host/info endpoint

### DIFF
--- a/supervisor/api/security.py
+++ b/supervisor/api/security.py
@@ -49,6 +49,7 @@ ADDONS_API_BYPASS = re.compile(
     r"|/services.*"
     r"|/discovery.*"
     r"|/auth"
+    r"|/host/info"
     r")$"
 )
 


### PR DESCRIPTION
Fixes #1884 