### PR TITLE
Quote CIFS password to remove strict requirements

### DIFF
--- a/supervisor/mounts/mount.py
+++ b/supervisor/mounts/mount.py
@@ -358,7 +358,8 @@ class CIFSMount(NetworkMount):
     def options(self) -> list[str]:
         """Options to use to mount."""
         return (
-            super().options + [f"username={self.username}", f"password={self.password}"]
+            super().options
+            + [f"username={self.username}", f"password='{self.password}'"]
             if self.username
             else []
         )

--- a/supervisor/mounts/validate.py
+++ b/supervisor/mounts/validate.py
@@ -21,13 +21,11 @@ from .const import (
 
 RE_MOUNT_NAME = re.compile(r"^\w+$")
 RE_PATH_PART = re.compile(r"^[^\\\/]+")
-RE_MOUNT_OPTION = re.compile(r"^[^,=]+$")
 
 VALIDATE_NAME = vol.Match(RE_MOUNT_NAME)
 VALIDATE_SERVER = vol.Match(RE_PATH_PART)
 VALIDATE_SHARE = vol.Match(RE_PATH_PART)
-VALIDATE_USERNAME = vol.Match(RE_MOUNT_OPTION)
-VALIDATE_PASSWORD = vol.Match(RE_MOUNT_OPTION)
+
 
 _SCHEMA_BASE_MOUNT_CONFIG = vol.Schema(
     {
@@ -49,8 +47,8 @@ SCHEMA_MOUNT_CIFS = _SCHEMA_MOUNT_NETWORK.extend(
     {
         vol.Required(ATTR_TYPE): MountType.CIFS.value,
         vol.Required(ATTR_SHARE): VALIDATE_SHARE,
-        vol.Inclusive(ATTR_USERNAME, "basic_auth"): VALIDATE_USERNAME,
-        vol.Inclusive(ATTR_PASSWORD, "basic_auth"): VALIDATE_PASSWORD,
+        vol.Inclusive(ATTR_USERNAME, "basic_auth"): str,
+        vol.Inclusive(ATTR_PASSWORD, "basic_auth"): str,
     }
 )
 

--- a/tests/mounts/test_mount.py
+++ b/tests/mounts/test_mount.py
@@ -39,7 +39,7 @@ async def test_cifs_mount(
         "server": "test.local",
         "share": "camera",
         "username": "admin",
-        "password": "password",
+        "password": "p@assword!,=",
     }
     mount: CIFSMount = Mount.from_dict(coresys, mount_data)
 
@@ -54,7 +54,7 @@ async def test_cifs_mount(
     assert mount.what == "//test.local/camera"
     assert mount.where == Path("/mnt/data/supervisor/mounts/test")
     assert mount.local_where == tmp_supervisor_data / "mounts" / "test"
-    assert mount.options == ["username=admin", "password=password"]
+    assert mount.options == ["username=admin", "password='p@assword!,='"]
 
     assert not mount.local_where.exists()
     assert mount.to_dict(skip_secrets=False) == mount_data
@@ -73,7 +73,7 @@ async def test_cifs_mount(
             "mnt-data-supervisor-mounts-test.mount",
             "fail",
             [
-                ["Options", Variant("s", "username=admin,password=password")],
+                ["Options", Variant("s", "username=admin,password='p@assword!,='")],
                 ["Type", Variant("s", "cifs")],
                 ["Description", Variant("s", "Supervisor cifs mount: test")],
                 ["What", Variant("s", "//test.local/camera")],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Removes the restrictions on the password by quoting it.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4352 fixes #4373
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
