### PR TITLE
Bad introspection causes DBus error not KeyError

### DIFF
--- a/supervisor/dbus/interface.py
+++ b/supervisor/dbus/interface.py
@@ -58,7 +58,7 @@ class DBusInterfaceProxy(DBusInterface):
         await super().connect(bus)
         await self.update()
 
-        if self.sync_properties:
+        if self.sync_properties and self.is_connected:
             self.dbus.sync_property_changes(self.properties_interface, self.update)
 
     @dbus_connected

--- a/supervisor/utils/dbus.py
+++ b/supervisor/utils/dbus.py
@@ -147,8 +147,8 @@ class DBus:
 
     async def get_properties(self, interface: str) -> dict[str, Any]:
         """Read all properties from interface."""
-        return await DBus.call_dbus(
-            self._proxies[DBUS_INTERFACE_PROPERTIES], "call_get_all", interface
+        return await DBusCallWrapper(self, DBUS_INTERFACE_PROPERTIES).call_get_all(
+            interface
         )
 
     def sync_property_changes(

--- a/tests/fixtures/test_no_properties_interface.xml
+++ b/tests/fixtures/test_no_properties_interface.xml
@@ -1,0 +1,21 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+                      "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg type="s" name="xml_data" direction="out"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Peer">
+    <method name="Ping"/>
+    <method name="GetMachineId">
+      <arg type="s" name="machine_uuid" direction="out"/>
+    </method>
+  </interface>
+  <interface name="test.no.properties.interface">
+    <method name="Hello">
+      <arg type="s" name="hello" direction="out"/>
+    </method>
+    <property type="s" name="World" access="read"/>
+  </interface>
+</node>

--- a/tests/utils/test_dbus.py
+++ b/tests/utils/test_dbus.py
@@ -1,0 +1,16 @@
+"""Test dbus utility."""
+from dbus_fast.aio.message_bus import MessageBus
+import pytest
+
+from supervisor.dbus.const import DBUS_OBJECT_BASE
+from supervisor.exceptions import DBusInterfaceMethodError
+from supervisor.utils.dbus import DBus
+
+
+async def test_missing_properties_interface(dbus_bus: MessageBus, dbus: list[str]):
+    """Test introspection missing properties interface."""
+    service = await DBus.connect(
+        dbus_bus, "test.no.properties.interface", DBUS_OBJECT_BASE
+    )
+    with pytest.raises(DBusInterfaceMethodError):
+        await service.get_properties("test.no.properties.interface")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

It seems we get back some bad introspections that don't include `org.freedesktop.DBus.Properties` from devices within NetworkManager. After the latest DBus changes this causes a `KeyError` rather then a `DBusInterfaceMethod` error.

Based on this it appears this is expected, we just need to return to raising the correct type of exception:
https://github.com/home-assistant/supervisor/blob/ff462ae9765157c8d74db724b26baa6b7f08744c/supervisor/dbus/network/__init__.py#L182-L187

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
