### PR TITLE
Speed up backups by increasing buffer size

### DIFF
--- a/supervisor/backups/backup.py
+++ b/supervisor/backups/backup.py
@@ -44,7 +44,7 @@ from ..exceptions import AddonsError, BackupError
 from ..utils import remove_folder
 from ..utils.dt import parse_datetime, utcnow
 from ..utils.json import write_json_file
-from .const import BackupType
+from .const import BUF_SIZE, BackupType
 from .utils import key_to_iv, password_to_key
 from .validate import SCHEMA_BACKUP
 
@@ -330,7 +330,11 @@ class Backup(CoreSysAttributes):
             """Task to store an add-on into backup."""
             tar_name = f"{addon.slug}.tar{'.gz' if self.compressed else ''}"
             addon_file = SecureTarFile(
-                Path(self._tmp.name, tar_name), "w", key=self._key, gzip=self.compressed
+                Path(self._tmp.name, tar_name),
+                "w",
+                key=self._key,
+                gzip=self.compressed,
+                bufsize=BUF_SIZE,
             )
 
             # Take backup
@@ -365,7 +369,11 @@ class Backup(CoreSysAttributes):
             """Task to restore an add-on into backup."""
             tar_name = f"{addon_slug}.tar{'.gz' if self.compressed else ''}"
             addon_file = SecureTarFile(
-                Path(self._tmp.name, tar_name), "r", key=self._key, gzip=self.compressed
+                Path(self._tmp.name, tar_name),
+                "r",
+                key=self._key,
+                gzip=self.compressed,
+                bufsize=BUF_SIZE,
             )
 
             # If exists inside backup
@@ -406,7 +414,7 @@ class Backup(CoreSysAttributes):
             # Take backup
             _LOGGER.info("Backing up folder %s", name)
             with SecureTarFile(
-                tar_name, "w", key=self._key, gzip=self.compressed
+                tar_name, "w", key=self._key, gzip=self.compressed, bufsize=BUF_SIZE
             ) as tar_file:
                 atomic_contents_add(
                     tar_file,
@@ -453,7 +461,11 @@ class Backup(CoreSysAttributes):
                 try:
                     _LOGGER.info("Restore folder %s", name)
                     with SecureTarFile(
-                        tar_name, "r", key=self._key, gzip=self.compressed
+                        tar_name,
+                        "r",
+                        key=self._key,
+                        gzip=self.compressed,
+                        bufsize=BUF_SIZE,
                     ) as tar_file:
                         tar_file.extractall(path=origin_dir, members=tar_file)
                     _LOGGER.info("Restore folder %s done", name)
@@ -479,7 +491,7 @@ class Backup(CoreSysAttributes):
             self._tmp.name, f"homeassistant.tar{'.gz' if self.compressed else ''}"
         )
         homeassistant_file = SecureTarFile(
-            tar_name, "w", key=self._key, gzip=self.compressed
+            tar_name, "w", key=self._key, gzip=self.compressed, bufsize=BUF_SIZE
         )
 
         await self.sys_homeassistant.backup(homeassistant_file)
@@ -496,7 +508,7 @@ class Backup(CoreSysAttributes):
             self._tmp.name, f"homeassistant.tar{'.gz' if self.compressed else ''}"
         )
         homeassistant_file = SecureTarFile(
-            tar_name, "r", key=self._key, gzip=self.compressed
+            tar_name, "r", key=self._key, gzip=self.compressed, bufsize=BUF_SIZE
         )
 
         await self.sys_homeassistant.restore(homeassistant_file)


### PR DESCRIPTION
This is the same change as https://github.com/home-assistant/core/pull/90613 but for supervisor

If the backup takes too long, core will release the lock on the database and the backup will be no good

https://ptb.discord.com/channels/330944238910963714/332167321311510530/1093362241677570180
https://github.com/home-assistant/core/blob/2fc34e7cced87a8e042919e059d3a07bb760c77f/homeassistant/components/recorder/core.py#L926

cpython uses copyfileobj under the hood for fast copies but the default buffer size is quite low which increases the amount of time in python code when copying the sqlite database. As this is the usually the bulk of the backup, increasing the buffer can help reduce the backup time quite a bit.

Ideally this would all use sendfile under the hood as it would shift nearly all the burden out of userspace but tarfile doesn't currently try that https://github.com/python/cpython/blob/4664a7cf689946f0c9854cadee7c6aa9c276a8cf/Lib/shutil.py#L106

related:
In testing (non encrypted) improvement was at least as good as https://github.com/python/cpython/issues/71386

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
