### PR TITLE
Support for Docker manifests base images add-on build

### DIFF
--- a/supervisor/addons/build.py
+++ b/supervisor/addons/build.py
@@ -50,6 +50,9 @@ class AddonBuild(FileConfiguration, CoreSysAttributes):
         if not self._data[ATTR_BUILD_FROM]:
             return f"ghcr.io/home-assistant/{self.sys_arch.default}-base:latest"
 
+        if isinstance(self._data[ATTR_BUILD_FROM], str):
+            return self._data[ATTR_BUILD_FROM]
+
         # Evaluate correct base image
         arch = self.sys_arch.match(list(self._data[ATTR_BUILD_FROM].keys()))
         return self._data[ATTR_BUILD_FROM][arch]

--- a/supervisor/addons/build.py
+++ b/supervisor/addons/build.py
@@ -15,6 +15,7 @@ from ..const import (
     META_ADDON,
 )
 from ..coresys import CoreSys, CoreSysAttributes
+from ..docker.interface import MAP_ARCH
 from ..exceptions import ConfigurationFileError
 from ..utils.common import FileConfiguration, find_one_filetype
 from .validate import SCHEMA_BUILD_CONFIG
@@ -90,6 +91,7 @@ class AddonBuild(FileConfiguration, CoreSysAttributes):
             "pull": True,
             "forcerm": not self.sys_dev,
             "squash": self.squash,
+            "platform": MAP_ARCH[self.sys_arch.match(self.addon.arch)],
             "labels": {
                 "io.hass.version": version,
                 "io.hass.arch": self.sys_arch.default,

--- a/supervisor/addons/validate.py
+++ b/supervisor/addons/validate.py
@@ -351,8 +351,9 @@ SCHEMA_ADDON_CONFIG = vol.All(
 # pylint: disable=no-value-for-parameter
 SCHEMA_BUILD_CONFIG = vol.Schema(
     {
-        vol.Optional(ATTR_BUILD_FROM, default=dict): vol.Schema(
-            {vol.In(ARCH_ALL): vol.Match(RE_DOCKER_IMAGE_BUILD)}
+        vol.Optional(ATTR_BUILD_FROM, default=dict): vol.Any(
+            vol.Match(RE_DOCKER_IMAGE_BUILD),
+            vol.Schema({vol.In(ARCH_ALL): vol.Match(RE_DOCKER_IMAGE_BUILD)}),
         ),
         vol.Optional(ATTR_SQUASH, default=False): vol.Boolean(),
         vol.Optional(ATTR_ARGS, default=dict): vol.Schema({str: str}),

--- a/tests/addons/test_build.py
+++ b/tests/addons/test_build.py
@@ -1,0 +1,21 @@
+"""Test addon build."""
+from unittest.mock import PropertyMock, patch
+
+from awesomeversion import AwesomeVersion
+
+from supervisor.addons.addon import Addon
+from supervisor.addons.build import AddonBuild
+from supervisor.coresys import CoreSys
+
+
+async def test_platform_set(coresys: CoreSys, install_addon_ssh: Addon):
+    """Test platform set in docker args."""
+    build = AddonBuild(coresys, install_addon_ssh)
+    with patch.object(
+        type(coresys.arch), "supported", new=PropertyMock(return_value=["amd64"])
+    ), patch.object(
+        type(coresys.arch), "default", new=PropertyMock(return_value="amd64")
+    ):
+        args = build.get_docker_args(AwesomeVersion("latest"))
+
+    assert args["platform"] == "linux/amd64"

--- a/tests/addons/test_config.py
+++ b/tests/addons/test_config.py
@@ -146,6 +146,13 @@ def test_valid_basic_build():
     vd.SCHEMA_BUILD_CONFIG(config)
 
 
+async def test_valid_manifest_build():
+    """Validate build config with manifest build from."""
+    config = load_json_fixture("build-config-manifest.json")
+
+    vd.SCHEMA_BUILD_CONFIG(config)
+
+
 def test_valid_machine():
     """Validate valid machine config."""
     config = load_json_fixture("basic-addon-config.json")
@@ -241,3 +248,7 @@ def test_watchdog_url():
     ):
         config["watchdog"] = test_options
         assert vd.SCHEMA_ADDON_CONFIG(config)
+
+
+async def test_addon_build_from():
+    """Test build per arch or manifest approach."""

--- a/tests/addons/test_config.py
+++ b/tests/addons/test_config.py
@@ -248,7 +248,3 @@ def test_watchdog_url():
     ):
         config["watchdog"] = test_options
         assert vd.SCHEMA_ADDON_CONFIG(config)
-
-
-async def test_addon_build_from():
-    """Test build per arch or manifest approach."""

--- a/tests/fixtures/build-config-manifest.json
+++ b/tests/fixtures/build-config-manifest.json
@@ -1,0 +1,7 @@
+{
+  "build_from": "mycustom/base-image:latest",
+  "squash": false,
+  "args": {
+    "my_build_arg": "xy"
+  }
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Since we support manifests now for add-on images, this PR set in motion to use a single base image for all architectures using a manifest, by allowing `build_from` to be a string (instead of mapping for each architecture).

So instead of doing this:

```yaml
# build.yaml
build_from:
  aarch64: ghcr.io/hassio-addons/base:12.2.0
  amd64: ghcr.io/hassio-addons/base:12.2.0
  armhf: ghcr.io/hassio-addons/base:12.2.0
  armv7: ghcr.io/hassio-addons/base:12.2.0
  i386: ghcr.io/hassio-addons/base:12.2.0
```

This PR will also allow for this:

```yaml
# build.yaml
build_from: ghcr.io/hassio-addons/base:12.2.0
```

Needs:
- [ ] Documentation adjustments
- [ ] Support for the builder to handle this
- [ ] Adjustment to add-on linter GitHub Action

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
