### PR TITLE
Format API error messages

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -552,7 +552,7 @@ class Addon(AddonModel):
             await self.instance.run()
         except DockerAPIError as err:
             self.state = AddonState.ERROR
-            raise AddonsError() from err
+            raise AddonsError(err) from None
         else:
             self.state = AddonState.STARTED
 

--- a/supervisor/docker/__init__.py
+++ b/supervisor/docker/__init__.py
@@ -149,7 +149,7 @@ class DockerAPI:
             container.start()
         except (docker.errors.DockerException, requests.RequestException) as err:
             _LOGGER.error("Can't start %s: %s", name, err)
-            raise DockerAPIError() from err
+            raise DockerAPIError(err) from None
 
         # Update metadata
         with suppress(docker.errors.DockerException, requests.RequestException):

--- a/supervisor/utils/log_format.py
+++ b/supervisor/utils/log_format.py
@@ -1,0 +1,15 @@
+"""Custom log messages."""
+import re
+
+RE_BIND_FAILED = re.compile(r".*Bind for.*:(\d*) failed: port is already allocated.*")
+
+
+def format_message(message: str) -> str:
+    """Return a formated message if it's known."""
+    match = RE_BIND_FAILED.match(message)
+    if match:
+        return (
+            f"Port '{match.group(1)}' is already in use by something else on the host."
+        )
+
+    return message

--- a/tests/utils/test_log_format.py
+++ b/tests/utils/test_log_format.py
@@ -1,0 +1,11 @@
+"""Tests for message formater."""
+from supervisor.utils.log_format import format_message
+
+
+def test_format_message():
+    """Tests for message formater."""
+    message = '500 Server Error: Internal Server Error:  Bind for 0.0.0.0:80 failed: port is already allocated")'
+    assert (
+        format_message(message)
+        == "Port '80' is already in use by something else on the host."
+    )


### PR DESCRIPTION
With this change we can get something like this example shown in the UI:
![image](https://user-images.githubusercontent.com/15093472/91644603-f0ad1100-ea3d-11ea-8168-9c47b6d5e6c0.png)

Instead of "Unknown Error, see logs", which makes you check the SU logs (maybe, if you find them) that will show:

```
Can't start addon_core_ssh: 500 Server Error: Internal Server Error ("driver failed programming external connectivity on endpoint addon_core_ssh (e98012852d7261d79918b8fb64b21778a1c30b1374138616bf60eec0ee624d4c): Bind for 0.0.0.0:80 failed: port is already allocated")

```