### PR TITLE
Use noserverino option in cifs mounts

### DIFF
--- a/supervisor/mounts/mount.py
+++ b/supervisor/mounts/mount.py
@@ -383,7 +383,7 @@ class CIFSMount(NetworkMount):
     @property
     def options(self) -> list[str]:
         """Options to use to mount."""
-        options = super().options
+        options = super().options + ["noserverino"]
         if self.version:
             options.append(f"vers={self.version}")
 

--- a/tests/mounts/test_manager.py
+++ b/tests/mounts/test_manager.py
@@ -116,7 +116,7 @@ async def test_load(
             "mnt-data-supervisor-mounts-backup_test.mount",
             "fail",
             [
-                ["Options", Variant("s", "guest")],
+                ["Options", Variant("s", "noserverino,guest")],
                 ["Type", Variant("s", "cifs")],
                 ["Description", Variant("s", "Supervisor cifs mount: backup_test")],
                 ["What", Variant("s", "//backup.local/backups")],

--- a/tests/mounts/test_mount.py
+++ b/tests/mounts/test_mount.py
@@ -77,7 +77,7 @@ async def test_cifs_mount(
     assert mount.what == "//test.local/camera"
     assert mount.where == Path("/mnt/data/supervisor/mounts/test")
     assert mount.local_where == tmp_supervisor_data / "mounts" / "test"
-    assert mount.options == expected_options + [
+    assert mount.options == ["noserverino"] + expected_options + [
         f"username={mount_data['username']}",
         f"password={mount_data['password']}",
     ]
@@ -104,7 +104,8 @@ async def test_cifs_mount(
                     Variant(
                         "s",
                         ",".join(
-                            expected_options
+                            ["noserverino"]
+                            + expected_options
                             + [
                                 f"username={mount_data['username']}",
                                 f"password={mount_data['password']}",
@@ -215,7 +216,7 @@ async def test_load(
             "mnt-data-supervisor-mounts-test.mount",
             "fail",
             [
-                ["Options", Variant("s", "guest")],
+                ["Options", Variant("s", "noserverino,guest")],
                 ["Type", Variant("s", "cifs")],
                 ["Description", Variant("s", "Supervisor cifs mount: test")],
                 ["What", Variant("s", "//test.local/share")],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The default for cifs mounts is to use inodes from the server when possible (not always possible, in which case it falls back to generating inodes on the client). This is a problematic default because sometimes it creates issues like https://github.com/home-assistant/operating-system/issues/2585 . The benefit (being able to easily distinguish hardlinks) doesn't seem worth the risk.

Changing to always use client generated inodes as that should fix the stale file handle issue without really any downside to other users.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/operating-system/issues/2585
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
