### PR TITLE
Allow GET method on /auth with BasicAuth

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -248,6 +248,7 @@ class RestAPI(CoreSysAttributes):
 
         self.webapp.add_routes(
             [
+                web.get("/auth", api_auth.auth),
                 web.post("/auth", api_auth.auth),
                 web.post("/auth/reset", api_auth.reset),
                 web.delete("/auth/cache", api_auth.cache),

--- a/supervisor/api/auth.py
+++ b/supervisor/api/auth.py
@@ -5,7 +5,7 @@ from typing import Dict
 
 from aiohttp import BasicAuth, web
 from aiohttp.hdrs import AUTHORIZATION, CONTENT_TYPE, WWW_AUTHENTICATE
-from aiohttp.web_exceptions import HTTPBadRequest, HTTPUnauthorized
+from aiohttp.web_exceptions import HTTPUnauthorized
 import voluptuous as vol
 
 from ..addons.addon import Addon
@@ -67,17 +67,11 @@ class APIAuth(CoreSysAttributes):
 
         # Json
         if request.headers.get(CONTENT_TYPE) == CONTENT_TYPE_JSON:
-            if request.method == "GET":
-                raise HTTPBadRequest(text="json auth requires HTTP POST instead of GET")
             data = await request.json()
             return await self._process_dict(request, addon, data)
 
         # URL encoded
         if request.headers.get(CONTENT_TYPE) == CONTENT_TYPE_URL:
-            if request.method == "GET":
-                raise HTTPBadRequest(
-                    text="URL encoded auth requires HTTP POST instead of GET"
-                )
             data = await request.post()
             return await self._process_dict(request, addon, data)
 

--- a/supervisor/api/auth.py
+++ b/supervisor/api/auth.py
@@ -5,7 +5,7 @@ from typing import Dict
 
 from aiohttp import BasicAuth, web
 from aiohttp.hdrs import AUTHORIZATION, CONTENT_TYPE, WWW_AUTHENTICATE
-from aiohttp.web_exceptions import HTTPUnauthorized
+from aiohttp.web_exceptions import HTTPBadRequest, HTTPUnauthorized
 import voluptuous as vol
 
 from ..addons.addon import Addon
@@ -67,11 +67,17 @@ class APIAuth(CoreSysAttributes):
 
         # Json
         if request.headers.get(CONTENT_TYPE) == CONTENT_TYPE_JSON:
+            if request.method == "GET":
+                raise HTTPBadRequest(text="json auth requires HTTP POST instead of GET")
             data = await request.json()
             return await self._process_dict(request, addon, data)
 
         # URL encoded
         if request.headers.get(CONTENT_TYPE) == CONTENT_TYPE_URL:
+            if request.method == "GET":
+                raise HTTPBadRequest(
+                    text="URL encoded auth requires HTTP POST instead of GET"
+                )
             data = await request.post()
             return await self._process_dict(request, addon, data)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

nginx has a convenient feature named [Authentication Based on Subrequest Result](https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-subrequest-authentication/) which allows to grant/deny access using basic authentication based on the result of a subrequest. That nginx module however only works with GET requests.

This Pull Requests allows users to provide auth credentials using Basic Auth in a GET request. This is convenient because it is then possible to use nginx to authenticate a third party app. Within the nginx server directive an add-on developer could use something like:

```
location = /.ha-auth {
    internal;
    proxy_pass              http://supervisor/auth;
    proxy_pass_request_body off;
    proxy_set_header        Content-Length "";
    proxy_set_header        X-Supervisor-Token "${SUPERVISOR_TOKEN}"; # The ${SUPERVISOR_TOKEN} needs to be set
}

location / {
    auth_request     /.ha-auth;
    auth_request_set $auth_status $upstream_status;
    proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header  Host $http_host;
    #proxy_set_header X-Remote-User $remote_user;
    #proxy_set_header   X-Forwarded-User $http_authorization;
    proxy_pass http://127.0.0.1:5000/;  # your addon could use the X-Remote-User header with the username
}
```


## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/767

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [X] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
