### PR TITLE
Drop unnecessary command from CLI plug-in

### DIFF
--- a/supervisor/docker/cli.py
+++ b/supervisor/docker/cli.py
@@ -38,7 +38,6 @@ class DockerCli(DockerInterface, CoreSysAttributes):
         docker_container = self.sys_docker.run(
             self.image,
             entrypoint=["/init"],
-            command=["/bin/bash", "-c", "sleep infinity"],
             tag=str(self.sys_plugins.cli.version),
             init=False,
             ipv4=self.sys_docker.network.cli,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The CLI plug-in stays up even without command. This saves a few
kilobytes of RAM.

It also allows s6-overlay's stage2 to complete. The stage2 execlineb
process has an enormously long cmdline, with strings like "init-stage2
failed" in it. [This has previously led people to believe that there is a
problem](https://community.home-assistant.io/t/docker-init-stage2-failed/399975) (while there isn't). So as a side effect, getting stage2 to
complete side steps such confusion and makes the list of processes
cleaner.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
