### PR TITLE
Fix swapped volume/bind variables in Journald volume support

### DIFF
--- a/supervisor/docker/addon.py
+++ b/supervisor/docker/addon.py
@@ -418,14 +418,14 @@ class DockerAddon(DockerInterface):
         # System Journal access
         if self.addon.with_journald:
             # Systemd uses volatile by default, unless persistent location exists.
-            bind = SYSTEMD_JOURNAL_VOLATILE
+            journal = SYSTEMD_JOURNAL_VOLATILE
             if SYSTEMD_JOURNAL_PERSISTENT.exists():
-                bind = SYSTEMD_JOURNAL_PERSISTENT
+                journal = SYSTEMD_JOURNAL_PERSISTENT
 
             volumes.update(
                 {
-                    str(SYSTEMD_JOURNAL_PERSISTENT): {
-                        "bind": str(bind),
+                    str(journal): {
+                        "bind": str(SYSTEMD_JOURNAL_PERSISTENT),
                         "mode": "ro",
                     }
                 }

--- a/tests/docker/test_addon.py
+++ b/tests/docker/test_addon.py
@@ -105,11 +105,11 @@ def test_journald_addon_volatile(coresys: CoreSys, addonsdata_system: Dict[str, 
         )
         volumes = docker_addon.volumes
 
-    assert str(SYSTEMD_JOURNAL_PERSISTENT) in volumes
-    assert volumes.get(str(SYSTEMD_JOURNAL_PERSISTENT)).get("bind") == str(
-        SYSTEMD_JOURNAL_VOLATILE
+    assert str(SYSTEMD_JOURNAL_VOLATILE) in volumes
+    assert volumes.get(str(SYSTEMD_JOURNAL_VOLATILE)).get("bind") == str(
+        SYSTEMD_JOURNAL_PERSISTENT
     )
-    assert volumes.get(str(SYSTEMD_JOURNAL_PERSISTENT)).get("mode") == "ro"
+    assert volumes.get(str(SYSTEMD_JOURNAL_VOLATILE)).get("mode") == "ro"
 
 
 def test_journald_addon_persistent(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The volume & bind location was swapped for the Add-on journald support.

Both persistent and volatile locations should be mapped consistently to the persistent location inside the add-on.


## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
