### PR TITLE
Disambiguate HTTPUnauthorized on user/password validation

### DIFF
--- a/supervisor/homeassistant/api.py
+++ b/supervisor/homeassistant/api.py
@@ -13,6 +13,7 @@ from ..exceptions import HomeAssistantAPIError, HomeAssistantAuthError
 from ..utils import check_port
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+_ALLOWED_401_REASONS = ["invalid user/password"]
 
 
 class HomeAssistantAPI(CoreSysAttributes):
@@ -88,7 +89,7 @@ class HomeAssistantAPI(CoreSysAttributes):
                     params=params,
                 ) as resp:
                     # Access token expired
-                    if resp.status == 401:
+                    if resp.status == 401 and resp.reason not in _ALLOWED_401_REASONS:
                         self.access_token = None
                         continue
                     yield resp


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The HA core API usually returns 401 when the request does not have proper authentication tokens or they have expired.

However the user/password validation endpoint may also return 401 when the given user/password is invalid.

This PR lets the supervisor check the response reason, and distinguish between 401 responses.

I have submitted https://github.com/home-assistant/core/pull/44940, so home-assistant reports the reason to the supervisor. Merging this PR and https://github.com/home-assistant/core/pull/44940 will close the associated issue linked below.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #2408, Required PR: https://github.com/home-assistant/core/pull/44940
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
