### PR TITLE
Don't disconnect in executor

### DIFF
--- a/supervisor/dbus/agent/__init__.py
+++ b/supervisor/dbus/agent/__init__.py
@@ -106,10 +106,13 @@ class OSAgent(DBusInterfaceProxy):
         if not changed and self.datadisk.is_connected:
             await self.datadisk.update()
 
-    def disconnect(self) -> None:
-        """Disconnect from D-Bus."""
-        self.cgroup.disconnect()
-        self.apparmor.disconnect()
-        self.system.disconnect()
-        self.datadisk.disconnect()
-        super().disconnect()
+    def shutdown(self) -> None:
+        """Shutdown the object and disconnect from D-Bus.
+
+        This method is irreversible.
+        """
+        self.cgroup.shutdown()
+        self.apparmor.shutdown()
+        self.system.shutdown()
+        self.datadisk.shutdown()
+        super().shutdown()

--- a/supervisor/dbus/interface.py
+++ b/supervisor/dbus/interface.py
@@ -29,11 +29,17 @@ class DBusInterface(ABC):
     name: str | None = None
     bus_name: str | None = None
     object_path: str | None = None
+    _shutdown: bool = False
 
     @property
     def is_connected(self) -> bool:
         """Return True, if they is connected to D-Bus."""
         return self.dbus is not None
+
+    @property
+    def is_shutdown(self) -> bool:
+        """Return True, if the object has been shutdown."""
+        return self._shutdown
 
     async def connect(self, bus: MessageBus) -> None:
         """Connect to D-Bus."""
@@ -44,6 +50,14 @@ class DBusInterface(ABC):
         if self.is_connected:
             self.dbus.disconnect()
             self.dbus = None
+
+    def shutdown(self) -> None:
+        """Shutdown the object and disconnect from D-Bus.
+
+        This method is irreversible.
+        """
+        self._shutdown = True
+        self.disconnect()
 
 
 class DBusInterfaceProxy(DBusInterface):

--- a/supervisor/dbus/manager.py
+++ b/supervisor/dbus/manager.py
@@ -135,7 +135,7 @@ class DBusManager(CoreSysAttributes):
             return
 
         for dbus in self.all:
-            dbus.disconnect()
+            dbus.shutdown()
 
         self.bus.disconnect()
         _LOGGER.info("Closed conection to system D-Bus.")

--- a/supervisor/dbus/network/connection.py
+++ b/supervisor/dbus/network/connection.py
@@ -1,6 +1,5 @@
 """Connection object for Network Manager."""
 
-import asyncio
 from typing import Any
 
 from supervisor.dbus.network.setting import NetworkSetting
@@ -82,7 +81,7 @@ class NetworkConnection(DBusInterfaceProxy):
     def settings(self, settings: NetworkSetting | None) -> None:
         """Set settings."""
         if self._settings and self._settings is not settings:
-            asyncio.get_event_loop().run_in_executor(None, self._settings.disconnect)
+            self._settings.disconnect()
 
         self._settings = settings
 
@@ -95,7 +94,7 @@ class NetworkConnection(DBusInterfaceProxy):
     def ipv4(self, ipv4: IpConfiguration | None) -> None:
         """Set ipv4 configuration."""
         if self._ipv4 and self._ipv4 is not ipv4:
-            asyncio.get_event_loop().run_in_executor(None, self._ipv4.disconnect)
+            self._ipv4.disconnect()
 
         self._ipv4 = ipv4
 
@@ -108,7 +107,7 @@ class NetworkConnection(DBusInterfaceProxy):
     def ipv6(self, ipv6: IpConfiguration | None) -> None:
         """Set ipv6 configuration."""
         if self._ipv6 and self._ipv6 is not ipv6:
-            asyncio.get_event_loop().run_in_executor(None, self._ipv6.disconnect)
+            self._ipv6.disconnect()
 
         self._ipv6 = ipv6
 

--- a/supervisor/dbus/network/connection.py
+++ b/supervisor/dbus/network/connection.py
@@ -81,7 +81,7 @@ class NetworkConnection(DBusInterfaceProxy):
     def settings(self, settings: NetworkSetting | None) -> None:
         """Set settings."""
         if self._settings and self._settings is not settings:
-            self._settings.disconnect()
+            self._settings.shutdown()
 
         self._settings = settings
 
@@ -94,7 +94,7 @@ class NetworkConnection(DBusInterfaceProxy):
     def ipv4(self, ipv4: IpConfiguration | None) -> None:
         """Set ipv4 configuration."""
         if self._ipv4 and self._ipv4 is not ipv4:
-            self._ipv4.disconnect()
+            self._ipv4.shutdown()
 
         self._ipv4 = ipv4
 
@@ -107,7 +107,7 @@ class NetworkConnection(DBusInterfaceProxy):
     def ipv6(self, ipv6: IpConfiguration | None) -> None:
         """Set ipv6 configuration."""
         if self._ipv6 and self._ipv6 is not ipv6:
-            self._ipv6.disconnect()
+            self._ipv6.shutdown()
 
         self._ipv6 = ipv6
 
@@ -165,12 +165,15 @@ class NetworkConnection(DBusInterfaceProxy):
             else:
                 self.settings = None
 
-    def disconnect(self) -> None:
-        """Disconnect from D-Bus."""
+    def shutdown(self) -> None:
+        """Shutdown the object and disconnect from D-Bus.
+
+        This method is irreversible.
+        """
         if self.ipv4:
-            self.ipv4.disconnect()
+            self.ipv4.shutdown()
         if self.ipv6:
-            self.ipv6.disconnect()
+            self.ipv6.shutdown()
         if self.settings:
-            self.settings.disconnect()
-        super().disconnect()
+            self.settings.shutdown()
+        super().shutdown()

--- a/supervisor/dbus/network/interface.py
+++ b/supervisor/dbus/network/interface.py
@@ -76,7 +76,7 @@ class NetworkInterface(DBusInterfaceProxy):
     def connection(self, connection: NetworkConnection | None) -> None:
         """Set connection for interface."""
         if self._connection and self._connection is not connection:
-            self._connection.disconnect()
+            self._connection.shutdown()
 
         self._connection = connection
 
@@ -94,7 +94,7 @@ class NetworkInterface(DBusInterfaceProxy):
     def wireless(self, wireless: NetworkWireless | None) -> None:
         """Set wireless for interface."""
         if self._wireless and self._wireless is not wireless:
-            self._wireless.disconnect()
+            self._wireless.shutdown()
 
         self._wireless = wireless
 
@@ -138,10 +138,13 @@ class NetworkInterface(DBusInterfaceProxy):
                 self.wireless = NetworkWireless(self.object_path)
                 await self.wireless.connect(self.dbus.bus)
 
-    def disconnect(self) -> None:
-        """Disconnect from D-Bus."""
+    def shutdown(self) -> None:
+        """Shutdown the object and disconnect from D-Bus.
+
+        This method is irreversible.
+        """
         if self.connection:
-            self.connection.disconnect()
+            self.connection.shutdown()
         if self.wireless:
-            self.wireless.disconnect()
-        super().disconnect()
+            self.wireless.shutdown()
+        super().shutdown()

--- a/supervisor/dbus/network/interface.py
+++ b/supervisor/dbus/network/interface.py
@@ -1,6 +1,5 @@
 """NetworkInterface object for Network Manager."""
 
-import asyncio
 from typing import Any
 
 from dbus_fast.aio.message_bus import MessageBus
@@ -77,7 +76,7 @@ class NetworkInterface(DBusInterfaceProxy):
     def connection(self, connection: NetworkConnection | None) -> None:
         """Set connection for interface."""
         if self._connection and self._connection is not connection:
-            asyncio.get_event_loop().run_in_executor(None, self._connection.disconnect)
+            self._connection.disconnect()
 
         self._connection = connection
 
@@ -95,7 +94,7 @@ class NetworkInterface(DBusInterfaceProxy):
     def wireless(self, wireless: NetworkWireless | None) -> None:
         """Set wireless for interface."""
         if self._wireless and self._wireless is not wireless:
-            asyncio.get_event_loop().run_in_executor(None, self._wireless.disconnect)
+            self._wireless.disconnect()
 
         self._wireless = wireless
 

--- a/supervisor/dbus/network/setting/__init__.py
+++ b/supervisor/dbus/network/setting/__init__.py
@@ -167,13 +167,6 @@ class NetworkSetting(DBusInterface):
 
         self.dbus.Settings.Connection.on_updated(self.reload)
 
-    def disconnect(self) -> None:
-        """Disconnect from D-Bus."""
-        if self.is_connected:
-            self.dbus.Settings.Connection.off_updated(self.reload)
-
-        super().disconnect()
-
     @dbus_connected
     async def reload(self):
         """Get current settings for connection."""

--- a/supervisor/dbus/network/wireless.py
+++ b/supervisor/dbus/network/wireless.py
@@ -41,7 +41,7 @@ class NetworkWireless(DBusInterfaceProxy):
     def active(self, active: NetworkWirelessAP | None) -> None:
         """Set active wireless AP."""
         if self._active and self._active is not active:
-            asyncio.get_event_loop().run_in_executor(None, self._active.disconnect)
+            self._active.disconnect()
 
         self._active = active
 

--- a/supervisor/dbus/network/wireless.py
+++ b/supervisor/dbus/network/wireless.py
@@ -41,7 +41,7 @@ class NetworkWireless(DBusInterfaceProxy):
     def active(self, active: NetworkWirelessAP | None) -> None:
         """Set active wireless AP."""
         if self._active and self._active is not active:
-            self._active.disconnect()
+            self._active.shutdown()
 
         self._active = active
 

--- a/supervisor/dbus/utils.py
+++ b/supervisor/dbus/utils.py
@@ -9,7 +9,7 @@ def dbus_connected(method):
     def wrap_dbus(api, *args, **kwargs):
         """Check if D-Bus is connected before call a method."""
         if api.is_shutdown:
-            return
+            return None
         if api.dbus is None:
             raise DBusNotConnectedError()
         return method(api, *args, **kwargs)

--- a/supervisor/dbus/utils.py
+++ b/supervisor/dbus/utils.py
@@ -8,6 +8,8 @@ def dbus_connected(method):
 
     def wrap_dbus(api, *args, **kwargs):
         """Check if D-Bus is connected before call a method."""
+        if api.is_shutdown:
+            return
         if api.dbus is None:
             raise DBusNotConnectedError()
         return method(api, *args, **kwargs)

--- a/supervisor/dbus/utils.py
+++ b/supervisor/dbus/utils.py
@@ -3,13 +3,17 @@
 from ..exceptions import DBusNotConnectedError
 
 
+async def noop():
+    """Return a noop coroutine."""
+
+
 def dbus_connected(method):
     """Wrap check if D-Bus is connected."""
 
     def wrap_dbus(api, *args, **kwargs):
         """Check if D-Bus is connected before call a method."""
         if api.is_shutdown:
-            return None
+            return noop()
         if api.dbus is None:
             raise DBusNotConnectedError()
         return method(api, *args, **kwargs)

--- a/supervisor/utils/dbus.py
+++ b/supervisor/utils/dbus.py
@@ -193,9 +193,12 @@ class DBus:
         for intr, signals in self._signal_monitors.items():
             for name, callbacks in signals.items():
                 for callback in callbacks:
-                    getattr(self._proxies[intr], f"off_{name}")(
-                        callback, unpack_variants=True
-                    )
+                    try:
+                        getattr(self._proxies[intr], f"off_{name}")(
+                            callback, unpack_variants=True
+                        )
+                    except Exception:  # pylint: disable=broad-except
+                        _LOGGER.exception("Can't remove signal listener")
 
         self._signal_monitors = {}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Not threadsafe to disconnect in executor. Latest version of dbus-fast exposed the race condition this can cause since it makes a call to dbus to remove the match rule.

After reviewing Dbus-fast code around unattaching signal listeners I am pretty sure it doesn't raise any errors. To be safe though, ensuring we don't raise any exceptions while unattaching signal listeners during disconnect. As all the spots we call disconnect from don't want to see errors from it, we just want them logged if they occur.

After further review with @bdraco , the other issue occurring is callbacks for signals can be pending at the time we disconnect dbus objects. This raises `DBusNotConnectedErrors` when the callbacks try to run. To fix this we're separating `shutdown` and `disconnect`.

Shutdown is an irreversible operation that says "we're done with this dbus object". The `dbus_connected` annotation will tnot raise for a shutdown object as it is expected to be disconnected, it simply does nothing. Disconnect is now primarily called as part of shutdown with one exception:
https://github.com/home-assistant/supervisor/blob/48e666e1fc53ae13b325b7575abec67e901fb5eb/supervisor/dbus/network/__init__.py#L136-L142

Here we should return these objects to their unconnected state as if they were never connected since we found an invalid version. This will likely cause `DBusNotConnectedErrors` to raise but we need those for the API in this case and its an unsupported system anyway.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
