### PR TITLE
Temporary operations for backups take place in destination folder

### DIFF
--- a/supervisor/backups/backup.py
+++ b/supervisor/backups/backup.py
@@ -183,7 +183,15 @@ class Backup(CoreSysAttributes):
             days=self.sys_backups.days_until_stale
         )
 
-    def new(self, slug, name, date, sys_type, password=None, compressed=True):
+    def new(
+        self,
+        slug: str,
+        name: str,
+        date: str,
+        sys_type: BackupType,
+        password: str | None = None,
+        compressed: bool = True,
+    ):
         """Initialize a new backup."""
         # Init metadata
         self._data[ATTR_VERSION] = 2
@@ -288,7 +296,7 @@ class Backup(CoreSysAttributes):
 
     async def __aenter__(self):
         """Async context to open a backup."""
-        self._tmp = TemporaryDirectory(dir=str(self.sys_config.path_tmp))
+        self._tmp = TemporaryDirectory(dir=str(self.tarfile.parent))
 
         # create a backup
         if not self.tarfile.is_file():

--- a/tests/backups/test_backup.py
+++ b/tests/backups/test_backup.py
@@ -1,0 +1,22 @@
+"""Test backups."""
+
+from os import listdir
+from pathlib import Path
+
+from supervisor.backups.backup import Backup
+from supervisor.backups.const import BackupType
+from supervisor.coresys import CoreSys
+
+
+async def test_new_backup_stays_in_folder(coresys: CoreSys, tmp_path: Path):
+    """Test making a new backup operates entirely within folder where backup will be stored."""
+    backup = Backup(coresys, tmp_path / "my_backup.tar")
+    backup.new("test", "test", "2023-07-21T21:05:00.000000+00:00", BackupType.FULL)
+    assert not listdir(tmp_path)
+
+    async with backup:
+        assert len(listdir(tmp_path)) == 1
+        assert not backup.tarfile.exists()
+
+    assert len(listdir(tmp_path)) == 1
+    assert backup.tarfile.exists()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Currently the process of making/extracting a backup (collecting everything into a temporary folder) always takes place on the data partition, even if the backup is destined for a mount. This causes unnecessary churn on the data partition. This changes it so temporary operations take place in the same folder that the backup will live in.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
