### PR TITLE
supervisor/backup: Ensure compressed flag is respected by homeassistant

### DIFF
--- a/supervisor/backups/backup.py
+++ b/supervisor/backups/backup.py
@@ -465,8 +465,11 @@ class Backup(CoreSysAttributes):
         self._data[ATTR_HOMEASSISTANT] = {ATTR_VERSION: self.sys_homeassistant.version}
 
         # Backup Home Assistant Core config directory
+        tar_name = Path(
+            self._tmp.name, f"homeassistant.tar{'.gz' if self.compressed else ''}"
+        )
         homeassistant_file = SecureTarFile(
-            Path(self._tmp.name, "homeassistant.tar.gz"), "w", key=self._key
+            tar_name, "w", key=self._key, gzip=self.compressed
         )
 
         await self.sys_homeassistant.backup(homeassistant_file)
@@ -479,8 +482,11 @@ class Backup(CoreSysAttributes):
         await self.sys_homeassistant.core.stop()
 
         # Restore Home Assistant Core config directory
+        tar_name = Path(
+            self._tmp.name, f"homeassistant.tar{'.gz' if self.compressed else ''}"
+        )
         homeassistant_file = SecureTarFile(
-            Path(self._tmp.name, "homeassistant.tar.gz"), "r", key=self._key
+            tar_name, "r", key=self._key, gzip=self.compressed
         )
 
         await self.sys_homeassistant.restore(homeassistant_file)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

As per commit 80e67b3 we're supporting a compressed flag on backups to
define whether a tar archive should be fully compressed or not, but
while we respect this for all the addons and folders we don't do it for
the actual homeassistant archive, that is always compressed despite the
passed flag.

Fix this by applying the same logic to the homeassistant archive too.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #3838
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
