### PR TITLE
Use `=` instead of deprecated `:` as security option separator

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -219,7 +219,7 @@ jobs:
           docker create --name hassio_supervisor \
             --privileged \
             --security-opt seccomp=unconfined \
-            --security-opt apparmor:unconfined \
+            --security-opt apparmor=unconfined \
             -v /run/docker.sock:/run/docker.sock \
             -v /run/dbus:/run/dbus \
             -v /tmp/supervisor/data:/data \

--- a/scripts/supervisor.sh
+++ b/scripts/supervisor.sh
@@ -36,7 +36,7 @@ function run_supervisor() {
         --name hassio_supervisor \
         --privileged \
         --security-opt seccomp=unconfined \
-        --security-opt apparmor:unconfined \
+        --security-opt apparmor=unconfined \
         -v /run/docker.sock:/run/docker.sock:rw \
         -v /run/dbus:/run/dbus:ro \
         -v /run/udev:/run/udev:ro \

--- a/supervisor/docker/addon.py
+++ b/supervisor/docker/addon.py
@@ -196,7 +196,7 @@ class DockerAddon(DockerInterface):
         # AppArmor
         apparmor = self.sys_host.apparmor.available
         if not apparmor or self.addon.apparmor == SECURITY_DISABLE:
-            security.append("apparmor:unconfined")
+            security.append("apparmor=unconfined")
         elif self.addon.apparmor == SECURITY_PROFILE:
             security.append(f"apparmor={self.addon.slug}")
 


### PR DESCRIPTION
Docker reports:
Sep 23 08:16:31 homeassistant dockerd[467]: time="2021-09-23T08:16:31.771717436Z" level=warning msg="Security options with `:` as a separator are deprecated and will be completely unsupported in 17.04, use `=` instead."

Since it seems that Docker supports `=` since quite a while, we should
use `=` only.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
