### PR TITLE
Separate startup event from update check event

### DIFF
--- a/supervisor/const.py
+++ b/supervisor/const.py
@@ -451,6 +451,7 @@ class BusEvent(str, Enum):
     HARDWARE_NEW_DEVICE = "hardware_new_device"
     HARDWARE_REMOVE_DEVICE = "hardware_remove_device"
     DOCKER_CONTAINER_STATE_CHANGE = "docker_container_state_change"
+    SUPERVISOR_STATE_CHANGE = "supervisor_state_change"
 
 
 class CpuArch(str, Enum):
@@ -461,3 +462,10 @@ class CpuArch(str, Enum):
     AARCH64 = "aarch64"
     I386 = "i386"
     AMD64 = "amd64"
+
+
+STARTING_STATES = [
+    CoreState.INITIALIZE,
+    CoreState.STARTUP,
+    CoreState.SETUP,
+]

--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -7,7 +7,14 @@ import logging
 
 import async_timeout
 
-from .const import ATTR_STARTUP, RUN_SUPERVISOR_STATE, AddonStartup, CoreState
+from .const import (
+    ATTR_STARTUP,
+    RUN_SUPERVISOR_STATE,
+    STARTING_STATES,
+    AddonStartup,
+    BusEvent,
+    CoreState,
+)
 from .coresys import CoreSys, CoreSysAttributes
 from .exceptions import (
     HassioError,
@@ -63,9 +70,13 @@ class Core(CoreSysAttributes):
             )
         finally:
             self._state = new_state
-            self.sys_homeassistant.websocket.supervisor_update_event(
-                "info", {"state": new_state}
-            )
+            self.sys_bus.fire_event(BusEvent.SUPERVISOR_STATE_CHANGE, new_state)
+
+            # These will be received by HA after startup has completed which won't make sense
+            if new_state not in STARTING_STATES:
+                self.sys_homeassistant.websocket.supervisor_update_event(
+                    "info", {"state": new_state}
+                )
 
     async def connect(self):
         """Connect Supervisor container."""

--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -7,7 +7,7 @@ import logging
 
 import async_timeout
 
-from .const import RUN_SUPERVISOR_STATE, AddonStartup, CoreState
+from .const import ATTR_STARTUP, RUN_SUPERVISOR_STATE, AddonStartup, CoreState
 from .coresys import CoreSys, CoreSysAttributes
 from .exceptions import (
     HassioError,
@@ -266,7 +266,9 @@ class Core(CoreSysAttributes):
             self.sys_create_task(self.sys_resolution.healthcheck())
 
             self.state = CoreState.RUNNING
-            self.sys_homeassistant.websocket.supervisor_update_event("supervisor", {})
+            self.sys_homeassistant.websocket.supervisor_update_event(
+                "supervisor", {ATTR_STARTUP: "complete"}
+            )
             _LOGGER.info("Supervisor is up and running")
 
     async def stop(self):

--- a/supervisor/homeassistant/module.py
+++ b/supervisor/homeassistant/module.py
@@ -260,6 +260,7 @@ class HomeAssistant(FileConfiguration, CoreSysAttributes):
         """Prepare Home Assistant object."""
         await asyncio.wait(
             [
+                self.sys_create_task(self.websocket.load()),
                 self.sys_create_task(self.secrets.load()),
                 self.sys_create_task(self.core.load()),
             ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Currently users see this a lot in core:
```
Logger: homeassistant.components.hassio.issues
Source: components/hassio/issues.py:312
Integration: Home Assistant Supervisor (documentation, issues)
First occurred: 17:31:34 (1 occurrences)
Last logged: 17:31:34

Failed to update supervisor issues: HassioAPIError('System is not ready with state: setup')
```
This is because when the hassio integration sees a message with type `supervisor_update` and key `supervisor` it assumes supervisor has just finished startup and asks for issues. The problem is we actually fire this message twice:
https://github.com/home-assistant/supervisor/blob/48e9e1c4f94cf89d3f2dbbebe93de7d5744fb6ae/supervisor/core.py#L269
https://github.com/home-assistant/supervisor/blob/48e9e1c4f94cf89d3f2dbbebe93de7d5744fb6ae/supervisor/updater.py#L297

The second one in particular is the issue since it occurs before setup is complete. Therefore every time you restart supervisor without restarting core you see this error.

Nothing breaks so this isn't urgent but it is log noise that should be removed. This PR allows us to distinguish between these two messages and only listen for the first one.

It also queues messages sent to core before startup has completed and sends them after to prevent situations like this where the client reacts by asking for more information before supervisor's API is ready. Commands (where supervisor tells core to do something and blocks waiting for a response) are still allowed as that should be ok. Plus we can't just put those in a queue the caller is blocked and waiting.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
