### PR TITLE
Fix AppArmor name-related exceptions

### DIFF
--- a/supervisor/utils/apparmor.py
+++ b/supervisor/utils/apparmor.py
@@ -25,9 +25,15 @@ def get_profile_name(profile_file):
             f"Can't read AppArmor profile: {err}", _LOGGER.error
         ) from err
 
+    if len(profiles) == 0:
+        raise AppArmorInvalidError(
+            f"Missing AppArmor profile inside file: {profile_file.name}", _LOGGER.error
+        )
+
     if len(profiles) != 1:
         raise AppArmorInvalidError(
-            f"To many profiles inside file: {profiles}", _LOGGER.error
+            f"Too many AppArmor profiles inside file: {profile_file.name}",
+            _LOGGER.error,
         )
 
     return profiles.pop()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

- 'Too many' is misleading if there are no profiles. (Which can happen if a person actively developing an add-on has forgotten to explicitly disable AppArmor using `apparmor: false`.)
- profiles just returns set() -- using profile_file should be more correct.

Sorry if this change comes across as "rushed" -- I've been trying to develop my own add-on and this issue resulted in an exhausting time sink.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: https://github.com/home-assistant/addons/issues/1850 (unrelated, but only place where the error was brought up)
- Link to documentation pull request: N/A
- Link to cli pull request: N/A

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally. (cannot be done easily by me right now, as I am actively working with another supervisor environment)
- [x] Local tests pass. **Your PR cannot be merged unless tests pass** (`tox run-parallel`, only two `supervisor.exceptions.CodeNotaryError`'s and a `supervisor.exceptions.UpdaterError` caused by them appear)
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant