### PR TITLE
Fix journald add-on option to work with default Debian

### DIFF
--- a/supervisor/const.py
+++ b/supervisor/const.py
@@ -27,7 +27,8 @@ MACHINE_ID = Path("/etc/machine-id")
 SOCKET_DBUS = Path("/run/dbus/system_bus_socket")
 SOCKET_DOCKER = Path("/run/docker.sock")
 RUN_SUPERVISOR_STATE = Path("/run/supervisor")
-SYSTEMD_JOURNAL = Path("/var/logs/journal")
+SYSTEMD_JOURNAL_PERSISTENT = Path("/var/logs/journal")
+SYSTEMD_JOURNAL_VOLATILE = Path("/run/log/journal")
 
 DOCKER_NETWORK = "hassio"
 DOCKER_NETWORK_MASK = ip_network("172.30.32.0/23")

--- a/supervisor/docker/addon.py
+++ b/supervisor/docker/addon.py
@@ -26,7 +26,8 @@ from ..const import (
     MAP_SSL,
     SECURITY_DISABLE,
     SECURITY_PROFILE,
-    SYSTEMD_JOURNAL,
+    SYSTEMD_JOURNAL_PERSISTENT,
+    SYSTEMD_JOURNAL_VOLATILE,
 )
 from ..coresys import CoreSys
 from ..exceptions import CoreDNSError, DockerError, DockerNotFound, HardwareNotFound
@@ -416,10 +417,15 @@ class DockerAddon(DockerInterface):
 
         # System Journal access
         if self.addon.with_journald:
+            # Systemd uses volatile by default, unless persistent location exists.
+            bind = SYSTEMD_JOURNAL_VOLATILE
+            if SYSTEMD_JOURNAL_PERSISTENT.exists():
+                bind = SYSTEMD_JOURNAL_PERSISTENT
+
             volumes.update(
                 {
-                    str(SYSTEMD_JOURNAL): {
-                        "bind": str(SYSTEMD_JOURNAL),
+                    str(SYSTEMD_JOURNAL_PERSISTENT): {
+                        "bind": str(bind),
                         "mode": "ro",
                     }
                 }

--- a/tests/docker/test_addon.py
+++ b/tests/docker/test_addon.py
@@ -7,7 +7,7 @@ import pytest
 from supervisor.addons import validate as vd
 from supervisor.addons.addon import Addon
 from supervisor.addons.model import Data
-from supervisor.const import SYSTEMD_JOURNAL
+from supervisor.const import SYSTEMD_JOURNAL_PERSISTENT, SYSTEMD_JOURNAL_VOLATILE
 from supervisor.coresys import CoreSys
 from supervisor.docker.addon import DockerAddon
 
@@ -97,16 +97,35 @@ def test_addon_map_folder_defaults(
     assert str(docker_addon.sys_config.path_extern_share) not in volumes
 
 
-def test_journald_addon(coresys: CoreSys, addonsdata_system: Dict[str, Data]):
-    """Validate volume for journald option."""
+def test_journald_addon_volatile(coresys: CoreSys, addonsdata_system: Dict[str, Data]):
+    """Validate volume for journald option, with volatile logs."""
     docker_addon = get_docker_addon(
         coresys, addonsdata_system, "journald-addon-config.json"
     )
     volumes = docker_addon.volumes
 
-    assert str(SYSTEMD_JOURNAL) in volumes
-    assert volumes.get(str(SYSTEMD_JOURNAL)).get("bind") == str(SYSTEMD_JOURNAL)
-    assert volumes.get(str(SYSTEMD_JOURNAL)).get("mode") == "ro"
+    assert str(SYSTEMD_JOURNAL_PERSISTENT) in volumes
+    assert volumes.get(str(SYSTEMD_JOURNAL_PERSISTENT)).get("bind") == str(
+        SYSTEMD_JOURNAL_VOLATILE
+    )
+    assert volumes.get(str(SYSTEMD_JOURNAL_PERSISTENT)).get("mode") == "ro"
+
+
+def test_journald_addon_persistent(
+    coresys: CoreSys, addonsdata_system: Dict[str, Data]
+):
+    """Validate volume for journald option, with persistent logs."""
+    with patch("pathlib.Path.exists", return_value=True):
+        docker_addon = get_docker_addon(
+            coresys, addonsdata_system, "journald-addon-config.json"
+        )
+        volumes = docker_addon.volumes
+
+    assert str(SYSTEMD_JOURNAL_PERSISTENT) in volumes
+    assert volumes.get(str(SYSTEMD_JOURNAL_PERSISTENT)).get("bind") == str(
+        SYSTEMD_JOURNAL_PERSISTENT
+    )
+    assert volumes.get(str(SYSTEMD_JOURNAL_PERSISTENT)).get("mode") == "ro"
 
 
 def test_not_journald_addon(coresys: CoreSys, addonsdata_system: Dict[str, Data]):
@@ -116,4 +135,4 @@ def test_not_journald_addon(coresys: CoreSys, addonsdata_system: Dict[str, Data]
     )
     volumes = docker_addon.volumes
 
-    assert str(SYSTEMD_JOURNAL) not in volumes
+    assert str(SYSTEMD_JOURNAL_PERSISTENT) not in volumes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Recently the `journald` option for add-ons was added, however, this doesn't work in all cases.
For Debian, the Storage is by default set to `auto`, which means, it will only write to the persistent storage location, if it exists (`/var/logs/journal`).

Right now, the Supervisor assumes the folder always exist, causing it not to work when the folder is missing. This PR adds a check that mimics the behavior of the journal service by checking if the persistent location exists, if not, it will fall back to the volatile location (`/run/log/journal`). The volatile location exists, as it is created if missing.

See: <https://www.freedesktop.org/software/systemd/man/journald.conf.html#Storage=>

This PR mounts either location consistently in the same location within the add-on, to ensure the use of the add-ons are consistent.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
