### PR TITLE
Add Support for NetworkManager managed bridge interfaces.

### DIFF
--- a/supervisor/dbus/const.py
+++ b/supervisor/dbus/const.py
@@ -213,6 +213,7 @@ class DeviceType(int, Enum):
     VLAN = 11
     TUN = 16
     VETH = 20
+    BRIDGE = 13
 
 
 class WirelessMethodType(int, Enum):

--- a/supervisor/dbus/network/__init__.py
+++ b/supervisor/dbus/network/__init__.py
@@ -207,6 +207,7 @@ class NetworkManager(DBusInterfaceProxy):
                     DeviceType.ETHERNET,
                     DeviceType.WIRELESS,
                     DeviceType.VLAN,
+                    DeviceType.BRIDGE,
                 ]
                 or not interface.managed
             ):

--- a/supervisor/host/const.py
+++ b/supervisor/host/const.py
@@ -20,6 +20,7 @@ class InterfaceType(str, Enum):
     ETHERNET = "ethernet"
     WIRELESS = "wireless"
     VLAN = "vlan"
+    BRIDGE = "bridge"
 
 
 class AuthMethod(str, Enum):

--- a/supervisor/host/network.py
+++ b/supervisor/host/network.py
@@ -454,6 +454,7 @@ class Interface:
             DeviceType.ETHERNET: InterfaceType.ETHERNET,
             DeviceType.WIRELESS: InterfaceType.WIRELESS,
             DeviceType.VLAN: InterfaceType.VLAN,
+            DeviceType.BRIDGE: InterfaceType.BRIDGE,
         }
         return mapping[device_type]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

https://github.com/home-assistant/operating-system/pull/2304 added support for managed bridge interfaces in Home Assistant Operating System. It allows for example the realization of a simple WiFi-ethernet bridge within a custom add-in.
This PR allows the supervisor to handle such bridge interfaces and is needed for other add-ins like the Samba add-in to see the bridge interfaces.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
