### PR TITLE
Improve handling of NFS mounts and backup manager errors

### DIFF
--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterable
 import logging
 from pathlib import Path
 
@@ -27,6 +28,15 @@ from .utils import create_slug
 from .validate import ALL_FOLDERS, SCHEMA_BACKUPS_CONFIG
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+def _list_backup_files(path: Path) -> Iterable[Path]:
+    """Return iterable of backup files, suppress and log OSError for network mounts."""
+    try:
+        return path.glob("*.tar")
+    except OSError as err:
+        _LOGGER.error("Could not list backups from %s: %s", path.as_posix(), err)
+        return []
 
 
 class BackupManager(FileConfiguration, CoreSysAttributes):
@@ -119,7 +129,7 @@ class BackupManager(FileConfiguration, CoreSysAttributes):
         tasks = [
             self.sys_create_task(_load_backup(tar_file))
             for path in self.backup_locations
-            for tar_file in path.glob("*.tar")
+            for tar_file in _list_backup_files(path)
         ]
 
         _LOGGER.info("Found %d backup files", len(tasks))

--- a/supervisor/mounts/mount.py
+++ b/supervisor/mounts/mount.py
@@ -381,6 +381,11 @@ class NFSMount(NetworkMount):
         """What to mount."""
         return f"{self.server}:{self.path.as_posix()}"
 
+    @property
+    def options(self) -> list[str]:
+        """Options to use to mount."""
+        return super().options + ["soft", "timeo=200"]
+
 
 class BindMount(Mount):
     """A bind type mount."""

--- a/tests/mounts/test_manager.py
+++ b/tests/mounts/test_manager.py
@@ -126,6 +126,7 @@ async def test_load(
             "mnt-data-supervisor-mounts-media_test.mount",
             "fail",
             [
+                ["Options", Variant("s", "soft,timeo=200")],
                 ["Type", Variant("s", "nfs")],
                 ["Description", Variant("s", "Supervisor nfs mount: media_test")],
                 ["What", Variant("s", "media.local:/media")],
@@ -189,6 +190,7 @@ async def test_load_share_mount(
             "mnt-data-supervisor-mounts-share_test.mount",
             "fail",
             [
+                ["Options", Variant("s", "soft,timeo=200")],
                 ["Type", Variant("s", "nfs")],
                 ["Description", Variant("s", "Supervisor nfs mount: share_test")],
                 ["What", Variant("s", "share.local:/share")],

--- a/tests/mounts/test_mount.py
+++ b/tests/mounts/test_mount.py
@@ -114,7 +114,7 @@ async def test_nfs_mount(
     assert mount.what == "test.local:/media/camera"
     assert mount.where == Path("/mnt/data/supervisor/mounts/test")
     assert mount.local_where == tmp_supervisor_data / "mounts" / "test"
-    assert mount.options == ["port=1234"]
+    assert mount.options == ["port=1234", "soft", "timeo=200"]
 
     assert not mount.local_where.exists()
     assert mount.to_dict() == mount_data
@@ -130,7 +130,7 @@ async def test_nfs_mount(
             "mnt-data-supervisor-mounts-test.mount",
             "fail",
             [
-                ["Options", Variant("s", "port=1234")],
+                ["Options", Variant("s", "port=1234,soft,timeo=200")],
                 ["Type", Variant("s", "nfs")],
                 ["Description", Variant("s", "Supervisor nfs mount: test")],
                 ["What", Variant("s", "test.local:/media/camera")],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

NFS mounts behave differently then CIFS mounts. Operations never timeout by default. Which means right now when supervisor is asked to do operations on a backup NFS mount and its down it simply hangs. Changing to use `soft` and a reasonable timeout for NFS mounts to prevent this.

Additionally during this I noticed that the following sequence causes a setup failure:
1. Make a working backup mount
2. Take it offline
3. Restart supervisor

Supervisor then adopts the existing systemd unit which things the mount is active. Backup manager tries to list files from it and gets a timeout error, failing setup. Fixing this so if backup manager cannot list files in a particular backup location it simply logs and ignores it.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
