### PR TITLE
Protect backup manager from setup failures for mount down

### DIFF
--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -33,10 +33,13 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 def _list_backup_files(path: Path) -> Iterable[Path]:
     """Return iterable of backup files, suppress and log OSError for network mounts."""
     try:
-        return path.glob("*.tar")
+        # is_dir does a stat syscall which raises if the mount is down
+        if path.is_dir():
+            return path.glob("*.tar")
     except OSError as err:
         _LOGGER.error("Could not list backups from %s: %s", path.as_posix(), err)
-        return []
+
+    return []
 
 
 class BackupManager(FileConfiguration, CoreSysAttributes):

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -690,7 +690,7 @@ async def test_load_network_error(
 
     # This should not raise, manager should just ignore backup locations with errors
     mock_path = MagicMock()
-    mock_path.glob.side_effect = OSError("Host is down")
+    mock_path.is_dir.side_effect = OSError("Host is down")
     mock_path.as_posix.return_value = "/data/backup_test"
     with patch.object(Mount, "local_where", new=PropertyMock(return_value=mock_path)):
         await coresys.backups.load()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

https://github.com/home-assistant/supervisor/pull/4323 did not fix the setup failures from backup manager. The `OSError` is only thrown once you ask the generator from `glob` for a value, not on creation of the generator. Added an `is_dir` call to do a `stat` which raises on mount down.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
