### PR TITLE
Don't notify listeners on CoreState.CLOSE

### DIFF
--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -70,13 +70,16 @@ class Core(CoreSysAttributes):
             )
         finally:
             self._state = new_state
-            self.sys_bus.fire_event(BusEvent.SUPERVISOR_STATE_CHANGE, new_state)
 
-            # These will be received by HA after startup has completed which won't make sense
-            if new_state not in STARTING_STATES:
-                self.sys_homeassistant.websocket.supervisor_update_event(
-                    "info", {"state": new_state}
-                )
+            # Don't attempt to notify anyone on CLOSE as we're about to stop the event loop
+            if new_state != CoreState.CLOSE:
+                self.sys_bus.fire_event(BusEvent.SUPERVISOR_STATE_CHANGE, new_state)
+
+                # These will be received by HA after startup has completed which won't make sense
+                if new_state not in STARTING_STATES:
+                    self.sys_homeassistant.websocket.supervisor_update_event(
+                        "info", {"state": new_state}
+                    )
 
     async def connect(self):
         """Connect Supervisor container."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Don't attempt to notify others about a transition to `CoreState.CLOSE`. Supervisor is about to close the event loop so this just causes a stream of errors as the tasks created from this transition get cancelled like this:

```
23-08-24 16:19:37 ERROR (MainThread) [asyncio] Task was destroyed but it is pending!
source_traceback: Object created at (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/src/supervisor/supervisor/__main__.py", line 60, in <module>
    loop.run_forever()
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 607, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 1914, in _run_once
    handle._run()
  File "/usr/local/lib/python3.11/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/src/supervisor/supervisor/core.py", line 329, in stop
    self.state = CoreState.CLOSE
  File "/usr/src/supervisor/supervisor/core.py", line 73, in state
    self.sys_bus.fire_event(BusEvent.SUPERVISOR_STATE_CHANGE, new_state)
  File "/usr/src/supervisor/supervisor/bus.py", line 44, in fire_event
    self.sys_create_task(listener.callback(reference))
  File "/usr/src/supervisor/supervisor/coresys.py", line 714, in sys_create_task
    return self.coresys.create_task(coroutine)
  File "/usr/src/supervisor/supervisor/coresys.py", line 534, in create_task
    return self.loop.create_task(coroutine)
task: <Task pending name='Task-307' coro=<HomeAssistantWebSocket._process_queue() running at /usr/src/supervisor/supervisor/homeassistant/websocket.py:186> created at /usr/src/supervisor/supervisor/coresys.py:534>
/usr/local/lib/python3.11/asyncio/base_events.py:678: RuntimeWarning: coroutine 'HomeAssistantWebSocket._process_queue' was never awaited
Coroutine created at (most recent call last)
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/src/supervisor/supervisor/__main__.py", line 60, in <module>
    loop.run_forever()
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 607, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 1914, in _run_once
    handle._run()
  File "/usr/local/lib/python3.11/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/src/supervisor/supervisor/core.py", line 329, in stop
    self.state = CoreState.CLOSE
  File "/usr/src/supervisor/supervisor/core.py", line 73, in state
    self.sys_bus.fire_event(BusEvent.SUPERVISOR_STATE_CHANGE, new_state)
  File "/usr/src/supervisor/supervisor/bus.py", line 44, in fire_event
    self.sys_create_task(listener.callback(reference))
  self._ready.clear()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```
It's not really a state anyone else should know about or be reacting to anyway. They can react to `SHUTDOWN` and `STOPPING` on the way there but not `CLOSE` itself, that is the end.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
