### PR TITLE
Clarify message when addon unavailable

### DIFF
--- a/supervisor/addons/__init__.py
+++ b/supervisor/addons/__init__.py
@@ -158,10 +158,7 @@ class AddonManager(CoreSysAttributes):
         if not store:
             raise AddonsError(f"Add-on {slug} does not exist", _LOGGER.error)
 
-        if not store.available:
-            raise AddonsNotSupportedError(
-                f"Add-on {slug} not supported on this platform", _LOGGER.error
-            )
+        store.validate_availability()
 
         self.data.install(store)
         addon = Addon(self.coresys, slug)
@@ -263,10 +260,7 @@ class AddonManager(CoreSysAttributes):
             raise AddonsError(f"No update available for add-on {slug}", _LOGGER.warning)
 
         # Check if available, Maybe something have changed
-        if not store.available:
-            raise AddonsNotSupportedError(
-                f"Add-on {slug} not supported on that platform", _LOGGER.error
-            )
+        store.validate_availability()
 
         if backup:
             await self.sys_backups.do_backup_partial(

--- a/tests/common.py
+++ b/tests/common.py
@@ -8,6 +8,7 @@ from dbus_fast.introspection import Method, Property, Signal
 
 from supervisor.dbus.interface import DBusInterface, DBusInterfaceProxy
 from supervisor.utils.dbus import DBUS_INTERFACE_PROPERTIES
+from supervisor.utils.yaml import read_yaml_file
 
 
 def get_dbus_name(intr_list: list[Method | Property | Signal], snake_case: str) -> str:
@@ -69,6 +70,12 @@ def load_json_fixture(filename: str) -> Any:
     """Load a json fixture."""
     path = Path(Path(__file__).parent.joinpath("fixtures"), filename)
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_yaml_fixture(filename: str) -> Any:
+    """Load a YAML fixture."""
+    path = Path(Path(__file__).parent.joinpath("fixtures"), filename)
+    return read_yaml_file(path)
 
 
 def load_fixture(filename: str) -> str:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

When an addon is unavailable for the current system, the message is always the same:
> Add-on {slug} not supported on this platform

This is ok if the reason is the addon doesn't support the architecture or machine type the user is running. It would be nice if it said which was the issue but there's nothing they can do about that.

However its not ok if the reason is it requires a newer version of Home Assistant. The message doesn't say that at all and the user can fix that by updating.

Changed the message to say why it is unavailable. Also test ensures a partial backup is not taken when the user cannot update to the next version of the addon because it is unavailable, per https://github.com/home-assistant/core/pull/84943

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
