### PR TITLE
Use backup mounts

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -576,6 +576,7 @@ class RestAPI(CoreSysAttributes):
         self.webapp.add_routes(
             [
                 web.get("/mounts", api_mounts.info),
+                web.post("/mounts/options", api_mounts.options),
                 web.post("/mounts", api_mounts.create_mount),
                 web.put("/mounts/{mount}", api_mounts.update_mount),
                 web.delete("/mounts/{mount}", api_mounts.delete_mount),

--- a/supervisor/api/mounts.py
+++ b/supervisor/api/mounts.py
@@ -8,10 +8,17 @@ import voluptuous as vol
 from ..const import ATTR_NAME, ATTR_STATE
 from ..coresys import CoreSysAttributes
 from ..exceptions import APIError
+from ..mounts.const import ATTR_DEFAULT_BACKUP_MOUNT, MountUsage
 from ..mounts.mount import Mount
 from ..mounts.validate import SCHEMA_MOUNT_CONFIG
 from .const import ATTR_MOUNTS
 from .utils import api_process, api_validate
+
+SCHEMA_OPTIONS = vol.Schema(
+    {
+        vol.Optional(ATTR_DEFAULT_BACKUP_MOUNT): vol.Maybe(str),
+    }
+)
 
 
 class APIMounts(CoreSysAttributes):
@@ -21,11 +28,32 @@ class APIMounts(CoreSysAttributes):
     async def info(self, request: web.Request) -> dict[str, Any]:
         """Return MountManager info."""
         return {
+            ATTR_DEFAULT_BACKUP_MOUNT: self.sys_mounts.default_backup_mount.name
+            if self.sys_mounts.default_backup_mount.name
+            else None,
             ATTR_MOUNTS: [
                 mount.to_dict() | {ATTR_STATE: mount.state}
                 for mount in self.sys_mounts.mounts
-            ]
+            ],
         }
+
+    @api_process
+    async def options(self, request: web.Request) -> None:
+        """Set Mount Manager options."""
+        body = await api_validate(SCHEMA_OPTIONS, request)
+
+        if ATTR_DEFAULT_BACKUP_MOUNT in body:
+            name: str | None = body[ATTR_DEFAULT_BACKUP_MOUNT]
+            if name is None:
+                self.sys_mounts.default_backup_mount = None
+            elif (mount := self.sys_mounts.get(name)).usage != MountUsage.BACKUP:
+                raise APIError(
+                    f"Mount {name} is not used for backups, cannot use it as default backup mount"
+                )
+            else:
+                self.sys_mounts.default_backup_mount = mount
+
+        self.sys_mounts.save_data()
 
     @api_process
     async def create_mount(self, request: web.Request) -> None:
@@ -35,41 +63,62 @@ class APIMounts(CoreSysAttributes):
         if body[ATTR_NAME] in self.sys_mounts:
             raise APIError(f"A mount already exists with name {body[ATTR_NAME]}")
 
-        await self.sys_mounts.create_mount(Mount.from_dict(self.coresys, body))
+        mount = Mount.from_dict(self.coresys, body)
+        await self.sys_mounts.create_mount(mount)
+
+        # If it's a backup mount, reload backups
+        if mount.usage == MountUsage.BACKUP:
+            self.sys_create_task(self.sys_backups.reload())
+
+            # If there's no default backup mount, set it to the new mount
+            if not self.sys_mounts.default_backup_mount:
+                self.sys_mounts.default_backup_mount = mount
+
         self.sys_mounts.save_data()
 
     @api_process
     async def update_mount(self, request: web.Request) -> None:
         """Update an existing mount in supervisor."""
-        mount = request.match_info.get("mount")
+        name = request.match_info.get("mount")
         name_schema = vol.Schema(
-            {vol.Optional(ATTR_NAME, default=mount): mount}, extra=vol.ALLOW_EXTRA
+            {vol.Optional(ATTR_NAME, default=name): name}, extra=vol.ALLOW_EXTRA
         )
         body = await api_validate(vol.All(name_schema, SCHEMA_MOUNT_CONFIG), request)
 
-        if mount not in self.sys_mounts:
-            raise APIError(f"No mount exists with name {mount}")
+        if name not in self.sys_mounts:
+            raise APIError(f"No mount exists with name {name}")
 
-        await self.sys_mounts.create_mount(Mount.from_dict(self.coresys, body))
+        mount = Mount.from_dict(self.coresys, body)
+        await self.sys_mounts.create_mount(mount)
+
+        # If it's a backup mount, reload backups
+        if mount.usage == MountUsage.BACKUP:
+            self.sys_create_task(self.sys_backups.reload())
+
+        # If this mount was the default backup mount and isn't for backups any more, remove it
+        elif self.sys_mounts.default_backup_mount == mount:
+            self.sys_mounts.default_backup_mount = None
+
         self.sys_mounts.save_data()
 
     @api_process
     async def delete_mount(self, request: web.Request) -> None:
         """Delete an existing mount in supervisor."""
-        mount = request.match_info.get("mount")
+        name = request.match_info.get("mount")
+        mount = await self.sys_mounts.remove_mount(name)
 
-        if mount not in self.sys_mounts:
-            raise APIError(f"No mount exists with name {mount}")
+        # If it was a backup mount, reload backups
+        if mount.usage == MountUsage.BACKUP:
+            self.sys_create_task(self.sys_backups.reload())
 
-        await self.sys_mounts.remove_mount(mount)
         self.sys_mounts.save_data()
 
     @api_process
     async def reload_mount(self, request: web.Request) -> None:
         """Reload an existing mount in supervisor."""
-        mount = request.match_info.get("mount")
+        name = request.match_info.get("mount")
+        await self.sys_mounts.reload_mount(name)
 
-        if mount not in self.sys_mounts:
-            raise APIError(f"No mount exists with name {mount}")
-
-        await self.sys_mounts.reload_mount(mount)
+        # If it's a backup mount, reload backups
+        if self.sys_mounts.get(name).usage == MountUsage.BACKUP:
+            self.sys_create_task(self.sys_backups.reload())

--- a/supervisor/api/mounts.py
+++ b/supervisor/api/mounts.py
@@ -29,7 +29,7 @@ class APIMounts(CoreSysAttributes):
         """Return MountManager info."""
         return {
             ATTR_DEFAULT_BACKUP_MOUNT: self.sys_mounts.default_backup_mount.name
-            if self.sys_mounts.default_backup_mount.name
+            if self.sys_mounts.default_backup_mount
             else None,
             ATTR_MOUNTS: [
                 mount.to_dict() | {ATTR_STATE: mount.state}

--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -13,8 +13,10 @@ from ..const import (
     CoreState,
 )
 from ..coresys import CoreSysAttributes
+from ..dbus.const import UnitActiveState
 from ..exceptions import AddonsError
 from ..jobs.decorator import Job, JobCondition
+from ..mounts.mount import Mount
 from ..utils.common import FileConfiguration
 from ..utils.dt import utcnow
 from ..utils.sentry import capture_exception
@@ -51,9 +53,28 @@ class BackupManager(FileConfiguration, CoreSysAttributes):
         """Set days until backup is considered stale."""
         self._data[ATTR_DAYS_UNTIL_STALE] = value
 
+    @property
+    def backup_locations(self) -> list[Path]:
+        """List of locations containing backups."""
+        return [self.sys_config.path_backup] + [
+            mount.local_where
+            for mount in self.sys_mounts.backup_mounts
+            if mount.state == UnitActiveState.ACTIVE
+        ]
+
     def get(self, slug):
         """Return backup object."""
         return self._backups.get(slug)
+
+    def _get_base_path(self, location: Mount | None = None) -> Path:
+        """Get base path for backup using location or default location."""
+        if location:
+            return location.local_where
+
+        if self.sys_mounts.default_backup_mount:
+            return self.sys_mounts.default_backup_mount.local_where
+
+        return self.sys_config.path_backup
 
     def _create_backup(
         self,
@@ -61,11 +82,12 @@ class BackupManager(FileConfiguration, CoreSysAttributes):
         sys_type: BackupType,
         password: str | None,
         compressed: bool = True,
+        location: Mount | None = None,
     ) -> Backup:
         """Initialize a new backup object from name."""
         date_str = utcnow().isoformat()
         slug = create_slug(name, date_str)
-        tar_file = Path(self.sys_config.path_backup, f"{slug}.tar")
+        tar_file = Path(self._get_base_path(location), f"{slug}.tar")
 
         # init object
         backup = Backup(self.coresys, tar_file)
@@ -95,7 +117,8 @@ class BackupManager(FileConfiguration, CoreSysAttributes):
 
         tasks = [
             _load_backup(tar_file)
-            for tar_file in self.sys_config.path_backup.glob("*.tar")
+            for path in self.backup_locations
+            for tar_file in path.glob("*.tar")
         ]
 
         _LOGGER.info("Found %d backup files", len(tasks))
@@ -182,13 +205,17 @@ class BackupManager(FileConfiguration, CoreSysAttributes):
             self.sys_core.state = CoreState.RUNNING
 
     @Job(conditions=[JobCondition.FREE_SPACE, JobCondition.RUNNING])
-    async def do_backup_full(self, name="", password=None, compressed=True):
+    async def do_backup_full(
+        self, name="", password=None, compressed=True, location: Mount | None = None
+    ):
         """Create a full backup."""
         if self.lock.locked():
             _LOGGER.error("A backup/restore process is already running")
             return None
 
-        backup = self._create_backup(name, BackupType.FULL, password, compressed)
+        backup = self._create_backup(
+            name, BackupType.FULL, password, compressed, location
+        )
 
         _LOGGER.info("Creating new full backup with slug %s", backup.slug)
         async with self.lock:
@@ -208,6 +235,7 @@ class BackupManager(FileConfiguration, CoreSysAttributes):
         password: str | None = None,
         homeassistant: bool = False,
         compressed: bool = True,
+        location: Mount | None = None,
     ):
         """Create a partial backup."""
         if self.lock.locked():
@@ -225,7 +253,9 @@ class BackupManager(FileConfiguration, CoreSysAttributes):
         if len(addons) == 0 and len(folders) == 0 and not homeassistant:
             _LOGGER.error("Nothing to create backup for")
 
-        backup = self._create_backup(name, BackupType.PARTIAL, password, compressed)
+        backup = self._create_backup(
+            name, BackupType.PARTIAL, password, compressed, location
+        )
 
         _LOGGER.info("Creating new partial backup with slug %s", backup.slug)
         async with self.lock:

--- a/supervisor/misc/tasks.py
+++ b/supervisor/misc/tasks.py
@@ -33,6 +33,7 @@ RUN_WATCHDOG_ADDON_APPLICATON = 120
 RUN_WATCHDOG_OBSERVER_APPLICATION = 180
 
 RUN_REFRESH_ADDON = 15
+RUN_REFRESH_MOUNTS = 900
 
 PLUGIN_AUTO_UPDATE_CONDITIONS = PLUGIN_UPDATE_CONDITIONS + [JobCondition.RUNNING]
 
@@ -62,6 +63,7 @@ class Tasks(CoreSysAttributes):
         self.sys_scheduler.register_task(self.sys_backups.reload, RUN_RELOAD_BACKUPS)
         self.sys_scheduler.register_task(self.sys_host.reload, RUN_RELOAD_HOST)
         self.sys_scheduler.register_task(self.sys_ingress.reload, RUN_RELOAD_INGRESS)
+        self.sys_scheduler.register_task(self.sys_mounts.reload, RUN_REFRESH_MOUNTS)
 
         # Watchdog
         self.sys_scheduler.register_task(

--- a/supervisor/mounts/const.py
+++ b/supervisor/mounts/const.py
@@ -5,6 +5,7 @@ from pathlib import PurePath
 
 FILE_CONFIG_MOUNTS = PurePath("mounts.json")
 
+ATTR_DEFAULT_BACKUP_MOUNT = "default_backup_mount"
 ATTR_MOUNTS = "mounts"
 ATTR_PATH = "path"
 ATTR_SERVER = "server"
@@ -25,11 +26,3 @@ class MountUsage(str, Enum):
 
     BACKUP = "backup"
     MEDIA = "media"
-
-
-class MountState(str, Enum):
-    """Mount state."""
-
-    ACTIVE = "active"
-    FAILED = "failed"
-    UNKNOWN = "unknown"

--- a/supervisor/mounts/manager.py
+++ b/supervisor/mounts/manager.py
@@ -10,7 +10,7 @@ from ..const import ATTR_NAME
 from ..coresys import CoreSys, CoreSysAttributes
 from ..dbus.const import UnitActiveState
 from ..exceptions import MountActivationError, MountError, MountNotFound
-from ..resolution.const import ContextType, IssueType, SuggestionType
+from ..resolution.const import SuggestionType
 from ..utils.common import FileConfiguration
 from ..utils.sentry import capture_exception
 from .const import (

--- a/supervisor/resolution/module.py
+++ b/supervisor/resolution/module.py
@@ -178,11 +178,19 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
         suggestions: list[SuggestionType] | None = None,
     ) -> None:
         """Create issues and suggestion."""
+        self.add_issue(Issue(issue, context, reference), suggestions)
+
+    def add_issue(
+        self, issue: Issue, suggestions: list[SuggestionType] | None = None
+    ) -> None:
+        """Add an issue and suggestions."""
         if suggestions:
             for suggestion in suggestions:
-                self.suggestions = Suggestion(suggestion, context, reference)
+                self.suggestions = Suggestion(
+                    suggestion, issue.context, issue.reference
+                )
 
-        self.issues = Issue(issue, context, reference)
+        self.issues = issue
 
     async def load(self):
         """Load the resoulution manager."""

--- a/supervisor/utils/sentinel.py
+++ b/supervisor/utils/sentinel.py
@@ -1,0 +1,22 @@
+"""Sentinel to use when None is a valid value."""
+
+from typing import Literal
+
+
+class SentinelMeta(type):
+    """Metaclass for sentinel to improve representation and make falsy.
+
+    Credit to https://stackoverflow.com/a/69243488 .
+    """
+
+    def __repr__(cls) -> str:
+        """Represent class more like an enum."""
+        return f"<{cls.__name__}>"
+
+    def __bool__(cls) -> Literal[False]:
+        """Return false as a sentinel is akin to an empty value."""
+        return False
+
+
+class DEFAULT(metaclass=SentinelMeta):
+    """Sentinel for default value when None is valid."""

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -1,8 +1,10 @@
 """Test backups API."""
 
+from pathlib import Path, PurePath
 from unittest.mock import patch
 
 from aiohttp.test_utils import TestClient
+import pytest
 
 from supervisor.backups.backup import Backup
 from supervisor.const import CoreState
@@ -49,24 +51,33 @@ async def test_options(api_client, coresys: CoreSys):
     assert coresys.backups.days_until_stale == 10
 
 
-async def test_backup_to_mount(
-    api_client: TestClient, coresys: CoreSys, tmp_supervisor_data, path_extern
+@pytest.mark.parametrize(
+    "location,backup_dir",
+    [("backup_test", PurePath("mounts", "backup_test")), (None, PurePath("backup"))],
+)
+async def test_backup_to_location(
+    api_client: TestClient,
+    coresys: CoreSys,
+    location: str | None,
+    backup_dir: PurePath,
+    tmp_supervisor_data: Path,
+    path_extern,
 ):
-    """Test making a backup to a backup mount."""
+    """Test making a backup to a specific location with default mount."""
     await coresys.mounts.load()
-    (mount_dir := coresys.config.path_mounts / "backup_test").mkdir()
-    await coresys.mounts.create_mount(
-        Mount.from_dict(
-            coresys,
-            {
-                "name": "backup_test",
-                "type": "cifs",
-                "usage": "backup",
-                "server": "backup.local",
-                "share": "backups",
-            },
-        )
+    (coresys.config.path_mounts / "backup_test").mkdir()
+    mount = Mount.from_dict(
+        coresys,
+        {
+            "name": "backup_test",
+            "type": "cifs",
+            "usage": "backup",
+            "server": "backup.local",
+            "share": "backups",
+        },
     )
+    await coresys.mounts.create_mount(mount)
+    coresys.mounts.default_backup_mount = mount
 
     coresys.core.state = CoreState.RUNNING
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
@@ -74,8 +85,40 @@ async def test_backup_to_mount(
         "/backups/new/full",
         json={
             "name": "Mount test",
-            "location": "backup_test",
+            "location": location,
         },
+    )
+    result = await resp.json()
+    assert result["result"] == "ok"
+    slug = result["data"]["slug"]
+
+    assert (tmp_supervisor_data / backup_dir / f"{slug}.tar").exists()
+
+
+async def test_backup_to_default(
+    api_client: TestClient, coresys: CoreSys, tmp_supervisor_data, path_extern
+):
+    """Test making backup to default mount."""
+    await coresys.mounts.load()
+    (mount_dir := coresys.config.path_mounts / "backup_test").mkdir()
+    mount = Mount.from_dict(
+        coresys,
+        {
+            "name": "backup_test",
+            "type": "cifs",
+            "usage": "backup",
+            "server": "backup.local",
+            "share": "backups",
+        },
+    )
+    await coresys.mounts.create_mount(mount)
+    coresys.mounts.default_backup_mount = mount
+
+    coresys.core.state = CoreState.RUNNING
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    resp = await api_client.post(
+        "/backups/new/full",
+        json={"name": "Mount test"},
     )
     result = await resp.json()
     assert result["result"] == "ok"

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -2,8 +2,12 @@
 
 from unittest.mock import patch
 
+from aiohttp.test_utils import TestClient
+
 from supervisor.backups.backup import Backup
+from supervisor.const import CoreState
 from supervisor.coresys import CoreSys
+from supervisor.mounts.mount import Mount
 
 
 async def test_info(api_client, coresys: CoreSys, mock_full_backup: Backup):
@@ -43,3 +47,38 @@ async def test_options(api_client, coresys: CoreSys):
         save_data.assert_called_once()
 
     assert coresys.backups.days_until_stale == 10
+
+
+async def test_backup_to_mount(
+    api_client: TestClient, coresys: CoreSys, tmp_supervisor_data, path_extern
+):
+    """Test making a backup to a backup mount."""
+    await coresys.mounts.load()
+    (mount_dir := coresys.config.path_mounts / "backup_test").mkdir()
+    await coresys.mounts.create_mount(
+        Mount.from_dict(
+            coresys,
+            {
+                "name": "backup_test",
+                "type": "cifs",
+                "usage": "backup",
+                "server": "backup.local",
+                "share": "backups",
+            },
+        )
+    )
+
+    coresys.core.state = CoreState.RUNNING
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    resp = await api_client.post(
+        "/backups/new/full",
+        json={
+            "name": "Mount test",
+            "location": "backup_test",
+        },
+    )
+    result = await resp.json()
+    assert result["result"] == "ok"
+    slug = result["data"]["slug"]
+
+    assert (mount_dir / f"{slug}.tar").exists()

--- a/tests/api/test_mounts.py
+++ b/tests/api/test_mounts.py
@@ -310,7 +310,10 @@ async def test_api_reload_error_mount_missing(api_client: TestClient):
     assert resp.status == 400
     result = await resp.json()
     assert result["result"] == "error"
-    assert result["message"] == "No mount exists with name backup_test"
+    assert (
+        result["message"]
+        == "Cannot reload 'backup_test', no mount exists with that name"
+    )
 
 
 async def test_api_delete_mount(api_client: TestClient, coresys: CoreSys, mount):
@@ -333,7 +336,10 @@ async def test_api_delete_error_mount_missing(api_client: TestClient):
     assert resp.status == 400
     result = await resp.json()
     assert result["result"] == "error"
-    assert result["message"] == "No mount exists with name backup_test"
+    assert (
+        result["message"]
+        == "Cannot remove 'backup_test', no mount exists with that name"
+    )
 
 
 async def test_api_create_backup_mount_sets_default(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -372,6 +372,7 @@ async def tmp_supervisor_data(coresys: CoreSys, tmp_path: Path) -> Path:
         coresys.config.path_mounts.mkdir()
         coresys.config.path_backup.mkdir()
         coresys.config.path_tmp.mkdir()
+        coresys.config.path_homeassistant.mkdir()
         yield tmp_path
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Add support for backup mounts. Users can make backups to them and backups are listed from them. One backup mount can also be marked as default and all backups will be made there unless a location is otherwise specified. If a backup mount is added and there is no default it will automatically be set as the default.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1777
- Link to cli pull request: https://github.com/home-assistant/cli/pull/399

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
