### PR TITLE
Improve addon slug validation

### DIFF
--- a/supervisor/addons/const.py
+++ b/supervisor/addons/const.py
@@ -26,3 +26,5 @@ ADDON_UPDATE_CONDITIONS = [
     JobCondition.PLUGINS_UPDATED,
     JobCondition.SUPERVISOR_UPDATED,
 ]
+
+RE_SLUG = r"[-_.A-Za-z0-9]+"

--- a/supervisor/addons/validate.py
+++ b/supervisor/addons/validate.py
@@ -109,7 +109,7 @@ from ..validate import (
     uuid_match,
     version_tag,
 )
-from .const import ATTR_BACKUP, ATTR_CODENOTARY, AddonBackupMode
+from .const import ATTR_BACKUP, ATTR_CODENOTARY, RE_SLUG, AddonBackupMode
 from .options import RE_SCHEMA_ELEMENT
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -146,6 +146,8 @@ RE_MACHINE = re.compile(
     r"|tinker"
     r")$"
 )
+
+RE_SLUG_FIELD = re.compile(r"^" + RE_SLUG + r"$")
 
 
 def _warn_addon_config(config: dict[str, Any]):
@@ -252,7 +254,7 @@ _SCHEMA_ADDON_CONFIG = vol.Schema(
     {
         vol.Required(ATTR_NAME): str,
         vol.Required(ATTR_VERSION): version_tag,
-        vol.Required(ATTR_SLUG): str,
+        vol.Required(ATTR_SLUG): vol.Match(RE_SLUG_FIELD),
         vol.Required(ATTR_DESCRIPTON): str,
         vol.Required(ATTR_ARCH): [vol.In(ARCH_ALL)],
         vol.Optional(ATTR_MACHINE): vol.All([vol.Match(RE_MACHINE)], vol.Unique()),

--- a/supervisor/api/middleware/security.py
+++ b/supervisor/api/middleware/security.py
@@ -8,6 +8,7 @@ from aiohttp.web import Request, RequestHandler, Response, middleware
 from aiohttp.web_exceptions import HTTPBadRequest, HTTPForbidden, HTTPUnauthorized
 from awesomeversion import AwesomeVersion
 
+from ...addons.const import RE_SLUG
 from ...const import (
     REQUEST_FROM,
     ROLE_ADMIN,
@@ -27,7 +28,7 @@ _CORE_VERSION: Final = AwesomeVersion("2023.3.0")
 
 _CORE_FRONTEND_PATHS: Final = (
     r"|/app/.*\.(?:js|gz|json|map)"
-    r"|/(store/)?addons/[^/]+/(logo|icon)"
+    r"|/(store/)?addons/" + RE_SLUG + r"/(logo|icon)"
 )
 
 CORE_FRONTEND: Final = re.compile(
@@ -51,7 +52,7 @@ NO_SECURITY_CHECK: Final = re.compile(
     r"|/core/api/.*"
     r"|/core/websocket"
     r"|/supervisor/ping"
-    r"|/ingress/[^/]+/.*"
+    r"|/ingress/[-_A-Za-z0-9]+/.*"
     + _CORE_FRONTEND_PATHS
     + r")$"
 )
@@ -98,7 +99,7 @@ ADDONS_ROLE_ACCESS: dict[str, re.Pattern] = {
     ROLE_MANAGER: re.compile(
         r"^(?:"
         r"|/.+/info"
-        r"|/addons(?:/[^/]+/(?!security).+|/reload)?"
+        r"|/addons(?:/" + RE_SLUG + r"/(?!security).+|/reload)?"
         r"|/audio/.+"
         r"|/auth/cache"
         r"|/cli/.+"

--- a/tests/addons/test_config.py
+++ b/tests/addons/test_config.py
@@ -249,3 +249,38 @@ def test_watchdog_url():
     ):
         config["watchdog"] = test_options
         assert vd.SCHEMA_ADDON_CONFIG(config)
+
+
+def test_valid_slug():
+    """Test valid and invalid addon slugs."""
+    config = load_json_fixture("basic-addon-config.json")
+
+    # All examples pulled from https://analytics.home-assistant.io/addons.json
+    config["slug"] = "uptime-kuma"
+    assert vd.SCHEMA_ADDON_CONFIG(config)
+
+    config["slug"] = "hassio_google_drive_backup"
+    assert vd.SCHEMA_ADDON_CONFIG(config)
+
+    config["slug"] = "paradox_alarm_interface_3.x"
+    assert vd.SCHEMA_ADDON_CONFIG(config)
+
+    config["slug"] = "Lupusec2Mqtt"
+    assert vd.SCHEMA_ADDON_CONFIG(config)
+
+    # No whitespace
+    config["slug"] = "my addon"
+    with pytest.raises(vol.Invalid):
+        assert vd.SCHEMA_ADDON_CONFIG(config)
+
+    # No url control chars (or other non-word ascii characters)
+    config["slug"] = "a/b_&_c\\d_@ddon$:_test=#2?"
+    with pytest.raises(vol.Invalid):
+        assert vd.SCHEMA_ADDON_CONFIG(config)
+
+    # No unicode
+    config["slug"] = "complemento telefónico"
+    with pytest.raises(vol.Invalid):
+        assert vd.SCHEMA_ADDON_CONFIG(config)
+
+    #


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Addon slugs currently have no validation on what can and cannot be in the string. This is a problem because
1. it shouldn't be that open-ended
1. the slug is in URLs so it needs to be URL safe

I went to our [addons analytics](https://analytics.home-assistant.io/addons.json) and came up with a regex that restricts slugs to what will work where we need it to without breaking backwards compatibility for any of the known addons.

It's mostly what you would expect (`-_a-z0-9`). Although turns out some addons used upper case letters and periods. Those probably wouldn't be included if this regex had existed from the beginning. Since it didn't and they are url safe better to include them and keep backwards compatibility.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
