### PR TITLE
Allow to clear explicit image name

### DIFF
--- a/supervisor/api/homeassistant.py
+++ b/supervisor/api/homeassistant.py
@@ -43,7 +43,7 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 SCHEMA_OPTIONS = vol.Schema(
     {
         vol.Optional(ATTR_BOOT): vol.Boolean(),
-        vol.Optional(ATTR_IMAGE): docker_image,
+        vol.Optional(ATTR_IMAGE): vol.Maybe(docker_image),
         vol.Optional(ATTR_PORT): network_port,
         vol.Optional(ATTR_SSL): vol.Boolean(),
         vol.Optional(ATTR_WATCHDOG): vol.Boolean(),

--- a/supervisor/homeassistant/module.py
+++ b/supervisor/homeassistant/module.py
@@ -156,7 +156,7 @@ class HomeAssistant(FileConfiguration, CoreSysAttributes):
         return f"ghcr.io/home-assistant/{self.sys_machine}-homeassistant"
 
     @image.setter
-    def image(self, value: str) -> None:
+    def image(self, value: Optional[str]) -> None:
         """Set image name of Home Assistant container."""
         self._data[ATTR_IMAGE] = value
 
@@ -201,7 +201,7 @@ class HomeAssistant(FileConfiguration, CoreSysAttributes):
         return self._data.get(ATTR_REFRESH_TOKEN)
 
     @refresh_token.setter
-    def refresh_token(self, value: str):
+    def refresh_token(self, value: Optional[str]):
         """Set Home Assistant refresh_token."""
         self._data[ATTR_REFRESH_TOKEN] = value
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The documentation says that passing null to `image` allows to clear
the option. Currently `null` is not allowed leading to:
Error: expected string or buffer for dictionary value @ data['image']. Got None

While at it, also update type annotation to reflect what the API
currently allows.


## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: somewhat related: https://github.com/home-assistant/developers.home-assistant/pull/1146
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
