### PR TITLE
Adjust CPU runtime allocation to support multiple add-ons

### DIFF
--- a/supervisor/const.py
+++ b/supervisor/const.py
@@ -32,6 +32,17 @@ DOCKER_NETWORK = "hassio"
 DOCKER_NETWORK_MASK = ip_network("172.30.32.0/23")
 DOCKER_NETWORK_RANGE = ip_network("172.30.33.0/24")
 
+# This needs to match the dockerd --cpu-rt-runtime= argument.
+DOCKER_CPU_RUNTIME_TOTAL = 950_000
+
+# The rt runtimes are guarantees, hence we cannot allocate more
+# time than available! Support up to 5 containers with equal time
+# allocated.
+# Note that the time is multiplied by CPU count. This means that
+# a single container can schedule up to 950/5*4 = 760ms in RT priority
+# on a quad core system.
+DOCKER_CPU_RUNTIME_ALLOCATION = int(DOCKER_CPU_RUNTIME_TOTAL / 5)
+
 DNS_SUFFIX = "local.hass.io"
 
 LABEL_ARCH = "io.hass.arch"

--- a/supervisor/docker/addon.py
+++ b/supervisor/docker/addon.py
@@ -14,6 +14,7 @@ import requests
 
 from ..addons.build import AddonBuild
 from ..const import (
+    DOCKER_CPU_RUNTIME_ALLOCATION,
     ENV_TIME,
     ENV_TOKEN,
     ENV_TOKEN_HASSIO,
@@ -285,7 +286,7 @@ class DockerAddon(DockerInterface):
 
         # If need CPU RT
         if self.addon.with_realtime:
-            return 950000
+            return DOCKER_CPU_RUNTIME_ALLOCATION
         return None
 
     @property

--- a/supervisor/docker/audio.py
+++ b/supervisor/docker/audio.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 
 import docker
 
-from ..const import ENV_TIME, MACHINE_ID
+from ..const import DOCKER_CPU_RUNTIME_ALLOCATION, ENV_TIME, MACHINE_ID
 from ..coresys import CoreSysAttributes
 from ..docker.const import Capabilities
 from ..hardware.const import PolicyGroup
@@ -67,7 +67,7 @@ class DockerAudio(DockerInterface, CoreSysAttributes):
         """Limit CPU real-time runtime in microseconds."""
         if not self.sys_docker.info.support_cpu_realtime:
             return None
-        return 950000
+        return DOCKER_CPU_RUNTIME_ALLOCATION
 
     def _run(self) -> None:
         """Run Docker image.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust realtime CPU runtime allocation to support multiple
add-ons/plug-ins with the runtime flag set.

The cpu.rt_runtime_us allocation is somewhat special as it
allocates the guaranteed runtime. Hence we cannot simply allocate all
time to each add-on.

Unfortunately we cannot distribute the CPU time equally based on the
number of add-ons as we don't know the number of add-ons which will use
realtime ahead of time. Also adjusting at runtime is currenlty not
supported by the Docker Python SDK (the underlying http API does
however, so this would be a possible future improvement).

This solution distributes the total available time of 950ms to up to 5
add-ons/plug-ins in equal slices. On a quad-core system this allows up
to 760ms CPU time in the real-time scheduler per 1s (76% of one CPU)
which should be sufficient for most cases.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/operating-system/issues/1235
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
