### PR TITLE
Only tell HA to refresh ingress on restore on change

### DIFF
--- a/supervisor/addons/__init__.py
+++ b/supervisor/addons/__init__.py
@@ -389,11 +389,12 @@ class AddonManager(CoreSysAttributes):
         if slug not in self.local:
             _LOGGER.debug("Add-on %s is not local available for restore", slug)
             addon = Addon(self.coresys, slug)
+            had_ingress = False
         else:
             _LOGGER.debug("Add-on %s is local available for restore", slug)
             addon = self.local[slug]
+            had_ingress = addon.ingress_panel
 
-        had_ingress = addon.ingress_panel
         wait_for_start = await addon.restore(tar_file)
 
         # Check if new

--- a/supervisor/addons/__init__.py
+++ b/supervisor/addons/__init__.py
@@ -393,6 +393,7 @@ class AddonManager(CoreSysAttributes):
             _LOGGER.debug("Add-on %s is local available for restore", slug)
             addon = self.local[slug]
 
+        had_ingress = addon.ingress_panel
         wait_for_start = await addon.restore(tar_file)
 
         # Check if new
@@ -401,7 +402,7 @@ class AddonManager(CoreSysAttributes):
             self.local[slug] = addon
 
         # Update ingress
-        if addon.with_ingress:
+        if had_ingress != addon.ingress_panel:
             await self.sys_ingress.reload()
             with suppress(HomeAssistantAPIError):
                 await self.sys_ingress.update_hass_panel(addon)

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -532,10 +532,8 @@ async def test_restore(
     tarfile = SecureTarFile(get_fixture_path(f"backup_local_ssh_{status}.tar.gz"), "r")
     with patch.object(DockerAddon, "is_running", return_value=False), patch.object(
         CpuArch, "supported", new=PropertyMock(return_value=["aarch64"])
-    ), patch.object(Ingress, "update_hass_panel") as update_hass_panel:
+    ):
         start_task = await coresys.addons.restore(TEST_ADDON_SLUG, tarfile)
-
-        update_hass_panel.assert_called_once()
 
     assert bool(start_task) is (status == "running")
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

On restore of an addon, supervisor always tells HA to add or delete an ingress panel if the addon has ingress after the restore. This creates two problems:

1. If a version of the addon was restored which does not have ingress, supervisor does not tell HA to remove the panel
2. If the panel is already visible and supervisor says to add it or not visible and supervisor says to delete it the user sees an error like this:
```
2023-09-04 15:19:11.191 ERROR (MainThread) [aiohttp.server] Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/aiohttp/web_protocol.py", line 433, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/aiohttp/web_app.py", line 504, in _handle
    resp = await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/aiohttp/web_middlewares.py", line 117, in impl
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/security_filter.py", line 85, in security_filter_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/forwarded.py", line 100, in forwarded_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/request_context.py", line 28, in request_context_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/ban.py", line 80, in ban_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/auth.py", line 236, in auth_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/headers.py", line 31, in headers_middleware
    response = await handler(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/view.py", line 148, in handle
    result = await handler(request, **request.match_info)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/hassio/addon_panel.py", line 65, in post
    await _register_panel(self.hass, addon, data)
  File "/usr/src/homeassistant/homeassistant/components/hassio/addon_panel.py", line 85, in _register_panel
    await panel_custom.async_register_panel(
  File "/usr/src/homeassistant/homeassistant/components/panel_custom/__init__.py", line 124, in async_register_panel
    frontend.async_register_built_in_panel(
  File "/usr/src/homeassistant/homeassistant/components/frontend/__init__.py", line 289, in async_register_built_in_panel
    raise ValueError(f"Overwriting panel {panel.frontend_url_path}")
ValueError: Overwriting panel core_ssh
```

We should just be telling Home Assistant to update its ingress panels if something changed during the restore.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
