### PR TITLE
Reduce patching call dbus in tests

### DIFF
--- a/tests/api/test_network.py
+++ b/tests/api/test_network.py
@@ -1,5 +1,5 @@
 """Test NetwrokInterface API."""
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -99,27 +99,28 @@ async def test_api_network_interface_info_default(api_client):
 
 
 @pytest.mark.asyncio
-async def test_api_network_interface_update(api_client, coresys: CoreSys):
+async def test_api_network_interface_update(
+    api_client, coresys: CoreSys, dbus: list[str]
+):
     """Test network manager api."""
-    with patch.object(
-        type(coresys.host.sys_dbus.network),
-        "check_connectivity",
-        new=Mock(wraps=coresys.host.sys_dbus.network.check_connectivity),
-    ) as check_connectivity:
-        resp = await api_client.post(
-            f"/network/interface/{TEST_INTERFACE}/update",
-            json={
-                "ipv4": {
-                    "method": "static",
-                    "nameservers": ["1.1.1.1"],
-                    "address": ["192.168.2.148/24"],
-                    "gateway": "192.168.1.1",
-                }
-            },
-        )
-        result = await resp.json()
-        assert result["result"] == "ok"
-        check_connectivity.assert_called_once_with(force=True)
+    dbus.clear()
+    resp = await api_client.post(
+        f"/network/interface/{TEST_INTERFACE}/update",
+        json={
+            "ipv4": {
+                "method": "static",
+                "nameservers": ["1.1.1.1"],
+                "address": ["192.168.2.148/24"],
+                "gateway": "192.168.1.1",
+            }
+        },
+    )
+    result = await resp.json()
+    assert result["result"] == "ok"
+    assert (
+        "/org/freedesktop/NetworkManager-org.freedesktop.NetworkManager.CheckConnectivity"
+        in dbus
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

I recently realized the dbus fixture returns a list of dbus commands. Checking this list to see what dbus commands have been run is a much better approach then monkeypatching `call_dbus` and checking its args. I fixed most in #3854 , here's a couple I missed.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
