### PR TITLE
Handle UnicodeDecodeError

### DIFF
--- a/supervisor/store/git.py
+++ b/supervisor/store/git.py
@@ -61,7 +61,8 @@ class GitRepo(CoreSysAttributes):
             except (
                 git.InvalidGitRepositoryError,
                 git.NoSuchPathError,
-                git.GitCommandError,
+                git.CommandError,
+                UnicodeDecodeError,
             ) as err:
                 _LOGGER.error("Can't load %s", self.path)
                 raise StoreGitError() from err
@@ -71,7 +72,7 @@ class GitRepo(CoreSysAttributes):
             try:
                 _LOGGER.debug("Integrity check add-on %s repository", self.path)
                 await self.sys_run_in_executor(self.repo.git.execute, ["git", "fsck"])
-            except git.GitCommandError as err:
+            except git.CommandError as err:
                 _LOGGER.error("Integrity check on %s failed: %s.", self.path, err)
                 raise StoreGitError() from err
 
@@ -104,7 +105,8 @@ class GitRepo(CoreSysAttributes):
             except (
                 git.InvalidGitRepositoryError,
                 git.NoSuchPathError,
-                git.GitCommandError,
+                git.CommandError,
+                UnicodeDecodeError,
             ) as err:
                 _LOGGER.error("Can't clone %s repository: %s.", self.url, err)
                 raise StoreGitCloneError() from err
@@ -159,9 +161,10 @@ class GitRepo(CoreSysAttributes):
             except (
                 git.InvalidGitRepositoryError,
                 git.NoSuchPathError,
-                git.GitCommandError,
+                git.CommandError,
                 ValueError,
                 AssertionError,
+                UnicodeDecodeError,
             ) as err:
                 _LOGGER.error("Can't update %s repo: %s.", self.url, err)
                 self.sys_resolution.create_issue(

--- a/tests/store/test_repository_git.py
+++ b/tests/store/test_repository_git.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
-from git import GitCommandError, GitError, InvalidGitRepositoryError, NoSuchPathError
+from git import GitCommandError, InvalidGitRepositoryError, NoSuchPathError
 import pytest
 
 from supervisor.coresys import CoreSys
@@ -44,10 +44,15 @@ async def test_git_clone(
 
 @pytest.mark.parametrize(
     "git_error",
-    [InvalidGitRepositoryError(), NoSuchPathError(), GitCommandError("clone")],
+    [
+        InvalidGitRepositoryError(),
+        NoSuchPathError(),
+        GitCommandError("clone"),
+        UnicodeDecodeError("decode", b"", 0, 0, ""),
+    ],
 )
 async def test_git_clone_error(
-    coresys: CoreSys, tmp_path: Path, clone_from: AsyncMock, git_error: GitError
+    coresys: CoreSys, tmp_path: Path, clone_from: AsyncMock, git_error: Exception
 ):
     """Test git clone error."""
     repo = GitRepo(coresys, tmp_path, REPO_URL)
@@ -77,12 +82,11 @@ async def test_git_load(coresys: CoreSys, tmp_path: Path):
         InvalidGitRepositoryError(),
         NoSuchPathError(),
         GitCommandError("init"),
+        UnicodeDecodeError("decode", b"", 0, 0, ""),
         [AsyncMock(), GitCommandError("fsck")],
     ],
 )
-async def test_git_load_error(
-    coresys: CoreSys, tmp_path: Path, git_errors: GitError | list[GitError | None]
-):
+async def test_git_load_error(coresys: CoreSys, tmp_path: Path, git_errors: Exception):
     """Test git load error."""
     repo = GitRepo(coresys, tmp_path, REPO_URL)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Catch and handle UnicodeDecodeError from git and code notary modules. So we don't bubble that up and break setup. Fixes the following from sentry:
- https://sentry.io/organizations/home-assistant-io/issues/2471308411/?project=5370612
- https://sentry.io/organizations/home-assistant-io/issues/3673140086/?project=5370612
- https://sentry.io/organizations/home-assistant-io/issues/3673142729/?project=5370612

Additionally noticed that sometimes a decode error when pumping stderr causes the git library to throw `CommandError` instead of `GitCommandError` (which we weren't catching). Since `GitCommandError` inherits from `CommandError` I made that except broader to handle this. Fixes this from sentry:
- https://sentry.io/organizations/home-assistant-io/issues/3723051227/?project=5370612


## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
