### PR TITLE
Fix network connection detection for bridge interfaces

### DIFF
--- a/supervisor/dbus/const.py
+++ b/supervisor/dbus/const.py
@@ -118,6 +118,7 @@ class DeviceType(int, Enum):
     VLAN = 11
     TUN = 16
     VETH = 20
+    BRIDGE = 13
 
 
 class WirelessMethodType(int, Enum):

--- a/supervisor/dbus/network/__init__.py
+++ b/supervisor/dbus/network/__init__.py
@@ -122,6 +122,7 @@ class NetworkManager(DBusInterface):
                     DeviceType.ETHERNET,
                     DeviceType.WIRELESS,
                     DeviceType.VLAN,
+                    DeviceType.BRIDGE,
                 ]
                 or not interface.managed
             ):

--- a/supervisor/host/const.py
+++ b/supervisor/host/const.py
@@ -16,6 +16,7 @@ class InterfaceType(str, Enum):
     ETHERNET = "ethernet"
     WIRELESS = "wireless"
     VLAN = "vlan"
+    BRIDGE = "bridge"
 
 
 class AuthMethod(str, Enum):

--- a/supervisor/host/network.py
+++ b/supervisor/host/network.py
@@ -283,7 +283,7 @@ class Interface:
                 inet.connection.ipv4.gateway,
                 inet.connection.ipv4.nameservers,
             )
-            if inet.settings.ipv4 and inet.connection and inet.connection.ipv4
+            if inet.settings and inet.settings.ipv4 and inet.connection and inet.connection.ipv4
             else IpConfig(InterfaceMethod.DISABLED, [], None, []),
             IpConfig(
                 Interface._map_nm_method(inet.settings.ipv6.method),
@@ -291,7 +291,7 @@ class Interface:
                 inet.connection.ipv6.gateway,
                 inet.connection.ipv6.nameservers,
             )
-            if inet.settings.ipv6 and inet.connection and inet.connection.ipv6
+            if inet.settings and inet.settings.ipv6 and inet.connection and inet.connection.ipv6
             else IpConfig(InterfaceMethod.DISABLED, [], None, []),
             Interface._map_nm_wifi(inet),
             Interface._map_nm_vlan(inet),

--- a/supervisor/host/network.py
+++ b/supervisor/host/network.py
@@ -325,6 +325,7 @@ class Interface:
             DeviceType.ETHERNET: InterfaceType.ETHERNET,
             DeviceType.WIRELESS: InterfaceType.WIRELESS,
             DeviceType.VLAN: InterfaceType.VLAN,
+            DeviceType.BRIDGE: InterfaceType.BRIDGE,
         }
         return mapping[device_type]
 

--- a/supervisor/host/network.py
+++ b/supervisor/host/network.py
@@ -283,7 +283,10 @@ class Interface:
                 inet.connection.ipv4.gateway,
                 inet.connection.ipv4.nameservers,
             )
-            if inet.settings and inet.settings.ipv4 and inet.connection and inet.connection.ipv4
+            if inet.settings
+            and inet.settings.ipv4
+            and inet.connection
+            and inet.connection.ipv4
             else IpConfig(InterfaceMethod.DISABLED, [], None, []),
             IpConfig(
                 Interface._map_nm_method(inet.settings.ipv6.method),
@@ -291,7 +294,10 @@ class Interface:
                 inet.connection.ipv6.gateway,
                 inet.connection.ipv6.nameservers,
             )
-            if inet.settings and inet.settings.ipv6 and inet.connection and inet.connection.ipv6
+            if inet.settings
+            and inet.settings.ipv6
+            and inet.connection
+            and inet.connection.ipv6
             else IpConfig(InterfaceMethod.DISABLED, [], None, []),
             Interface._map_nm_wifi(inet),
             Interface._map_nm_vlan(inet),

--- a/supervisor/host/network.py
+++ b/supervisor/host/network.py
@@ -283,7 +283,7 @@ class Interface:
                 inet.connection.ipv4.gateway,
                 inet.connection.ipv4.nameservers,
             )
-            if inet.connection and inet.connection.ipv4
+            if inet.settings.ipv4 and inet.connection and inet.connection.ipv4
             else IpConfig(InterfaceMethod.DISABLED, [], None, []),
             IpConfig(
                 Interface._map_nm_method(inet.settings.ipv6.method),
@@ -291,7 +291,7 @@ class Interface:
                 inet.connection.ipv6.gateway,
                 inet.connection.ipv6.nameservers,
             )
-            if inet.connection and inet.connection.ipv6
+            if inet.settings.ipv6 and inet.connection and inet.connection.ipv6
             else IpConfig(InterfaceMethod.DISABLED, [], None, []),
             Interface._map_nm_wifi(inet),
             Interface._map_nm_vlan(inet),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
My primary network connection is a bridge since I am running in parallel to HASS an LXC container with a Homematic CCU.
Since the last supervisor update my supervisor is throwing errors because that seems to trigger some issues in the network enumeration with NetworkManager connections that don't have IPv4 or IPv6 settings (i.e. bridge members). Issue is as follows:

    File "/usr/src/supervisor/supervisor/host/network.py", line 281, in from_dbus_interface
        Interface._map_nm_method(inet.settings.ipv4.method),
    AttributeError: 'NoneType' object has no attribute 'method'

The first commit avoids this by doing a check whether the inet.settings.ipvX object exists before accessing it.
The second commit adds support for detecting the bridge as primary connection and thus makes the IP address to be detected correctly.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
