### PR TITLE
Remove static-only fields when method is auto

### DIFF
--- a/tests/dbus/network/setting/test_init.py
+++ b/tests/dbus/network/setting/test_init.py
@@ -90,14 +90,10 @@ async def mock_call_dbus_get_settings_signature(
         assert settings["connection"]["autoconnect"] == Variant("b", True)
 
         assert "ipv4" in settings
-        assert settings["ipv4"]["gateway"] == Variant("s", "192.168.2.1")
         assert settings["ipv4"]["method"] == Variant("s", "auto")
-        assert settings["ipv4"]["dns"] == Variant("au", [16951488])
-        assert len(settings["ipv4"]["address-data"].value) == 1
-        assert settings["ipv4"]["address-data"].value[0]["address"] == Variant(
-            "s", "192.168.2.148"
-        )
-        assert settings["ipv4"]["address-data"].value[0]["prefix"] == Variant("u", 24)
+        assert "gateway" not in settings["ipv4"]
+        assert "dns" not in settings["ipv4"]
+        assert "address-data" not in settings["ipv4"]
         assert "addresses" not in settings["ipv4"]
         assert len(settings["ipv4"]["route-data"].value) == 1
         assert settings["ipv4"]["route-data"].value[0]["dest"] == Variant(
@@ -113,8 +109,11 @@ async def mock_call_dbus_get_settings_signature(
 
         assert "ipv6" in settings
         assert settings["ipv6"]["method"] == Variant("s", "auto")
-        assert settings["ipv6"]["addr-gen-mode"] == Variant("i", 0)
+        assert "gateway" not in settings["ipv6"]
+        assert "dns" not in settings["ipv6"]
+        assert "address-data" not in settings["ipv6"]
         assert "addresses" not in settings["ipv6"]
+        assert settings["ipv6"]["addr-gen-mode"] == Variant("i", 0)
 
         assert "proxy" in settings
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

When trying to reproduce issues caused by DHCP being unavailable I noticed that when some settings were being unintentionally kept when switching from `method: static` to `method: auto`. My network configuration still seemed to have `addresses`, `dns` and `gateway` filled in even though those don't make sense with `method: auto`. Usually it was silently incorrect but with ipv6 sometimes I got an error from Network Manager.

This is caused by the settings merge. Adjusted to ensure we don't merge fields that Supervisor controls, only the ones it doesn't understand.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
