### PR TITLE
Do not let aiohttp add a Content-Type header

### DIFF
--- a/supervisor/api/ingress.py
+++ b/supervisor/api/ingress.py
@@ -182,6 +182,7 @@ class APIIngress(CoreSysAttributes):
             allow_redirects=False,
             data=data,
             timeout=ClientTimeout(total=None),
+            skip_auto_headers={"Content-Type"},
         ) as result:
             headers = _response_header(result)
 

--- a/supervisor/api/ingress.py
+++ b/supervisor/api/ingress.py
@@ -182,7 +182,7 @@ class APIIngress(CoreSysAttributes):
             allow_redirects=False,
             data=data,
             timeout=ClientTimeout(total=None),
-            skip_auto_headers={"Content-Type"},
+            skip_auto_headers={hdrs.CONTENT_TYPE},
         ) as result:
             headers = _response_header(result)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
aiohttp adds a Content-Type header by default, as well as other headers.

This may usually be convenient, but it breaks APIs that explicitly ask for no content type header, for instance on post requests with an empty body.

Since ingress is proxying the requests from the browser to the add-on, it should avoid modifying them.

I only skip this header auto generation because it actually breaks the Adguard add-on.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- https://github.com/hassio-addons/addon-adguard-home/issues/359
- (possibly) https://github.com/home-assistant/core/issues/80639

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
