### PR TITLE
Watchdog restarts addons on successful but unexpected exits

### DIFF
--- a/supervisor/hardware/helper.py
+++ b/supervisor/hardware/helper.py
@@ -41,7 +41,7 @@ class HwHelper(CoreSysAttributes):
         return bool(self.sys_hardware.filter_devices(subsystem=UdevSubsystem.USB))
 
     @property
-    def last_boot(self) -> str | None:
+    def last_boot(self) -> datetime | None:
         """Return last boot time."""
         try:
             stats: str = _PROC_STAT.read_text(encoding="utf-8")

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -1,6 +1,7 @@
 """Test Home Assistant Add-ons."""
 
 import asyncio
+from datetime import timedelta
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from docker.errors import DockerException
@@ -9,11 +10,36 @@ import pytest
 from supervisor.addons.addon import Addon
 from supervisor.const import AddonState, BusEvent
 from supervisor.coresys import CoreSys
+from supervisor.docker.addon import DockerAddon
 from supervisor.docker.const import ContainerState
 from supervisor.docker.monitor import DockerContainerStateEvent
 from supervisor.exceptions import AddonsJobError, AudioUpdateError
+from supervisor.store.repository import Repository
+from supervisor.utils.dt import utcnow
 
 from ..const import TEST_ADDON_SLUG
+
+
+def _fire_test_event(coresys: CoreSys, name: str, state: ContainerState):
+    """Fire a test event."""
+    coresys.bus.fire_event(
+        BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
+        DockerContainerStateEvent(
+            name=name,
+            state=state,
+            id="abc123",
+            time=1,
+        ),
+    )
+
+
+async def mock_current_state(state: ContainerState) -> ContainerState:
+    """Mock for current state method."""
+    return state
+
+
+async def mock_stop() -> None:
+    """Mock for stop method."""
 
 
 def test_options_merge(coresys: CoreSys, install_addon_ssh: Addon) -> None:
@@ -71,172 +97,105 @@ def test_options_merge(coresys: CoreSys, install_addon_ssh: Addon) -> None:
 
 async def test_addon_state_listener(coresys: CoreSys, install_addon_ssh: Addon) -> None:
     """Test addon is setting state from docker events."""
-    with patch.object(type(install_addon_ssh.instance), "attach"):
+    with patch.object(DockerAddon, "attach"):
         await install_addon_ssh.load()
 
     assert install_addon_ssh.state == AddonState.UNKNOWN
 
-    with patch.object(type(install_addon_ssh), "watchdog_container"):
-        coresys.bus.fire_event(
-            BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
-            DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
-                state=ContainerState.RUNNING,
-                id="abc123",
-                time=1,
-            ),
-        )
+    with patch.object(Addon, "watchdog_container"):
+        _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
         await asyncio.sleep(0)
         assert install_addon_ssh.state == AddonState.STARTED
 
-        coresys.bus.fire_event(
-            BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
-            DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
-                state=ContainerState.STOPPED,
-                id="abc123",
-                time=1,
-            ),
-        )
+        _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.STOPPED)
         await asyncio.sleep(0)
         assert install_addon_ssh.state == AddonState.STOPPED
 
-        coresys.bus.fire_event(
-            BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
-            DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
-                state=ContainerState.HEALTHY,
-                id="abc123",
-                time=1,
-            ),
-        )
+        _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.HEALTHY)
         await asyncio.sleep(0)
         assert install_addon_ssh.state == AddonState.STARTED
 
-        coresys.bus.fire_event(
-            BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
-            DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
-                state=ContainerState.FAILED,
-                id="abc123",
-                time=1,
-            ),
-        )
+        _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.FAILED)
         await asyncio.sleep(0)
         assert install_addon_ssh.state == AddonState.ERROR
 
         # Test other addons are ignored
-        coresys.bus.fire_event(
-            BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
-            DockerContainerStateEvent(
-                name="addon_local_non_installed",
-                state=ContainerState.RUNNING,
-                id="abc123",
-                time=1,
-            ),
-        )
+        _fire_test_event(coresys, "addon_local_non_installed", ContainerState.RUNNING)
         await asyncio.sleep(0)
         assert install_addon_ssh.state == AddonState.ERROR
 
 
-async def mock_current_state(state: ContainerState) -> ContainerState:
-    """Mock for current state method."""
-    return state
-
-
-async def mock_stop() -> None:
-    """Mock for stop method."""
-
-
 async def test_addon_watchdog(coresys: CoreSys, install_addon_ssh: Addon) -> None:
     """Test addon watchdog works correctly."""
-    with patch.object(type(install_addon_ssh.instance), "attach"):
+    with patch.object(DockerAddon, "attach"):
         await install_addon_ssh.load()
 
     install_addon_ssh.watchdog = True
 
     with patch.object(Addon, "restart") as restart, patch.object(
         Addon, "start"
-    ) as start, patch.object(
-        type(install_addon_ssh.instance), "current_state"
-    ) as current_state:
+    ) as start, patch.object(DockerAddon, "current_state") as current_state:
+        # Restart if it becomes unhealthy
         current_state.return_value = mock_current_state(ContainerState.UNHEALTHY)
-        coresys.bus.fire_event(
-            BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
-            DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
-                state=ContainerState.UNHEALTHY,
-                id="abc123",
-                time=1,
-            ),
-        )
+        _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.UNHEALTHY)
         await asyncio.sleep(0)
         restart.assert_called_once()
         start.assert_not_called()
 
         restart.reset_mock()
-        current_state.return_value = mock_current_state(ContainerState.FAILED)
 
-        with patch.object(
-            type(install_addon_ssh.instance), "stop", return_value=mock_stop()
-        ) as stop:
-            coresys.bus.fire_event(
-                BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
-                DockerContainerStateEvent(
-                    name=f"addon_{TEST_ADDON_SLUG}",
-                    state=ContainerState.FAILED,
-                    id="abc123",
-                    time=1,
-                ),
-            )
+        # Rebuild if it failed
+        current_state.return_value = mock_current_state(ContainerState.FAILED)
+        with patch.object(DockerAddon, "stop", return_value=mock_stop()) as stop:
+            _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.FAILED)
             await asyncio.sleep(0)
             stop.assert_called_once_with(remove_container=True)
             restart.assert_not_called()
             start.assert_called_once()
 
         start.reset_mock()
+
         # Do not process event if container state has changed since fired
         current_state.return_value = mock_current_state(ContainerState.HEALTHY)
-        coresys.bus.fire_event(
-            BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
-            DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
-                state=ContainerState.FAILED,
-                id="abc123",
-                time=1,
-            ),
-        )
-        await asyncio.sleep(0)
-        restart.assert_not_called()
-        start.assert_not_called()
-
-        # Do not restart when addon stopped normally
-        coresys.bus.fire_event(
-            BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
-            DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
-                state=ContainerState.STOPPED,
-                id="abc123",
-                time=1,
-            ),
-        )
+        _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.FAILED)
         await asyncio.sleep(0)
         restart.assert_not_called()
         start.assert_not_called()
 
         # Other addons ignored
-        coresys.bus.fire_event(
-            BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
-            DockerContainerStateEvent(
-                name="addon_local_non_installed",
-                state=ContainerState.UNHEALTHY,
-                id="abc123",
-                time=1,
-            ),
-        )
+        current_state.return_value = mock_current_state(ContainerState.UNHEALTHY)
+        _fire_test_event(coresys, "addon_local_non_installed", ContainerState.UNHEALTHY)
         await asyncio.sleep(0)
         restart.assert_not_called()
         start.assert_not_called()
+
+
+async def test_watchdog_on_stop(coresys: CoreSys, install_addon_ssh: Addon) -> None:
+    """Test addon watchdog restarts addon on stop if not manual."""
+    with patch.object(DockerAddon, "attach"):
+        await install_addon_ssh.load()
+
+    install_addon_ssh.watchdog = True
+
+    with patch.object(Addon, "restart") as restart, patch.object(
+        DockerAddon,
+        "current_state",
+        return_value=mock_current_state(ContainerState.STOPPED),
+    ), patch.object(DockerAddon, "stop", return_value=mock_stop()):
+        # Do not restart when addon stopped by user
+        _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
+        await asyncio.sleep(0)
+        await install_addon_ssh.stop()
+        _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.STOPPED)
+        await asyncio.sleep(0)
+        restart.assert_not_called()
+
+        # Do restart addon if it stops and user didn't do it
+        _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
+        await asyncio.sleep(0)
+        _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.STOPPED)
+        await asyncio.sleep(0)
+        restart.assert_called_once()
 
 
 async def test_listener_attached_on_install(coresys: CoreSys, repository):
@@ -258,17 +217,43 @@ async def test_listener_attached_on_install(coresys: CoreSys, repository):
     ):
         await coresys.addons.install.__wrapped__(coresys.addons, TEST_ADDON_SLUG)
 
-    coresys.bus.fire_event(
-        BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
-        DockerContainerStateEvent(
-            name=f"addon_{TEST_ADDON_SLUG}",
-            state=ContainerState.RUNNING,
-            id="abc123",
-            time=1,
-        ),
-    )
+    _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
     await asyncio.sleep(0)
     assert coresys.addons.get(TEST_ADDON_SLUG).state == AddonState.STARTED
+
+
+@pytest.mark.parametrize(
+    "boot_timedelta,restart_count", [(timedelta(), 0), (timedelta(days=1), 1)]
+)
+async def test_watchdog_during_attach(
+    coresys: CoreSys,
+    repository: Repository,
+    boot_timedelta: timedelta,
+    restart_count: int,
+):
+    """Test host reboot treated as manual stop but not supervisor restart."""
+    store = coresys.addons.store[TEST_ADDON_SLUG]
+    coresys.addons.data.install(store)
+
+    with patch.object(Addon, "restart") as restart, patch.object(
+        type(coresys.hardware.helper),
+        "last_boot",
+        new=PropertyMock(return_value=utcnow()),
+    ), patch.object(DockerAddon, "attach"), patch.object(
+        DockerAddon,
+        "current_state",
+        return_value=mock_current_state(ContainerState.STOPPED),
+    ):
+        coresys.config.last_boot = coresys.hardware.helper.last_boot + boot_timedelta
+        addon = Addon(coresys, store.slug)
+        coresys.addons.local[addon.slug] = addon
+        addon.watchdog = True
+
+        await addon.load()
+        _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.STOPPED)
+        await asyncio.sleep(0)
+
+        assert restart.call_count == restart_count
 
 
 async def test_install_update_fails_if_out_of_date(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Our S6 V3 migration guide missed a step. Legacy services now also must set the exit code of the container as described here: https://github.com/just-containers/s6-overlay/commit/2fbf5ce27264c7e355729794fa2404c8bc4a6f30 . Otherwise the exit code of the container is always set to success.

Watchdog now looks at the exit code of the container and assumes addons were supposed to stop if the exit code was 0. It appears this is incorrect a lot currently. We should fix our addons and change the example finish script but in my opinion supervisor now needs to handle this. As it was our miss, its been a while since we announced the S6 V3 change and its backwards incompatible with how watchdog used to work (it had special treatment for user calling "stop").

In addition I am treating reboot as a "manual stop" for all addons. This ensures we only bring up the ones marked "run on startup" and only at their scheduled time. Currently there's a small risk we'd bring up an addon off-schedule if its container was not properly removed before reboot based on its exit code. Watchdog runs as normal after a restart/update of supervisor.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #3812 
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
