### PR TITLE
Address pytest warnings

### DIFF
--- a/supervisor/hardware/data.py
+++ b/supervisor/hardware/data.py
@@ -47,7 +47,7 @@ class Device:
             Path(udevice.device_node),
             Path(udevice.sys_path),
             udevice.subsystem,
-            None if not udevice.parent else Path(udevice.parent.sys_path),
+            None if udevice.parent is None else Path(udevice.parent.sys_path),
             [Path(node) for node in udevice.device_links],
             {attr: udevice.properties[attr] for attr in udevice.properties},
             [Path(node.sys_path) for node in udevice.children],

--- a/supervisor/store/__init__.py
+++ b/supervisor/store/__init__.py
@@ -108,7 +108,7 @@ class StoreManager(CoreSysAttributes):
             self.repositories[repository.slug] = repository
 
         repos = new_rep - old_rep
-        tasks = [_add_repository(url) for url in repos]
+        tasks = [self.sys_create_task(_add_repository(url)) for url in repos]
         if tasks:
             await asyncio.wait(tasks)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Create task before using `asyncio.wait()` to avoid deprecation warnings such as 
```
    tests/store/test_custom_repository.py: 5 warnings
      /workspaces/supervisor/supervisor/store/__init__.py:113: DeprecationWarning: The explicit passing of coroutine objects to asyncio.wait() is deprecated since Python 3.8, and scheduled for removal in Python 3.11.
        await asyncio.wait(tasks)
```

Change the if statement to avoid property access and the deprecation warning. The if statement currently causes access of a property of udevice.parent, leading to:
```
    tests/hardware/test_module.py: 104 warnings
      /workspaces/supervisor/supervisor/hardware/data.py:50: DeprecationWarning: Will be removed in 1.0. Access properties with Device.properties.
```



<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
