### PR TITLE
Shutdown using systemd-logind if available

### DIFF
--- a/supervisor/dbus/__init__.py
+++ b/supervisor/dbus/__init__.py
@@ -6,6 +6,7 @@ from ..const import SOCKET_DBUS
 from ..coresys import CoreSys, CoreSysAttributes
 from .hostname import Hostname
 from .interface import DBusInterface
+from .logind import Logind
 from .network import NetworkManager
 from .rauc import Rauc
 from .systemd import Systemd
@@ -21,6 +22,7 @@ class DBusManager(CoreSysAttributes):
         self.coresys: CoreSys = coresys
 
         self._systemd: Systemd = Systemd()
+        self._logind: Logind = Logind()
         self._hostname: Hostname = Hostname()
         self._rauc: Rauc = Rauc()
         self._network: NetworkManager = NetworkManager()
@@ -29,6 +31,11 @@ class DBusManager(CoreSysAttributes):
     def systemd(self) -> Systemd:
         """Return the systemd interface."""
         return self._systemd
+
+    @property
+    def logind(self) -> Logind:
+        """Return the logind interface."""
+        return self._logind
 
     @property
     def hostname(self) -> Hostname:
@@ -55,6 +62,7 @@ class DBusManager(CoreSysAttributes):
 
         dbus_loads: List[DBusInterface] = [
             self.systemd,
+            self.logind,
             self.hostname,
             self.network,
             self.rauc,

--- a/supervisor/dbus/const.py
+++ b/supervisor/dbus/const.py
@@ -18,6 +18,7 @@ DBUS_NAME_NM_CONNECTION_ACTIVE_CHANGED = (
     "org.freedesktop.NetworkManager.Connection.Active.PropertiesChanged"
 )
 DBUS_NAME_SYSTEMD = "org.freedesktop.systemd1"
+DBUS_NAME_LOGIND = "org.freedesktop.login1"
 
 DBUS_OBJECT_BASE = "/"
 DBUS_OBJECT_DNS = "/org/freedesktop/NetworkManager/DnsManager"
@@ -25,6 +26,7 @@ DBUS_OBJECT_SETTINGS = "/org/freedesktop/NetworkManager/Settings"
 DBUS_OBJECT_HOSTNAME = "/org/freedesktop/hostname1"
 DBUS_OBJECT_NM = "/org/freedesktop/NetworkManager"
 DBUS_OBJECT_SYSTEMD = "/org/freedesktop/systemd1"
+DBUS_OBJECT_LOGIND = "/org/freedesktop/login1"
 
 DBUS_ATTR_ACTIVE_CONNECTIONS = "ActiveConnections"
 DBUS_ATTR_ACTIVE_CONNECTION = "ActiveConnection"

--- a/supervisor/dbus/logind.py
+++ b/supervisor/dbus/logind.py
@@ -1,0 +1,41 @@
+"""Interface to Logind over D-Bus."""
+import logging
+
+from ..exceptions import DBusError, DBusInterfaceError
+from ..utils.gdbus import DBus
+from .const import DBUS_NAME_LOGIND, DBUS_OBJECT_LOGIND
+from .interface import DBusInterface
+from .utils import dbus_connected
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+class Logind(DBusInterface):
+    """Logind function handler."""
+
+    name = DBUS_NAME_LOGIND
+
+    async def connect(self):
+        """Connect to D-Bus."""
+        try:
+            self.dbus = await DBus.connect(DBUS_NAME_LOGIND, DBUS_OBJECT_LOGIND)
+        except DBusError:
+            _LOGGER.warning("Can't connect to systemd-logind")
+        except DBusInterfaceError:
+            _LOGGER.info("No systemd-logind support on the host.")
+
+    @dbus_connected
+    def reboot(self):
+        """Reboot host computer.
+
+        Return a coroutine.
+        """
+        return self.dbus.Manager.Reboot(False)
+
+    @dbus_connected
+    def power_off(self):
+        """Power off host computer.
+
+        Return a coroutine.
+        """
+        return self.dbus.Manager.PowerOff(False)


### PR DESCRIPTION
The Reboot() and PowerOff() methods of the systemd D-Bus API are not
meant to be called directly when logind is in use. Make sure to use the
logind APIs if available.

Since OS release 5.1 systemd-logind is enabled.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
