### PR TITLE
Detect missing frontend after update

### DIFF
--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -402,6 +402,15 @@ class HomeAssistantCore(CoreSysAttributes):
             # 2: Check if API response
             if await self.sys_homeassistant.api.check_api_state():
                 _LOGGER.info("Detect a running Home Assistant instance")
+                with suppress(HomeAssistantError):
+                    async with self.sys_homeassistant.api.make_request(
+                        "get", "api/config"
+                    ) as resp:
+                        data = await resp.json()
+                        integrations = data.get("components", [])
+                        if "frontend" not in integrations:
+                            _LOGGER.error("API responded but frontend is not loaded")
+                            break
                 self._error_state = False
                 return
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Detect and treat missing frontend integration after upgrade as failed to trigger rollback.
Without a frontend, there is no safe mode.
Verified with updating to `2021.10.0.dev20210910` which had issues with pillow, see attached logs at the bottom.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

```
21-09-13 22:42:02 DEBUG (MainThread) [supervisor.api.middleware.security] /core/update access from Home Assistant
21-09-13 22:42:02 INFO (MainThread) [supervisor.homeassistant.core] Updating Home Assistant to version 2021.10.0.dev20210910
21-09-13 22:42:02 INFO (SyncWorker_0) [supervisor.docker.interface] Updating image ghcr.io/home-assistant/qemux86-64-homeassistant:2021.10.0.dev20210826 to ghcr.io/home-assistant/qemux86-64-homeassistant:2021.10.0.dev20210910
21-09-13 22:42:02 INFO (SyncWorker_0) [supervisor.docker.interface] Downloading docker image ghcr.io/home-assistant/qemux86-64-homeassistant with tag 2021.10.0.dev20210910.
21-09-13 22:42:32 WARNING (MainThread) [supervisor.security] Disabled content-trust, skip validation
21-09-13 22:42:32 INFO (SyncWorker_0) [supervisor.docker.interface] Stopping homeassistant application
21-09-13 22:42:47 INFO (SyncWorker_0) [supervisor.docker.interface] Cleaning homeassistant application
21-09-13 22:42:47 INFO (MainThread) [supervisor.homeassistant.module] Update pulse/client.config: /data/tmp/homeassistant_pulse
21-09-13 22:42:47 INFO (SyncWorker_3) [supervisor.docker.homeassistant] Starting Home Assistant ghcr.io/home-assistant/qemux86-64-homeassistant with version 2021.10.0.dev20210910
21-09-13 22:42:47 INFO (MainThread) [supervisor.homeassistant.core] Wait until Home Assistant is ready
21-09-13 22:42:47 DEBUG (MainThread) [supervisor.homeassistant.core] Disable startup timeouts - early UI
21-09-13 22:42:48 DEBUG (MainThread) [supervisor.api.middleware.security] Passthrough /supervisor/ping
21-09-13 22:42:48 DEBUG (MainThread) [supervisor.api.middleware.security] /homeassistant/options access from Home Assistant
21-09-13 22:42:48 DEBUG (MainThread) [supervisor.api.middleware.security] /supervisor/options access from Home Assistant
21-09-13 22:42:48 INFO (MainThread) [supervisor.resolution.evaluate] Starting system evaluation with state CoreState.RUNNING
21-09-13 22:42:48 WARNING (MainThread) [supervisor.resolution.evaluations.source_mods] Disabled content-trust, skipping evaluation
21-09-13 22:42:49 INFO (MainThread) [supervisor.resolution.evaluate] System evaluation complete
21-09-13 22:42:49 DEBUG (MainThread) [supervisor.api.middleware.security] /info access from Home Assistant
21-09-13 22:42:49 DEBUG (MainThread) [supervisor.api.middleware.security] /host/info access from Home Assistant
21-09-13 22:42:49 DEBUG (MainThread) [supervisor.api.middleware.security] /store access from Home Assistant
21-09-13 22:42:49 DEBUG (MainThread) [supervisor.api.middleware.security] /core/info access from Home Assistant
21-09-13 22:42:49 DEBUG (MainThread) [supervisor.api.middleware.security] /supervisor/info access from Home Assistant
21-09-13 22:42:49 DEBUG (MainThread) [supervisor.api.middleware.security] /os/info access from Home Assistant
21-09-13 22:42:49 DEBUG (MainThread) [supervisor.api.middleware.security] /ingress/panels access from Home Assistant
21-09-13 22:42:49 DEBUG (MainThread) [supervisor.api.middleware.security] Passthrough /supervisor/ping
21-09-13 22:42:49 DEBUG (MainThread) [supervisor.api.middleware.security] /homeassistant/options access from Home Assistant
21-09-13 22:42:49 DEBUG (MainThread) [supervisor.api.middleware.security] /supervisor/options access from Home Assistant
21-09-13 22:42:49 INFO (MainThread) [supervisor.resolution.evaluate] Starting system evaluation with state CoreState.RUNNING
21-09-13 22:42:49 WARNING (MainThread) [supervisor.resolution.evaluations.source_mods] Disabled content-trust, skipping evaluation
21-09-13 22:42:50 INFO (MainThread) [supervisor.resolution.evaluate] System evaluation complete
21-09-13 22:42:50 DEBUG (MainThread) [supervisor.api.middleware.security] /info access from Home Assistant
21-09-13 22:42:50 DEBUG (MainThread) [supervisor.api.middleware.security] /host/info access from Home Assistant
21-09-13 22:42:50 DEBUG (MainThread) [supervisor.api.middleware.security] /store access from Home Assistant
21-09-13 22:42:50 DEBUG (MainThread) [supervisor.api.middleware.security] /core/info access from Home Assistant
21-09-13 22:42:50 DEBUG (MainThread) [supervisor.api.middleware.security] /supervisor/info access from Home Assistant
21-09-13 22:42:50 DEBUG (MainThread) [supervisor.api.middleware.security] /os/info access from Home Assistant
21-09-13 22:42:50 DEBUG (MainThread) [supervisor.api.middleware.security] /ingress/panels access from Home Assistant
21-09-13 22:42:50 DEBUG (MainThread) [supervisor.api.middleware.security] /discovery access from Home Assistant
21-09-13 22:42:52 INFO (MainThread) [supervisor.homeassistant.core] Detect a running Home Assistant instance
21-09-13 22:42:52 ERROR (MainThread) [supervisor.homeassistant.core] API responded but frontend is not loaded
21-09-13 22:42:52 CRITICAL (MainThread) [supervisor.homeassistant.core] HomeAssistant update failed -> rollback!
21-09-13 22:42:52 INFO (MainThread) [supervisor.resolution.module] Create new issue IssueType.UPDATE_ROLLBACK - ContextType.CORE / None
21-09-13 22:42:52 INFO (MainThread) [supervisor.homeassistant.core] A backup of the logfile is stored in /config/home-assistant-rollback.log
21-09-13 22:42:52 INFO (MainThread) [supervisor.homeassistant.core] Updating Home Assistant to version 2021.10.0.dev20210826
21-09-13 22:42:52 INFO (SyncWorker_0) [supervisor.docker.interface] Updating image ghcr.io/home-assistant/qemux86-64-homeassistant:2021.10.0.dev20210910 to ghcr.io/home-assistant/qemux86-64-homeassistant:2021.10.0.dev20210826
21-09-13 22:42:52 INFO (SyncWorker_0) [supervisor.docker.interface] Downloading docker image ghcr.io/home-assistant/qemux86-64-homeassistant with tag 2021.10.0.dev20210826.
21-09-13 22:42:53 WARNING (MainThread) [supervisor.security] Disabled content-trust, skip validation
21-09-13 22:42:53 INFO (SyncWorker_0) [supervisor.docker.interface] Stopping homeassistant application
21-09-13 22:43:06 INFO (SyncWorker_0) [supervisor.docker.interface] Cleaning homeassistant application
21-09-13 22:43:06 INFO (MainThread) [supervisor.homeassistant.module] Update pulse/client.config: /data/tmp/homeassistant_pulse
21-09-13 22:43:07 INFO (SyncWorker_2) [supervisor.docker.homeassistant] Starting Home Assistant ghcr.io/home-assistant/qemux86-64-homeassistant with version 2021.10.0.dev20210826
21-09-13 22:43:07 INFO (MainThread) [supervisor.homeassistant.core] Wait until Home Assistant is ready
21-09-13 22:43:07 DEBUG (MainThread) [supervisor.homeassistant.core] Disable startup timeouts - early UI
21-09-13 22:43:08 DEBUG (MainThread) [supervisor.api.middleware.security] Passthrough /supervisor/ping
21-09-13 22:43:08 DEBUG (MainThread) [supervisor.api.middleware.security] /homeassistant/options access from Home Assistant
21-09-13 22:43:08 DEBUG (MainThread) [supervisor.api.middleware.security] /supervisor/options access from Home Assistant
21-09-13 22:43:08 INFO (MainThread) [supervisor.resolution.evaluate] Starting system evaluation with state CoreState.RUNNING
21-09-13 22:43:08 WARNING (MainThread) [supervisor.resolution.evaluations.source_mods] Disabled content-trust, skipping evaluation
21-09-13 22:43:09 INFO (MainThread) [supervisor.resolution.evaluate] System evaluation complete
21-09-13 22:43:09 DEBUG (MainThread) [supervisor.api.middleware.security] /info access from Home Assistant
21-09-13 22:43:09 DEBUG (MainThread) [supervisor.api.middleware.security] /host/info access from Home Assistant
21-09-13 22:43:09 DEBUG (MainThread) [supervisor.api.middleware.security] /store access from Home Assistant
21-09-13 22:43:09 DEBUG (MainThread) [supervisor.api.middleware.security] /core/info access from Home Assistant
21-09-13 22:43:09 DEBUG (MainThread) [supervisor.api.middleware.security] /supervisor/info access from Home Assistant
21-09-13 22:43:09 DEBUG (MainThread) [supervisor.api.middleware.security] /os/info access from Home Assistant
21-09-13 22:43:09 DEBUG (MainThread) [supervisor.api.middleware.security] /ingress/panels access from Home Assistant
21-09-13 22:43:10 DEBUG (MainThread) [supervisor.api.middleware.security] /discovery access from Home Assistant
21-09-13 22:43:10 DEBUG (MainThread) [supervisor.api.middleware.security] /host/info access from Home Assistant
21-09-13 22:43:10 DEBUG (MainThread) [supervisor.api.middleware.security] /supervisor/info access from Home Assistant
21-09-13 22:43:10 DEBUG (MainThread) [supervisor.api.middleware.security] /info access from Home Assistant
21-09-13 22:43:10 DEBUG (MainThread) [supervisor.api.middleware.security] /core/info access from Home Assistant
21-09-13 22:43:10 DEBUG (MainThread) [supervisor.api.middleware.security] /network/info access from Home Assistant
21-09-13 22:43:10 DEBUG (MainThread) [supervisor.api.middleware.security] /resolution/info access from Home Assistant
21-09-13 22:43:10 DEBUG (MainThread) [supervisor.api.middleware.security] /os/info access from Home Assistant
21-09-13 22:43:10 DEBUG (MainThread) [supervisor.api.middleware.security] /addons access from Home Assistant
21-09-13 22:43:10 DEBUG (MainThread) [supervisor.api.middleware.security] /store access from Home Assistant
21-09-13 22:43:10 DEBUG (MainThread) [supervisor.api.middleware.security] /core/stats access from Home Assistant
21-09-13 22:43:10 DEBUG (MainThread) [supervisor.api.middleware.security] /supervisor/stats access from Home Assistant
21-09-13 22:43:10 DEBUG (MainThread) [supervisor.api.middleware.security] /network/info access from Home Assistant
21-09-13 22:43:10 DEBUG (MainThread) [supervisor.api.middleware.security] /supervisor/logs access from Home Assistant
21-09-13 22:43:12 INFO (MainThread) [supervisor.homeassistant.core] Detect a running Home Assistant instance
21-09-13 22:43:12 INFO (MainThread) [supervisor.homeassistant.core] Successful started Home Assistant 2021.10.0.dev20210826
21-09-13 22:43:12 INFO (SyncWorker_0) [supervisor.docker.interface] Cleanup images: ['ghcr.io/home-assistant/qemux86-64-homeassistant:2021.10.0.dev20210910']
```

```
2021-09-13 22:42:48 ERROR (MainThread) [homeassistant.setup] Setup failed for image: Unable to import component: cannot import name '_imaging' from 'PIL' (/usr/local/lib/python3.9/site-packages/PIL/__init__.py)
2021-09-13 22:42:48 ERROR (MainThread) [homeassistant.setup] Unable to set up dependencies of person. Setup failed for dependencies: image
2021-09-13 22:42:48 ERROR (MainThread) [homeassistant.setup] Setup failed for person: Could not set up all dependencies.
2021-09-13 22:42:48 ERROR (MainThread) [homeassistant.setup] Unable to set up dependencies of onboarding. Setup failed for dependencies: person
2021-09-13 22:42:48 ERROR (MainThread) [homeassistant.setup] Setup failed for onboarding: Could not set up all dependencies.
2021-09-13 22:42:48 ERROR (MainThread) [homeassistant.setup] Unable to set up dependencies of frontend. Setup failed for dependencies: onboarding
2021-09-13 22:42:48 ERROR (MainThread) [homeassistant.setup] Setup failed for frontend: Could not set up all dependencies.
2021-09-13 22:42:49 ERROR (MainThread) [homeassistant.setup] Unable to set up dependencies of map. Setup failed for dependencies: frontend
2021-09-13 22:42:49 ERROR (MainThread) [homeassistant.setup] Setup failed for map: Could not set up all dependencies.
2021-09-13 22:42:49 ERROR (MainThread) [homeassistant.setup] Unable to set up dependencies of logbook. Setup failed for dependencies: frontend
2021-09-13 22:42:49 ERROR (MainThread) [homeassistant.setup] Setup failed for logbook: Could not set up all dependencies.
2021-09-13 22:42:49 ERROR (MainThread) [homeassistant.setup] Unable to set up dependencies of my. Setup failed for dependencies: frontend
2021-09-13 22:42:49 ERROR (MainThread) [homeassistant.setup] Setup failed for my: Could not set up all dependencies.
2021-09-13 22:42:49 ERROR (MainThread) [homeassistant.setup] Unable to set up dependencies of mobile_app. Setup failed for dependencies: person
2021-09-13 22:42:49 ERROR (MainThread) [homeassistant.setup] Setup failed for mobile_app: Could not set up all dependencies.
2021-09-13 22:42:49 ERROR (MainThread) [homeassistant.setup] Unable to set up dependencies of default_config. Setup failed for dependencies: frontend, logbook, map, mobile_app, my, person
2021-09-13 22:42:49 ERROR (MainThread) [homeassistant.setup] Setup failed for default_config: Could not set up all dependencies.
2021-09-13 22:42:49 WARNING (MainThread) [homeassistant.bootstrap] Detected that frontend did not load. Activating safe mode
2021-09-13 22:42:49 ERROR (MainThread) [homeassistant.setup] Setup failed for image: Unable to import component: cannot import name '_imaging' from 'PIL' (/usr/local/lib/python3.9/site-packages/PIL/__init__.py)
2021-09-13 22:42:49 ERROR (MainThread) [homeassistant.setup] Unable to set up dependencies of person. Setup failed for dependencies: image
2021-09-13 22:42:49 ERROR (MainThread) [homeassistant.setup] Setup failed for person: Could not set up all dependencies.
2021-09-13 22:42:49 ERROR (MainThread) [homeassistant.setup] Unable to set up dependencies of onboarding. Setup failed for dependencies: person
2021-09-13 22:42:49 ERROR (MainThread) [homeassistant.setup] Setup failed for onboarding: Could not set up all dependencies.
2021-09-13 22:42:49 ERROR (MainThread) [homeassistant.setup] Unable to set up dependencies of frontend. Setup failed for dependencies: onboarding
2021-09-13 22:42:49 ERROR (MainThread) [homeassistant.setup] Setup failed for frontend: Could not set up all dependencies.
2021-09-13 22:42:50 ERROR (MainThread) [homeassistant.setup] Unable to set up dependencies of safe_mode. Setup failed for dependencies: frontend
2021-09-13 22:42:50 ERROR (MainThread) [homeassistant.setup] Setup failed for safe_mode: Could not set up all dependencies.
```


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
