### PR TITLE
Address addon storage race condition

### DIFF
--- a/supervisor/store/data.py
+++ b/supervisor/store/data.py
@@ -1,5 +1,5 @@
 """Init file for Supervisor add-on data."""
-from collections.abc import Awaitable
+from dataclasses import dataclass
 import logging
 from pathlib import Path
 from typing import Any
@@ -29,6 +29,72 @@ from .validate import SCHEMA_REPOSITORY_CONFIG
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
+@dataclass(slots=True)
+class ProcessedRepository:
+    """Representation of a repository processed from its git folder."""
+
+    slug: str
+    path: Path
+    config: dict[str, Any]
+
+
+def _read_addon_translations(addon_path: Path) -> dict:
+    """Read translations from add-ons folder.
+
+    Should be run in the executor.
+    """
+    translations_dir = addon_path / "translations"
+    translations = {}
+
+    if not translations_dir.exists():
+        return translations
+
+    translation_files = [
+        translation
+        for translation in translations_dir.glob("*")
+        if translation.suffix in FILE_SUFFIX_CONFIGURATION
+    ]
+
+    for translation in translation_files:
+        try:
+            translations[translation.stem] = SCHEMA_ADDON_TRANSLATIONS(
+                read_json_or_yaml_file(translation)
+            )
+
+        except (ConfigurationFileError, vol.Invalid) as err:
+            _LOGGER.warning("Can't read translations from %s - %s", translation, err)
+            continue
+
+    return translations
+
+
+def _read_git_repository(path: Path) -> ProcessedRepository | None:
+    """Process a custom repository folder."""
+    slug = extract_hash_from_path(path)
+
+    # exists repository json
+    try:
+        repository_file = find_one_filetype(
+            path, "repository", FILE_SUFFIX_CONFIGURATION
+        )
+    except ConfigurationFileError:
+        _LOGGER.warning("No repository information exists at %s", path)
+        return None
+
+    try:
+        return ProcessedRepository(
+            slug,
+            path,
+            SCHEMA_REPOSITORY_CONFIG(read_json_or_yaml_file(repository_file)),
+        )
+    except ConfigurationFileError:
+        _LOGGER.warning("Can't read repository information from %s", repository_file)
+        return None
+    except vol.Invalid:
+        _LOGGER.warning("Repository parse error %s", repository_file)
+        return None
+
+
 class StoreData(CoreSysAttributes):
     """Hold data for Add-ons inside Supervisor."""
 
@@ -38,63 +104,43 @@ class StoreData(CoreSysAttributes):
         self.repositories: dict[str, Any] = {}
         self.addons: dict[str, Any] = {}
 
-    async def update(self) -> Awaitable[None]:
+    async def update(self) -> None:
         """Read data from add-on repository."""
-        return await self.sys_run_in_executor(self._update)
-
-    def _update(self) -> None:
         self.repositories.clear()
         self.addons.clear()
 
         # read core repository
-        self._read_addons_folder(self.sys_config.path_addons_core, REPOSITORY_CORE)
+        await self._read_addons_folder(
+            self.sys_config.path_addons_core, REPOSITORY_CORE
+        )
 
         # read local repository
-        self._read_addons_folder(self.sys_config.path_addons_local, REPOSITORY_LOCAL)
+        await self._read_addons_folder(
+            self.sys_config.path_addons_local, REPOSITORY_LOCAL
+        )
 
         # add built-in repositories information
-        self._set_builtin_repositories()
+        await self._set_builtin_repositories()
 
         # read custom git repositories
-        for repository_element in self.sys_config.path_addons_git.iterdir():
-            if repository_element.is_dir():
-                self._read_git_repository(repository_element)
+        def _read_git_repositories() -> list[ProcessedRepository]:
+            return [
+                repo
+                for repository_element in self.sys_config.path_addons_git.iterdir()
+                if repository_element.is_dir()
+                and (repo := _read_git_repository(repository_element))
+            ]
 
-    def _read_git_repository(self, path: Path) -> None:
-        """Process a custom repository folder."""
-        slug = extract_hash_from_path(path)
+        for repo in await self.sys_run_in_executor(_read_git_repositories):
+            self.repositories[repo.slug] = repo.config
+            self._read_addons_folder(repo.path, repo.slug)
 
-        # exists repository json
-        try:
-            repository_file = find_one_filetype(
-                path, "repository", FILE_SUFFIX_CONFIGURATION
-            )
-        except ConfigurationFileError:
-            _LOGGER.warning("No repository information exists at %s", path)
-            return
-
-        try:
-            repository_info = SCHEMA_REPOSITORY_CONFIG(
-                read_json_or_yaml_file(repository_file)
-            )
-        except ConfigurationFileError:
-            _LOGGER.warning(
-                "Can't read repository information from %s", repository_file
-            )
-            return
-        except vol.Invalid:
-            _LOGGER.warning("Repository parse error %s", repository_file)
-            return
-
-        # process data
-        self.repositories[slug] = repository_info
-        self._read_addons_folder(path, slug)
-
-    def _find_addons(self, path: Path, repository: dict) -> list[Path] | None:
+    async def _find_addons(self, path: Path, repository: dict) -> list[Path] | None:
         """Find add-ons in the path."""
-        try:
+
+        def _get_addons_list() -> list[Path]:
             # Generate a list without artefact, safe for corruptions
-            addon_list = [
+            return [
                 addon
                 for addon in path.glob("**/config.*")
                 if not [
@@ -104,6 +150,9 @@ class StoreData(CoreSysAttributes):
                 ]
                 and addon.suffix in FILE_SUFFIX_CONFIGURATION
             ]
+
+        try:
+            addon_list = await self.sys_run_in_executor(_get_addons_list)
         except OSError as err:
             suggestion = None
             if path.stem != StoreType.LOCAL:
@@ -120,77 +169,59 @@ class StoreData(CoreSysAttributes):
             return None
         return addon_list
 
-    def _read_addons_folder(self, path: Path, repository: dict) -> None:
+    async def _read_addons_folder(self, path: Path, repository: str) -> None:
         """Read data from add-ons folder."""
-        if not (addon_list := self._find_addons(path, repository)):
+        if not (addon_list := await self._find_addons(path, repository)):
             return
 
-        for addon in addon_list:
-            try:
-                addon_config = read_json_or_yaml_file(addon)
-            except ConfigurationFileError:
-                _LOGGER.warning("Can't read %s from repository %s", addon, repository)
-                continue
+        def _process_addons_config() -> dict[str, dict[str, Any]]:
+            addons_config: dict[str, dict[str, Any]] = {}
+            for addon in addon_list:
+                try:
+                    addon_config = read_json_or_yaml_file(addon)
+                except ConfigurationFileError:
+                    _LOGGER.warning(
+                        "Can't read %s from repository %s", addon, repository
+                    )
+                    continue
 
-            # validate
-            try:
-                addon_config = SCHEMA_ADDON_CONFIG(addon_config)
-            except vol.Invalid as ex:
-                _LOGGER.warning(
-                    "Can't read %s: %s", addon, humanize_error(addon_config, ex)
-                )
-                continue
+                # validate
+                try:
+                    addon_config = SCHEMA_ADDON_CONFIG(addon_config)
+                except vol.Invalid as ex:
+                    _LOGGER.warning(
+                        "Can't read %s: %s", addon, humanize_error(addon_config, ex)
+                    )
+                    continue
 
-            # Generate slug
-            addon_slug = f"{repository}_{addon_config[ATTR_SLUG]}"
+                # Generate slug
+                addon_slug = f"{repository}_{addon_config[ATTR_SLUG]}"
 
-            # store
-            addon_config[ATTR_REPOSITORY] = repository
-            addon_config[ATTR_LOCATON] = str(addon.parent)
-            addon_config[ATTR_TRANSLATIONS] = self._read_addon_translations(
-                addon.parent
-            )
-            self.addons[addon_slug] = addon_config
+                # store
+                addon_config[ATTR_REPOSITORY] = repository
+                addon_config[ATTR_LOCATON] = str(addon.parent)
+                addon_config[ATTR_TRANSLATIONS] = _read_addon_translations(addon.parent)
+                addons_config[addon_slug] = addon_config
 
-    def _set_builtin_repositories(self):
+            return addons_config
+
+        self.addons.update(await self.sys_run_in_executor(_process_addons_config))
+
+    async def _set_builtin_repositories(self):
         """Add local built-in repository into dataset."""
-        try:
-            builtin_file = Path(__file__).parent.joinpath("built-in.json")
-            builtin_data = read_json_file(builtin_file)
-        except ConfigurationFileError:
-            _LOGGER.warning("Can't read built-in json")
-            return
 
-        # core repository
-        self.repositories[REPOSITORY_CORE] = builtin_data[REPOSITORY_CORE]
-
-        # local repository
-        self.repositories[REPOSITORY_LOCAL] = builtin_data[REPOSITORY_LOCAL]
-
-    def _read_addon_translations(self, addon_path: Path) -> dict:
-        """Read translations from add-ons folder."""
-        translations_dir = addon_path / "translations"
-        translations = {}
-
-        if not translations_dir.exists():
-            return translations
-
-        translation_files = [
-            translation
-            for translation in translations_dir.glob("*")
-            if translation.suffix in FILE_SUFFIX_CONFIGURATION
-        ]
-
-        for translation in translation_files:
+        def _get_builtins() -> dict[str, dict[str, str]] | None:
             try:
-                translations[translation.stem] = SCHEMA_ADDON_TRANSLATIONS(
-                    read_json_or_yaml_file(translation)
-                )
+                builtin_file = Path(__file__).parent.joinpath("built-in.json")
+                return read_json_file(builtin_file)
+            except ConfigurationFileError:
+                _LOGGER.warning("Can't read built-in json")
+                return None
 
-            except (ConfigurationFileError, vol.Invalid) as err:
-                _LOGGER.warning(
-                    "Can't read translations from %s - %s", translation, err
-                )
-                continue
+        builtin_data = await self.sys_run_in_executor(_get_builtins)
+        if builtin_data:
+            # core repository
+            self.repositories[REPOSITORY_CORE] = builtin_data[REPOSITORY_CORE]
 
-        return translations
+            # local repository
+            self.repositories[REPOSITORY_LOCAL] = builtin_data[REPOSITORY_LOCAL]

--- a/tests/store/test_reading_addons.py
+++ b/tests/store/test_reading_addons.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from supervisor.coresys import CoreSys
 
 
-def test_read_addon_files(coresys: CoreSys):
+async def test_read_addon_files(coresys: CoreSys):
     """Test that we are reading add-on files correctly."""
     with patch(
         "pathlib.Path.glob",
@@ -19,7 +19,7 @@ def test_read_addon_files(coresys: CoreSys):
             Path(".circleci/config.yml"),
         ],
     ):
-        addon_list = coresys.store.data._find_addons(Path("test"), {})
+        addon_list = await coresys.store.data._find_addons(Path("test"), {})
 
         assert len(addon_list) == 1
         assert str(addon_list[0]) == "addon/config.yml"

--- a/tests/store/test_translation_load.py
+++ b/tests/store/test_translation_load.py
@@ -3,6 +3,7 @@
 import os
 
 from supervisor.coresys import CoreSys
+from supervisor.store.data import _read_addon_translations
 from supervisor.utils.common import write_json_or_yaml_file
 
 
@@ -10,7 +11,7 @@ def test_loading_traslations(coresys: CoreSys, tmp_path):
     """Test loading add-translation."""
     os.makedirs(tmp_path / "translations")
     # no transaltions
-    assert coresys.store.data._read_addon_translations(tmp_path) == {}
+    assert _read_addon_translations(tmp_path) == {}
 
     for file in ("en.json", "es.json"):
         write_json_or_yaml_file(
@@ -27,7 +28,7 @@ def test_loading_traslations(coresys: CoreSys, tmp_path):
             },
         )
 
-    translations = coresys.store.data._read_addon_translations(tmp_path)
+    translations = _read_addon_translations(tmp_path)
 
     assert translations["en"]["configuration"]["test"]["name"] == "test"
     assert translations["es"]["configuration"]["test"]["name"] == "test"

--- a/tests/store/test_translation_load.py
+++ b/tests/store/test_translation_load.py
@@ -1,13 +1,16 @@
 """Test loading add-translation."""
 # pylint: disable=import-error,protected-access
 import os
+from pathlib import Path
+
+import pytest
 
 from supervisor.coresys import CoreSys
 from supervisor.store.data import _read_addon_translations
 from supervisor.utils.common import write_json_or_yaml_file
 
 
-def test_loading_traslations(coresys: CoreSys, tmp_path):
+def test_loading_traslations(coresys: CoreSys, tmp_path: Path):
     """Test loading add-translation."""
     os.makedirs(tmp_path / "translations")
     # no transaltions
@@ -38,3 +41,22 @@ def test_loading_traslations(coresys: CoreSys, tmp_path):
     assert "test" not in translations["en"]["configuration"]["test"]
 
     assert translations["no"]["network"]["80/tcp"] == "Webserver port"
+
+
+def test_translation_file_failure(
+    coresys: CoreSys, tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
+    """Test translations load if one fails."""
+    os.makedirs(tmp_path / "translations")
+    write_json_or_yaml_file(
+        tmp_path / "translations" / "en.json",
+        {"configuration": {"test": {"name": "test", "test": "test"}}},
+    )
+    fail_path = tmp_path / "translations" / "de.json"
+    with fail_path.open("w") as de_file:
+        de_file.write("not json")
+
+    translations = _read_addon_translations(tmp_path)
+
+    assert translations["en"]["configuration"]["test"]["name"] == "test"
+    assert f"Can't read translations from {fail_path.as_posix()}" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

When processing addon data into the store we understandably do file I/O in the executor. But we also update the store data global in the executor which can cause race conditions. I believe this to be the source of errors like this:
```
23-06-27 23:38:56 INFO (MainThread) [supervisor.addons] Add-on 'core_whisper' successfully updated
23-06-27 23:38:56 ERROR (MainThread) [supervisor.jobs] Unhandled exception: 'core_whisper'
Traceback (most recent call last):
  File "/usr/src/supervisor/supervisor/jobs/decorator.py", line 154, in wrapper
    return await self._method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/supervisor/supervisor/addons/__init__.py", line 293, in update
    self.data.update(store)
  File "/usr/src/supervisor/supervisor/addons/data.py", line 58, in update
    self.system[addon.slug] = deepcopy(addon.data)
                                       ^^^^^^^^^^
  File "/usr/src/supervisor/supervisor/store/addon.py", line 19, in data
    return self.sys_store.data.addons[self.slug]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 'core_whisper'
```
Where after we have passed our checks determining if an addon exists we find it missing. Removing the cache/global updates from executor and only doing file I/O there should eliminate this.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
