### PR TITLE
Add Sentry release GitHub Action workflow

### DIFF
--- a/.github/workflows/sentry.yaml
+++ b/.github/workflows/sentry.yaml
@@ -1,0 +1,21 @@
+name: Sentry Release
+
+# yamllint disable-line rule:truthy
+on:
+  release:
+    types: [published, prereleased]
+
+jobs:
+  createSentryRelease:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2
+      - name: Sentry Release
+        uses: getsentry/action-release@v1.0.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          environment: production


### PR DESCRIPTION
Adds a GitHub Actions workflow for handling Sentry releases automatically.