### PR TITLE
Don't autoremove repos with addons

### DIFF
--- a/supervisor/store/git.py
+++ b/supervisor/store/git.py
@@ -127,6 +127,8 @@ class GitRepo(CoreSysAttributes):
                     suggestions=[
                         SuggestionType.EXECUTE_RELOAD
                         if self.builtin
+                        or self.path.stem
+                        in (addon.repository for addon in self.sys_addons.installed)
                         else SuggestionType.EXECUTE_REMOVE
                     ],
                 )
@@ -208,7 +210,7 @@ class GitRepo(CoreSysAttributes):
 class GitRepoHassIO(GitRepo):
     """Supervisor add-ons repository."""
 
-    builtin: bool = False
+    builtin: bool = True
 
     def __init__(self, coresys):
         """Initialize Git Supervisor add-on repository."""

--- a/tests/store/test_git.py
+++ b/tests/store/test_git.py
@@ -1,0 +1,108 @@
+"""Test Supervisor add-on git."""
+from unittest.mock import patch
+
+from git import GitCommandError, InvalidGitRepositoryError, NoSuchPathError
+import pytest
+
+from supervisor.addons.addon import Addon
+from supervisor.const import ATTR_REPOSITORY
+from supervisor.coresys import CoreSys
+from supervisor.exceptions import StoreGitError
+from supervisor.resolution.const import ContextType, IssueType, SuggestionType
+from supervisor.store.git import GitRepoCustom, GitRepoHassIO
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        GitCommandError("clone"),
+        InvalidGitRepositoryError(),
+        NoSuchPathError(),
+    ],
+)
+async def test_clone_core(coresys: CoreSys, error: Exception):
+    """Test cloning core add-on repo."""
+    core = GitRepoHassIO(coresys)
+
+    with patch("supervisor.store.git.git.Repo.clone_from") as clone_from:
+        assert len(coresys.resolution.issues) == 0
+        assert len(coresys.resolution.suggestions) == 0
+
+        await core.clone.__wrapped__(core)
+
+        clone_from.assert_called_once_with(
+            "https://github.com/home-assistant/addons",
+            str(coresys.config.path_addons_core),
+            **{"recursive": True, "depth": 1, "shallow-submodules": True},
+        )
+        assert len(coresys.resolution.issues) == 0
+        assert len(coresys.resolution.suggestions) == 0
+
+        clone_from.side_effect = error
+        with pytest.raises(StoreGitError):
+            await core.clone.__wrapped__(core)
+
+        assert len(coresys.resolution.issues) == 1
+        assert coresys.resolution.issues[0].type == IssueType.FATAL_ERROR
+        assert coresys.resolution.issues[0].context == ContextType.STORE
+        assert coresys.resolution.issues[0].reference == "core"
+
+        assert len(coresys.resolution.suggestions) == 1
+        assert coresys.resolution.suggestions[0].type == SuggestionType.EXECUTE_RELOAD
+        assert coresys.resolution.suggestions[0].context == ContextType.STORE
+        assert coresys.resolution.suggestions[0].reference == "core"
+
+
+async def test_clone_custom_issue(coresys: CoreSys):
+    """Test issue cloning custom add-on repo."""
+    repo = GitRepoCustom(coresys, "https://github.com/example/addons")
+
+    with patch("supervisor.store.git.git.Repo.clone_from") as clone_from:
+        assert len(coresys.resolution.issues) == 0
+        assert len(coresys.resolution.suggestions) == 0
+
+        clone_from.side_effect = GitCommandError("clone")
+        with pytest.raises(StoreGitError):
+            await repo.clone.__wrapped__(repo)
+
+        clone_from.assert_called_once_with(
+            "https://github.com/example/addons",
+            f"{coresys.config.path_addons_git}/25d47127",
+            **{"recursive": True, "depth": 1, "shallow-submodules": True},
+        )
+
+        assert len(coresys.resolution.issues) == 1
+        assert coresys.resolution.issues[0].type == IssueType.FATAL_ERROR
+        assert coresys.resolution.issues[0].context == ContextType.STORE
+        assert coresys.resolution.issues[0].reference == "25d47127"
+
+        assert len(coresys.resolution.suggestions) == 1
+        assert coresys.resolution.suggestions[0].type == SuggestionType.EXECUTE_REMOVE
+        assert coresys.resolution.suggestions[0].context == ContextType.STORE
+        assert coresys.resolution.suggestions[0].reference == "25d47127"
+
+
+async def test_clone_custom_issue_with_addon_installed(coresys: CoreSys):
+    """Test issue cloning custom add-on repo with addon installed."""
+    repo = GitRepoCustom(coresys, "https://github.com/example/addons")
+    fake = Addon(coresys, "25d47127_test")
+    coresys.addons.data.system["25d47127_test"] = {ATTR_REPOSITORY: "25d47127"}
+    coresys.addons.local = {"25d47127_test": fake}
+
+    with patch("supervisor.store.git.git.Repo.clone_from") as clone_from:
+        assert len(coresys.resolution.suggestions) == 0
+
+        clone_from.side_effect = GitCommandError("clone")
+        with pytest.raises(StoreGitError):
+            await repo.clone.__wrapped__(repo)
+
+        clone_from.assert_called_once_with(
+            "https://github.com/example/addons",
+            f"{coresys.config.path_addons_git}/25d47127",
+            **{"recursive": True, "depth": 1, "shallow-submodules": True},
+        )
+
+        assert len(coresys.resolution.suggestions) == 1
+        assert coresys.resolution.suggestions[0].type == SuggestionType.EXECUTE_RELOAD
+        assert coresys.resolution.suggestions[0].context == ContextType.STORE
+        assert coresys.resolution.suggestions[0].reference == "25d47127"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently if there is a problem cloning the addon repo Supervisor suggests removing it unless its a built-in repository. It should not suggest this for repositories that users have installed addons from either as this will actually remove the addon repo (something we normally wouldn't allow the user to do) and creates major issues. And often it seems to be the result of a transient git error (plenty of issues showing this happen for the core and community addons repos for instance which are obviously fine).

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #3590, fixes #3526, fixes #3404, 
- This PR is related to issue: #3561 and #3575 (they get a lot worse when random github issues also remove the repo)
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
