### PR TITLE
Cancel startup wait task on addon uninstallation

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -129,6 +129,7 @@ class Addon(AddonModel):
         )
         self._listeners: list[EventListener] = []
         self._startup_event = asyncio.Event()
+        self._startup_task: asyncio.Task | None = None
 
         @Job(
             name=f"addon_{slug}_restart_after_problem",
@@ -608,6 +609,11 @@ class Addon(AddonModel):
 
     async def unload(self) -> None:
         """Unload add-on and remove data."""
+        if self._startup_task:
+            # If we were waiting on startup, cancel that and let the task finish before proceeding
+            self._startup_task.cancel(f"Removing add-on {self.name} from system")
+            await asyncio.sleep(0)
+
         for listener in self._listeners:
             self.sys_bus.remove_listener(listener)
 
@@ -699,13 +705,18 @@ class Addon(AddonModel):
     async def _wait_for_startup(self) -> None:
         """Wait for startup event to be set with timeout."""
         try:
-            await asyncio.wait_for(self._startup_event.wait(), STARTUP_TIMEOUT)
+            self._startup_task = self.sys_create_task(self._startup_event.wait())
+            await asyncio.wait_for(self._startup_task, STARTUP_TIMEOUT)
         except asyncio.TimeoutError:
             _LOGGER.warning(
                 "Timeout while waiting for addon %s to start, took more then %s seconds",
                 self.name,
                 STARTUP_TIMEOUT,
             )
+        except asyncio.CancelledError as err:
+            _LOGGER.info("Wait for addon startup task cancelled due to: %s", err)
+        finally:
+            self._startup_task = None
 
     async def start(self) -> Awaitable[None]:
         """Set options and start add-on.

--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -612,7 +612,8 @@ class Addon(AddonModel):
         if self._startup_task:
             # If we were waiting on startup, cancel that and let the task finish before proceeding
             self._startup_task.cancel(f"Removing add-on {self.name} from system")
-            await self._startup_task
+            with suppress(asyncio.CancelledError):
+                await self._startup_task
 
         for listener in self._listeners:
             self.sys_bus.remove_listener(listener)

--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -612,7 +612,7 @@ class Addon(AddonModel):
         if self._startup_task:
             # If we were waiting on startup, cancel that and let the task finish before proceeding
             self._startup_task.cancel(f"Removing add-on {self.name} from system")
-            await asyncio.sleep(0)
+            await self._startup_task
 
         for listener in self._listeners:
             self.sys_bus.remove_listener(listener)

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -523,6 +523,7 @@ async def test_restore(
     path_extern,
 ) -> None:
     """Test restoring an addon."""
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     install_addon_ssh.path_data.mkdir()
     await install_addon_ssh.load()
 

--- a/tests/api/test_addons.py
+++ b/tests/api/test_addons.py
@@ -171,6 +171,7 @@ async def test_api_addon_rebuild_healthcheck(
     path_extern,
 ):
     """Test rebuilding an addon waits for healthy."""
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     container.status = "running"
     install_addon_ssh.path_data.mkdir()
     container.attrs["Config"] = {"Healthcheck": "exists"}

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -125,6 +125,7 @@ async def test_api_store_update_healthcheck(
     path_extern,
 ):
     """Test updating an addon with healthcheck waits for health status."""
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     container.status = "running"
     container.attrs["Config"] = {"Healthcheck": "exists"}
     install_addon_ssh.path_data.mkdir()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

If addon installation occurs while we're waiting on the addon to tell us it has properly started, ensure that task is cancelled and allowed to complete first. Otherwise it may get stuck and timeout with errors.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
