### PR TITLE
Set autoreconnect to true for interfaces

### DIFF
--- a/supervisor/dbus/network/setting/generate.py
+++ b/supervisor/dbus/network/setting/generate.py
@@ -51,6 +51,7 @@ def get_connection_from_interface(
         "uuid": Variant("s", uuid),
         "llmnr": Variant("i", 2),
         "mdns": Variant("i", 2),
+        "autoconnect": Variant("b", True),
     }
 
     if interface.type != InterfaceType.VLAN:

--- a/tests/dbus/network/setting/test_init.py
+++ b/tests/dbus/network/setting/test_init.py
@@ -87,6 +87,7 @@ async def mock_call_dbus_get_settings_signature(
         assert settings["connection"]["uuid"] == Variant(
             "s", "0c23631e-2118-355c-bbb0-8943229cb0d6"
         )
+        assert settings["connection"]["autoconnect"] == Variant("b", True)
 
         assert "ipv4" in settings
         assert settings["ipv4"]["gateway"] == Variant("s", "192.168.2.1")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

There was an issue reported [in discord](https://discord.com/channels/330944238910963714/361377176379195393/1007374190518734948) as well as #3730 where `autoconnect` was being set to `false` in the config for the interface. 

As I responded in that now closed issue I am really not sure how this could occur. Supervisor does not touch this field when updating an interface currently. HAOS [does not set it](https://github.com/home-assistant/operating-system/blob/dev/buildroot-external/rootfs-overlay/etc/NetworkManager/NetworkManager.conf) and neither does the [supervised installer](https://github.com/home-assistant/supervised-installer/blob/main/homeassistant-supervised/etc/NetworkManager/NetworkManager.conf). I also can say this field does not have a value on any of my HAOS systems. Yet it seems we have a user with a supported supervised system showing it being set on restart of supervisor.

Although I don't know the root cause I put up this PR anyway because I realized we essentially don't support `autoconnect=false`. Supervisor does not provide any way to start/connect an enabled but unconnected interface. My thinking is if its an interface managed by supervisor it should be `autoconnect=true`. Something I thought was always the default but if not then we can add it to be certain.

Bear in mind if merged this will be automatically added to the config of every managed interface next supervisor update since we automatically post an update at startup. So if anyone can think of a reason adding `autoconnect=true` could create an issue please say so, I don't want to merge it if so.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #3730
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
