### PR TITLE
Ensure addon.start always returns coroutine

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -716,7 +716,7 @@ class Addon(AddonModel):
         """
         if await self.instance.is_running():
             _LOGGER.warning("%s is already running!", self.slug)
-            return
+            return self._wait_for_startup()
 
         # Access Token
         self.persist[ATTR_ACCESS_TOKEN] = secrets.token_hex(56)

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -471,3 +471,22 @@ async def test_restore(
         start_task = await coresys.addons.restore(TEST_ADDON_SLUG, tarfile)
 
     assert bool(start_task) is (status == "running")
+
+
+async def test_start_when_running(
+    coresys: CoreSys,
+    install_addon_ssh: Addon,
+    container: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test starting an addon without healthcheck."""
+    container.status = "running"
+    await install_addon_ssh.load()
+    assert install_addon_ssh.state == AddonState.STARTED
+
+    caplog.clear()
+    start_task = await install_addon_ssh.start()
+    assert start_task
+    await start_task
+
+    assert "local_ssh is already running" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Addon.start was returning `None` if the addon was already running and callers expected it to always return a awaitable they could use to wait on it being started. Addon.start should always return coroutine callers can use to wait on it being ready and available, even if the addon has previously been started (might not be healthy yet).

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://home-assistant-io.sentry.io/issues/4270085037/events/5ae137c2b30c432292b5e7441800ef2f/
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
