### PR TITLE
Call dbus with string value not enum

### DIFF
--- a/supervisor/dbus/rauc.py
+++ b/supervisor/dbus/rauc.py
@@ -95,7 +95,7 @@ class Rauc(DBusInterfaceProxy):
     @dbus_connected
     async def mark(self, state: RaucState, slot_identifier: str) -> tuple[str, str]:
         """Get slot status."""
-        return await self.dbus.Installer.call_mark(state, slot_identifier)
+        return await self.dbus.Installer.call_mark(state.value, slot_identifier)
 
     @dbus_connected
     async def update(self, changed: dict[str, Any] | None = None) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

After dbus-fast update to 1.73.0:
```
Nov 14 18:54:13 homeassistant hassio_supervisor[470]: 22-11-14 12:54:13 INFO (MainThread) [__main__] Running Supervisor
Nov 14 18:54:13 homeassistant hassio_supervisor[470]: TypeError: Expected unicode, got RaucState
Nov 14 18:54:13 homeassistant hassio_supervisor[470]: Exception ignored in: 'dbus_fast._private.marshaller.Marshaller._write_single'
Nov 14 18:54:13 homeassistant hassio_supervisor[470]: Traceback (most recent call last):
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:   File "/usr/local/lib/python3.10/site-packages/dbus_fast/aio/message_bus.py", line 103, in buffer_message
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:     msg._marshall(self.negotiate_unix_fd),
Nov 14 18:54:13 homeassistant hassio_supervisor[470]: TypeError: Expected unicode, got RaucState
Nov 14 18:54:13 homeassistant dbus-broker[203]: Peer :1.563 is being disconnected as it sent a message with an invalid body.
Nov 14 18:54:13 homeassistant hassio_supervisor[470]: 22-11-14 12:54:13 ERROR (MainThread) [supervisor.jobs] Unhandled exception: 
Nov 14 18:54:13 homeassistant hassio_supervisor[470]: Traceback (most recent call last):
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:   File "/usr/src/supervisor/supervisor/jobs/decorator.py", line 154, in wrapper
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:     return await self._method(*args, **kwargs)
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:   File "/usr/src/supervisor/supervisor/os/manager.py", line 232, in mark_healthy
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:     response = await self.sys_dbus.rauc.mark(RaucState.GOOD, "booted")
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:   File "/usr/src/supervisor/supervisor/dbus/rauc.py", line 98, in mark
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:     return await self.dbus.Installer.call_mark(state, slot_identifier)
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:   File "/usr/src/supervisor/supervisor/utils/dbus.py", line 100, in call_dbus
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:     return await getattr(proxy_interface, method)(
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:   File "/usr/local/lib/python3.10/site-packages/dbus_fast/aio/proxy_object.py", line 90, in method_fn
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:     msg = await self.bus.call(
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:   File "/usr/local/lib/python3.10/site-packages/dbus_fast/aio/message_bus.py", line 370, in call
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:     await future
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:   File "src/dbus_fast/aio/message_reader.py", line 24, in dbus_fast.aio.message_reader.build_message_reader._message_reader
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:   File "src/dbus_fast/_private/unmarshaller.py", line 641, in dbus_fast._private.unmarshaller.Unmarshaller._unmarshall
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:   File "src/dbus_fast/_private/unmarshaller.py", line 524, in dbus_fast._private.unmarshaller.Unmarshaller._read_header
Nov 14 18:54:13 homeassistant hassio_supervisor[470]:   File "src/dbus_fast/_private/unmarshaller.py", line 276, in dbus_fast._private.unmarshaller.Unmarshaller._read_to_pos
Nov 14 18:54:13 homeassistant hassio_supervisor[470]: EOFError
```
Fixed by https://github.com/Bluetooth-Devices/dbus-fast/pull/163 but should also be fixed in supervisor as we are passing the wrong type of value. Combed the dbus code and could not find any other instances of this so I think it was just this one.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
