### PR TITLE
Ignore veth changes

### DIFF
--- a/supervisor/dbus/network/__init__.py
+++ b/supervisor/dbus/network/__init__.py
@@ -10,7 +10,6 @@ from ...exceptions import (
     DBusError,
     DBusFatalError,
     DBusInterfaceError,
-    DBusInterfaceMethodError,
     HostNotSupportedError,
 )
 from ..const import (
@@ -178,14 +177,14 @@ class NetworkManager(DBusInterfaceProxy):
                 # Connect to interface
                 try:
                     await interface.connect(self.dbus.bus)
-                except (DBusFatalError, DBusInterfaceMethodError) as err:
+                except (DBusFatalError, DBusInterfaceError) as err:
                     # Docker creates and deletes interfaces quite often, sometimes
                     # this causes a race condition: A device disappears while we
                     # try to query it. Ignore those cases.
-                    _LOGGER.warning("Can't process %s: %s", device, err)
+                    _LOGGER.debug("Can't process %s: %s", device, err)
                     continue
                 except Exception as err:  # pylint: disable=broad-except
-                    _LOGGER.exception("Error while processing interface: %s", err)
+                    _LOGGER.exception("Error while processing %s: %s", device, err)
                     sentry_sdk.capture_exception(err)
                     continue
 

--- a/supervisor/dbus/network/setting/generate.py
+++ b/supervisor/dbus/network/setting/generate.py
@@ -5,7 +5,7 @@ import socket
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-from dbus_fast.signature import Variant
+from dbus_fast import Variant
 
 from . import (
     ATTR_ASSIGNED_MAC,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,7 +253,6 @@ async def network_manager(dbus, dbus_bus: MessageBus) -> NetworkManager:
 
     # Init
     await nm_obj.connect(dbus_bus)
-    await nm_obj.update()
 
     yield nm_obj
 

--- a/tests/dbus/test_interface.py
+++ b/tests/dbus/test_interface.py
@@ -7,7 +7,9 @@ from unittest.mock import MagicMock
 from dbus_fast.aio.message_bus import MessageBus
 import pytest
 
+from supervisor.dbus.const import DBUS_OBJECT_BASE
 from supervisor.dbus.interface import DBusInterfaceProxy
+from supervisor.exceptions import DBusInterfaceError
 
 from tests.common import fire_property_change_signal, fire_watched_signal
 
@@ -106,3 +108,15 @@ async def test_dbus_proxy_shutdown_pending_task(proxy: DBusInterfaceProxyMock):
     proxy.obj.shutdown()
     await asyncio.sleep(0)
     assert device == "/test/obj/1"
+
+
+async def test_proxy_missing_properties_interface(dbus_bus: MessageBus):
+    """Test proxy instance disconnects and errors when missing properties interface."""
+    proxy = DBusInterfaceProxy()
+    proxy.bus_name = "test.no.properties.interface"
+    proxy.object_path = DBUS_OBJECT_BASE
+    proxy.properties_interface = "test.no.properties.interface"
+
+    with pytest.raises(DBusInterfaceError):
+        await proxy.connect(dbus_bus)
+        assert proxy.is_connected is False

--- a/tests/utils/test_dbus.py
+++ b/tests/utils/test_dbus.py
@@ -3,7 +3,7 @@ from dbus_fast.aio.message_bus import MessageBus
 import pytest
 
 from supervisor.dbus.const import DBUS_OBJECT_BASE
-from supervisor.exceptions import DBusInterfaceMethodError
+from supervisor.exceptions import DBusInterfaceError
 from supervisor.utils.dbus import DBus
 
 
@@ -12,5 +12,5 @@ async def test_missing_properties_interface(dbus_bus: MessageBus, dbus: list[str
     service = await DBus.connect(
         dbus_bus, "test.no.properties.interface", DBUS_OBJECT_BASE
     )
-    with pytest.raises(DBusInterfaceMethodError):
+    with pytest.raises(DBusInterfaceError):
         await service.get_properties("test.no.properties.interface")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Veth interfaces are recreated a lot, particular when docker is having problems. This can create big problems now that we listen for property change signals. Since we must make a dbus call to find out an interface is a veth (which can flood the network) and they often just fail since the veth already vanished (which floods the log with noise). That results in issues like #3919

Changing a few things to address this:
1. If the introspection is missing the `org.freedesktop.DBus.Properties` interface for a dbus object we're expecting to be able to get properties for, raise `DBusInterfaceError` and disconnect. We found something unusable, the dbus object is probably gone.
2. If network manager finds an unusable device log that at debug level rather then warning. It could be useful info for debugging at some point but this does not warrant the attention of most users.
3. If a property change signal includes changes to devices but our known managed devices are still in there, don't re-process the devices. We'll most likely just find a bunch of unmanaged devices changed and supervisor doesn't care about that. In rare cases where someone activated a new managed device outside of supervisor there's still a `host.update` scheduled task so it'll be picked up eventually. Just may take an hour or two.


## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #3919 
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
