### PR TITLE
Udev - move away form depricated callback / increase buffer

### DIFF
--- a/supervisor/hardware/monitor.py
+++ b/supervisor/hardware/monitor.py
@@ -1,5 +1,4 @@
 """Supervisor Hardware monitor based on udev."""
-from contextlib import suppress
 import logging
 from pathlib import Path
 from pprint import pformat
@@ -31,7 +30,9 @@ class HwMonitor(CoreSysAttributes):
         """Start hardware monitor."""
         try:
             self.monitor = pyudev.Monitor.from_netlink(self.context, "kernel")
-            self.observer = pyudev.MonitorObserver(self.monitor, self._udev_events)
+            self.observer = pyudev.MonitorObserver(
+                self.monitor, callback=self._udev_events
+            )
         except OSError:
             self.sys_resolution.unhealthy = UnhealthyReason.PRIVILEGED
             _LOGGER.critical("Not privileged to run udev monitor!")
@@ -47,29 +48,29 @@ class HwMonitor(CoreSysAttributes):
         self.observer.stop()
         _LOGGER.info("Stopped Supervisor hardware monitor")
 
-    def _udev_events(self, action: str, kernel: pyudev.Device):
+    def _udev_events(self, kernel: pyudev.Device):
         """Incomming events from udev.
 
         This is inside a observe thread and need pass into our eventloop.
         """
-        _LOGGER.debug("Hardware monitor: %s - %s", action, pformat(kernel))
-        udev = None
-        with suppress(pyudev.DeviceNotFoundAtPathError):
-            udev = pyudev.Devices.from_sys_path(self.context, kernel.sys_path)
-
+        _LOGGER.debug("Hardware monitor: %s - %s", kernel.action, pformat(kernel))
         self.sys_loop.call_soon_threadsafe(
-            self._async_udev_events, action, kernel, udev
+            self._async_udev_events, kernel.action, kernel
         )
 
-    def _async_udev_events(
-        self, action: str, kernel: pyudev.Device, udev: Optional[pyudev.Device]
-    ):
+    def _async_udev_events(self, action: str, kernel: pyudev.Device):
         """Incomming events from udev into loop."""
         # Update device List
         if not kernel.device_node or self.sys_hardware.helper.hide_virtual_device(
             kernel
         ):
             return
+
+        # Load kernel module
+        try:
+            udev = pyudev.Devices.from_sys_path(self.context, kernel.sys_path)
+        except pyudev.DeviceNotFoundAtPathError:
+            udev = None
 
         hw_action = None
         device = None

--- a/supervisor/hardware/monitor.py
+++ b/supervisor/hardware/monitor.py
@@ -30,6 +30,8 @@ class HwMonitor(CoreSysAttributes):
         """Start hardware monitor."""
         try:
             self.monitor = pyudev.Monitor.from_netlink(self.context, "kernel")
+            self.monitor.set_receive_buffer_size(32 * 1024 * 1024)
+
             self.observer = pyudev.MonitorObserver(
                 self.monitor,
                 callback=lambda x: self.sys_loop.call_soon_threadsafe(

--- a/supervisor/hardware/monitor.py
+++ b/supervisor/hardware/monitor.py
@@ -60,9 +60,9 @@ class HwMonitor(CoreSysAttributes):
             kernel
         ):
             return
-
-        # Load kernel module
         _LOGGER.debug("Hardware monitor: %s - %s", kernel.action, pformat(kernel))
+
+        # Lookup udev device data
         try:
             udev = pyudev.Devices.from_sys_path(self.context, kernel.sys_path)
         except pyudev.DeviceNotFoundAtPathError:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

We used from old days the old depricated callback handler. This is now migrated. Also it fix the error:
```
OSError: Error while polling fd: 24
  File "pyudev/monitor.py", line 531, in run
    for device in iter(read_device, None):
  File "pyudev/_util.py", line 159, in eintr_retry_call
    return func(*args, **kwargs)
  File "pyudev/monitor.py", line 354, in poll
    if eintr_retry_call(poll.Poll.for_events((self, 'r')).poll, timeout):
  File "pyudev/_util.py", line 159, in eintr_retry_call
    return func(*args, **kwargs)
  File "pyudev/_os/poll.py", line 94, in poll
    return list(
  File "pyudev/_os/poll.py", line 110, in _parse_events
    raise IOError('Error while polling fd: {0!r}'.format(fd))
```

We increase the buffer. Just for the records, other systems like systemd use default 128mb

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
