### PR TITLE
Switch to using the get core state api call to check if the API is up

### DIFF
--- a/supervisor/homeassistant/api.py
+++ b/supervisor/homeassistant/api.py
@@ -109,7 +109,7 @@ class HomeAssistantAPI(CoreSysAttributes):
 
         raise HomeAssistantAPIError()
 
-    async def _get(self, path: str) -> dict[str, Any]:
+    async def _get_json(self, path: str) -> dict[str, Any]:
         """Return Home Assistant get API."""
         async with self.make_request("get", path) as resp:
             if resp.status in (200, 201):
@@ -120,11 +120,11 @@ class HomeAssistantAPI(CoreSysAttributes):
 
     async def get_config(self) -> dict[str, Any]:
         """Return Home Assistant config."""
-        await self._get("api/config")
+        await self._get_json("api/config")
 
     async def get_core_state(self) -> dict[str, Any]:
         """Return Home Assistant state."""
-        return await self._get("api/core/state")
+        return await self._get_json("api/core/state")
 
     async def check_api_state(self) -> bool:
         """Return True if Home Assistant up and running."""

--- a/supervisor/homeassistant/api.py
+++ b/supervisor/homeassistant/api.py
@@ -120,7 +120,7 @@ class HomeAssistantAPI(CoreSysAttributes):
 
     async def get_config(self) -> dict[str, Any]:
         """Return Home Assistant config."""
-        await self._get_json("api/config")
+        return await self._get_json("api/config")
 
     async def get_core_state(self) -> dict[str, Any]:
         """Return Home Assistant core state."""

--- a/supervisor/homeassistant/api.py
+++ b/supervisor/homeassistant/api.py
@@ -18,7 +18,7 @@ from .const import LANDINGPAGE
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
-GET_CORE_STATE_MIN_VERSION: AwesomeVersion = AwesomeVersion("2023.8.0dev0")
+GET_CORE_STATE_MIN_VERSION: AwesomeVersion = AwesomeVersion("2023.8.0.dev20230720")
 
 
 class HomeAssistantAPI(CoreSysAttributes):

--- a/supervisor/homeassistant/api.py
+++ b/supervisor/homeassistant/api.py
@@ -123,7 +123,7 @@ class HomeAssistantAPI(CoreSysAttributes):
         await self._get_json("api/config")
 
     async def get_core_state(self) -> dict[str, Any]:
-        """Return Home Assistant state."""
+        """Return Home Assistant core state."""
         return await self._get_json("api/core/state")
 
     async def check_api_state(self) -> bool:

--- a/supervisor/homeassistant/api.py
+++ b/supervisor/homeassistant/api.py
@@ -18,7 +18,7 @@ from .const import LANDINGPAGE
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
-GET_CORE_STATE_MIN_VERSION: AwesomeVersion = AwesomeVersion("2023.8.0")
+GET_CORE_STATE_MIN_VERSION: AwesomeVersion = AwesomeVersion("2023.8.0dev0")
 
 
 class HomeAssistantAPI(CoreSysAttributes):


### PR DESCRIPTION
Should wait until after nightly core has been published to merge

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
related https://github.com/home-assistant/core/pull/96860

This call is made OFTEN and its likely the most common api call supervisor makes.


```
Jul 19 17:04:24 homeassistant hassio_supervisor[546]: 23-07-19 12:04:24 INFO (MainThread) [supervisor.host.services] Updating service information
Jul 19 17:04:24 homeassistant hassio_supervisor[546]: 23-07-19 12:04:24 WARNING (MainThread) [supervisor.homeassistant.api] Home Assistant API response: {'latitude': 29.7738, 'longitude': -95.406, 'elevation': 0, 'unit_system': {'length': 'mi', 'accumulated_precipitation': 'in', 'mass': 'lb', 'pressure': 'psi', 'temperature': '°F', 'volume': 'gal', 'wind_speed': 'mph'}, 'location_name': 'N2alex', 'time_zone': 'America/Chicago', 'components': ['sensor.command_line', 'webhook', 'sensor.hassio', 'cover.switchbot', 'alarm_control_panel.mqtt', 'repairs', 'default_config', 'mopeka', 'sensor.switchbot', 'govee_ble', 'sensor', 'moat', 'vacuum.mqtt', 'search', 'onboarding', 'humidifier.mqtt', 'stt', 'stream', 'command_line', 'sensor.xiaomi_ble', 'bluetooth', 'zeroconf', 'select.mqtt', 'ssdp', 'automation', 'sensor.oralb', 'binary_sensor.hassio', 'scene.mqtt', 'lock.mqtt', 'energy', 'light.mqtt', 'scene.homeassistant', 'lovelace', 'influxdb', 'sensor.homekit_controller', 'binary_sensor.homekit_controller', 'sensor.thermopro', 'notify.mobile_app', 'device_tracker', 'notify', 'update.mqtt', 'sensor.mopeka', 'tts', 'binary_sensor.qingping', 'fan.mqtt', 'websocket_api', 'update', 'binary_sensor.mobile_app', 'group', 'http', 'climate', 'api', 'qingping', 'binary_sensor.mqtt', 'update.hassio', 'cover', 'schedule', 'binary_sensor', 'device_tracker.mobile_app', 'sensor.qingping', 'xiaomi_ble', 'usb', 'input_text', 'script', 'lock.switchbot', 'input_boolean', 'input_number', 'logger', 'trace', 'lock', 'binary_sensor.bthome', 'camera', 'text', 'blueprint', 'input_select', 'switch.switchbot', 'mobile_app', 'sensor.bthome', 'cloud', 'tts.google_translate', 'application_credentials', 'image', 'sensor.govee_ble', 'my', 'bluemaestro', 'homeassistant', 'sensor.mobile_app', 'persistent_notification', 'select', 'auth', 'device_tracker.mqtt', 'sensor.sensorpro', 'person', 'button.mqtt', 'number', 'siren.mqtt', 'camera.mqtt', 'image.mqtt', 'thread', 'conversation', 'timer', 'water_heater.mqtt', 'system_log', 'counter', 'analytics', 'hassio', 'bluetooth_adapters', 'sensor.sun', 'light.homekit_controller', 'sensor.energy', 'light', 'input_datetime', 'hacs', 'climate.mqtt', 'zone', 'frontend', 'switch', 'switch.mqtt', 'system_health', 'device_automation', 'bthome', 'image_upload', 'homeassistant_alerts', 'scene', 'media_source', 'sensor.ibeacon', 'oralb', 'alarm_control_panel', 'switchbot', 'sensor.bluemaestro', 'sensorpro', 'ibeacon', 'sensor.moat', 'vacuum', 'binary_sensor.switchbot', 'device_tracker.ibeacon', 'homekit', 'binary_sensor.xiaomi_ble', 'remote', 'hardware', 'text.mqtt', 'dhcp', 'profiler', 'rtsp_to_webrtc', 'sensor.hacs', 'input_button', 'cover.mqtt', 'config', 'button', 'homekit_controller', 'sun', 'history', 'siren', 'button.homekit_controller', 'number.mqtt', 'water_heater', 'file_upload', 'sensorpush', 'network', 'tag', 'hardkernel', 'recorder', 'map', 'thermopro', 'logbook', 'diagnostics', 'humidifier', 'sensor.mqtt', 'mqtt', 'fan', 'ffmpeg', 'assist_pipeline', 'sensor.sensorpush'], 'config_dir': '/config', 'whitelist_external_dirs': ['/media', '/config/www'], 'allowlist_external_dirs': ['/media', '/config/www'], 'allowlist_external_urls': [], 'version': '2023.8.0.dev0', 'config_source': 'storage', 'safe_mode': False, 'state': 'RUNNING', 'external_url': None, 'internal_url': None, 'currency': 'USD', 'country': 'US', 'language': 'en'}
Jul 19 17:04:24 homeassistant hassio_supervisor[546]: 23-07-19 12:04:24 INFO (MainThread) [supervisor.host.network] Updating local network information
Jul 19 17:04:24 homeassistant hassio_supervisor[546]: 23-07-19 12:04:24 WARNING (MainThread) [supervisor.homeassistant.api] Home Assistant API response: {'latitude': 29.7738, 'longitude': -95.406, 'elevation': 0, 'unit_system': {'length': 'mi', 'accumulated_precipitation': 'in', 'mass': 'lb', 'pressure': 'psi', 'temperature': '°F', 'volume': 'gal', 'wind_speed': 'mph'}, 'location_name': 'N2alex', 'time_zone': 'America/Chicago', 'components': ['sensor.command_line', 'webhook', 'sensor.hassio', 'cover.switchbot', 'alarm_control_panel.mqtt', 'repairs', 'default_config', 'mopeka', 'sensor.switchbot', 'govee_ble', 'sensor', 'moat', 'vacuum.mqtt', 'search', 'onboarding', 'humidifier.mqtt', 'stt', 'stream', 'command_line', 'sensor.xiaomi_ble', 'bluetooth', 'zeroconf', 'select.mqtt', 'ssdp', 'automation', 'sensor.oralb', 'binary_sensor.hassio', 'scene.mqtt', 'lock.mqtt', 'energy', 'light.mqtt', 'scene.homeassistant', 'lovelace', 'influxdb', 'sensor.homekit_controller', 'binary_sensor.homekit_controller', 'sensor.thermopro', 'notify.mobile_app', 'device_tracker', 'notify', 'update.mqtt', 'sensor.mopeka', 'tts', 'binary_sensor.qingping', 'fan.mqtt', 'websocket_api', 'update', 'binary_sensor.mobile_app', 'group', 'http', 'climate', 'api', 'qingping', 'binary_sensor.mqtt', 'update.hassio', 'cover', 'schedule', 'binary_sensor', 'device_tracker.mobile_app', 'sensor.qingping', 'xiaomi_ble', 'usb', 'input_text', 'script', 'lock.switchbot', 'input_boolean', 'input_number', 'logger', 'trace', 'lock', 'binary_sensor.bthome', 'camera', 'text', 'blueprint', 'input_select', 'switch.switchbot', 'mobile_app', 'sensor.bthome', 'cloud', 'tts.google_translate', 'application_credentials', 'image', 'sensor.govee_ble', 'my', 'bluemaestro', 'homeassistant', 'sensor.mobile_app', 'persistent_notification', 'select', 'auth', 'device_tracker.mqtt', 'sensor.sensorpro', 'person', 'button.mqtt', 'number', 'siren.mqtt', 'camera.mqtt', 'image.mqtt', 'thread', 'conversation', 'timer', 'water_heater.mqtt', 'system_log', 'counter', 'analytics', 'hassio', 'bluetooth_adapters', 'sensor.sun', 'light.homekit_controller', 'sensor.energy', 'light', 'input_datetime', 'hacs', 'climate.mqtt', 'zone', 'frontend', 'switch', 'switch.mqtt', 'system_health', 'device_automation', 'bthome', 'image_upload', 'homeassistant_alerts', 'scene', 'media_source', 'sensor.ibeacon', 'oralb', 'alarm_control_panel', 'switchbot', 'sensor.bluemaestro', 'sensorpro', 'ibeacon', 'sensor.moat', 'vacuum', 'binary_sensor.switchbot', 'device_tracker.ibeacon', 'homekit', 'binary_sensor.xiaomi_ble', 'remote', 'hardware', 'text.mqtt', 'dhcp', 'profiler', 'rtsp_to_webrtc', 'sensor.hacs', 'input_button', 'cover.mqtt', 'config', 'button', 'homekit_controller', 'sun', 'history', 'siren', 'button.homekit_controller', 'number.mqtt', 'water_heater', 'file_upload', 'sensorpush', 'network', 'tag', 'hardkernel', 'recorder', 'map', 'thermopro', 'logbook', 'diagnostics', 'humidifier', 'sensor.mqtt', 'mqtt', 'fan', 'ffmpeg', 'assist_pipeline', 'sensor.sensorpush'], 'config_dir': '/config', 'whitelist_external_dirs': ['/media', '/config/www'], 'allowlist_external_dirs': ['/media', '/config/www'], 'allowlist_external_urls': [], 'version': '2023.8.0.dev0', 'config_source': 'storage', 'safe_mode': False, 'state': 'RUNNING', 'external_url': None, 'internal_url': None, 'currency': 'USD', 'country': 'US', 'language': 'en'}
Jul 19 17:04:24 homeassistant hassio_supervisor[546]: 23-07-19 12:04:24 WARNING (MainThread) [supervisor.homeassistant.api] Home Assistant API response: {'latitude': 29.7738, 'longitude': -95.406, 'elevation': 0, 'unit_system': {'length': 'mi', 'accumulated_precipitation': 'in', 'mass': 'lb', 'pressure': 'psi', 'temperature': '°F', 'volume': 'gal', 'wind_speed': 'mph'}, 'location_name': 'N2alex', 'time_zone': 'America/Chicago', 'components': ['sensor.command_line', 'webhook', 'sensor.hassio', 'cover.switchbot', 'alarm_control_panel.mqtt', 'repairs', 'default_config', 'mopeka', 'sensor.switchbot', 'govee_ble', 'sensor', 'moat', 'vacuum.mqtt', 'search', 'onboarding', 'humidifier.mqtt', 'stt', 'stream', 'command_line', 'sensor.xiaomi_ble', 'bluetooth', 'zeroconf', 'select.mqtt', 'ssdp', 'automation', 'sensor.oralb', 'binary_sensor.hassio', 'scene.mqtt', 'lock.mqtt', 'energy', 'light.mqtt', 'scene.homeassistant', 'lovelace', 'influxdb', 'sensor.homekit_controller', 'binary_sensor.homekit_controller', 'sensor.thermopro', 'notify.mobile_app', 'device_tracker', 'notify', 'update.mqtt', 'sensor.mopeka', 'tts', 'binary_sensor.qingping', 'fan.mqtt', 'websocket_api', 'update', 'binary_sensor.mobile_app', 'group', 'http', 'climate', 'api', 'qingping', 'binary_sensor.mqtt', 'update.hassio', 'cover', 'schedule', 'binary_sensor', 'device_tracker.mobile_app', 'sensor.qingping', 'xiaomi_ble', 'usb', 'input_text', 'script', 'lock.switchbot', 'input_boolean', 'input_number', 'logger', 'trace', 'lock', 'binary_sensor.bthome', 'camera', 'text', 'blueprint', 'input_select', 'switch.switchbot', 'mobile_app', 'sensor.bthome', 'cloud', 'tts.google_translate', 'application_credentials', 'image', 'sensor.govee_ble', 'my', 'bluemaestro', 'homeassistant', 'sensor.mobile_app', 'persistent_notification', 'select', 'auth', 'device_tracker.mqtt', 'sensor.sensorpro', 'person', 'button.mqtt', 'number', 'siren.mqtt', 'camera.mqtt', 'image.mqtt', 'thread', 'conversation', 'timer', 'water_heater.mqtt', 'system_log', 'counter', 'analytics', 'hassio', 'bluetooth_adapters', 'sensor.sun', 'light.homekit_controller', 'sensor.energy', 'light', 'input_datetime', 'hacs', 'climate.mqtt', 'zone', 'frontend', 'switch', 'switch.mqtt', 'system_health', 'device_automation', 'bthome', 'image_upload', 'homeassistant_alerts', 'scene', 'media_source', 'sensor.ibeacon', 'oralb', 'alarm_control_panel', 'switchbot', 'sensor.bluemaestro', 'sensorpro', 'ibeacon', 'sensor.moat', 'vacuum', 'binary_sensor.switchbot', 'device_tracker.ibeacon', 'homekit', 'binary_sensor.xiaomi_ble', 'remote', 'hardware', 'text.mqtt', 'dhcp', 'profiler', 'rtsp_to_webrtc', 'sensor.hacs', 'input_button', 'cover.mqtt', 'config', 'button', 'homekit_controller', 'sun', 'history', 'siren', 'button.homekit_controller', 'number.mqtt', 'water_heater', 'file_upload', 'sensorpush', 'network', 'tag', 'hardkernel', 'recorder', 'map', 'thermopro', 'logbook', 'diagnostics', 'humidifier', 'sensor.mqtt', 'mqtt', 'fan', 'ffmpeg', 'assist_pipeline', 'sensor.sensorpush'], 'config_dir': '/config', 'whitelist_external_dirs': ['/media', '/config/www'], 'allowlist_external_dirs': ['/media', '/config/www'], 'allowlist_external_urls': [], 'version': '2023.8.0.dev0', 'config_source': 'storage', 'safe_mode': False, 'state': 'RUNNING', 'external_url': None, 'internal_url': None, 'currency': 'USD', 'country': 'US', 'language': 'en'}
Jul 19 17:04:24 homeassistant hassio_supervisor[546]: 23-07-19 12:04:24 INFO (MainThread) [supervisor.resolution.checks.base] Run check for IssueType.NO_CURRENT_BACKUP/ContextType.SYSTEM
Jul 19 17:02:07 homeassistant hassio_supervisor[546]: 23-07-19 12:02:07 WARNING (MainThread) [supervisor.homeassistant.api] Home Assistant API response: None
Jul 19 17:02:07 homeassistant hassio_supervisor[546]: 23-07-19 12:02:07 WARNING (MainThread) [supervisor.homeassistant.api] Home Assistant API response: None
Jul 19 17:02:07 homeassistant hassio_supervisor[546]: 23-07-19 12:02:07 WARNING (MainThread) [supervisor.homeassistant.api] Using get_config to check API state
Jul 19 17:02:07 homeassistant hassio_supervisor[546]: 23-07-19 12:02:07 WARNING (MainThread) [supervisor.homeassistant.api] Home Assistant API response: None
Jul 19 17:02:07 homeassistant hassio_supervisor[546]: 23-07-19 12:02:07 WARNING (MainThread) [supervisor.homeassistant.api] Using get_config to check API state
Jul 19 17:02:07 homeassistant hassio_supervisor[546]: 23-07-19 12:02:07 WARNING (MainThread) [supervisor.homeassistant.api] Home Assistant API response: None
Jul 19 17:02:07 homeassistant hassio_supervisor[546]: 23-07-19 12:02:07 WARNING (MainThread) [supervisor.homeassistant.api] Using get_config to check API state
Jul 19 17:02:07 homeassistant hassio_supervisor[546]: 23-07-19 12:02:07 WARNING (MainThread) [supervisor.homeassistant.api] Home Assistant API response: None
Jul 19 17:02:07 homeassistant hassio_supervisor[546]: 23-07-19 12:02:07 WARNING (MainThread) [supervisor.homeassistant.api] Using get_config to check API state
Jul 19 17:02:07 homeassistant hassio_supervisor[546]: 23-07-19 12:02:07 WARNING (MainThread) [supervisor.homeassistant.api] Home Assistant API response: None
Jul 19 17:02:07 homeassistant hassio_supervisor[546]: 23-07-19 12:02:07 WARNING (MainThread) [supervisor.homeassistant.api] Using get_config to check API state
Jul 19 17:02:07 homeassistant hassio_supervisor[546]: 23-07-19 12:02:07 WARNING (MainThread) [supervisor.homeassistant.api] Home Assistant API response: None
```

new version (still often, but its cheap now)

```
Jul 19 17:06:04 homeassistant hassio_supervisor[546]: 23-07-19 12:06:04 INFO (MainThread) [supervisor.host.network] Updating local network information
Jul 19 17:06:04 homeassistant hassio_supervisor[546]: 23-07-19 12:06:04 WARNING (MainThread) [supervisor.homeassistant.api] Home Assistant API response: {'state': 'RUNNING'}
Jul 19 17:06:04 homeassistant hassio_supervisor[546]: 23-07-19 12:06:04 WARNING (MainThread) [supervisor.homeassistant.api] Home Assistant API response: {'state': 'RUNNING'}
Jul 19 17:06:04 homeassistant hassio_supervisor[546]: 23-07-19 12:06:04 WARNING (MainThread) [supervisor.homeassistant.api] Home Assistant API response: {'state': 'RUNNING'}
Jul 19 17:06:04 homeassistant hassio_supervisor[546]: 23-07-19 12:06:04 INFO (MainThread) [supervisor.resolution.checks.base] Run check for IssueType.NO_CURRENT_BACKUP/ContextType.SYSTEM
```


## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
