### PR TITLE
Allow API calls from HA core to supervisor when core state is "setup" (HA core / supervisor race condition)

### DIFF
--- a/supervisor/api/middleware/security.py
+++ b/supervisor/api/middleware/security.py
@@ -190,6 +190,7 @@ class SecurityMiddleware(CoreSysAttributes):
     ) -> Response:
         """Check if core is ready to response."""
         if self.sys_core.state not in (
+            CoreState.SETUP,
             CoreState.STARTUP,
             CoreState.RUNNING,
             CoreState.FREEZE,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

There seems to be a race condition between HA supervisor and HA core which occasionally leads to the first HA core startup failing after OS boot especially on powerful machines. This has been documented by multiple users:
https://github.com/home-assistant/core/issues/86622
https://github.com/home-assistant/core/issues/95887

When the issue happens HA supervisor API is responding to HA core with:
`homeassistant.components.hassio.handler.HassioAPIError: System is not ready with state: setup`
which if I'm looking in the code is actually counter-intuitive as the check seems to check core state, not supervisor state and is commented with 'Check if core is ready to response.' which it obviously is.

I'm proposing (for lack of a better understanding) to allow core to call supervisor API when core.state is still "setup". Alternatively the core state detection could possibly be fixed but I didn't have the time to dig into that.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issues: https://github.com/home-assistant/core/issues/86622
https://github.com/home-assistant/core/issues/95887

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
