### PR TITLE
Only support IPv4 for DNS

### DIFF
--- a/supervisor/validate.py
+++ b/supervisor/validate.py
@@ -74,9 +74,13 @@ def dns_url(url: str) -> str:
         raise vol.Invalid("Doesn't start with dns://") from None
     address: str = url[6:]  # strip the dns:// off
     try:
-        ipaddress.ip_address(address)  # matches ipv4 or ipv6 addresses
+        ip = ipaddress.ip_address(address)  # matches ipv4 or ipv6 addresses
     except ValueError:
         raise vol.Invalid(f"Invalid DNS URL: {url}") from None
+
+    # Currently only IPv4 work with docker network
+    if ip.version != 4:
+        raise vol.Invalid(f"Only IPv4 is working for DNS: {url}") from None
     return url
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -26,8 +26,9 @@ async def test_dns_url_v4_good():
 
 def test_dns_url_v6_good():
     """Test the DNS validator with known-good ipv6 DNS URLs."""
-    for url in DNS_GOOD_V6:
-        assert validate.dns_url(url)
+    with pytest.raises(vol.error.Invalid):
+        for url in DNS_GOOD_V6:
+            assert validate.dns_url(url)
 
 
 def test_dns_server_list_v4():
@@ -37,16 +38,19 @@ def test_dns_server_list_v4():
 
 def test_dns_server_list_v6():
     """Test a list with v6 addresses."""
-    assert validate.dns_server_list(DNS_GOOD_V6)
+    with pytest.raises(vol.error.Invalid):
+        assert validate.dns_server_list(DNS_GOOD_V6)
 
 
 def test_dns_server_list_combined():
     """Test a list with both v4 and v6 addresses."""
     combined = DNS_GOOD_V4 + DNS_GOOD_V6
     # test the matches
-    assert validate.dns_server_list(combined)
+    with pytest.raises(vol.error.Invalid):
+        validate.dns_server_list(combined)
     # test max_length is OK still
-    assert validate.dns_server_list(combined)
+    with pytest.raises(vol.error.Invalid):
+        validate.dns_server_list(combined)
     # test that it fails when the list is too long
     with pytest.raises(vol.error.Invalid):
         validate.dns_server_list(combined + combined + combined + combined)
@@ -72,6 +76,7 @@ def test_version_complex():
     """Test version simple with good version."""
     for version in (
         "landingpage",
+        "dev",
         "1c002dd",
         "1.1.1",
         "1.0",


### PR DESCRIPTION
If no one provide an proof picture that IPv6 server address work inside hassio_dns container, we remove this feature because it would only lead in issues.