### PR TITLE
Fix for build on debian WSL.

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -8,6 +8,10 @@ function start_docker() {
     dockerd 2> /dev/null &
     DOCKER_PID=$!
 
+    #Fix for Debian WSL Docker uses legacy IP Tables. Check if we are running in Microsoft WSL and are root, and are on debian, and running in a docker container
+    if [[ $(grep icrosoft.*WSL /proc/version) ]]  && [[ $(id) == *'uid=0'* ]]  && [ -e /etc/debian_version ]  && [[ $(cat /proc/1/cgroup|grep docker 2>&1 > /dev/null) ]]; then
+        update-alternatives --set iptables /usr/sbin/iptables-legacy
+    fi
     echo "Waiting for docker to initialize..."
     starttime="$(date +%s)"
     endtime="$(date +%s)"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -9,7 +9,7 @@ function start_docker() {
     DOCKER_PID=$!
 
     #Fix for Debian WSL Docker uses legacy IP Tables. Check if we are running in Microsoft WSL and are root, and are on debian, and running in a docker container
-    if [[ $(grep icrosoft.*WSL /proc/version) ]]  && [[ $(id) == *'uid=0'* ]]  && [ -e /etc/debian_version ]  && [[ $(cat /proc/1/cgroup|grep docker 2>&1 > /dev/null) ]]; then
+    if [[ $(grep icrosoft.*WSL /proc/version) ]]  && [[ $(id) == *'uid=0'* ]]  && [ -e /etc/debian_version ]  && [[ $(grep docker /proc/1/cgroup 2>&1 > /dev/null) ]]; then
         update-alternatives --set iptables /usr/sbin/iptables-legacy
     fi
     echo "Waiting for docker to initialize..."


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes "Build Supervisor" and "Start Supervisor" on WSL Debian. 
This is a conditional statement which works around legacy IP tables within debian under WSL under certain conditions:
1. Container is running a Microsoft WSL kernel, checked by  verifing /proc/version contains "icrosoft" followed by "WSL"
2. User is operating as root within the dev container
3. Operating system is debian
4. System is operating within a docker container. 

This is required to get connectivity with docker under WSL and otherwise requires a command to be run in terminal. 

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

Tests are not possible on the build system and build system is verified by the tests.  No new tests were required. 

If API endpoints of add-on configuration are added/changed:

- [x] Documentation added/updated for [developers.home-assistant.io][docs-repository]

See WSL instruction Pull Request here:  https://github.com/home-assistant/developers.home-assistant/pull/807

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
