### PR TITLE
Healthy/Unhealthy state means addon started

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -888,7 +888,11 @@ class Addon(AddonModel):
         if event.name != self.instance.name:
             return
 
-        if event.state == ContainerState.RUNNING:
+        if event.state in [
+            ContainerState.RUNNING,
+            ContainerState.HEALTHY,
+            ContainerState.UNHEALTHY,
+        ]:
             self.state = AddonState.STARTED
         elif event.state == ContainerState.STOPPED:
             self.state = AddonState.STOPPED

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -103,6 +103,18 @@ async def test_addon_state_listener(coresys: CoreSys, install_addon_ssh: Addon) 
             BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
             DockerContainerStateEvent(
                 name=f"addon_{TEST_ADDON_SLUG}",
+                state=ContainerState.HEALTHY,
+                id="abc123",
+                time=1,
+            ),
+        )
+        await asyncio.sleep(0)
+        assert install_addon_ssh.state == AddonState.STARTED
+
+        coresys.bus.fire_event(
+            BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
+            DockerContainerStateEvent(
+                name=f"addon_{TEST_ADDON_SLUG}",
                 state=ContainerState.FAILED,
                 id="abc123",
                 time=1,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

On supervisor startup it tries to attach to currently running containers for addons. If it finds one it fires an event with their current state (in this case `started`, `healthy` or `unhealthy`). Addons currently assumed they could ignore healthy or unhealthy when setting their state since it just meant `started` and they would've already received a `started` event. This may not happen on startup so a health status now also means `started`

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
