### PR TITLE
Store load ignores supervisor updated condition

### DIFF
--- a/supervisor/store/__init__.py
+++ b/supervisor/store/__init__.py
@@ -95,9 +95,13 @@ class StoreManager(CoreSysAttributes, FileConfiguration):
         conditions=[JobCondition.INTERNET_SYSTEM, JobCondition.SUPERVISOR_UPDATED],
         on_condition=StoreJobError,
     )
-    async def add_repository(
+    async def add_repository(self, url: str, *, persist: bool = True) -> None:
+        """Add a repository."""
+        await self._add_repository(url, persist=persist, add_with_errors=False)
+
+    async def _add_repository(
         self, url: str, *, persist: bool = True, add_with_errors: bool = False
-    ):
+    ) -> None:
         """Add a repository."""
         if url == URL_HASSIO_ADDONS:
             url = StoreType.CORE
@@ -216,7 +220,9 @@ class StoreManager(CoreSysAttributes, FileConfiguration):
         # Add new repositories
         add_errors = await asyncio.gather(
             *[
-                self.add_repository(url, persist=False, add_with_errors=add_with_errors)
+                self._add_repository(url, persist=False, add_with_errors=True)
+                if add_with_errors
+                else self.add_repository(url, persist=False)
                 for url in new_rep - old_rep
             ],
             return_exceptions=True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

`add_repository` is also called to load existing repository information back into memory on startup. Therefore it cannot be wrapped in a job condition else we get nonsense failures on startup if supervisor is out of date or has no internet. We only need to require those things to actually add a new repository.

Note that this change does leave two small edge cases where the user could get validation errors:
1) On startup if supervisor finds the folder for a repo is gone it will clone it. If supervisor is out of date this new clone may be invalid for current supervisor. Since we have no clone to fall back on there's not really a better option.
2) Restore of a backup may include a repo we don't have a clone for. Can cause same problems as above if supervisor is out of date. We may want to consider protecting against this by not allowing the backup to be restored until supervisor is up to date. Will look at it for a follow-up PR.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
