### PR TITLE
Don't include addresses in network update

### DIFF
--- a/supervisor/dbus/network/setting/__init__.py
+++ b/supervisor/dbus/network/setting/__init__.py
@@ -122,7 +122,12 @@ class NetworkSetting(DBusInterfaceProxy):
         )
         _merge_settings_attribute(new_settings, settings, CONF_ATTR_VLAN)
         _merge_settings_attribute(new_settings, settings, CONF_ATTR_IPV4)
+        if "addresses" in new_settings[CONF_ATTR_IPV4]:
+            del new_settings[CONF_ATTR_IPV4]["addresses"]
+
         _merge_settings_attribute(new_settings, settings, CONF_ATTR_IPV6)
+        if "addresses" in new_settings[CONF_ATTR_IPV6]:
+            del new_settings[CONF_ATTR_IPV6]["addresses"]
 
         return await self.dbus.Settings.Connection.Update(("a{sa{sv}}", new_settings))
 

--- a/supervisor/dbus/network/setting/generate.py
+++ b/supervisor/dbus/network/setting/generate.py
@@ -27,7 +27,6 @@ def get_connection_from_interface(
     interface: Interface, name: str | None = None, uuid: str | None = None
 ) -> Any:
     """Generate message argument for network interface update."""
-
     # Generate/Update ID/name
     if not name or not name.startswith("Supervisor"):
         name = f"Supervisor {interface.name}"

--- a/supervisor/dbus/network/setting/generate.py
+++ b/supervisor/dbus/network/setting/generate.py
@@ -27,6 +27,7 @@ def get_connection_from_interface(
     interface: Interface, name: str | None = None, uuid: str | None = None
 ) -> Any:
     """Generate message argument for network interface update."""
+
     # Generate/Update ID/name
     if not name or not name.startswith("Supervisor"):
         name = f"Supervisor {interface.name}"

--- a/tests/dbus/network/setting/test_init.py
+++ b/tests/dbus/network/setting/test_init.py
@@ -97,6 +97,7 @@ async def mock_call_dbus_get_settings_signature(
             "s", "192.168.2.148"
         )
         assert settings["ipv4"]["address-data"].value[0]["prefix"] == Variant("u", 24)
+        assert "addresses" not in settings["ipv4"]
         assert len(settings["ipv4"]["route-data"].value) == 1
         assert settings["ipv4"]["route-data"].value[0]["dest"] == Variant(
             "s", "192.168.122.0"
@@ -112,6 +113,7 @@ async def mock_call_dbus_get_settings_signature(
         assert "ipv6" in settings
         assert settings["ipv6"]["method"] == Variant("s", "auto")
         assert settings["ipv6"]["addr-gen-mode"] == Variant("i", 0)
+        assert "addresses" not in settings["ipv6"]
 
         assert "proxy" in settings
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

#3570 had an unexpected side effect. It appears the response of get settings included the deprecated [addresses property](https://developer-old.gnome.org/NetworkManager/stable/settings-ipv4.html). This field was used before `address-data`, `gateway` and `dns` were split out. So when provided it wins over those.

The reason it went unnoticed is because if you have already set network settings then it fails silently, accepting the input but actually keeping the same value. Which is only noticeable if you try and change interface config (not a common task after initially setting it). It clearly breaks for users without existing network config.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #3610 
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
