### PR TITLE
Add the log stream from docker if build fails

### DIFF
--- a/supervisor/docker/addon.py
+++ b/supervisor/docker/addon.py
@@ -421,6 +421,15 @@ class DockerAddon(DockerInterface):
 
         except (docker.errors.DockerException, requests.RequestException) as err:
             _LOGGER.error("Can't build %s:%s: %s", self.image, tag, err)
+            if hasattr(err, "build_log"):
+                log = "\n".join(
+                    [
+                        x["stream"]
+                        for x in err.build_log  # pylint: disable=no-member
+                        if "stream" in x
+                    ]
+                )
+                _LOGGER.error("Build log: \n%s", log)
             raise DockerError() from err
 
         _LOGGER.info("Build %s:%s done", self.image, tag)

--- a/supervisor/docker/addon.py
+++ b/supervisor/docker/addon.py
@@ -426,7 +426,7 @@ class DockerAddon(DockerInterface):
                     [
                         x["stream"]
                         for x in err.build_log  # pylint: disable=no-member
-                        if "stream" in x
+                        if isinstance(x, dict) and "stream" in x
                     ]
                 )
                 _LOGGER.error("Build log: \n%s", log)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds more logs when docker builds fails giving add-on devs a chance to see what's wrong with out building locally on their machine with docker.

In addition to the cryptic:

```
20-11-02 10:11:11 ERROR (SyncWorker_2) [supervisor.docker.addon] Can't build local/amd64-addon-sync:0.4: The command '/bin/ash -o pipefail -c apk add --no-cache jq==223' returned a non-zero code: 1
```

With this PR it adds the build log as well:

```
20-11-02 10:11:11 ERROR (SyncWorker_2) [supervisor.docker.addon] Build log: 
Step 1/12 : ARG BUILD_FROM
Step 2/12 : FROM $BUILD_FROM
 ---> b70ac30ea587
Step 3/12 : ENV LANG C.UTF-8
 ---> Using cache
 ---> 21a3a2cca551
Step 4/12 : RUN apk add --no-cache jq==223
 ---> Running in 661ea6b65db9
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:

  jq-1.6-r1:
    breaks: world[jq=223]
Removing intermediate container 661ea6b65db9
```

![image](https://user-images.githubusercontent.com/15093472/97856460-9e69c400-1cfc-11eb-994c-2f71d2e61a87.png)

I think this change will be very much welcome by add-on developers.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
