### PR TITLE
Removed setting unheathy state when udev could not be initialized

### DIFF
--- a/supervisor/misc/hwmon.py
+++ b/supervisor/misc/hwmon.py
@@ -29,8 +29,10 @@ class HwMonitor(CoreSysAttributes):
             self.monitor = pyudev.Monitor.from_netlink(self.context)
             self.observer = pyudev.MonitorObserver(self.monitor, self._udev_events)
         except OSError:
-            self.sys_resolution.unhealthy = UnhealthyReason.PRIVILEGED
-            _LOGGER.critical("Not privileged to run udev monitor!")
+            _LOGGER.critical("udev monitor could not be initialized!")
+            _LOGGER.critical(
+                "This is likely because you are using an unsupported system, some features may not work becuase of this"
+            )
         else:
             self.observer.start()
             _LOGGER.info("Started Supervisor hardware monitor")

--- a/supervisor/misc/hwmon.py
+++ b/supervisor/misc/hwmon.py
@@ -7,7 +7,6 @@ from typing import Optional
 import pyudev
 
 from ..coresys import CoreSys, CoreSysAttributes
-from ..resolution.const import UnhealthyReason
 from ..utils import AsyncCallFilter
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Don't set the unheathly no-priv state when udev cannot be loaded

This is a known issue with somewhat funky installations on different OS-es
Whist not supported, this change allows those users to still update etc

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #2447
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [?] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
