### PR TITLE
Fix addon image changed on update

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -468,6 +468,11 @@ class Addon(AddonModel):
         return ATTR_IMAGE not in self.data
 
     @property
+    def latest_need_build(self) -> bool:
+        """Return True if the latest version of the addon needs a local build."""
+        return ATTR_IMAGE not in self.data_store
+
+    @property
     def path_data(self) -> Path:
         """Return add-on data path inside Supervisor."""
         return Path(self.sys_config.path_addons_data, self.slug)

--- a/tests/addons/test_manager.py
+++ b/tests/addons/test_manager.py
@@ -1,0 +1,67 @@
+"""Test addon manager."""
+
+from unittest.mock import PropertyMock, patch
+
+from awesomeversion import AwesomeVersion
+import pytest
+
+from supervisor.addons.addon import Addon
+from supervisor.arch import CpuArch
+from supervisor.coresys import CoreSys
+from supervisor.docker.addon import DockerAddon
+from supervisor.docker.interface import DockerInterface
+
+from tests.common import load_json_fixture
+from tests.const import TEST_ADDON_SLUG
+
+
+@pytest.fixture(autouse=True)
+async def fixture_mock_arch_disk() -> None:
+    """Mock supported arch and disk space."""
+    with patch(
+        "shutil.disk_usage", return_value=(42, 42, 2 * (1024.0**3))
+    ), patch.object(CpuArch, "supported", new=PropertyMock(return_value=["amd64"])):
+        yield
+
+
+async def test_image_added_removed_on_update(
+    coresys: CoreSys, install_addon_ssh: Addon
+):
+    """Test image added or removed from addon config on update."""
+    assert install_addon_ssh.need_update is False
+    with patch(
+        "supervisor.store.data.read_json_or_yaml_file",
+        return_value=load_json_fixture("addon-config-add-image.json"),
+    ):
+        await coresys.store.data.update()
+
+    assert install_addon_ssh.need_update is True
+    assert install_addon_ssh.image == "local/amd64-addon-ssh"
+    assert coresys.addons.store.get(TEST_ADDON_SLUG).image == "test/amd64-my-ssh-addon"
+
+    with patch.object(DockerInterface, "_install") as install, patch.object(
+        DockerAddon, "_build"
+    ) as build:
+        await install_addon_ssh.update()
+        build.assert_not_called()
+        install.assert_called_once_with(
+            AwesomeVersion("10.0.0"), "test/amd64-my-ssh-addon", False, None
+        )
+
+    assert install_addon_ssh.need_update is False
+    with patch(
+        "supervisor.store.data.read_json_or_yaml_file",
+        return_value=load_json_fixture("addon-config-remove-image.json"),
+    ):
+        await coresys.store.data.update()
+
+    assert install_addon_ssh.need_update is True
+    assert install_addon_ssh.image == "test/amd64-my-ssh-addon"
+    assert coresys.addons.store.get(TEST_ADDON_SLUG).image == "local/amd64-addon-ssh"
+
+    with patch.object(DockerInterface, "_install") as install, patch.object(
+        DockerAddon, "_build"
+    ) as build:
+        await install_addon_ssh.update()
+        build.assert_called_once_with(AwesomeVersion("11.0.0"))
+        install.assert_not_called()

--- a/tests/fixtures/addon-config-add-image.json
+++ b/tests/fixtures/addon-config-add-image.json
@@ -1,0 +1,46 @@
+{
+  "name": "Terminal & SSH",
+  "version": "10.0.0",
+  "slug": "ssh",
+  "description": "Allow logging in remotely to Home Assistant using SSH",
+  "url": "https://github.com/home-assistant/hassio-addons/tree/master/ssh",
+  "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
+  "init": false,
+  "advanced": true,
+  "host_dbus": true,
+  "ingress": true,
+  "panel_icon": "mdi:console",
+  "panel_title": "Terminal",
+  "hassio_api": true,
+  "hassio_role": "manager",
+  "audio": true,
+  "uart": true,
+  "ports": {
+    "22/tcp": null
+  },
+  "map": [
+    "config:rw",
+    "ssl:rw",
+    "addons:rw",
+    "share:rw",
+    "backup:rw",
+    "media:rw"
+  ],
+  "options": {
+    "authorized_keys": [],
+    "apks": [],
+    "password": "",
+    "server": {
+      "tcp_forwarding": false
+    }
+  },
+  "schema": {
+    "authorized_keys": ["str"],
+    "password": "password",
+    "server": {
+      "tcp_forwarding": "bool"
+    },
+    "apks": ["str"]
+  },
+  "image": "test/{arch}-my-ssh-addon"
+}

--- a/tests/fixtures/addon-config-remove-image.json
+++ b/tests/fixtures/addon-config-remove-image.json
@@ -1,0 +1,45 @@
+{
+  "name": "Terminal & SSH",
+  "version": "11.0.0",
+  "slug": "ssh",
+  "description": "Allow logging in remotely to Home Assistant using SSH",
+  "url": "https://github.com/home-assistant/hassio-addons/tree/master/ssh",
+  "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
+  "init": false,
+  "advanced": true,
+  "host_dbus": true,
+  "ingress": true,
+  "panel_icon": "mdi:console",
+  "panel_title": "Terminal",
+  "hassio_api": true,
+  "hassio_role": "manager",
+  "audio": true,
+  "uart": true,
+  "ports": {
+    "22/tcp": null
+  },
+  "map": [
+    "config:rw",
+    "ssl:rw",
+    "addons:rw",
+    "share:rw",
+    "backup:rw",
+    "media:rw"
+  ],
+  "options": {
+    "authorized_keys": [],
+    "apks": [],
+    "password": "",
+    "server": {
+      "tcp_forwarding": false
+    }
+  },
+  "schema": {
+    "authorized_keys": ["str"],
+    "password": "password",
+    "server": {
+      "tcp_forwarding": "bool"
+    },
+    "apks": ["str"]
+  }
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

When an addon is updated `need_build` is determined by looking at the current config of the addon. Which means if the `image` was added or removed as part of the update it doesn't work.

If the image was added in the update you get #3414 (we build an image and then fail on run). If the image was removed in the update then the image pull most likely fails since the author probably didn't publish it with the new version (no issue for this currently but it is a bug).

Fixes it by looking at the store config during update to determine if we need to build an image or not.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #3414
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
