### PR TITLE
Correct /store/addons api output

### DIFF
--- a/supervisor/api/store.py
+++ b/supervisor/api/store.py
@@ -186,12 +186,14 @@ class APIStore(CoreSysAttributes):
         }
 
     @api_process
-    async def addons_list(self, request: web.Request) -> list[dict[str, Any]]:
+    async def addons_list(self, request: web.Request) -> dict[str, Any]:
         """Return all store add-ons."""
-        return [
-            self._generate_addon_information(self.sys_addons.store[addon])
-            for addon in self.sys_addons.store
-        ]
+        return {
+            ATTR_ADDONS: [
+                self._generate_addon_information(self.sys_addons.store[addon])
+                for addon in self.sys_addons.store
+            ]
+        }
 
     @api_process
     def addons_addon_install(self, request: web.Request) -> Awaitable[None]:

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -50,7 +50,7 @@ async def test_api_store_addons(api_client: TestClient, store_addon: AddonStore)
     result = await resp.json()
     print(result)
 
-    assert result["data"][-1]["slug"] == store_addon.slug
+    assert result["data"]["addons"][-1]["slug"] == store_addon.slug
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The response from `/store/addons` is not consistent with all other supervisor APIs as `data` is a list instead of a dictionary. This causes the issue shown here: https://github.com/home-assistant/cli/pull/360

This is a breaking change as it changes the structure of the response of this existing API. However Core does not rely on this API to our knowledge, it only uses `/store`. The CLI relies on it but cannot use it currently, this will fix it. So it should be safe to make and better to make the API consistent. 

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
