### PR TITLE
Avoid sending backup start notification to HA Core 2021.12

### DIFF
--- a/supervisor/homeassistant/websocket.py
+++ b/supervisor/homeassistant/websocket.py
@@ -21,8 +21,8 @@ from .const import CLOSING_STATES, WSEvent, WSType
 
 MIN_VERSION = {
     WSType.SUPERVISOR_EVENT: "2021.2.4",
-    WSType.BACKUP_START: "2021.12.0",
-    WSType.BACKUP_END: "2021.12.0",
+    WSType.BACKUP_START: "2022.1.0",
+    WSType.BACKUP_END: "2022.1.0",
 }
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid sending backup start notification to Home Assistant Core 2021.12. The implementation in 2021.12 has a bug when non-SQLite databases are used. The bug is scheduled to be fixed in 2022.2 (see https://github.com/home-assistant/core/pull/63847/).

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
