### PR TITLE
Always stop the addon before restoring it

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -962,6 +962,11 @@ class Addon(AddonModel):
                 self.slug, data[ATTR_USER], data[ATTR_SYSTEM], restore_image
             )
 
+            # Stop it first if its running
+            if await self.instance.is_running():
+                with suppress(DockerError):
+                    await self.instance.stop()
+
             # Check version / restore image
             version = data[ATTR_VERSION]
             if not await self.instance.exists():
@@ -979,9 +984,6 @@ class Addon(AddonModel):
                 _LOGGER.info("Restore/Update of image for addon %s", self.slug)
                 with suppress(DockerError):
                     await self.instance.update(version, restore_image)
-            else:
-                with suppress(DockerError):
-                    await self.instance.stop()
 
             # Restore data
             def _restore_data():

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -18,6 +18,7 @@ from supervisor.docker.addon import DockerAddon
 from supervisor.docker.const import ContainerState
 from supervisor.docker.monitor import DockerContainerStateEvent
 from supervisor.exceptions import AddonsError, AddonsJobError, AudioUpdateError
+from supervisor.ingress import Ingress
 from supervisor.store.repository import Repository
 from supervisor.utils.dt import utcnow
 
@@ -530,8 +531,10 @@ async def test_restore(
     tarfile = SecureTarFile(get_fixture_path(f"backup_local_ssh_{status}.tar.gz"), "r")
     with patch.object(DockerAddon, "is_running", return_value=False), patch.object(
         CpuArch, "supported", new=PropertyMock(return_value=["aarch64"])
-    ):
+    ), patch.object(Ingress, "update_hass_panel") as update_hass_panel:
         start_task = await coresys.addons.restore(TEST_ADDON_SLUG, tarfile)
+
+        update_hass_panel.assert_called_once()
 
     assert bool(start_task) is (status == "running")
 
@@ -552,7 +555,7 @@ async def test_restore_while_running(
     tarfile = SecureTarFile(get_fixture_path("backup_local_ssh_stopped.tar.gz"), "r")
     with patch.object(DockerAddon, "is_running", return_value=True), patch.object(
         CpuArch, "supported", new=PropertyMock(return_value=["aarch64"])
-    ):
+    ), patch.object(Ingress, "update_hass_panel"):
         start_task = await coresys.addons.restore(TEST_ADDON_SLUG, tarfile)
 
     assert bool(start_task) is False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The organization of the conditional during addon restore meant that if restore attempted to change the version of the addon (like a rollback) the addon was never stopped. This caused two serious issues:

1. The addon version actually did not change after a restore. It would be corrected the next time the addon restarted but immediately after restore the user was still running same version of the addon that they were before the restore
2. Supervisor never properly collected meta information for the container. It cleared out its meta information at the beginning of restore and never got new info because start was skipped (since the addon never stopped running). This caused supervisor to forget its IP address and be unable to direct users to it for ingress after a restore. It showed this unintuitive error message instead:

![Screenshot 2023-08-14 at 4 01 46 PM](https://github.com/home-assistant/supervisor/assets/2037026/ad0731b7-a7fa-49eb-bfb3-b7ca59981464)

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
