### PR TITLE
Revert "Use volume as Docker storage location"

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,6 @@
     "visualstudioexptteam.vscodeintellicode",
     "esbenp.prettier-vscode"
   ],
-  "mounts": [ "type=volume,target=/var/lib/docker" ],
   "settings": {
     "terminal.integrated.profiles.linux": {
       "zsh": {


### PR DESCRIPTION
This break the hole logic how it works. Since path are all inside devcontainer but now not anymore and all point into wrong folders

Reverts home-assistant/supervisor#3337