### PR TITLE
Add fields back for legacy addons info routing

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -418,9 +418,7 @@ class RestAPI(CoreSysAttributes):
                 return dict(
                     await api_store.addons_addon_info_wrapped(request),
                     state=AddonState.UNKNOWN,
-                    options=self.sys_addons.store.get(
-                        request.match_info.get("addon")
-                    ).options,
+                    options=self.sys_addons.store[request.match_info["addon"]].options,
                 )
 
         self.webapp.add_routes([web.get("/addons/{addon}/info", addons_addon_info)])

--- a/supervisor/api/store.py
+++ b/supervisor/api/store.py
@@ -212,6 +212,11 @@ class APIStore(CoreSysAttributes):
     @api_process
     async def addons_addon_info(self, request: web.Request) -> dict[str, Any]:
         """Return add-on information."""
+        return await self.addons_addon_info_wrapped(request)
+
+    # Used by legacy routing for addons/{addon}/info, can be refactored out when that is removed (1/2023)
+    async def addons_addon_info_wrapped(self, request: web.Request) -> dict[str, Any]:
+        """Return add-on information directly (not api)."""
         addon: AddonStore = self._extract_addon(request)
         return self._generate_addon_information(addon, True)
 

--- a/tests/api/test_addons.py
+++ b/tests/api/test_addons.py
@@ -35,6 +35,7 @@ async def test_addons_info_not_installed(
     assert result["data"]["version_latest"] == "9.2.1"
     assert result["data"]["version"] is None
     assert result["data"]["state"] == "unknown"
+    assert result["data"]["update_available"] is False
     assert result["data"]["options"] == {
         "authorized_keys": [],
         "apks": [],

--- a/tests/api/test_addons.py
+++ b/tests/api/test_addons.py
@@ -34,3 +34,10 @@ async def test_addons_info_not_installed(
     result = await resp.json()
     assert result["data"]["version_latest"] == "9.2.1"
     assert result["data"]["version"] is None
+    assert result["data"]["state"] == "unknown"
+    assert result["data"]["options"] == {
+        "authorized_keys": [],
+        "apks": [],
+        "password": "",
+        "server": {"tcp_forwarding": False},
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

ZWaveJS requires that `/addons/{addon}/info` response includes `state` and `options` or it will break on old versions. Adding those fields back in the legacy routing path only to support this.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
