### PR TITLE
Allow discovery messages for unknown services with a warning

### DIFF
--- a/supervisor/addons/validate.py
+++ b/supervisor/addons/validate.py
@@ -100,7 +100,6 @@ from ..const import (
 )
 from ..discovery.validate import valid_discovery_service
 from ..docker.const import Capabilities
-from ..utils.sentry import capture_event
 from ..validate import (
     docker_image,
     docker_ports,
@@ -184,22 +183,10 @@ def _warn_addon_config(config: dict[str, Any]):
             invalid_services.append(service)
 
     if invalid_services:
-        # Logging at debug level as addon config is processed regularly and user may not have even installed this addon
-        _LOGGER.debug(
+        _LOGGER.warning(
             "Add-on lists the following unknown services for discovery: %s. Please report this to the maintainer of %s",
-            (services_list := ", ".join(invalid_services)),
+            ", ".join(invalid_services),
             name,
-        )
-        capture_event(
-            {
-                "message": f"Add-on {name} lists the following unknown services for discovery: {services_list}",
-                "name": name,
-                "slug": (slug := config[ATTR_SLUG]),
-                "version": (version := str(config[ATTR_VERSION])),
-                "url": config.get(ATTR_URL),
-                "discovery": config[ATTR_DISCOVERY],
-            },
-            only_once=f"addon_invalid_discovery_{slug}_{version}",
         )
 
     return config

--- a/supervisor/discovery/validate.py
+++ b/supervisor/discovery/validate.py
@@ -33,7 +33,7 @@ SCHEMA_DISCOVERY = vol.Schema(
             {
                 vol.Required(ATTR_UUID): uuid_match,
                 vol.Required(ATTR_ADDON): str,
-                vol.Required(ATTR_SERVICE): valid_discovery_service,
+                vol.Required(ATTR_SERVICE): str,
                 vol.Required(ATTR_CONFIG): vol.Maybe(dict),
             },
             extra=vol.REMOVE_EXTRA,

--- a/supervisor/utils/sentry.py
+++ b/supervisor/utils/sentry.py
@@ -1,6 +1,7 @@
 """Utilities for sentry."""
 
 import logging
+from typing import Any
 
 import sentry_sdk
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
@@ -15,6 +16,8 @@ from ..coresys import CoreSys
 from ..misc.filter import filter_data
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+only_once_events: set[str] = set()
 
 
 def sentry_connected() -> bool:
@@ -42,6 +45,14 @@ def init_sentry(coresys: CoreSys) -> None:
             release=SUPERVISOR_VERSION,
             max_breadcrumbs=30,
         )
+
+
+def capture_event(event: dict[str, Any], only_once: str | None = None):
+    """Capture an event and send to sentry."""
+    if sentry_connected():
+        if only_once and only_once not in only_once_events:
+            only_once_events.add(only_once)
+            sentry_sdk.capture_event(event)
 
 
 def capture_exception(err: Exception) -> None:

--- a/tests/addons/test_config.py
+++ b/tests/addons/test_config.py
@@ -1,7 +1,7 @@
 """Validate Add-on configs."""
 
 import logging
-from unittest.mock import ANY, Mock
+from unittest.mock import Mock
 
 import pytest
 import voluptuous as vol
@@ -294,21 +294,5 @@ def test_invalid_discovery(capture_event: Mock, caplog: pytest.LogCaptureFixture
 
     assert vd.SCHEMA_ADDON_CONFIG(config)
 
-    assert "unknown services for discovery: junk, junk2" not in caplog.text
-    capture_event.assert_called_once_with(
-        {
-            "message": ANY,
-            "name": "Test Add-on",
-            "slug": "test_addon",
-            "version": "1.0.1",
-            "url": "https://www.home-assistant.io/",
-            "discovery": ["mqtt", "junk", "junk2"],
-        }
-    )
-
-    capture_event.reset_mock()
-    with caplog.at_level(logging.DEBUG):
-        assert vd.SCHEMA_ADDON_CONFIG(config)
-
-    assert "unknown services for discovery: junk, junk2" in caplog.text
-    capture_event.assert_not_called()
+    with caplog.at_level(logging.WARNING):
+        assert "unknown services for discovery: junk, junk2" in caplog.text

--- a/tests/api/test_discovery.py
+++ b/tests/api/test_discovery.py
@@ -1,0 +1,53 @@
+"""Test discovery API."""
+
+import logging
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from aiohttp.test_utils import TestClient
+import pytest
+
+from supervisor.addons.addon import Addon
+from supervisor.discovery import Discovery
+
+
+@pytest.mark.parametrize("api_client", ["local_ssh"], indirect=True)
+async def test_discovery_forbidden(
+    api_client: TestClient, caplog: pytest.LogCaptureFixture, install_addon_ssh
+):
+    """Test addon sending discovery message for an unregistered service."""
+    caplog.clear()
+
+    with caplog.at_level(logging.ERROR):
+        resp = await api_client.post("/discovery", json={"service": "mqtt"})
+
+    assert resp.status == 400
+    result = await resp.json()
+    assert result["result"] == "error"
+    assert (
+        result["message"]
+        == "Add-ons must list services they provide via discovery in their config!"
+    )
+    assert "Please report this to the maintainer of the add-on" in caplog.text
+
+
+@pytest.mark.parametrize("api_client", ["local_ssh"], indirect=True)
+async def test_discovery_unknown_service(
+    api_client: TestClient, caplog: pytest.LogCaptureFixture, install_addon_ssh: Addon
+):
+    """Test addon sending discovery message for an unkown service."""
+    caplog.clear()
+    install_addon_ssh.data["discovery"] = ["junk"]
+
+    message = MagicMock()
+    message.uuid = uuid4().hex
+
+    with caplog.at_level(logging.WARNING), patch.object(
+        Discovery, "send", return_value=message
+    ):
+        resp = await api_client.post("/discovery", json={"service": "junk"})
+
+    assert resp.status == 200
+    result = await resp.json()
+    assert result["data"]["uuid"] == message.uuid
+    assert "Please report this to the maintainer of the add-on" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Supervisor is too protective when it comes to discovery messages. It won't even let the user see an addon if it lists an unknown type of service in discovery. Also removing a service from the list of known types of discovery can cause the discovery json file to fail validation on startup.

This PR makes the following changes:
1. Supervisor will not check the name of the service in discovery messages stored on disk at startup. Any string will pass
2. ~~If an addon lists an unknown type of service in discovery it will still appear in the store. A message will be logged about this at debug level and an event sent to sentry with basic addon details. This event will only be sent once per system per restart of supervisor to limit noise (as we fetch and process addon config regularly)~~
3. If an addon attempts to send a discovery message with an unknown service it will be allowed and a warning logged asking the user to contact the add-on developer about this.

~~The difference between 2 and 3 is significant IMO hence the difference in log levels. 2 will occur regularly due to scheduled task for addons the user has never installed. Maybe they don't even see them if they are marked advanced. We are likely better able to follow-up then most users, hence the sentry event. 3 though will only occur for an addon the user has installed and started, that name won't be foreign to them.~~

After discussing with @pvizeli using sentry will be too noisy. The reason this PR exists is because we wanted to add  a new type of discovery to an addon in a core repo. The addon was merged with that change and then a beta pushed so users could test it. But that meant every user on stable was hitting an error for discovery of an unknown type of service, we can't send all those events to sentry.

So for now, we always just log a warning in all cases. Can revisit if/when we add support for beta and dev channels of an addon repo so changes to addon config can be pushed through a similar pipeline.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
