### PR TITLE
JobGroups check active job to determine if in progress

### DIFF
--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -1,7 +1,6 @@
 """Interface class for Supervisor Docker object."""
 from __future__ import annotations
 
-import asyncio
 from collections import defaultdict
 from collections.abc import Awaitable
 from contextlib import suppress
@@ -92,7 +91,6 @@ class DockerInterface(JobGroup):
         )
         self.coresys: CoreSys = coresys
         self._meta: dict[str, Any] | None = None
-        self.lock: asyncio.Lock = asyncio.Lock()
 
     @property
     def timeout(self) -> int:
@@ -153,7 +151,7 @@ class DockerInterface(JobGroup):
     @property
     def in_progress(self) -> bool:
         """Return True if a task is in progress."""
-        return self.lock.locked()
+        return self.active_job
 
     @property
     def restart_policy(self) -> RestartPolicy | None:

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -58,7 +58,6 @@ class HomeAssistantCore(JobGroup):
         """Initialize Home Assistant object."""
         super().__init__(coresys, JOB_GROUP_HOME_ASSISTANT_CORE)
         self.instance: DockerHomeAssistant = DockerHomeAssistant(coresys)
-        self.lock: asyncio.Lock = asyncio.Lock()
         self._error_state: bool = False
 
     @property
@@ -402,7 +401,7 @@ class HomeAssistantCore(JobGroup):
     @property
     def in_progress(self) -> bool:
         """Return True if a task is in progress."""
-        return self.instance.in_progress or self.lock.locked()
+        return self.instance.in_progress or self.active_job
 
     async def check_config(self) -> ConfigResult:
         """Run Home Assistant config check."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Descendents of Job Groups do not use a a lock member on the class to track whether a task is in progress, they ask the job group if there's an active job. This currently creates issues like `JobGroupExecutionLimitExceeded: Another job is running for job group container_hassio_observer` from plugin watchdog as it does not know another job is already happening.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
