### PR TITLE
Wifi mode old NM

### DIFF
--- a/supervisor/host/network.py
+++ b/supervisor/host/network.py
@@ -334,6 +334,11 @@ class Interface:
         elif inet.settings.wireless_security.key_mgmt == "wpa-psk":
             auth = AuthMethod.WPA_PSK
 
+        # WifiMode
+        mode = WifiMode.INFRASTRUCTURE
+        if inet.settings.wireless.mode:
+            mode = WifiMode(inet.settings.wireless.mode)
+
         # Signal
         if inet.wireless:
             signal = inet.wireless.active.strength
@@ -341,7 +346,7 @@ class Interface:
             signal = None
 
         return WifiConfig(
-            WifiMode(inet.settings.wireless.mode),
+            mode,
             inet.settings.wireless.ssid,
             auth,
             inet.settings.wireless_security.psk,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

```
Traceback (most recent call last):
File "/usr/local/lib/python3.8/site-packages/aiohttp/web_protocol.py", line 422, in _handle_request
resp = await self._request_handler(request)
File "/usr/local/lib/python3.8/site-packages/sentry_sdk/integrations/aiohttp.py", line 123, in sentry_app_handle
reraise(*_capture_exception(hub))
File "/usr/local/lib/python3.8/site-packages/sentry_sdk/_compat.py", line 54, in reraise
raise value
File "/usr/local/lib/python3.8/site-packages/sentry_sdk/integrations/aiohttp.py", line 113, in sentry_app_handle
response = await old_handle(self, request)
File "/usr/local/lib/python3.8/site-packages/aiohttp/web_app.py", line 499, in _handle
resp = await handler(request)
File "/usr/local/lib/python3.8/site-packages/aiohttp/web_middlewares.py", line 118, in impl
return await handler(request)
File "/usr/src/supervisor/supervisor/api/security.py", line 132, in system_validation
return await handler(request)
File "/usr/src/supervisor/supervisor/api/security.py", line 194, in token_validation
return await handler(request)
File "/usr/src/supervisor/supervisor/api/utils.py", line 60, in wrap_api
answer = await method(api, *args, **kwargs)
File "/usr/src/supervisor/supervisor/api/network.py", line 156, in info
for interface in self.sys_host.network.interfaces
File "/usr/src/supervisor/supervisor/host/network.py", line 54, in interfaces
interfaces.append(Interface.from_dbus_interface(inet))
File "/usr/src/supervisor/supervisor/host/network.py", line 291, in from_dbus_interface
Interface._map_nm_wifi(inet),
File "/usr/src/supervisor/supervisor/host/network.py", line 348, in _map_nm_wifi
WifiMode(inet.settings.wireless.mode),
File "/usr/local/lib/python3.8/enum.py", line 315, in call
return cls.new(cls, value)
File "/usr/local/lib/python3.8/enum.py", line 617, in new
raise ve_exc
ValueError: None is not a valid WifiMode
```

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #2278 
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
