### PR TITLE
Add uuid to update payload

### DIFF
--- a/supervisor/dbus/network/interface.py
+++ b/supervisor/dbus/network/interface.py
@@ -60,6 +60,11 @@ class NetworkInterface:
         return self.connection.id
 
     @property
+    def uuid(self) -> str:
+        """Return the interface uuid."""
+        return self.connection.uuid
+
+    @property
     def method(self) -> InterfaceMethod:
         """Return the interface method."""
         return InterfaceMethod(self.connection.ip4_config.method)

--- a/supervisor/dbus/payloads/interface_update.tmpl
+++ b/supervisor/dbus/payloads/interface_update.tmpl
@@ -2,7 +2,8 @@
     'connection':
         {
             'id': <'{{interface.id}}'>,
-            'type': <'{{interface.type}}'>
+            'type': <'{{interface.type}}'>,
+            'uuid': <'{{interface.uuid}}'>
         },
 
 {% if options.get("method") == "auto" %}

--- a/tests/dbus/payloads/test_interface_update_payload.py
+++ b/tests/dbus/payloads/test_interface_update_payload.py
@@ -18,6 +18,10 @@ async def test_interface_update_payload_ethernet(network_interface):
     assert DBus.parse_gvariant(data)["ipv4"]["method"] == "manual"
     assert DBus.parse_gvariant(data)["ipv4"]["address-data"][0]["address"] == "1.1.1.1"
     assert DBus.parse_gvariant(data)["ipv4"]["dns"] == [16843009, 16777217]
+    assert (
+        DBus.parse_gvariant(data)["connection"]["uuid"]
+        == "0c23631e-2118-355c-bbb0-8943229cb0d6"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
On older versions of NM, if the `uuid` is not present it just generates a new one, which is not allowed.

currently tested with success on 1.22.10 and 1.14.6

blocks https://github.com/home-assistant/architecture/pull/431
fixes https://github.com/home-assistant/supervisor/issues/2068