### PR TITLE
Replace __del__ with explicit disconnect

### DIFF
--- a/supervisor/dbus/interface.py
+++ b/supervisor/dbus/interface.py
@@ -35,10 +35,6 @@ class DBusInterface(ABC):
         """Return True, if they is connected to D-Bus."""
         return self.dbus is not None
 
-    def __del__(self) -> None:
-        """Disconnect on delete."""
-        self.disconnect()
-
     async def connect(self, bus: MessageBus) -> None:
         """Connect to D-Bus."""
         self.dbus = await DBus.connect(bus, self.bus_name, self.object_path)

--- a/supervisor/dbus/network/__init__.py
+++ b/supervisor/dbus/network/__init__.py
@@ -1,4 +1,5 @@
 """Network Manager implementation for DBUS."""
+import asyncio
 import logging
 from typing import Any
 
@@ -209,6 +210,14 @@ class NetworkManager(DBusInterfaceProxy):
                 interface.primary = True
 
             interfaces[interface.name] = interface
+
+        # Disconnect removed devices
+        for device in set(curr_devices.keys()) - set(
+            self.properties[DBUS_ATTR_DEVICES]
+        ):
+            asyncio.get_event_loop().run_in_executor(
+                None, curr_devices[device].disconnect
+            )
 
         self._interfaces = interfaces
 

--- a/supervisor/dbus/network/connection.py
+++ b/supervisor/dbus/network/connection.py
@@ -1,5 +1,6 @@
 """Connection object for Network Manager."""
 
+import asyncio
 from typing import Any
 
 from supervisor.dbus.network.setting import NetworkSetting
@@ -77,15 +78,39 @@ class NetworkConnection(DBusInterfaceProxy):
         """Return settings."""
         return self._settings
 
+    @settings.setter
+    def settings(self, settings: NetworkSetting | None) -> None:
+        """Set settings."""
+        if self._settings and self._settings is not settings:
+            asyncio.get_event_loop().run_in_executor(None, self._settings.disconnect)
+
+        self._settings = settings
+
     @property
     def ipv4(self) -> IpConfiguration | None:
         """Return a ip4 configuration object for the connection."""
         return self._ipv4
 
+    @ipv4.setter
+    def ipv4(self, ipv4: IpConfiguration | None) -> None:
+        """Set ipv4 configuration."""
+        if self._ipv4 and self._ipv4 is not ipv4:
+            asyncio.get_event_loop().run_in_executor(None, self._ipv4.disconnect)
+
+        self._ipv4 = ipv4
+
     @property
     def ipv6(self) -> IpConfiguration | None:
         """Return a ip6 configuration object for the connection."""
         return self._ipv6
+
+    @ipv6.setter
+    def ipv6(self, ipv6: IpConfiguration | None) -> None:
+        """Set ipv6 configuration."""
+        if self._ipv6 and self._ipv6 is not ipv6:
+            asyncio.get_event_loop().run_in_executor(None, self._ipv6.disconnect)
+
+        self._ipv6 = ipv6
 
     @dbus_connected
     async def update(self, changed: dict[str, Any] | None = None) -> None:
@@ -102,46 +127,44 @@ class NetworkConnection(DBusInterfaceProxy):
         # IPv4
         if not changed or DBUS_ATTR_IP4CONFIG in changed:
             if (
-                self._ipv4
-                and self._ipv4.is_connected
-                and self._ipv4.object_path == self.properties[DBUS_ATTR_IP4CONFIG]
+                self.ipv4
+                and self.ipv4.is_connected
+                and self.ipv4.object_path == self.properties[DBUS_ATTR_IP4CONFIG]
             ):
-                await self._ipv4.update()
+                await self.ipv4.update()
             elif self.properties[DBUS_ATTR_IP4CONFIG] != DBUS_OBJECT_BASE:
-                self._ipv4 = IpConfiguration(self.properties[DBUS_ATTR_IP4CONFIG])
-                await self._ipv4.connect(self.dbus.bus)
+                self.ipv4 = IpConfiguration(self.properties[DBUS_ATTR_IP4CONFIG])
+                await self.ipv4.connect(self.dbus.bus)
             else:
-                self._ipv4 = None
+                self.ipv4 = None
 
         # IPv6
         if not changed or DBUS_ATTR_IP6CONFIG in changed:
             if (
-                self._ipv6
-                and self._ipv6.is_connected
-                and self._ipv6.object_path == self.properties[DBUS_ATTR_IP6CONFIG]
+                self.ipv6
+                and self.ipv6.is_connected
+                and self.ipv6.object_path == self.properties[DBUS_ATTR_IP6CONFIG]
             ):
-                await self._ipv6.update()
+                await self.ipv6.update()
             elif self.properties[DBUS_ATTR_IP6CONFIG] != DBUS_OBJECT_BASE:
-                self._ipv6 = IpConfiguration(
-                    self.properties[DBUS_ATTR_IP6CONFIG], False
-                )
-                await self._ipv6.connect(self.dbus.bus)
+                self.ipv6 = IpConfiguration(self.properties[DBUS_ATTR_IP6CONFIG], False)
+                await self.ipv6.connect(self.dbus.bus)
             else:
-                self._ipv6 = None
+                self.ipv6 = None
 
         # Settings
         if not changed or DBUS_ATTR_CONNECTION in changed:
             if (
-                self._settings
-                and self._settings.is_connected
-                and self._settings.object_path == self.properties[DBUS_ATTR_CONNECTION]
+                self.settings
+                and self.settings.is_connected
+                and self.settings.object_path == self.properties[DBUS_ATTR_CONNECTION]
             ):
-                await self._settings.reload()
+                await self.settings.reload()
             elif self.properties[DBUS_ATTR_CONNECTION] != DBUS_OBJECT_BASE:
-                self._settings = NetworkSetting(self.properties[DBUS_ATTR_CONNECTION])
-                await self._settings.connect(self.dbus.bus)
+                self.settings = NetworkSetting(self.properties[DBUS_ATTR_CONNECTION])
+                await self.settings.connect(self.dbus.bus)
             else:
-                self._settings = None
+                self.settings = None
 
     def disconnect(self) -> None:
         """Disconnect from D-Bus."""

--- a/supervisor/dbus/network/setting/__init__.py
+++ b/supervisor/dbus/network/setting/__init__.py
@@ -169,7 +169,9 @@ class NetworkSetting(DBusInterface):
 
     def disconnect(self) -> None:
         """Disconnect from D-Bus."""
-        self.dbus.Settings.Connection.off_updated(self.reload)
+        if self.is_connected:
+            self.dbus.Settings.Connection.off_updated(self.reload)
+
         super().disconnect()
 
     @dbus_connected

--- a/tests/dbus/network/test_connection.py
+++ b/tests/dbus/network/test_connection.py
@@ -1,0 +1,47 @@
+"""Test connection object."""
+
+import asyncio
+
+from supervisor.dbus.network import NetworkManager
+
+from tests.common import fire_property_change_signal
+from tests.const import TEST_INTERFACE
+
+
+async def test_old_ipv4_disconnect(network_manager: NetworkManager):
+    """Test old ipv4 disconnects on ipv4 change."""
+    connection = network_manager.interfaces[TEST_INTERFACE].connection
+    ipv4 = connection.ipv4
+    assert ipv4.is_connected is True
+
+    fire_property_change_signal(connection, {"Ip4Config": "/"})
+    await asyncio.sleep(0)
+
+    assert connection.ipv4 is None
+    assert ipv4.is_connected is False
+
+
+async def test_old_ipv6_disconnect(network_manager: NetworkManager):
+    """Test old ipv6 disconnects on ipv6 change."""
+    connection = network_manager.interfaces[TEST_INTERFACE].connection
+    ipv6 = connection.ipv6
+    assert ipv6.is_connected is True
+
+    fire_property_change_signal(connection, {"Ip6Config": "/"})
+    await asyncio.sleep(0)
+
+    assert connection.ipv6 is None
+    assert ipv6.is_connected is False
+
+
+async def test_old_settings_disconnect(network_manager: NetworkManager):
+    """Test old settings disconnects on settings change."""
+    connection = network_manager.interfaces[TEST_INTERFACE].connection
+    settings = connection.settings
+    assert settings.is_connected is True
+
+    fire_property_change_signal(connection, {"Connection": "/"})
+    await asyncio.sleep(0)
+
+    assert connection.settings is None
+    assert settings.is_connected is False

--- a/tests/dbus/network/test_interface.py
+++ b/tests/dbus/network/test_interface.py
@@ -57,3 +57,29 @@ async def test_network_interface_wlan(network_manager: NetworkManager):
     interface = network_manager.interfaces[TEST_INTERFACE_WLAN]
     assert interface.name == TEST_INTERFACE_WLAN
     assert interface.type == DeviceType.WIRELESS
+
+
+async def test_old_connection_disconnect(network_manager: NetworkManager):
+    """Test old connection disconnects on connection change."""
+    interface = network_manager.interfaces[TEST_INTERFACE]
+    connection = interface.connection
+    assert connection.is_connected is True
+
+    fire_property_change_signal(interface, {"ActiveConnection": "/"})
+    await asyncio.sleep(0)
+
+    assert interface.connection is None
+    assert connection.is_connected is False
+
+
+async def test_old_wireless_disconnect(network_manager: NetworkManager):
+    """Test old wireless disconnects on type change."""
+    interface = network_manager.interfaces[TEST_INTERFACE_WLAN]
+    wireless = interface.wireless
+    assert wireless.is_connected is True
+
+    fire_property_change_signal(interface, {"DeviceType": DeviceType.ETHERNET})
+    await asyncio.sleep(0)
+
+    assert interface.wireless is None
+    assert wireless.is_connected is False

--- a/tests/dbus/network/test_network_manager.py
+++ b/tests/dbus/network/test_network_manager.py
@@ -11,7 +11,7 @@ from supervisor.exceptions import HostNotSupportedError
 from .setting.test_init import SETTINGS_WITH_SIGNATURE
 
 from tests.common import fire_property_change_signal
-from tests.const import TEST_INTERFACE
+from tests.const import TEST_INTERFACE, TEST_INTERFACE_WLAN
 
 # pylint: disable=protected-access
 
@@ -93,3 +93,17 @@ async def test_add_and_activate_connection(
         "/org/freedesktop/NetworkManager-org.freedesktop.NetworkManager.AddAndActivateConnection",
         "/org/freedesktop/NetworkManager/Settings/1-org.freedesktop.NetworkManager.Settings.Connection.GetSettings",
     ]
+
+
+async def test_removed_devices_disconnect(network_manager: NetworkManager):
+    """Test removed devices are disconnected."""
+    wlan = network_manager.interfaces[TEST_INTERFACE_WLAN]
+    assert wlan.is_connected is True
+
+    fire_property_change_signal(
+        network_manager, {"Devices": ["/org/freedesktop/NetworkManager/Devices/1"]}
+    )
+    await asyncio.sleep(0)
+
+    assert TEST_INTERFACE_WLAN not in network_manager.interfaces
+    assert wlan.is_connected is False

--- a/tests/dbus/network/test_wireless.py
+++ b/tests/dbus/network/test_wireless.py
@@ -4,32 +4,39 @@ import asyncio
 from supervisor.dbus.network import NetworkManager
 
 from tests.common import fire_property_change_signal
+from tests.const import TEST_INTERFACE_WLAN
 
 
 async def test_wireless(network_manager: NetworkManager):
     """Test wireless properties."""
-    assert network_manager.interfaces["wlan0"].wireless.active is None
+    assert network_manager.interfaces[TEST_INTERFACE_WLAN].wireless.active is None
 
     fire_property_change_signal(
-        network_manager.interfaces["wlan0"].wireless,
+        network_manager.interfaces[TEST_INTERFACE_WLAN].wireless,
         {"ActiveAccessPoint": "/org/freedesktop/NetworkManager/AccessPoint/43099"},
     )
     await asyncio.sleep(0)
     assert (
-        network_manager.interfaces["wlan0"].wireless.active.mac == "E4:57:40:A9:D7:DE"
+        network_manager.interfaces[TEST_INTERFACE_WLAN].wireless.active.mac
+        == "E4:57:40:A9:D7:DE"
     )
 
     fire_property_change_signal(
-        network_manager.interfaces["wlan0"].wireless, {}, ["ActiveAccessPoint"]
+        network_manager.interfaces[TEST_INTERFACE_WLAN].wireless,
+        {},
+        ["ActiveAccessPoint"],
     )
     await asyncio.sleep(0)
-    assert network_manager.interfaces["wlan0"].wireless.active is None
+    assert network_manager.interfaces[TEST_INTERFACE_WLAN].wireless.active is None
 
 
 async def test_request_scan(network_manager: NetworkManager, dbus: list[str]):
     """Test request scan."""
     dbus.clear()
-    assert await network_manager.interfaces["wlan0"].wireless.request_scan() is None
+    assert (
+        await network_manager.interfaces[TEST_INTERFACE_WLAN].wireless.request_scan()
+        is None
+    )
     assert dbus == [
         "/org/freedesktop/NetworkManager/Devices/3-org.freedesktop.NetworkManager.Device.Wireless.RequestScan"
     ]
@@ -39,7 +46,7 @@ async def test_get_all_access_points(network_manager: NetworkManager, dbus: list
     """Test get all access points."""
     dbus.clear()
     accesspoints = await network_manager.interfaces[
-        "wlan0"
+        TEST_INTERFACE_WLAN
     ].wireless.get_all_accesspoints()
     assert len(accesspoints) == 2
     assert accesspoints[0].mac == "E4:57:40:A9:D7:DE"
@@ -49,3 +56,22 @@ async def test_get_all_access_points(network_manager: NetworkManager, dbus: list
     assert dbus == [
         "/org/freedesktop/NetworkManager/Devices/3-org.freedesktop.NetworkManager.Device.Wireless.GetAllAccessPoints"
     ]
+
+
+async def test_old_active_ap_disconnects(network_manager: NetworkManager):
+    """Test old access point disconnects on active ap change."""
+    wireless = network_manager.interfaces[TEST_INTERFACE_WLAN].wireless
+    fire_property_change_signal(
+        wireless,
+        {"ActiveAccessPoint": "/org/freedesktop/NetworkManager/AccessPoint/43099"},
+    )
+    await asyncio.sleep(0)
+
+    active = wireless.active
+    assert active.is_connected is True
+
+    fire_property_change_signal(wireless, {"ActiveAccessPoint": "/"})
+    await asyncio.sleep(0)
+
+    assert wireless.active is None
+    assert active.is_connected is False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Supercedes #3890 

Network Manager has many sub-objects that go in and out of existence as things change. After #3872 this poses a problem because we create signal listeners for almost every proxy interface we connect to a dbus object. The `__del__` code was an attempt to keep that under control without putting explicit disconnects everywhere.

This doesn't really work though. Since dbus-next keeps a list of callbacks and those callbacks point to our dbus objects. So removing this and instead whenever we replace a connected object in an NM object we do an explicit disconnect on the old one. These disconnects of old objects are being done in the executor because the result shouldn't impact connecting to and updating the current NM objects.

Also wrapped [this](https://github.com/home-assistant/supervisor/blob/262fd05c6d3136dba50eb9c8fb69da4f178b8d5b/supervisor/dbus/network/setting/__init__.py#L172) in an `is_connected` check as that was missing and creating test noise.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
