### PR TITLE
Manual stop true after a reboot

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -114,7 +114,7 @@ class Addon(AddonModel):
         self.instance: DockerAddon = DockerAddon(coresys, self)
         self._state: AddonState = AddonState.UNKNOWN
         self._manual_stop: bool = (
-            self.sys_hardware.helper.last_boot == self.sys_config.last_boot
+            self.sys_hardware.helper.last_boot != self.sys_config.last_boot
         )
         self._listeners: list[EventListener] = []
 

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -223,7 +223,7 @@ async def test_listener_attached_on_install(coresys: CoreSys, repository):
 
 
 @pytest.mark.parametrize(
-    "boot_timedelta,restart_count", [(timedelta(), 0), (timedelta(days=1), 1)]
+    "boot_timedelta,restart_count", [(timedelta(), 1), (timedelta(days=1), 0)]
 )
 async def test_watchdog_during_attach(
     coresys: CoreSys,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Initialize of manual stop needs to be inverted. It should be the opposite of the logic from here:
https://github.com/home-assistant/supervisor/blob/48e666e1fc53ae13b325b7575abec67e901fb5eb/supervisor/core.py#L206-L208

Because supervisor restart is not considered a manual stop of an addon, host reboot is.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
