### PR TITLE
Fix bind mounting and remove on create failure

### DIFF
--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -579,6 +579,10 @@ class MountError(HassioError):
     """Raise on an error related to mounting/unmounting."""
 
 
+class MountActivationError(MountError):
+    """Raise on mount not reaching active state after mount/reload."""
+
+
 class MountInvalidError(MountError):
     """Raise on invalid mount attempt."""
 

--- a/tests/api/test_mounts.py
+++ b/tests/api/test_mounts.py
@@ -238,7 +238,7 @@ async def test_api_update_dbus_error_mount_remains(
             "type": "cifs",
             "usage": "backup",
             "server": "backup.local",
-            "share": "backups1",
+            "share": "backups",
             "state": None,
         }
     ]
@@ -277,7 +277,7 @@ async def test_api_update_dbus_error_mount_remains(
             "type": "cifs",
             "usage": "backup",
             "server": "backup.local",
-            "share": "backups2",
+            "share": "backups",
             "state": None,
         }
     ]

--- a/tests/api/test_mounts.py
+++ b/tests/api/test_mounts.py
@@ -1,6 +1,7 @@
 """Test mounts API."""
 
 from aiohttp.test_utils import TestClient
+from dbus_fast import DBusError, ErrorType
 import pytest
 
 from supervisor.coresys import CoreSys
@@ -8,6 +9,7 @@ from supervisor.mounts.mount import Mount
 
 from tests.dbus_service_mocks.base import DBusServiceMock
 from tests.dbus_service_mocks.systemd import Systemd as SystemdService
+from tests.dbus_service_mocks.systemd_unit import SystemdUnit as SystemdUnitService
 
 
 @pytest.fixture(name="mount")
@@ -87,6 +89,70 @@ async def test_api_create_error_mount_exists(api_client: TestClient, mount):
     assert result["message"] == "A mount already exists with name backup_test"
 
 
+async def test_api_create_dbus_error_mount_not_added(
+    api_client: TestClient,
+    all_dbus_services: dict[str, DBusServiceMock],
+    tmp_supervisor_data,
+    path_extern,
+):
+    """Test mount not added to list of mounts if a dbus error occurs."""
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
+    systemd_service.response_get_unit = DBusError(
+        "org.freedesktop.systemd1.NoSuchUnit", "error"
+    )
+    systemd_service.response_start_transient_unit = DBusError(ErrorType.FAILED, "fail")
+
+    resp = await api_client.post(
+        "/mounts",
+        json={
+            "name": "backup_test",
+            "type": "cifs",
+            "usage": "backup",
+            "server": "backup.local",
+            "share": "backups",
+        },
+    )
+    assert resp.status == 400
+    result = await resp.json()
+    assert result["result"] == "error"
+    assert result["message"] == "Could not mount backup_test due to: fail"
+
+    resp = await api_client.get("/mounts")
+    result = await resp.json()
+    assert result["data"]["mounts"] == []
+
+    systemd_service.response_get_unit = [
+        DBusError("org.freedesktop.systemd1.NoSuchUnit", "error"),
+        "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
+        "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
+    ]
+    systemd_service.response_start_transient_unit = "/org/freedesktop/systemd1/job/7623"
+    systemd_unit_service.active_state = "failed"
+
+    resp = await api_client.post(
+        "/mounts",
+        json={
+            "name": "backup_test",
+            "type": "cifs",
+            "usage": "backup",
+            "server": "backup.local",
+            "share": "backups",
+        },
+    )
+    assert resp.status == 400
+    result = await resp.json()
+    assert result["result"] == "error"
+    assert (
+        result["message"]
+        == "Mounting backup_test did not succeed. Check host logs for errors from mount or systemd unit mnt-data-supervisor-mounts-backup_test.mount for details."
+    )
+
+    resp = await api_client.get("/mounts")
+    result = await resp.json()
+    assert result["data"]["mounts"] == []
+
+
 async def test_api_update_mount(api_client: TestClient, coresys: CoreSys, mount):
     """Test updating a mount via API."""
     resp = await api_client.put(
@@ -132,6 +198,89 @@ async def test_api_update_error_mount_missing(api_client: TestClient):
     result = await resp.json()
     assert result["result"] == "error"
     assert result["message"] == "No mount exists with name backup_test"
+
+
+async def test_api_update_dbus_error_mount_remains(
+    api_client: TestClient,
+    all_dbus_services: dict[str, DBusServiceMock],
+    mount,
+    tmp_supervisor_data,
+    path_extern,
+):
+    """Test mount remains in list with unsuccessful state if dbus error occurs during update."""
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
+    systemd_service.response_get_unit = [
+        "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
+        DBusError("org.freedesktop.systemd1.NoSuchUnit", "error"),
+    ]
+    systemd_service.response_start_transient_unit = DBusError(ErrorType.FAILED, "fail")
+
+    resp = await api_client.put(
+        "/mounts/backup_test",
+        json={
+            "type": "cifs",
+            "usage": "backup",
+            "server": "backup.local",
+            "share": "backups1",
+        },
+    )
+    assert resp.status == 400
+    result = await resp.json()
+    assert result["result"] == "error"
+    assert result["message"] == "Could not mount backup_test due to: fail"
+
+    resp = await api_client.get("/mounts")
+    result = await resp.json()
+    assert result["data"]["mounts"] == [
+        {
+            "name": "backup_test",
+            "type": "cifs",
+            "usage": "backup",
+            "server": "backup.local",
+            "share": "backups1",
+            "state": None,
+        }
+    ]
+
+    systemd_service.response_get_unit = [
+        "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
+        DBusError("org.freedesktop.systemd1.NoSuchUnit", "error"),
+        "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
+        "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
+    ]
+    systemd_service.response_start_transient_unit = "/org/freedesktop/systemd1/job/7623"
+    systemd_unit_service.active_state = "failed"
+
+    resp = await api_client.put(
+        "/mounts/backup_test",
+        json={
+            "type": "cifs",
+            "usage": "backup",
+            "server": "backup.local",
+            "share": "backups2",
+        },
+    )
+    assert resp.status == 400
+    result = await resp.json()
+    assert result["result"] == "error"
+    assert (
+        result["message"]
+        == "Mounting backup_test did not succeed. Check host logs for errors from mount or systemd unit mnt-data-supervisor-mounts-backup_test.mount for details."
+    )
+
+    resp = await api_client.get("/mounts")
+    result = await resp.json()
+    assert result["data"]["mounts"] == [
+        {
+            "name": "backup_test",
+            "type": "cifs",
+            "usage": "backup",
+            "server": "backup.local",
+            "share": "backups2",
+            "state": None,
+        }
+    ]
 
 
 async def test_api_reload_mount(

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -377,6 +377,8 @@ async def test_backup_media_with_mounts(
         "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
         DBusError("org.freedesktop.systemd1.NoSuchUnit", "error"),
         "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
+        "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
+        "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
     ]
 
     # Make some normal test files

--- a/tests/mounts/test_mount.py
+++ b/tests/mounts/test_mount.py
@@ -73,9 +73,9 @@ async def test_cifs_mount(
             "fail",
             [
                 ["Options", Variant("s", "username=admin,password=password")],
+                ["Type", Variant("s", "cifs")],
                 ["Description", Variant("s", "Supervisor cifs mount: test")],
                 ["What", Variant("s", "//test.local/camera")],
-                ["Type", Variant("s", "cifs")],
             ],
             [],
         )
@@ -130,9 +130,9 @@ async def test_nfs_mount(
             "fail",
             [
                 ["Options", Variant("s", "port=1234")],
+                ["Type", Variant("s", "nfs")],
                 ["Description", Variant("s", "Supervisor nfs mount: test")],
                 ["What", Variant("s", "test.local:/media/camera")],
-                ["Type", Variant("s", "nfs")],
             ],
             [],
         )
@@ -176,9 +176,9 @@ async def test_load(
             "mnt-data-supervisor-mounts-test.mount",
             "fail",
             [
+                ["Type", Variant("s", "cifs")],
                 ["Description", Variant("s", "Supervisor cifs mount: test")],
                 ["What", Variant("s", "//test.local/share")],
-                ["Type", Variant("s", "cifs")],
             ],
             [],
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Follow up to #4269, `bind` is not a type for mount. There is no type and you say `bind` as an option, this does bind mounts correctly.

In addition when we fail to mount on create, keep the new mount out of the list of mounts. Rather then adding it as a failure. Also try to remove the systemd unit first if it was created so the user doesn't get a confusing error when they retry.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
