### PR TITLE
Fix #4547: Ensure Ingress user headers are strings

### DIFF
--- a/supervisor/api/ingress.py
+++ b/supervisor/api/ingress.py
@@ -281,9 +281,9 @@ def _init_header(
     headers = {}
 
     if session_data is not None:
-        headers[HEADER_REMOTE_USER_ID] = session_data.user.id
-        headers[HEADER_REMOTE_USER_NAME] = session_data.user.username
-        headers[HEADER_REMOTE_USER_DISPLAY_NAME] = session_data.user.display_name
+        headers[HEADER_REMOTE_USER_ID] = str(session_data.user.id)
+        headers[HEADER_REMOTE_USER_NAME] = str(session_data.user.username)
+        headers[HEADER_REMOTE_USER_DISPLAY_NAME] = str(session_data.user.display_name)
 
     # filter flags
     for name, value in request.headers.items():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Ensure that user headers (`X-Remote-User-ID`, `X-Remote-User-Name`, `X-Remote-User-Display-Name`) are always strings, even if user data has the corresponding attributes as `None`.

This will ensure Ingress can properly handle headers when using [Command Line Authentication](https://www.home-assistant.io/docs/authentication/providers/#command-line) for HA Core.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4547
- This PR is related to issue: https://github.com/home-assistant/core/issues/99811
- Link to documentation pull request: N/A
- Link to cli pull request: N/A

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
