### PR TITLE
Add backup location to info/list API calls

### DIFF
--- a/supervisor/api/backups.py
+++ b/supervisor/api/backups.py
@@ -10,6 +10,7 @@ from aiohttp import web
 from aiohttp.hdrs import CONTENT_DISPOSITION
 import voluptuous as vol
 
+from ..backups.backup import Backup
 from ..backups.validate import ALL_FOLDERS, FOLDER_HOMEASSISTANT, days_until_stale
 from ..const import (
     ATTR_ADDONS,
@@ -91,6 +92,14 @@ class APIBackups(CoreSysAttributes):
             raise APIError("Backup does not exist")
         return backup
 
+    def _backup_location(self, backup: Backup) -> str | None:
+        """Return the location of the backup."""
+        backup_path = backup.tarfile.as_posix()
+        for backup_mount in self.sys_mounts.backup_mounts:
+            if backup_path.startswith(backup_mount.local_where.as_posix()):
+                return backup_mount.name
+        return None
+
     def _list_backups(self):
         """Return list of backups."""
         return [
@@ -100,6 +109,7 @@ class APIBackups(CoreSysAttributes):
                 ATTR_DATE: backup.date,
                 ATTR_TYPE: backup.sys_type,
                 ATTR_SIZE: backup.size,
+                ATTR_LOCATON: self._backup_location(backup),
                 ATTR_PROTECTED: backup.protected,
                 ATTR_COMPRESSED: backup.compressed,
                 ATTR_CONTENT: {
@@ -172,6 +182,7 @@ class APIBackups(CoreSysAttributes):
             ATTR_PROTECTED: backup.protected,
             ATTR_SUPERVISOR_VERSION: backup.supervisor_version,
             ATTR_HOMEASSISTANT: backup.homeassistant_version,
+            ATTR_LOCATON: self._backup_location(backup),
             ATTR_ADDONS: data_addons,
             ATTR_REPOSITORIES: backup.repositories,
             ATTR_FOLDERS: backup.folders,

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -95,6 +95,11 @@ async def test_backup_to_location(
 
     assert (tmp_supervisor_data / backup_dir / f"{slug}.tar").exists()
 
+    resp = await api_client.get(f"/backups/{slug}/info")
+    result = await resp.json()
+    assert result["result"] == "ok"
+    assert result["data"]["location"] == location
+
 
 async def test_backup_to_default(
     api_client: TestClient,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I want to know if my backup exist on the local filesystem or in my backup mount, so I can determine what to cleanup.
Currently there is no indication in the API that say if the backup is local or remote.

This PR adds a new `"location"` key to both the list and info API calls that includes the mount name if its on a mount or `None` if it's local.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
