### PR TITLE
Never disable interfaces at startup

### DIFF
--- a/supervisor/host/network.py
+++ b/supervisor/host/network.py
@@ -119,6 +119,10 @@ class NetworkManager(CoreSysAttributes):
                     self.apply_changes(interface, update_only=True)
                     for interface in interfaces
                     if interface.enabled
+                    and (
+                        interface.ipv4.method != InterfaceMethod.DISABLED
+                        or interface.ipv6.method != InterfaceMethod.DISABLED
+                    )
                 ]
             )
 

--- a/tests/host/test_network.py
+++ b/tests/host/test_network.py
@@ -2,6 +2,9 @@
 from unittest.mock import Mock, patch
 
 from supervisor.coresys import CoreSys
+from supervisor.dbus.const import InterfaceMethod
+from supervisor.host.const import InterfaceType
+from supervisor.host.network import Interface, IpConfig
 
 
 async def test_load(coresys: CoreSys):
@@ -24,8 +27,32 @@ async def test_load(coresys: CoreSys):
         assert coresys.host.network.interfaces[1].name == "wlan0"
         assert coresys.host.network.interfaces[1].enabled is False
 
-        assert activate_connection.call_count == 1
-        assert activate_connection.call_args.args == (
+        activate_connection.assert_called_once_with(
             "/org/freedesktop/NetworkManager/Settings/1",
             "/org/freedesktop/NetworkManager/Devices/1",
         )
+
+
+async def test_load_with_disabled_methods(coresys: CoreSys):
+    """Test load does not disable methods of interfaces."""
+    with patch(
+        "supervisor.host.network.Interface.from_dbus_interface",
+        return_value=Interface(
+            "eth0",
+            True,
+            False,
+            False,
+            InterfaceType.ETHERNET,
+            IpConfig(InterfaceMethod.DISABLED, [], None, []),
+            IpConfig(InterfaceMethod.DISABLED, [], None, []),
+            None,
+            None,
+        ),
+    ), patch.object(
+        coresys.host.sys_dbus.network,
+        "activate_connection",
+        new=Mock(wraps=coresys.host.sys_dbus.network.activate_connection),
+    ) as activate_connection:
+        await coresys.host.network.load()
+
+        activate_connection.assert_not_called()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

If the IPv4 and IPv6 methods are disabled for an enabled interface, do not push an update to the interface at startup. This can be caused a connectivity or DHCP issue at startup and then Supervisor will make this small issue a big one by permanently disabling the interface. After that the user can only fix it by connecting a monitor and keyboard after connectivity has been re-established.

Plus if an interface actually has both interfaces disabled then it really doesn't matter if its defaults are up to date.

### Steps to reproduce issue

It's not obvious how this breaks so here is what I was doing to reproduce this 100% of the time:
1) Have a fully functional, network connected HAOS system with ipv4 or ipv6 method set to `auto`
2) Shut it down
3) While shut down, turn off the DHCP server in the network it will connect to (I switched its port from a VLAN with a DHCP server to one without one)
4) Turn it back on
5) Run `ha network info` - should say `disabled`
6) SSH into the host shell and run `nmcli con show 'Supervisor eth0'`. Check `ipv4.method` or `ipv6.method` (whichever you had set to `auto`)

6 is the key. Prior to this PR that would say `disabled` and the user would be screwed. Network access is permanently shut off and can really only be fixed with a keyboard and monitor.

After this PR it still says `auto` and should come right back up if you turn the DHCP server back on and reboot it. Or if the DHCP server comes on before NetworkManager times out waiting for it.


## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #3674 
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
