### PR TITLE
Attach event monitor after addon restore

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
-      
+
       - name: Write env-file
         if: needs.init.outputs.requirements == 'true'
         run: |
@@ -297,6 +297,12 @@ jobs:
             exit 1
           fi
 
+          # Make sure its state is started
+          test="$(docker exec hassio_cli ha addons info core_ssh --no-progress --raw-json | jq -r '.data.state')"
+          if [ "$test" != "started" ]; then
+            exit 1
+          fi
+
       - name: Check the Supervisor code sign
         if: needs.init.outputs.publish == 'true'
         run: |
@@ -366,6 +372,12 @@ jobs:
           # Make sure it actually installed
           test=$(docker exec hassio_cli ha addons info core_ssh --no-progress --raw-json | jq -r '.data.version')
           if [[ "$test" == "null" ]]; then
+            exit 1
+          fi
+
+          # Make sure its state is started
+          test="$(docker exec hassio_cli ha addons info core_ssh --no-progress --raw-json | jq -r '.data.state')"
+          if [ "$test" != "started" ]; then
             exit 1
           fi
 

--- a/supervisor/addons/__init__.py
+++ b/supervisor/addons/__init__.py
@@ -203,7 +203,7 @@ class AddonManager(CoreSysAttributes):
         else:
             addon.state = AddonState.UNKNOWN
 
-        await addon.remove_data()
+        await addon.unload()
 
         # Cleanup audio settings
         if addon.path_pulse.exists():
@@ -354,7 +354,6 @@ class AddonManager(CoreSysAttributes):
         if slug not in self.local:
             _LOGGER.debug("Add-on %s is not local available for restore", slug)
             addon = Addon(self.coresys, slug)
-            await addon.load()
         else:
             _LOGGER.debug("Add-on %s is local available for restore", slug)
             addon = self.local[slug]

--- a/supervisor/addons/__init__.py
+++ b/supervisor/addons/__init__.py
@@ -354,6 +354,7 @@ class AddonManager(CoreSysAttributes):
         if slug not in self.local:
             _LOGGER.debug("Add-on %s is not local available for restore", slug)
             addon = Addon(self.coresys, slug)
+            await addon.load()
         else:
             _LOGGER.debug("Add-on %s is local available for restore", slug)
             addon = self.local[slug]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

When restore installed an addon we weren't calling `load` on the new `Addon` object. This meant the docker events monitor was never attached. Corrected that. Also it looks like listeners weren't being unattached on addon uninstall, corrected that as well.

To test, modified the `Run the Supervisor` workflow to check that supervisor says the addon is running. This serves as a test for this and also should help us identify some of the recent issues around the state in the API being off in advance.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
