### PR TITLE
Skip plugin update on startup if supervisor out of date

### DIFF
--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -135,10 +135,10 @@ class Core(CoreSysAttributes):
             self.sys_mounts.load(),
             # Load Docker manager
             self.sys_docker.load(),
-            # Load Plugins container
-            self.sys_plugins.load(),
             # load last available data
             self.sys_updater.load(),
+            # Load Plugins container
+            self.sys_plugins.load(),
             # Load Home Assistant
             self.sys_homeassistant.load(),
             # Load CPU/Arch

--- a/supervisor/plugins/manager.py
+++ b/supervisor/plugins/manager.py
@@ -75,8 +75,11 @@ class PluginManager(CoreSysAttributes):
                 )
                 capture_exception(err)
 
+        # Exit if supervisor out of date. Plugins can't update until then
+        if self.sys_supervisor.need_update:
+            return
+
         # Check requirements
-        await self.sys_updater.reload()
         for plugin in self.all_plugins:
             # Check if need an update
             if not plugin.need_update:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Plugin manager load should not try to update plugins if supervisor is out of date. They will all fail to update and just make log noise. Supervisor is just going to auto-update and restart again in a moment anyway.

Additionally I noticed that loading the plugin manager was calling `reload` on updater. But core was actually loading updater after plugin manager. I reversed these and removed the call to `reload` in plugin manager as it just caused us to fetch data twice in a row.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
