### PR TITLE
Revert "Tweak check API path"

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -228,7 +228,9 @@ class RestAPI(CoreSysAttributes):
         self.webapp.add_routes(
             [
                 web.get("/resolution/info", api_resolution.info),
-                web.post("/resolution/check/{check}", api_resolution.options_check),
+                web.post(
+                    "/resolution/check/{check}/options", api_resolution.options_check
+                ),
                 web.post(
                     "/resolution/suggestion/{suggestion}",
                     api_resolution.apply_suggestion,

--- a/tests/api/test_resolution.py
+++ b/tests/api/test_resolution.py
@@ -109,11 +109,11 @@ async def test_api_resolution_check_options(coresys: CoreSys, api_client):
 
     assert free_space.enabled
     await api_client.post(
-        f"/resolution/check/{free_space.slug}", json={"enabled": False}
+        f"/resolution/check/{free_space.slug}/options", json={"enabled": False}
     )
     assert not free_space.enabled
 
     await api_client.post(
-        f"/resolution/check/{free_space.slug}", json={"enabled": True}
+        f"/resolution/check/{free_space.slug}/options", json={"enabled": True}
     )
     assert free_space.enabled


### PR DESCRIPTION
Reverts home-assistant/supervisor#2714

This API call makes no sense. It remembers me why we did that differently on others. Now we can also not run the check manually.

More details: https://github.com/home-assistant/cli/pull/280