### PR TITLE
Dictionary configs in addons can be optional

### DIFF
--- a/supervisor/addons/options.py
+++ b/supervisor/addons/options.py
@@ -250,6 +250,15 @@ class AddonOptions(CoreSysAttributes):
             if isinstance(miss_schema, str) and miss_schema.endswith("?"):
                 continue
 
+            if isinstance(miss_schema, dict):
+                try:
+                    self._check_missing_options(miss_schema, {}, miss_opt)
+                    continue
+                except vol.Invalid:
+                    # We want to raise the exception below that says they are missing the object field
+                    # Not one that says they are missing a field within an object they didn't enter
+                    pass
+
             raise vol.Invalid(
                 f"Missing option '{miss_opt}' in {root} in {self._name} ({self._slug})"
             ) from None

--- a/tests/addons/test_options.py
+++ b/tests/addons/test_options.py
@@ -139,14 +139,14 @@ def test_optional_schema_list_dict(coresys):
     """Test with an optional list of dict schema."""
     assert AddonOptions(
         coresys,
-        {"name": "str", "password": "password", "extend": [{"opt": "str?"]},
+        {"name": "str", "password": "password", "extend": [{"opt": "str?"}],
         MOCK_ADDON_NAME,
         MOCK_ADDON_SLUG,
     )({"name": "Pascal", "password": "1234"})
 
     assert AddonOptions(
         coresys,
-        {"name": "str", "password": "password", "extend": [{"opt": "str?"]},
+        {"name": "str", "password": "password", "extend": [{"opt": "str?"}],
         MOCK_ADDON_NAME,
         MOCK_ADDON_SLUG,
     )({"name": "Pascal", "password": "1234", "extend": []})
@@ -154,14 +154,14 @@ def test_optional_schema_list_dict(coresys):
     with pytest.raises(vol.error.Invalid):
         AddonOptions(
             coresys,
-            {"name": "str", "password": "password", "extend": [{"req": "str"]},
+            {"name": "str", "password": "password", "extend": [{"req": "str"}],
             MOCK_ADDON_NAME,
             MOCK_ADDON_SLUG,
         )({"name": "Pascal", "password": "1234"})
 
     assert AddonOptions(
         coresys,
-        {"name": "str", "password": "password", "extend": [{"req": "str"]},
+        {"name": "str", "password": "password", "extend": [{"req": "str"}],
         MOCK_ADDON_NAME,
         MOCK_ADDON_SLUG,
     )({"name": "Pascal", "password": "1234", "extend": []})

--- a/tests/addons/test_options.py
+++ b/tests/addons/test_options.py
@@ -102,6 +102,71 @@ def test_optional_schema_list(coresys):
     )({"name": "Pascal", "password": "1234", "extend": []})
 
 
+def test_optional_schema_dict(coresys):
+    """Test with an optional dict schema."""
+    assert AddonOptions(
+        coresys,
+        {"name": "str", "password": "password", "extend": {"opt": "str?"}},
+        MOCK_ADDON_NAME,
+        MOCK_ADDON_SLUG,
+    )({"name": "Pascal", "password": "1234"})
+
+    assert AddonOptions(
+        coresys,
+        {"name": "str", "password": "password", "extend": {"opt": "str?"}},
+        MOCK_ADDON_NAME,
+        MOCK_ADDON_SLUG,
+    )({"name": "Pascal", "password": "1234", "extend": {}})
+
+    with pytest.raises(vol.error.Invalid):
+        assert AddonOptions(
+            coresys,
+            {"name": "str", "password": "password", "extend": {"req": "str"}},
+            MOCK_ADDON_NAME,
+            MOCK_ADDON_SLUG,
+        )({"name": "Pascal", "password": "1234"})
+
+    with pytest.raises(vol.error.Invalid):
+        assert AddonOptions(
+            coresys,
+            {"name": "str", "password": "password", "extend": {"req": "str"}},
+            MOCK_ADDON_NAME,
+            MOCK_ADDON_SLUG,
+        )({"name": "Pascal", "password": "1234", "extend": {}})
+
+
+def test_optional_schema_list_dict(coresys):
+    """Test with an optional list of dict schema."""
+    assert AddonOptions(
+        coresys,
+        {"name": "str", "password": "password", "extend": [{"opt": "str?"]},
+        MOCK_ADDON_NAME,
+        MOCK_ADDON_SLUG,
+    )({"name": "Pascal", "password": "1234"})
+
+    assert AddonOptions(
+        coresys,
+        {"name": "str", "password": "password", "extend": [{"opt": "str?"]},
+        MOCK_ADDON_NAME,
+        MOCK_ADDON_SLUG,
+    )({"name": "Pascal", "password": "1234", "extend": []})
+
+    with pytest.raises(vol.error.Invalid):
+        AddonOptions(
+            coresys,
+            {"name": "str", "password": "password", "extend": [{"req": "str"]},
+            MOCK_ADDON_NAME,
+            MOCK_ADDON_SLUG,
+        )({"name": "Pascal", "password": "1234"})
+
+    assert AddonOptions(
+        coresys,
+        {"name": "str", "password": "password", "extend": [{"req": "str"]},
+        MOCK_ADDON_NAME,
+        MOCK_ADDON_SLUG,
+    )({"name": "Pascal", "password": "1234", "extend": []})
+
+
 def test_complex_schema_dict(coresys):
     """Test with complex dict schema."""
     assert AddonOptions(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is a follow-up to a [discussion](https://github.com/home-assistant/supervisor/pull/2752#pullrequestreview-621949641) on #2752 . That PR made it so configs with a schema definition of ["str?"] became optional, this makes it so dictionary configs become optional if all keys within the dictionary are optional. That also applies to configs which are a list of dictionaries.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/supervisor/pull/2752#pullrequestreview-621949641
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
