### PR TITLE
implify API calls for supervisor

### DIFF
--- a/supervisor/api/supervisor.py
+++ b/supervisor/api/supervisor.py
@@ -145,8 +145,11 @@ class APISupervisor(CoreSysAttributes):
 
         self.sys_updater.save_data()
         self.sys_config.save_data()
-        self.reload()
 
+        # Reload the supervisor after options changed
+        await asyncio.shield(self.reload())
+
+        # Return the changed data
         return await self.info()
 
     @api_process

--- a/supervisor/api/supervisor.py
+++ b/supervisor/api/supervisor.py
@@ -145,6 +145,9 @@ class APISupervisor(CoreSysAttributes):
 
         self.sys_updater.save_data()
         self.sys_config.save_data()
+        self.reload()
+
+        return await self.info()
 
     @api_process
     async def stats(self, request: web.Request) -> Dict[str, Any]:


### PR DESCRIPTION
Currently, when a user changes the "channel" for instance in the UI, we have to make 3 API calls for it to reflect in the UI.
With this change, that drops to 1 call.

