### PR TITLE
Handle both cases of bind failures

### DIFF
--- a/supervisor/utils/log_format.py
+++ b/supervisor/utils/log_format.py
@@ -6,7 +6,9 @@ import sentry_sdk
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
-RE_BIND_FAILED = re.compile(r".*Bind for.*:(\d*) failed: port is already allocated.*")
+RE_BIND_FAILED = re.compile(
+    r".*[listen tcp|Bind for].*(?:[0-9]{1,3}\.){3}[0-9]{1,3}:(\d*).*[bind|failed]:[address already in use|port is already allocated].*"
+)
 
 
 def format_message(message: str) -> str:

--- a/tests/utils/test_log_format.py
+++ b/tests/utils/test_log_format.py
@@ -2,9 +2,18 @@
 from supervisor.utils.log_format import format_message
 
 
-def test_format_message():
+def test_format_message_port():
     """Tests for message formater."""
     message = '500 Server Error: Internal Server Error:  Bind for 0.0.0.0:80 failed: port is already allocated")'
+    assert (
+        format_message(message)
+        == "Port '80' is already in use by something else on the host."
+    )
+
+
+def test_format_message_port_alternative():
+    """Tests for message formater."""
+    message = 'Error starting userland proxy: listen tcp 0.0.0.0:80: bind: address already in use")'
     assert (
         format_message(message)
         == "Port '80' is already in use by something else on the host."


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We have  2 bind error messages depending on how you start it, this change makes sure we handle both.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
