### PR TITLE
Extend container image name validator

### DIFF
--- a/supervisor/validate.py
+++ b/supervisor/validate.py
@@ -49,7 +49,9 @@ RE_REGISTRY = re.compile(r"^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$")
 # pylint: disable=invalid-name
 network_port = vol.All(vol.Coerce(int), vol.Range(min=1, max=65535))
 wait_boot = vol.All(vol.Coerce(int), vol.Range(min=1, max=60))
-docker_image = vol.Match(r"^([a-zA-Z\-\.:\d{}]+/)*?([\-\w{}]+)/([\-\w{}]+)$")
+docker_image = vol.Match(
+    r"^([a-z0-9][a-z0-9.\-]*(:[0-9]+)?/)*?([a-z0-9{][a-z0-9.\-_{}]*/)*?([a-z0-9{][a-z0-9.\-_{}]*)$"
+)
 uuid_match = vol.Match(r"^[0-9a-f]{32}$")
 sha256 = vol.Match(r"^[0-9a-f]{64}$")
 token = vol.Match(r"^[0-9a-f]{32,256}$")

--- a/tests/addons/test_config.py
+++ b/tests/addons/test_config.py
@@ -110,7 +110,7 @@ def test_invalid_repository():
     """Validate basic config with invalid repositories."""
     config = load_json_fixture("basic-addon-config.json")
 
-    config["image"] = "something"
+    config["image"] = "-invalid-something"
     with pytest.raises(vol.Invalid):
         vd.SCHEMA_ADDON_CONFIG(config)
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -16,6 +16,24 @@ DNS_GOOD_V6 = [
     "DNS://2606:4700:4700::1001",  # cloudflare
 ]
 DNS_BAD = ["hello world", "https://foo.bar", "", "dns://example.com"]
+IMAGE_NAME_GOOD = [
+    "ghcr.io/home-assistant/{machine}-homeassistant",
+    "ghcr.io/home-assistant/{arch}-homeassistant",
+    "homeassistant/{arch}-homeassistant",
+    "doocker.io/homeassistant/{arch}-homeassistant",
+    "ghcr.io/home-assistant/amd64-homeassistant",
+    "homeassistant/amd64-homeassistant",
+    "ttl.sh/homeassistant",
+    "myreg.local:8080/homeassistant",
+]
+IMAGE_NAME_BAD = [
+    "ghcr.io/home-assistant/homeassistant:123",
+    ".ghcr.io/home-assistant/homeassistant",
+    "HOMEASSISTANT/homeassistant",
+    "homeassistant/HOMEASSISTANT",
+    "homeassistant/_homeassistant",
+    "homeassistant/-homeassistant",
+]
 
 
 async def test_dns_url_v4_good():
@@ -70,6 +88,19 @@ def test_dns_server_list_bad_combined():
     with pytest.raises(vol.error.Invalid):
         # bad list
         assert validate.dns_server_list(combined)
+
+
+def test_image_name_good():
+    """Test container image names validator with known-good image names."""
+    for image_name in IMAGE_NAME_GOOD:
+        assert validate.docker_image(image_name)
+
+
+def test_image_name_bad():
+    """Test container image names validator with known-bad image names."""
+    for image_name in IMAGE_NAME_BAD:
+        with pytest.raises(vol.error.Invalid):
+            assert validate.docker_image(image_name)
 
 
 def test_version_complex():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The current validator allows certain invalid names (e.g. upper case), but disallows valid cases (such as ttl.sh/myimage). Improve the container image validator to support more valid options and at the same time disallow some of the invalid options.

Note that this is not a complete/perfect validation still. A much much more sophisticated regex would be necessary to be 100% accurate. Also we format the string and replace {machine}/{arch} using Python format strings. In that regard the image format in Supervisor deviates from the Docker/OCI container image name format.


## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
