### PR TITLE
Create issue for multiple data disks detected

### DIFF
--- a/supervisor/dbus/udisks2/filesystem.py
+++ b/supervisor/dbus/udisks2/filesystem.py
@@ -63,9 +63,9 @@ class UDisks2Filesystem(DBusInterfaceProxy):
         await self.dbus.Filesystem.call_unmount(options | UDISKS2_DEFAULT_OPTIONS)
 
     @dbus_connected
-    async def set_label(self) -> None:
+    async def set_label(self, label: str) -> None:
         """Set filesystem label."""
-        await self.dbus.Filesystem.call_set_label(UDISKS2_DEFAULT_OPTIONS)
+        await self.dbus.Filesystem.call_set_label(label, UDISKS2_DEFAULT_OPTIONS)
 
     @dbus_connected
     async def check(self) -> bool:

--- a/supervisor/os/const.py
+++ b/supervisor/os/const.py
@@ -1,0 +1,5 @@
+"""Constants for OS."""
+
+FILESYSTEM_LABEL_DATA_DISK = "hassos-data"
+FILESYSTEM_LABEL_OLD_DATA_DISK = "hassos-data-old"
+PARTITION_NAME_EXTERNAL_DATA_DISK = "hassos-data-external"

--- a/supervisor/os/data_disk.py
+++ b/supervisor/os/data_disk.py
@@ -23,9 +23,9 @@ from ..exceptions import (
 from ..jobs.const import JobCondition, JobExecutionLimit
 from ..jobs.decorator import Job
 from ..utils.sentry import capture_exception
+from .const import PARTITION_NAME_EXTERNAL_DATA_DISK
 
 LINUX_DATA_PARTITION_GUID: Final = "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
-EXTERNAL_DATA_DISK_PARTITION_NAME: Final = "hassos-data-external"
 OS_AGENT_MARK_DATA_MOVE_VERSION: Final = AwesomeVersion("1.5.0")
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -250,7 +250,7 @@ class DataDisk(CoreSysAttributes):
 
         try:
             partition = await block_device.partition_table.create_partition(
-                0, 0, LINUX_DATA_PARTITION_GUID, EXTERNAL_DATA_DISK_PARTITION_NAME
+                0, 0, LINUX_DATA_PARTITION_GUID, PARTITION_NAME_EXTERNAL_DATA_DISK
             )
         except DBusError as err:
             capture_exception(err)

--- a/supervisor/resolution/checks/multiple_data_disks.py
+++ b/supervisor/resolution/checks/multiple_data_disks.py
@@ -1,0 +1,61 @@
+"""Helpers to check for multiple data disks."""
+
+from pathlib import Path
+
+from ...const import CoreState
+from ...coresys import CoreSys
+from ...dbus.udisks2.block import UDisks2Block
+from ...dbus.udisks2.data import DeviceSpecification
+from ...os.const import FILESYSTEM_LABEL_DATA_DISK
+from ..const import ContextType, IssueType, SuggestionType
+from .base import CheckBase
+
+
+def setup(coresys: CoreSys) -> CheckBase:
+    """Check setup function."""
+    return CheckMultipleDataDisks(coresys)
+
+
+class CheckMultipleDataDisks(CheckBase):
+    """CheckMultipleDataDisks class for check."""
+
+    async def run_check(self) -> None:
+        """Run check if not affected by issue."""
+        for block_device in self.sys_dbus.udisks2.block_devices:
+            if self._block_device_has_name_issue(block_device):
+                self.sys_resolution.create_issue(
+                    IssueType.MULTIPLE_DATA_DISKS,
+                    ContextType.SYSTEM,
+                    reference=block_device.device.as_posix(),
+                    suggestions=[SuggestionType.RENAME_DATA_DISK],
+                )
+
+    async def approve_check(self, reference: str | None = None) -> bool:
+        """Approve check if it is affected by issue."""
+        resolved = await self.sys_dbus.udisks2.resolve_device(
+            DeviceSpecification(path=Path(reference))
+        )
+        return resolved and self._block_device_has_name_issue(resolved[0])
+
+    def _block_device_has_name_issue(self, block_device: UDisks2Block) -> bool:
+        """Return true if filesystem block device incorrectly has data disk name."""
+        return (
+            block_device.filesystem
+            and block_device.id_label == FILESYSTEM_LABEL_DATA_DISK
+            and block_device.device != self.sys_dbus.agent.datadisk.current_device
+        )
+
+    @property
+    def issue(self) -> IssueType:
+        """Return a IssueType enum."""
+        return IssueType.MULTIPLE_DATA_DISKS
+
+    @property
+    def context(self) -> ContextType:
+        """Return a ContextType enum."""
+        return ContextType.SYSTEM
+
+    @property
+    def states(self) -> list[CoreState]:
+        """Return a list of valid states when this check can run."""
+        return [CoreState.RUNNING, CoreState.STARTUP]

--- a/supervisor/resolution/const.py
+++ b/supervisor/resolution/const.py
@@ -78,6 +78,7 @@ class IssueType(str, Enum):
     FREE_SPACE = "free_space"
     IPV4_CONNECTION_PROBLEM = "ipv4_connection_problem"
     MISSING_IMAGE = "missing_image"
+    MULTIPLE_DATA_DISKS = "multiple_data_disks"
     NO_CURRENT_BACKUP = "no_current_backup"
     PWNED = "pwned"
     REBOOT_REQUIRED = "reboot_required"
@@ -101,3 +102,4 @@ class SuggestionType(str, Enum):
     EXECUTE_STOP = "execute_stop"
     EXECUTE_UPDATE = "execute_update"
     REGISTRY_LOGIN = "registry_login"
+    RENAME_DATA_DISK = "rename_data_disk"

--- a/supervisor/resolution/fixups/system_rename_data_disk.py
+++ b/supervisor/resolution/fixups/system_rename_data_disk.py
@@ -1,0 +1,69 @@
+"""Rename data disk fixup."""
+
+import logging
+from pathlib import Path
+
+from ...coresys import CoreSys
+from ...dbus.udisks2.data import DeviceSpecification
+from ...exceptions import DBusError, ResolutionFixupError
+from ...os.const import FILESYSTEM_LABEL_OLD_DATA_DISK
+from ..const import ContextType, IssueType, SuggestionType
+from .base import FixupBase
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+def setup(coresys: CoreSys) -> FixupBase:
+    """Check setup function."""
+    return FixupSystemRenameDataDisk(coresys)
+
+
+class FixupSystemRenameDataDisk(FixupBase):
+    """Storage class for fixup."""
+
+    async def process_fixup(self, reference: str | None = None) -> None:
+        """Initialize the fixup class."""
+        resolved = await self.sys_dbus.udisks2.resolve_device(
+            DeviceSpecification(path=Path(reference))
+        )
+
+        if not resolved:
+            _LOGGER.info(
+                "Data disk at %s with name conflict was removed, skipping rename",
+                reference,
+            )
+            return
+
+        if not resolved[0].filesystem:
+            _LOGGER.warning(
+                "Data disk at %s no longer appears to be a filesystem, skipping rename",
+                reference,
+            )
+            return
+
+        _LOGGER.info(
+            "Renaming %s to %s to prevent data disk name conflict",
+            reference,
+            FILESYSTEM_LABEL_OLD_DATA_DISK,
+        )
+        try:
+            await resolved[0].filesystem.set_label(FILESYSTEM_LABEL_OLD_DATA_DISK)
+        except DBusError as err:
+            raise ResolutionFixupError(
+                f"Could not rename filesystem at {reference}: {err!s}", _LOGGER.error
+            ) from err
+
+    @property
+    def suggestion(self) -> SuggestionType:
+        """Return a SuggestionType enum."""
+        return SuggestionType.RENAME_DATA_DISK
+
+    @property
+    def context(self) -> ContextType:
+        """Return a ContextType enum."""
+        return ContextType.SYSTEM
+
+    @property
+    def issues(self) -> list[IssueType]:
+        """Return a IssueType enum list."""
+        return [IssueType.MULTIPLE_DATA_DISKS]

--- a/tests/dbus/udisks2/test_block.py
+++ b/tests/dbus/udisks2/test_block.py
@@ -67,10 +67,10 @@ async def test_block_device_info(
     assert sda.partition_table.type == PartitionTableType.GPT
     assert sda.filesystem is None
 
-    assert sda1.id_label == "hassos-data"
+    assert sda1.id_label == "hassos-data-old"
     assert sda1.symlinks == [
         Path("/dev/disk/by-id/usb-SSK_SSK_Storage_DF56419883D56-0:0-part1"),
-        Path("/dev/disk/by-label/hassos-data"),
+        Path("/dev/disk/by-label/hassos-data-old"),
         Path("/dev/disk/by-partlabel/hassos-data-external"),
         Path("/dev/disk/by-partuuid/6f3f99f4-4d34-476b-b051-77886da57fa9"),
         Path(
@@ -93,7 +93,7 @@ async def test_block_device_info(
     # Prop changes should not sync for this one
     block_sda1_service.emit_properties_changed({"IdLabel": "test"})
     await block_sda1_service.ping()
-    assert sda1.id_label == "hassos-data"
+    assert sda1.id_label == "hassos-data-old"
 
 
 async def test_format(block_sda_service: BlockService, dbus_session_bus: MessageBus):
@@ -139,7 +139,7 @@ async def test_check_type(dbus_session_bus: MessageBus):
     assert sda.partition_table is None
     assert sda1.filesystem is None
     assert sda.id_label == ""
-    assert sda1.id_label == "hassos-data"
+    assert sda1.id_label == "hassos-data-old"
 
     # Store current introspection then make sda into a partition table and sda1 into a filesystem
     orig_introspection = await sda.dbus.introspect()

--- a/tests/dbus/udisks2/test_filesystem.py
+++ b/tests/dbus/udisks2/test_filesystem.py
@@ -135,3 +135,14 @@ async def test_repair(
     assert filesystem_sda1_service.Repair.calls == [
         ({"auth.no_user_interaction": Variant("b", True)},)
     ]
+
+
+async def test_set_label(
+    sda1: UDisks2Filesystem, filesystem_sda1_service: FilesystemService
+):
+    """Test set label."""
+    filesystem_sda1_service.SetLabel.calls.clear()
+    await sda1.set_label("test")
+    assert filesystem_sda1_service.SetLabel.calls == [
+        ("test", {"auth.no_user_interaction": Variant("b", True)})
+    ]

--- a/tests/dbus_service_mocks/udisks2_block.py
+++ b/tests/dbus_service_mocks/udisks2_block.py
@@ -242,7 +242,7 @@ FIXTURES: dict[str, BlockFixture] = {
         PreferredDevice=b"/dev/sda1\x00",
         Symlinks=[
             b"/dev/disk/by-id/usb-SSK_SSK_Storage_DF56419883D56-0:0-part1\x00",
-            b"/dev/disk/by-label/hassos-data\x00",
+            b"/dev/disk/by-label/hassos-data-old\x00",
             b"/dev/disk/by-partlabel/hassos-data-external\x00",
             b"/dev/disk/by-partuuid/6f3f99f4-4d34-476b-b051-77886da57fa9\x00",
             b"/dev/disk/by-path/platform-xhci-hcd.1.auto-usb-0:1.4:1.0-scsi-0:0:0:0-part1\x00",
@@ -258,7 +258,7 @@ FIXTURES: dict[str, BlockFixture] = {
         IdUsage="filesystem",
         IdType="ext4",
         IdVersion="1.0",
-        IdLabel="hassos-data",
+        IdLabel="hassos-data-old",
         IdUUID="b82b23cb-0c47-4bbb-acf5-2a2afa8894a2",
         Configuration=[],
         CryptoBackingDevice="/",

--- a/tests/dbus_service_mocks/udisks2_manager.py
+++ b/tests/dbus_service_mocks/udisks2_manager.py
@@ -35,6 +35,7 @@ class UDisks2Manager(DBusServiceMock):
         "/org/freedesktop/UDisks2/block_devices/sdb1",
         "/org/freedesktop/UDisks2/block_devices/zram1",
     ]
+    resolved_devices = ["/org/freedesktop/UDisks2/block_devices/sda1"]
 
     @dbus_property(access=PropertyAccess.READ)
     def Version(self) -> "s":
@@ -100,4 +101,4 @@ class UDisks2Manager(DBusServiceMock):
     @dbus_method()
     def ResolveDevice(self, devspec: "a{sv}", options: "a{sv}") -> "ao":
         """Do ResolveDevice method."""
-        return ["/org/freedesktop/UDisks2/block_devices/sda1"]
+        return self.resolved_devices

--- a/tests/resolution/check/test_check_multiple_data_disks.py
+++ b/tests/resolution/check/test_check_multiple_data_disks.py
@@ -1,0 +1,96 @@
+"""Test check for multiple data disks."""
+# pylint: disable=import-error
+from dataclasses import replace
+from unittest.mock import patch
+
+import pytest
+
+from supervisor.const import CoreState
+from supervisor.coresys import CoreSys
+from supervisor.resolution.checks.multiple_data_disks import CheckMultipleDataDisks
+from supervisor.resolution.const import ContextType, IssueType, SuggestionType
+from supervisor.resolution.data import Issue, Suggestion
+
+from tests.dbus_service_mocks.base import DBusServiceMock
+from tests.dbus_service_mocks.udisks2_block import Block as BlockService
+
+
+@pytest.fixture(name="sda1_block_service")
+async def fixture_sda1_block_service(
+    udisks2_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]]
+) -> BlockService:
+    """Return sda1 block service."""
+    yield udisks2_services["udisks2_block"][
+        "/org/freedesktop/UDisks2/block_devices/sda1"
+    ]
+
+
+async def test_base(coresys: CoreSys):
+    """Test check basics."""
+    multiple_data_disks = CheckMultipleDataDisks(coresys)
+    assert multiple_data_disks.slug == "multiple_data_disks"
+    assert multiple_data_disks.enabled
+
+
+async def test_check(coresys: CoreSys, sda1_block_service: BlockService):
+    """Test check."""
+    multiple_data_disks = CheckMultipleDataDisks(coresys)
+    coresys.core.state = CoreState.RUNNING
+
+    await multiple_data_disks.run_check()
+
+    assert len(coresys.resolution.issues) == 0
+    assert len(coresys.resolution.suggestions) == 0
+
+    sda1_block_service.emit_properties_changed({"IdLabel": "hassos-data"})
+    await sda1_block_service.ping()
+
+    await multiple_data_disks.run_check()
+
+    assert coresys.resolution.issues == [
+        Issue(IssueType.MULTIPLE_DATA_DISKS, ContextType.SYSTEM, reference="/dev/sda1")
+    ]
+    assert coresys.resolution.suggestions == [
+        Suggestion(
+            SuggestionType.RENAME_DATA_DISK, ContextType.SYSTEM, reference="/dev/sda1"
+        )
+    ]
+
+
+async def test_approve(coresys: CoreSys, sda1_block_service: BlockService):
+    """Test approve."""
+    multiple_data_disks = CheckMultipleDataDisks(coresys)
+    coresys.core.state = CoreState.RUNNING
+
+    assert not await multiple_data_disks.approve_check(reference="/dev/sda1")
+
+    sda1_block_service.fixture = replace(
+        sda1_block_service.fixture, IdLabel="hassos-data"
+    )
+
+    assert await multiple_data_disks.approve_check(reference="/dev/sda1")
+
+
+async def test_did_run(coresys: CoreSys):
+    """Test that the check ran as expected."""
+    multiple_data_disks = CheckMultipleDataDisks(coresys)
+    should_run = multiple_data_disks.states
+    should_not_run = [state for state in CoreState if state not in should_run]
+    assert len(should_run) != 0
+    assert len(should_not_run) != 0
+
+    with patch(
+        "supervisor.resolution.checks.multiple_data_disks.CheckMultipleDataDisks.run_check",
+        return_value=None,
+    ) as check:
+        for state in should_run:
+            coresys.core.state = state
+            await multiple_data_disks()
+            check.assert_called_once()
+            check.reset_mock()
+
+        for state in should_not_run:
+            coresys.core.state = state
+            await multiple_data_disks()
+            check.assert_not_called()
+            check.reset_mock()

--- a/tests/resolution/fixup/test_system_rename_data_disk.py
+++ b/tests/resolution/fixup/test_system_rename_data_disk.py
@@ -1,0 +1,108 @@
+"""Test system fixup rename data disk."""
+# pylint: disable=import-error
+from dbus_fast import Variant
+import pytest
+
+from supervisor.coresys import CoreSys
+from supervisor.resolution.const import ContextType, IssueType, SuggestionType
+from supervisor.resolution.data import Issue, Suggestion
+from supervisor.resolution.fixups.system_rename_data_disk import (
+    FixupSystemRenameDataDisk,
+)
+
+from tests.dbus_service_mocks.base import DBusServiceMock
+from tests.dbus_service_mocks.udisks2_filesystem import Filesystem as FilesystemService
+from tests.dbus_service_mocks.udisks2_manager import (
+    UDisks2Manager as UDisks2ManagerService,
+)
+
+
+@pytest.fixture(name="sda1_filesystem_service")
+async def fixture_sda1_filesystem_service(
+    udisks2_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]]
+) -> FilesystemService:
+    """Return sda1 filesystem service."""
+    return udisks2_services["udisks2_filesystem"][
+        "/org/freedesktop/UDisks2/block_devices/sda1"
+    ]
+
+
+@pytest.fixture(name="udisks2_service")
+async def fixture_udisks2_service(
+    udisks2_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]]
+) -> UDisks2ManagerService:
+    """Return udisks2 manager service."""
+    return udisks2_services["udisks2_manager"]
+
+
+async def test_fixup(coresys: CoreSys, sda1_filesystem_service: FilesystemService):
+    """Test fixup."""
+    sda1_filesystem_service.SetLabel.calls.clear()
+    system_rename_data_disk = FixupSystemRenameDataDisk(coresys)
+
+    assert not system_rename_data_disk.auto
+
+    coresys.resolution.suggestions = Suggestion(
+        SuggestionType.RENAME_DATA_DISK, ContextType.SYSTEM, reference="/dev/sda1"
+    )
+    coresys.resolution.issues = Issue(
+        IssueType.MULTIPLE_DATA_DISKS, ContextType.SYSTEM, reference="/dev/sda1"
+    )
+
+    await system_rename_data_disk()
+
+    assert sda1_filesystem_service.SetLabel.calls == [
+        ("hassos-data-old", {"auth.no_user_interaction": Variant("b", True)})
+    ]
+    assert len(coresys.resolution.suggestions) == 0
+    assert len(coresys.resolution.issues) == 0
+
+
+async def test_fixup_device_removed(
+    coresys: CoreSys,
+    udisks2_service: UDisks2ManagerService,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test fixup when device removed."""
+    system_rename_data_disk = FixupSystemRenameDataDisk(coresys)
+
+    assert not system_rename_data_disk.auto
+
+    coresys.resolution.suggestions = Suggestion(
+        SuggestionType.RENAME_DATA_DISK, ContextType.SYSTEM, reference="/dev/sda1"
+    )
+    coresys.resolution.issues = Issue(
+        IssueType.MULTIPLE_DATA_DISKS, ContextType.SYSTEM, reference="/dev/sda1"
+    )
+
+    udisks2_service.resolved_devices = []
+    await system_rename_data_disk()
+
+    assert len(coresys.resolution.suggestions) == 0
+    assert len(coresys.resolution.issues) == 0
+    assert "Data disk at /dev/sda1 with name conflict was removed" in caplog.text
+
+
+async def test_fixup_device_not_filesystem(
+    coresys: CoreSys,
+    udisks2_service: UDisks2ManagerService,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test fixup when device is no longer a filesystem."""
+    system_rename_data_disk = FixupSystemRenameDataDisk(coresys)
+
+    assert not system_rename_data_disk.auto
+
+    coresys.resolution.suggestions = Suggestion(
+        SuggestionType.RENAME_DATA_DISK, ContextType.SYSTEM, reference="/dev/sda1"
+    )
+    coresys.resolution.issues = Issue(
+        IssueType.MULTIPLE_DATA_DISKS, ContextType.SYSTEM, reference="/dev/sda1"
+    )
+
+    udisks2_service.resolved_devices = ["/org/freedesktop/UDisks2/block_devices/sda"]
+    await system_rename_data_disk()
+
+    assert len(coresys.resolution.suggestions) == 0
+    assert len(coresys.resolution.issues) == 0
+    assert "Data disk at /dev/sda1 no longer appears to be a filesystem" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Create an issue when supervisor detects that a filesystem has the name `hassos-data` which is not the current device according to OS Agent. That also comes with a suggestion which when executed renames that filesystem to `hassos-data-old` to prevent a race condition at startup.

This should be all that is required to make a repair for this situation from supervisor's side. Since all issues and associated suggestions are pushed to core already via dispatcher. The follow-up is to modify the hassio component so it doesn't ignore this type of issue and instead makes a repair out of it, like was done for unsupported and unhealthy.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
