### PR TITLE
Allow return of all addon info in one api

### DIFF
--- a/supervisor/api/const.py
+++ b/supervisor/api/const.py
@@ -1,5 +1,7 @@
 """Const for API."""
 
+from enum import StrEnum
+
 CONTENT_TYPE_BINARY = "application/octet-stream"
 CONTENT_TYPE_JSON = "application/json"
 CONTENT_TYPE_PNG = "image/png"
@@ -53,3 +55,11 @@ ATTR_UPDATE_TYPE = "update_type"
 ATTR_USE_NTP = "use_ntp"
 ATTR_USAGE = "usage"
 ATTR_VENDOR = "vendor"
+
+
+class AddonView(StrEnum):
+    """Addon view."""
+
+    FULL = "full"
+    SIMPLE = "simple"
+    NONE = "none"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

@bdraco noted that the hassio integration in core can be quite expensive at startup. This is in part because it makes 3 calls per installed addon every time the data refreshes:
1. Get complete addon info (`/addons` only returns a partial view of each)
2. Get docker stats per addon
3. Get changelog per addon

https://github.com/home-assistant/core/blob/b8de7df6098e257cf6d0a347d141e5f40cae66ca/homeassistant/components/hassio/__init__.py#L903C19-L919

This API allows a client to get all of 1 and 2 in a single API call with new query string parameters for `/addons` so we can reduce IO in core. 3 is unchanged for now as changelogs can be quite large.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
