### PR TITLE
Fix propagation mode of mounts to allow Ha-Core to start

### DIFF
--- a/supervisor/docker/addon.py
+++ b/supervisor/docker/addon.py
@@ -387,7 +387,7 @@ class DockerAddon(DockerInterface):
                     source=self.sys_config.path_extern_share.as_posix(),
                     target="/share",
                     read_only=addon_mapping[MAP_SHARE],
-                    propagation=PropagationMode.SLAVE.value,
+                    propagation=PropagationMode.RSLAVE.value,
                 )
             )
 
@@ -398,7 +398,7 @@ class DockerAddon(DockerInterface):
                     source=self.sys_config.path_extern_media.as_posix(),
                     target="/media",
                     read_only=addon_mapping[MAP_MEDIA],
-                    propagation=PropagationMode.SLAVE.value,
+                    propagation=PropagationMode.RSLAVE.value,
                 )
             )
 

--- a/supervisor/docker/homeassistant.py
+++ b/supervisor/docker/homeassistant.py
@@ -97,14 +97,14 @@ class DockerHomeAssistant(DockerInterface):
                 source=self.sys_config.path_extern_share.as_posix(),
                 target="/share",
                 read_only=False,
-                propagation=PropagationMode.SLAVE.value,
+                propagation=PropagationMode.RSLAVE.value,
             ),
             Mount(
                 type=MountType.BIND.value,
                 source=self.sys_config.path_extern_media.as_posix(),
                 target="/media",
                 read_only=False,
-                propagation=PropagationMode.SLAVE.value,
+                propagation=PropagationMode.RSLAVE.value,
             ),
             # Configuration audio
             Mount(

--- a/supervisor/resolution/checks/docker_config.py
+++ b/supervisor/resolution/checks/docker_config.py
@@ -12,7 +12,7 @@ from .base import CheckBase
 def _check_container(container: DockerInterface) -> bool:
     """Return true if container has a config issue."""
     return any(
-        mount.get("Propagation") != PropagationMode.SLAVE.value
+        mount.get("Propagation") != PropagationMode.RSLAVE.value
         for mount in container.meta_mounts
         if mount.get("Destination") in ["/media", "/share"]
     )

--- a/tests/docker/test_addon.py
+++ b/tests/docker/test_addon.py
@@ -121,7 +121,7 @@ def test_addon_map_folder_defaults(
             source=coresys.config.path_extern_media.as_posix(),
             target="/media",
             read_only=True,
-            propagation="slave",
+            propagation="rslave",
         )
         in docker_addon.mounts
     )
@@ -133,7 +133,7 @@ def test_addon_map_folder_defaults(
             source=coresys.config.path_extern_share.as_posix(),
             target="/share",
             read_only=True,
-            propagation="slave",
+            propagation="rslave",
         )
         in docker_addon.mounts
     )


### PR DESCRIPTION
Change the mount propagation mode from SLAVE to RSLAVE in case of /media and /share
This should address the current  mounting blocker error at: https://github.com/home-assistant/supervisor/issues/4366
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/supervisor/issues/4366
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast supervisor tests`)
- [X] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
