### PR TITLE
Add API deprecation middleware

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -10,6 +10,7 @@ from .addons import APIAddons
 from .audio import APIAudio
 from .auth import APIAuth
 from .cli import APICli
+from .deprecation import DeprecationMiddleware
 from .discovery import APIDiscovery
 from .dns import APICoreDNS
 from .docker import APIDocker
@@ -43,11 +44,13 @@ class RestAPI(CoreSysAttributes):
         """Initialize Docker base wrapper."""
         self.coresys: CoreSys = coresys
         self.security: SecurityMiddleware = SecurityMiddleware(coresys)
+        self.deprecation: DeprecationMiddleware = DeprecationMiddleware(coresys)
         self.webapp: web.Application = web.Application(
             client_max_size=MAX_CLIENT_SIZE,
             middlewares=[
                 self.security.system_validation,
                 self.security.token_validation,
+                self.deprecation.check_deprecation,
             ],
         )
 

--- a/supervisor/api/deprecation.py
+++ b/supervisor/api/deprecation.py
@@ -65,7 +65,9 @@ class DeprecationMiddleware(CoreSysAttributes):
         else:
             addon = self.sys_addons.from_token(supervisor_token)
             if addon:
-                more_info = f"please report this to the maintainer of {addon.name}"
+                more_info = (
+                    f"please report this to the maintainer of the {addon.name} add-on"
+                )
                 request_from = addon.name
                 if addon.need_update:
                     more_info = f"you are currently running version {addon.version}, there is an update pending for {addon.latest_version}. If that does not help {more_info}"

--- a/supervisor/api/deprecation.py
+++ b/supervisor/api/deprecation.py
@@ -68,7 +68,7 @@ class DeprecationMiddleware(CoreSysAttributes):
                 more_info = f"please report this to the maintainer of {addon.name}"
                 request_from = addon.name
                 if addon.need_update:
-                    more_info = f"You are currently running version {addon.version}, there is an update pending for {addon.latest_version}. If that does not help {more_info}"
+                    more_info = f"you are currently running version {addon.version}, there is an update pending for {addon.latest_version}. If that does not help {more_info}"
 
         if more_info == "" and DEPRECATED_PATHS[request.path].get("message"):
             more_info = DEPRECATED_PATHS[request.path]["message"]

--- a/supervisor/api/deprecation.py
+++ b/supervisor/api/deprecation.py
@@ -1,0 +1,80 @@
+"""Handle deprecation of this API."""
+import datetime
+import logging
+
+from aiohttp.web import Request, RequestHandler, Response, middleware
+
+from ..coresys import CoreSys, CoreSysAttributes
+from .utils import excract_supervisor_token
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+DEFAULT_GRACE_PERIOD = datetime.timedelta(seconds=10)
+
+DEPRECATED_PATHS = {
+    "/hardware/trigger": {
+        "message": "Ignoring DEPRECATED hardware trigger function call",
+        "grace_period": datetime.timedelta(seconds=60),
+    }
+}
+
+
+class DeprecationMiddleware(CoreSysAttributes):
+    """Deprecation middleware functions."""
+
+    def __init__(self, coresys: CoreSys):
+        """Initialize security middleware."""
+        self.coresys: CoreSys = coresys
+        self._trottle = {}
+
+    @middleware
+    async def check_deprecation(
+        self, request: Request, handler: RequestHandler
+    ) -> Response:
+        """Check if the requested path is deprecated."""
+        if request.path in DEPRECATED_PATHS:
+            now = datetime.datetime.now()
+            if request.path not in self._trottle or (
+                now - self._trottle[request.path]
+            ) > DEPRECATED_PATHS[request.path].get(
+                "grace_period", DEFAULT_GRACE_PERIOD
+            ):
+                self._trottle[request.path] = now
+                self.write_log(request)
+
+        return await handler(request)
+
+    def write_log(self, request: Request):
+        """Write the log entry."""
+        request_from = "unknown"
+        more_info = None
+        supervisor_token = excract_supervisor_token(request)
+
+        if supervisor_token == self.sys_homeassistant.supervisor_token:
+            request_from = "Home Assistant"
+
+        # Host
+        elif supervisor_token == self.sys_plugins.cli.supervisor_token:
+            request_from = "Host"
+
+        # Observer
+        elif supervisor_token == self.sys_plugins.observer.supervisor_token:
+            request_from = "observer"
+
+        # addon
+        else:
+            addon = self.sys_addons.from_token(supervisor_token)
+            if addon:
+                request_from = addon.name
+
+        if DEPRECATED_PATHS[request.path].get("message"):
+            more_info = DEPRECATED_PATHS[request.path]["message"]
+        else:
+            more_info = f"report this to the maintainer of {request_from}"
+
+        _LOGGER.warning(
+            "Access to deprecated API '%s' detected from %s - %s",
+            request.path,
+            request_from,
+            more_info,
+        )

--- a/supervisor/api/deprecation.py
+++ b/supervisor/api/deprecation.py
@@ -53,7 +53,7 @@ class DeprecationMiddleware(CoreSysAttributes):
 
     def write_log(self, request: Request):
         """Write the log entry."""
-        request_from = request[REQUEST_FROM]
+        request_from = request.get(REQUEST_FROM, "unknown")
         origin = self.get_origin(request)
         more_info = ""
 
@@ -79,7 +79,7 @@ class DeprecationMiddleware(CoreSysAttributes):
 
     def get_origin(self, request: Request):
         """Determine where the request was sendt from."""
-        origin = request[REQUEST_FROM]
+        origin = request.get(REQUEST_FROM, "unknown")
 
         # Home Assistant
         if isinstance(origin, HomeAssistant):

--- a/supervisor/api/hardware.py
+++ b/supervisor/api/hardware.py
@@ -62,4 +62,3 @@ class APIHardware(CoreSysAttributes):
     @api_process
     async def trigger(self, request: web.Request) -> Awaitable[None]:
         """Trigger a udev device reload."""
-        _LOGGER.warning("Ignoring DEPRECATED hardware trigger function call.")

--- a/tests/api/test_deprecation.py
+++ b/tests/api/test_deprecation.py
@@ -1,0 +1,88 @@
+"""Test API security layer."""
+
+from unittest.mock import patch
+
+from aiohttp import web
+import pytest
+
+from supervisor.addons.addon import Addon
+from supervisor.api import RestAPI
+from supervisor.const import HEADER_TOKEN
+
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture
+async def api_deprecation(aiohttp_client, coresys):
+    """Fixture for RestAPI client."""
+    api = RestAPI(coresys)
+    api.webapp = web.Application()
+    await api.load()
+
+    api.webapp.middlewares.append(api.security.token_validation)
+    api.webapp.middlewares.append(api.deprecation.check_deprecation)
+    yield await aiohttp_client(api.webapp)
+
+
+@pytest.mark.asyncio
+async def test_api_from_home_assistant(api_deprecation, caplog):
+    """Test access to non deprecated API."""
+
+    resp = await api_deprecation.get("/supervisor/ping")
+    assert resp.status == 200
+    assert not caplog.messages
+
+
+@pytest.mark.asyncio
+async def test_deprecated_api_from_home_assistant(api_deprecation, coresys, caplog):
+    """Test deprecated API access from Home Assistant."""
+    coresys.homeassistant.supervisor_token = "xxx"
+
+    resp = await api_deprecation.post(
+        "/hardware/trigger",
+        headers={HEADER_TOKEN: coresys.homeassistant.supervisor_token},
+    )
+    assert resp.status == 200
+    assert "Access to deprecated API '/hardware/trigger'" in caplog.messages[0]
+
+
+@pytest.mark.asyncio
+async def test_deprecated_api_from_addon(api_deprecation, coresys, caplog):
+    """Test deprecated API access from Addon."""
+    addon = Addon(coresys, "example")
+    coresys.addons.local[addon.slug] = addon
+    coresys.addons.data._data["system"] = {"example": {"name": "example"}}
+
+    with patch("supervisor.addons.addon.Addon.supervisor_token", "xxx"):
+
+        resp = await api_deprecation.post(
+            "/hardware/trigger", headers={HEADER_TOKEN: "xxx"}
+        )
+        assert resp.status == 200
+        assert (
+            "Access to deprecated API '/hardware/trigger' detected from example - please report this to the maintainer of the example add-on"
+            in caplog.messages[0]
+        )
+
+
+@pytest.mark.asyncio
+async def test_deprecated_api_from_addon_with_update(api_deprecation, coresys, caplog):
+    """Test deprecated API access from Addon with update."""
+    addon = Addon(coresys, "example")
+    coresys.addons.local[addon.slug] = addon
+    coresys.addons.data._data["system"] = {"example": {"name": "example"}}
+
+    with patch("supervisor.addons.addon.Addon.supervisor_token", "xxx"), patch(
+        "supervisor.addons.addon.Addon.need_update", True
+    ), patch("supervisor.addons.addon.Addon.version", "1.0.0"), patch(
+        "supervisor.addons.addon.Addon.latest_version", "1.0.1"
+    ):
+
+        resp = await api_deprecation.post(
+            "/hardware/trigger", headers={HEADER_TOKEN: "xxx"}
+        )
+        assert resp.status == 200
+        assert (
+            "Access to deprecated API '/hardware/trigger' detected from example - you are currently running version 1.0.0, there is an update pending for 1.0.1. If that does not help please report this to the maintainer of the example add-on"
+            in caplog.messages[0]
+        )

--- a/tests/api/test_deprecation.py
+++ b/tests/api/test_deprecation.py
@@ -9,7 +9,7 @@ from supervisor.addons.addon import Addon
 from supervisor.api import RestAPI
 from supervisor.const import HEADER_TOKEN
 
-# pylint: disable=redefined-outer-name
+# pylint: disable=redefined-outer-name,protected-access
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Adds a new deprecation middleware to inform about deprecated API paths.
- Adds throttle logic to not spam the user with deprecation messages.

As a start, only `/hardware/trigger` is added to this, but all API paths that we have deprecated should use this as well.


Example logs:

```
WARNING (MainThread) [supervisor.api.deprecation] Access to deprecated API '/hardware/trigger' detected from deCONZ - please report this to the maintainer of the deCONZ add-on
```

```
WARNING (MainThread) [supervisor.api.deprecation] Access to deprecated API '/hardware/trigger' detected from deCONZ - you are currently running version 6.6.3, there is an update pending for 6.6.4. If that does not help please report this to the maintainer of the deCONZ add-on
```

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
