### PR TITLE
Format data disk in Supervisor instead of OS Agent

### DIFF
--- a/supervisor/dbus/agent/datadisk.py
+++ b/supervisor/dbus/agent/datadisk.py
@@ -33,3 +33,8 @@ class DataDisk(DBusInterfaceProxy):
     async def reload_device(self) -> None:
         """Reload device data."""
         await self.dbus.DataDisk.call_reload_device()
+
+    @dbus_connected
+    async def mark_data_move(self) -> None:
+        """Create marker to signal to do data disk migration next reboot."""
+        await self.dbus.DataDisk.call_mark_data_move()

--- a/supervisor/dbus/udisks2/__init__.py
+++ b/supervisor/dbus/udisks2/__init__.py
@@ -144,3 +144,14 @@ class UDisks2(DBusInterfaceProxy):
         }
         self._block_devices.update(resolved)
         return list(resolved.values())
+
+    def shutdown(self) -> None:
+        """Shutdown the object and disconnect from D-Bus.
+
+        This method is irreversible.
+        """
+        for block_device in self.block_devices:
+            block_device.shutdown()
+        for drive in self.drives:
+            drive.shutdown()
+        super().shutdown()

--- a/supervisor/dbus/udisks2/__init__.py
+++ b/supervisor/dbus/udisks2/__init__.py
@@ -139,6 +139,7 @@ class UDisks2(DBusInterfaceProxy):
         resolved = {
             device: self._block_devices[device]
             if device in self._block_devices
+            and self._block_devices[device].is_connected
             else await UDisks2Block.new(device, self.dbus.bus)
             for device in block_devices
         }

--- a/supervisor/dbus/udisks2/data.py
+++ b/supervisor/dbus/udisks2/data.py
@@ -82,7 +82,7 @@ class DeviceSpecification:
     def to_dict(self) -> dict[str, Variant]:
         """Return dict representation."""
         data = {
-            "path": Variant("s", str(self.path)) if self.path else None,
+            "path": Variant("s", self.path.as_posix()) if self.path else None,
             "label": _optional_variant("s", self.label),
             "uuid": _optional_variant("s", self.uuid),
         }

--- a/supervisor/dbus/udisks2/partition_table.py
+++ b/supervisor/dbus/udisks2/partition_table.py
@@ -48,14 +48,15 @@ class UDisks2PartitionTable(DBusInterfaceProxy):
         self,
         offset: int = 0,
         size: int = 0,
-        type_: PartitionTableType = PartitionTableType.UNKNOWN,
+        type_: str = "",
         name: str = "",
         options: CreatePartitionOptions | None = None,
     ) -> str:
         """Create a new partition and return object path of new block device.
 
-        'UNKNOWN' for type here means UDisks2 selects default based on partition table and OS.
-        Use with UDisks2Block.new to get block object. Or UDisks2.get_block_device after UDisks2.update.
+        Type should be a GUID from https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
+        or empty string and let UDisks2 choose a default based on partition table and OS.
+        Provide return value with UDisks2Block.new. Or UDisks2.get_block_device after UDisks2.update.
         """
         options = options.to_dict() if options else {}
         return await self.dbus.PartitionTable.call_create_partition(

--- a/supervisor/os/data_disk.py
+++ b/supervisor/os/data_disk.py
@@ -124,6 +124,7 @@ class DataDisk(CoreSysAttributes):
             size=0,
             device_path=self.sys_dbus.agent.datadisk.current_device,
             object_path="",
+            device_object_path="",
         )
 
     @property

--- a/supervisor/os/data_disk.py
+++ b/supervisor/os/data_disk.py
@@ -4,11 +4,13 @@ from contextlib import suppress
 from dataclasses import dataclass
 import logging
 from pathlib import Path
+from typing import Final
 
 from awesomeversion import AwesomeVersion
 
 from ..coresys import CoreSys, CoreSysAttributes
 from ..dbus.udisks2.block import UDisks2Block
+from ..dbus.udisks2.const import FormatType
 from ..dbus.udisks2.drive import UDisks2Drive
 from ..exceptions import (
     DBusError,
@@ -20,6 +22,11 @@ from ..exceptions import (
 )
 from ..jobs.const import JobCondition, JobExecutionLimit
 from ..jobs.decorator import Job
+from ..utils.sentry import capture_exception
+
+LINUX_DATA_PARTITION_GUID: Final = "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
+EXTERNAL_DATA_DISK_PARTITION_NAME: Final = "hassos-data-external"
+OS_AGENT_MARK_DATA_MOVE_VERSION: Final = AwesomeVersion("1.5.0")
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -35,6 +42,7 @@ class Disk:
     size: int
     device_path: Path
     object_path: str
+    device_object_path: str
 
     @staticmethod
     def from_udisks2_drive(
@@ -49,6 +57,7 @@ class Disk:
             size=drive.size,
             device_path=drive_block_device.device,
             object_path=drive.object_path,
+            device_object_path=drive_block_device.object_path,
         )
 
     @property
@@ -163,24 +172,37 @@ class DataDisk(CoreSysAttributes):
         # Force a dbus update first so all info is up to date
         await self.sys_dbus.udisks2.update()
 
-        try:
-            target_disk: Disk = next(
-                disk
-                for disk in self.available_disks
-                if disk.id == new_disk or disk.device_path.as_posix() == new_disk
-            )
-        except StopIteration:
+        target_disk: list[Disk] = [
+            disk
+            for disk in self.available_disks
+            if disk.id == new_disk or disk.device_path.as_posix() == new_disk
+        ]
+        if len(target_disk) != 1:
             raise HassOSDataDiskError(
                 f"'{new_disk!s}' not a valid data disk target!", _LOGGER.error
             ) from None
 
-        # Migrate data on Host
-        try:
-            await self.sys_dbus.agent.datadisk.change_device(target_disk.device_path)
-        except DBusError as err:
-            raise HassOSDataDiskError(
-                f"Can't move data partition to {new_disk!s}: {err!s}", _LOGGER.error
-            ) from err
+        # Older OS did not have mark data move API. Must let OS do disk format & migration
+        if self.sys_dbus.agent.version < OS_AGENT_MARK_DATA_MOVE_VERSION:
+            try:
+                await self.sys_dbus.agent.datadisk.change_device(
+                    target_disk[0].device_path
+                )
+            except DBusError as err:
+                raise HassOSDataDiskError(
+                    f"Can't move data partition to {new_disk!s}: {err!s}", _LOGGER.error
+                ) from err
+        else:
+            # Format disk then tell OS to migrate next reboot
+            await self._format_device_with_single_partition(target_disk[0])
+
+            try:
+                await self.sys_dbus.agent.datadisk.mark_data_move()
+            except DBusError as err:
+                raise HassOSDataDiskError(
+                    f"Unable to create data disk migration marker: {err!s}",
+                    _LOGGER.error,
+                ) from err
 
         # Restart Host for finish the process
         try:
@@ -190,3 +212,36 @@ class DataDisk(CoreSysAttributes):
                 f"Can't restart device to finish disk migration: {err!s}",
                 _LOGGER.warning,
             ) from err
+
+    async def _format_device_with_single_partition(self, new_disk: Disk) -> None:
+        """Format device with a single partition to use as data disk."""
+        block_device: UDisks2Block = self.sys_dbus.udisks2.get_block_device(
+            new_disk.device_object_path
+        )
+
+        try:
+            await block_device.format(FormatType.GPT)
+        except DBusError as err:
+            capture_exception(err)
+            raise HassOSDataDiskError(
+                f"Could not format {new_disk.id}: {err!s}", _LOGGER.error
+            ) from err
+
+        await block_device.check_type()
+        if not block_device.partition_table:
+            raise HassOSDataDiskError(
+                "Block device does not contain a partition table after format, cannot create data partition",
+                _LOGGER.error,
+            )
+
+        try:
+            partition = await block_device.partition_table.create_partition(
+                0, 0, LINUX_DATA_PARTITION_GUID, EXTERNAL_DATA_DISK_PARTITION_NAME
+            )
+        except DBusError as err:
+            capture_exception(err)
+            raise HassOSDataDiskError(
+                f"Could not create new data partition: {err!s}"
+            ) from err
+
+        _LOGGER.info("New partition D-Bus object: %s", partition)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -310,8 +310,6 @@ async def coresys(
     ):
         message_bus.return_value.connect = AsyncMock(return_value=dbus_session_bus)
         await coresys_obj._dbus.load()
-    # coresys_obj._dbus._bus = dbus_session_bus
-    # coresys_obj._dbus._network = network_manager
 
     # Mock docker
     coresys_obj._docker = docker
@@ -350,6 +348,7 @@ async def coresys(
     with patch("supervisor.store.git.GitRepo._remove"):
         yield coresys_obj
 
+    await coresys_obj.dbus.unload()
     await coresys_obj.websession.close()
 
 

--- a/tests/dbus/agent/test_datadisk.py
+++ b/tests/dbus/agent/test_datadisk.py
@@ -72,3 +72,19 @@ async def test_dbus_osagent_datadisk_reload_device(
 
     assert await os_agent.datadisk.reload_device() is None
     assert datadisk_service.ReloadDevice.calls == [tuple()]
+
+
+async def test_dbus_osagent_datadisk_mark_data_move(
+    datadisk_service: DataDiskService, dbus_session_bus: MessageBus
+):
+    """Create data disk migration marker for next reboot."""
+    datadisk_service.MarkDataMove.calls.clear()
+    os_agent = OSAgent()
+
+    with pytest.raises(DBusNotConnectedError):
+        await os_agent.datadisk.mark_data_move()
+
+    await os_agent.connect(dbus_session_bus)
+
+    assert await os_agent.datadisk.mark_data_move() is None
+    assert datadisk_service.MarkDataMove.calls == [tuple()]

--- a/tests/dbus/network/test_network_manager.py
+++ b/tests/dbus/network/test_network_manager.py
@@ -142,7 +142,7 @@ async def test_handling_bad_devices(
     caplog.clear()
     caplog.set_level(logging.INFO, "supervisor.dbus.network")
 
-    with patch.object(DBus, "_init_proxy", side_effect=DBusFatalError()):
+    with patch.object(DBus, "init_proxy", side_effect=DBusFatalError()):
         await network_manager.update(
             {"Devices": ["/org/freedesktop/NetworkManager/Devices/100"]}
         )
@@ -157,7 +157,7 @@ async def test_handling_bad_devices(
 
     # Unparseable introspections shouldn't happen, this one is logged and captured
     await network_manager.update()
-    with patch.object(DBus, "_init_proxy", side_effect=(err := DBusParseError())):
+    with patch.object(DBus, "init_proxy", side_effect=(err := DBusParseError())):
         await network_manager.update(
             {"Devices": [device := "/org/freedesktop/NetworkManager/Devices/102"]}
         )
@@ -167,7 +167,7 @@ async def test_handling_bad_devices(
     # We should be able to debug these situations if necessary
     caplog.set_level(logging.DEBUG, "supervisor.dbus.network")
     await network_manager.update()
-    with patch.object(DBus, "_init_proxy", side_effect=DBusFatalError()):
+    with patch.object(DBus, "init_proxy", side_effect=DBusFatalError()):
         await network_manager.update(
             {"Devices": [device := "/org/freedesktop/NetworkManager/Devices/103"]}
         )

--- a/tests/dbus/udisks2/test_manager.py
+++ b/tests/dbus/udisks2/test_manager.py
@@ -1,5 +1,7 @@
 """Test UDisks2 Manager interface."""
 
+from pathlib import Path
+
 from awesomeversion import AwesomeVersion
 from dbus_fast import Variant
 from dbus_fast.aio.message_bus import MessageBus
@@ -72,6 +74,7 @@ async def test_udisks2_manager_info(
     udisks2_manager_service.emit_properties_changed({}, ["SupportedFilesystems"])
     await udisks2_manager_service.ping()
     await udisks2_manager_service.ping()
+    await udisks2_manager_service.ping()  # Three pings: signal, get all properties and get block devices
     assert udisks2.supported_filesystems == [
         "ext4",
         "vfat",
@@ -126,11 +129,11 @@ async def test_resolve_device(
     udisks2 = UDisks2()
 
     with pytest.raises(DBusNotConnectedError):
-        await udisks2.resolve_device(DeviceSpecification(path="/dev/sda1"))
+        await udisks2.resolve_device(DeviceSpecification(path=Path("/dev/sda1")))
 
     await udisks2.connect(dbus_session_bus)
 
-    devices = await udisks2.resolve_device(DeviceSpecification(path="/dev/sda1"))
+    devices = await udisks2.resolve_device(DeviceSpecification(path=Path("/dev/sda1")))
     assert len(devices) == 1
     assert devices[0].id_label == "hassos-data"
     assert udisks2_manager_service.ResolveDevice.calls == [

--- a/tests/dbus/udisks2/test_partition_table.py
+++ b/tests/dbus/udisks2/test_partition_table.py
@@ -108,7 +108,7 @@ async def test_create_partition(
         await sda.create_partition(
             offset=0,
             size=1000000,
-            type_=PartitionTableType.DOS,
+            type_="0FC63DAF-8483-4772-8E79-3D69D8477DE4",
             name="hassos-data",
             options=CreatePartitionOptions(partition_type="primary"),
         )
@@ -118,7 +118,7 @@ async def test_create_partition(
         (
             0,
             1000000,
-            "dos",
+            "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
             "hassos-data",
             {
                 "partition-type": Variant("s", "primary"),

--- a/tests/dbus/udisks2/test_partition_table.py
+++ b/tests/dbus/udisks2/test_partition_table.py
@@ -112,7 +112,7 @@ async def test_create_partition(
             name="hassos-data",
             options=CreatePartitionOptions(partition_type="primary"),
         )
-        == "/org/freedesktop/UDisks2/block_devices/sda2"
+        == "/org/freedesktop/UDisks2/block_devices/sda1"
     )
     assert partition_table_sda_service.CreatePartition.calls == [
         (

--- a/tests/dbus_service_mocks/agent_datadisk.py
+++ b/tests/dbus_service_mocks/agent_datadisk.py
@@ -38,3 +38,7 @@ class DataDisk(DBusServiceMock):
     def ReloadDevice(self) -> "b":
         """Reload device."""
         return True
+
+    @dbus_method()
+    def MarkDataMove(self) -> None:
+        """Do MarkDataMove method."""

--- a/tests/dbus_service_mocks/udisks2_partition_table.py
+++ b/tests/dbus_service_mocks/udisks2_partition_table.py
@@ -57,6 +57,7 @@ class PartitionTable(DBusServiceMock):
     """
 
     interface = "org.freedesktop.UDisks2.PartitionTable"
+    new_partition = "/org/freedesktop/UDisks2/block_devices/sda1"
 
     def __init__(self, object_path: str):
         """Initialize object."""
@@ -79,7 +80,7 @@ class PartitionTable(DBusServiceMock):
         self, offset: "t", size: "t", type_: "s", name: "s", options: "a{sv}"
     ) -> "o":
         """Do CreatePartition method."""
-        return "/org/freedesktop/UDisks2/block_devices/sda2"
+        return self.new_partition
 
     @dbus_method()
     def CreatePartitionAndFormat(
@@ -93,4 +94,4 @@ class PartitionTable(DBusServiceMock):
         format_options: "a{sv}",
     ) -> "o":
         """Do CreatePartitionAndFormat method."""
-        return "/org/freedesktop/UDisks2/block_devices/sda2"
+        return self.new_partition

--- a/tests/os/test_data_disk.py
+++ b/tests/os/test_data_disk.py
@@ -26,7 +26,7 @@ from tests.dbus_service_mocks.udisks2_partition_table import (
 async def add_unusable_drive(
     coresys: CoreSys,
     udisks2_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
-):
+) -> None:
     """Add mock drive with multiple partition tables for negative tests."""
     await mock_dbus_services(
         {

--- a/tests/utils/test_dbus.py
+++ b/tests/utils/test_dbus.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, Mock, patch
 
 from dbus_fast.aio.message_bus import MessageBus
-from dbus_fast.service import method
+from dbus_fast.service import method, signal
 import pytest
 
 from supervisor.dbus.const import DBUS_OBJECT_BASE
@@ -23,6 +23,10 @@ class TestInterface(DBusServiceMock):
     @method(name="Test")
     def test(self, _: "b") -> None:  # noqa: F821
         """Do Test method."""
+
+    @signal(name="Test")
+    def signal_test(self) -> None:
+        """Signal Test."""
 
 
 @pytest.fixture(name="test_service")
@@ -74,3 +78,96 @@ async def test_internal_dbus_errors(
         await test_obj.call_test(True)
 
     capture_exception.assert_called_once_with(err)
+
+
+async def test_introspect(test_service: TestInterface, dbus_session_bus: MessageBus):
+    """Test introspect of dbus object."""
+    test_obj = DBus(dbus_session_bus, "service.test.TestInterface", DBUS_OBJECT_BASE)
+
+    introspection = await test_obj.introspect()
+
+    assert {"service.test.TestInterface", "org.freedesktop.DBus.Properties"} <= {
+        interface.name for interface in introspection.interfaces
+    }
+    test_interface = next(
+        interface
+        for interface in introspection.interfaces
+        if interface.name == "service.test.TestInterface"
+    )
+    assert "Test" in {method_.name for method_ in test_interface.methods}
+
+
+async def test_init_proxy(test_service: TestInterface, dbus_session_bus: MessageBus):
+    """Test init proxy on already connected object to update interfaces."""
+    test_obj = await DBus.connect(
+        dbus_session_bus, "service.test.TestInterface", DBUS_OBJECT_BASE
+    )
+    orig_introspection = await test_obj.introspect()
+    callback_count = 0
+
+    def test_callback():
+        nonlocal callback_count
+        callback_count += 1
+
+    class TestInterface2(TestInterface):
+        """Test interface 2."""
+
+        interface = "service.test.TestInterface.Test2"
+        object_path = DBUS_OBJECT_BASE
+
+    # Test interfaces and methods match expected
+    assert "service.test.TestInterface" in test_obj.proxies
+    assert await test_obj.call_test(True) is None
+    assert "service.test.TestInterface.Test2" not in test_obj.proxies
+
+    # Test basic signal listening works
+    test_obj.on_test(test_callback)
+    test_service.signal_test()
+    await test_service.ping()
+    assert callback_count == 1
+    callback_count = 0
+
+    # Export the second interface and re-create proxy
+    test_service_2 = TestInterface2()
+    test_service_2.export(dbus_session_bus)
+
+    await test_obj.init_proxy()
+
+    # Test interfaces and methods match expected
+    assert "service.test.TestInterface" in test_obj.proxies
+    assert await test_obj.call_test(True) is None
+    assert "service.test.TestInterface.Test2" in test_obj.proxies
+    assert await test_obj.Test2.call_test(True) is None
+
+    # Test signal listening. First listener should still be attached
+    test_obj.Test2.on_test(test_callback)
+    test_service_2.signal_test()
+    await test_service_2.ping()
+    assert callback_count == 1
+
+    test_service.signal_test()
+    await test_service.ping()
+    assert callback_count == 2
+    callback_count = 0
+
+    # Return to original introspection and test interfaces have reset
+    await test_obj.init_proxy(introspection=orig_introspection)
+
+    assert "service.test.TestInterface" in test_obj.proxies
+    assert "service.test.TestInterface.Test2" not in test_obj.proxies
+
+    # Signal listener for second interface should disconnect, first remains
+    test_service_2.signal_test()
+    await test_service_2.ping()
+    assert callback_count == 0
+
+    test_service.signal_test()
+    await test_service.ping()
+    assert callback_count == 1
+    callback_count = 0
+
+    # Should be able to disconnect first signal listener on new proxy obj
+    test_obj.off_test(test_callback)
+    test_service.signal_test()
+    await test_service.ping()
+    assert callback_count == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

On a migrate data disk request, supervisor formats the new drive using UDisks2 instead of OS Agent. It then uses the new MarkDataMove DBus API to tell OS Agent to do a migration to the already prepped drive next reboot. This significantly improves error handling since supervisor can see what went wrong and tell the user, instead of asking them to look in the host log.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
