### PR TITLE
Allow optional array configs

### DIFF
--- a/supervisor/addons/options.py
+++ b/supervisor/addons/options.py
@@ -241,8 +241,15 @@ class AddonOptions(CoreSysAttributes):
         """Check if all options are exists."""
         missing = set(origin) - set(exists)
         for miss_opt in missing:
-            if isinstance(origin[miss_opt], str) and origin[miss_opt].endswith("?"):
+            miss_schema = origin[miss_opt]
+
+            # If its a list then value in list decides if its optional like ["str?"]
+            if isinstance(miss_schema, list) and len(miss_schema) > 0:
+                miss_schema = miss_schema[0]
+
+            if isinstance(miss_schema, str) and miss_schema.endswith("?"):
                 continue
+
             raise vol.Invalid(
                 f"Missing option '{miss_opt}' in {root} in {self._name} ({self._slug})"
             ) from None

--- a/tests/addons/test_options.py
+++ b/tests/addons/test_options.py
@@ -70,6 +70,38 @@ def test_complex_schema_list(coresys):
         )({"name": "Pascal", "password": "1234", "extend": "test"})
 
 
+def test_optional_schema_list(coresys):
+    """Test with an optional list schema."""
+    assert AddonOptions(
+        coresys,
+        {"name": "str", "password": "password", "extend": ["str?"]},
+        MOCK_ADDON_NAME,
+        MOCK_ADDON_SLUG,
+    )({"name": "Pascal", "password": "1234"})
+
+    assert AddonOptions(
+        coresys,
+        {"name": "str", "password": "password", "extend": ["str?"]},
+        MOCK_ADDON_NAME,
+        MOCK_ADDON_SLUG,
+    )({"name": "Pascal", "password": "1234", "extend": []})
+
+    with pytest.raises(vol.error.Invalid):
+        AddonOptions(
+            coresys,
+            {"name": "str", "password": "password", "extend": ["str"]},
+            MOCK_ADDON_NAME,
+            MOCK_ADDON_SLUG,
+        )({"name": "Pascal", "password": "1234"})
+
+    assert AddonOptions(
+        coresys,
+        {"name": "str", "password": "password", "extend": ["str"]},
+        MOCK_ADDON_NAME,
+        MOCK_ADDON_SLUG,
+    )({"name": "Pascal", "password": "1234", "extend": []})
+
+
 def test_complex_schema_dict(coresys):
     """Test with complex dict schema."""
     assert AddonOptions(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

During a [review of a change](https://github.com/home-assistant/addons/pull/1941#pullrequestreview-620834679) to the MariaDB addon, it was raised that it should be possible to make an array config option in an add-on truly optional. Currently if you define the schema of a config as `["str?"]` then the option itself must be present to pass validation, even if its just `[]`. This makes it so if the element inside is optional then the entire config option is optional.

### Example

Given an addon with this schema:

```json
{
    "schema": {
        "log_level": "str",
        "privileges": ["list(x|y|z)?"]
    }
}
```

This configuration was invalid prior to this PR. Now it is valid:

```yaml
log_level: info
```

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/addons/pull/1941#pullrequestreview-620834679
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
