### PR TITLE
Allow nested dictionary to be optional in addon config

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -641,11 +641,7 @@ class Addon(AddonModel):
         )
 
         # create voluptuous
-        new_schema = vol.Schema(
-            vol.All(
-                dict, AddonOptions(self.coresys, new_raw_schema, self.name, self.slug)
-            )
-        )
+        new_schema = vol.Schema(vol.All(dict, AddonOptions(self, new_raw_schema)))
 
         # validate
         try:

--- a/supervisor/addons/model.py
+++ b/supervisor/addons/model.py
@@ -585,7 +585,7 @@ class AddonModel(JobGroup, ABC):
         if isinstance(raw_schema, bool):
             raw_schema = {}
 
-        return AddonOptions(self.coresys, raw_schema, self.name, self.slug)
+        return AddonOptions(self, raw_schema)
 
     @property
     def schema_ui(self) -> list[dict[any, any]] | None:

--- a/supervisor/addons/options.py
+++ b/supervisor/addons/options.py
@@ -107,6 +107,12 @@ class AddonOptions(CoreSysAttributes):
                     f"Type error for option '{key}' in {self.addon.name} "
                     f"({self.addon.slug})"
                 ) from None
+            except vol.Invalid as err:
+                if key not in err.msg:
+                    raise vol.Invalid(
+                        f"Invalid value for option '{key}': {err}"
+                    ) from None
+                raise err
 
         self._check_missing_options(self.raw_schema, options, "root")
         return options
@@ -150,23 +156,23 @@ class AddonOptions(CoreSysAttributes):
             if typ.startswith(_PASSWORD) and value:
                 self.pwned.add(hashlib.sha1(str(value).encode()).hexdigest())
             return vol.All(str(value), vol.Range(**range_args))(value)
-        elif typ.startswith(_INT):
+        if typ.startswith(_INT):
             return vol.All(vol.Coerce(int), vol.Range(**range_args))(value)
-        elif typ.startswith(_FLOAT):
+        if typ.startswith(_FLOAT):
             return vol.All(vol.Coerce(float), vol.Range(**range_args))(value)
-        elif typ.startswith(_BOOL):
+        if typ.startswith(_BOOL):
             return vol.Boolean()(value)
-        elif typ.startswith(_EMAIL):
+        if typ.startswith(_EMAIL):
             return vol.Email()(value)
-        elif typ.startswith(_URL):
+        if typ.startswith(_URL):
             return vol.Url()(value)
-        elif typ.startswith(_PORT):
+        if typ.startswith(_PORT):
             return network_port(value)
-        elif typ.startswith(_MATCH):
+        if typ.startswith(_MATCH):
             return vol.Match(match.group("match"))(str(value))
-        elif typ.startswith(_LIST):
+        if typ.startswith(_LIST):
             return vol.In(match.group("list").split("|"))(str(value))
-        elif typ.startswith(_DEVICE):
+        if typ.startswith(_DEVICE):
             try:
                 device = self.sys_hardware.get_by_path(Path(value))
             except HardwareNotFound:

--- a/supervisor/addons/options.py
+++ b/supervisor/addons/options.py
@@ -69,8 +69,6 @@ class AddonOptions(CoreSysAttributes):
         self.raw_schema: dict[str, Any] = raw_schema
         self.devices: set[Device] = set()
         self.pwned: set[str] = set()
-        self._name = addon.name
-        self._slug = addon.slug
 
     @property
     def validate(self) -> vol.Schema:
@@ -88,8 +86,8 @@ class AddonOptions(CoreSysAttributes):
                 _LOGGER.warning(
                     "Option '%s' does not exist in the schema for %s (%s)",
                     key,
-                    self._name,
-                    self._slug,
+                    self.addon.name,
+                    self.addon.slug,
                 )
                 continue
 
@@ -106,7 +104,8 @@ class AddonOptions(CoreSysAttributes):
                     options[key] = self._single_validate(typ, value, key)
             except (IndexError, KeyError):
                 raise vol.Invalid(
-                    f"Type error for option '{key}' in {self._name} ({self._slug})"
+                    f"Type error for option '{key}' in {self.addon.name} "
+                    f"({self.addon.slug})"
                 ) from None
 
         self._check_missing_options(self.raw_schema, options, "root")
@@ -118,7 +117,8 @@ class AddonOptions(CoreSysAttributes):
         # if required argument
         if value is None:
             raise vol.Invalid(
-                f"Missing required option '{key}' in {self._name} ({self._slug})"
+                f"Missing required option '{key}' in {self.addon.name} "
+                f"({self.addon.slug})"
             ) from None
 
         # Lookup secret
@@ -127,7 +127,8 @@ class AddonOptions(CoreSysAttributes):
             value = self.sys_homeassistant.secrets.get(secret)
             if value is None:
                 raise vol.Invalid(
-                    f"Unknown secret '{secret}' in {self._name} ({self._slug})"
+                    f"Unknown secret '{secret}' in {self.addon.name} "
+                    f"({self.addon.slug})"
                 ) from None
 
         # parse extend data from type
@@ -135,7 +136,7 @@ class AddonOptions(CoreSysAttributes):
 
         if not match:
             raise vol.Invalid(
-                f"Unknown type '{typ}' in {self._name} ({self._slug})"
+                f"Unknown type '{typ}' in {self.addon.name} ({self.addon.slug})"
             ) from None
 
         # prepare range
@@ -170,7 +171,8 @@ class AddonOptions(CoreSysAttributes):
                 device = self.sys_hardware.get_by_path(Path(value))
             except HardwareNotFound:
                 raise vol.Invalid(
-                    f"Device '{value}' does not exist in {self._name} ({self._slug})"
+                    f"Device '{value}' does not exist in {self.addon.name} "
+                    f"({self.addon.slug})"
                 ) from None
 
             # Have filter
@@ -179,7 +181,8 @@ class AddonOptions(CoreSysAttributes):
                 device_filter = _create_device_filter(str_filter)
                 if device not in self.sys_hardware.filter_devices(**device_filter):
                     raise vol.Invalid(
-                        f"Device '{value}' don't match the filter {str_filter}! in {self._name} ({self._slug})"
+                        f"Device '{value}' don't match the filter {str_filter}! "
+                        f"in {self.addon.name} ({self.addon.slug})"
                     )
 
             # Device valid
@@ -187,7 +190,8 @@ class AddonOptions(CoreSysAttributes):
             return str(device.path)
 
         raise vol.Invalid(
-            f"Fatal error for option '{key}' with type '{typ}' in {self._name} ({self._slug})"
+            f"Fatal error for option '{key}' with type '{typ}' in {self.addon.name} "
+            f"({self.addon.slug})"
         ) from None
 
     def _nested_validate_list(self, typ: Any, data_list: list[Any], key: str):
@@ -197,7 +201,8 @@ class AddonOptions(CoreSysAttributes):
         # Make sure it is a list
         if not isinstance(data_list, list):
             raise vol.Invalid(
-                f"Invalid list for option '{key}' in {self._name} ({self._slug})"
+                f"Invalid list for option '{key}' in {self.addon.name} "
+                f"({self.addon.slug})"
             ) from None
 
         # Process list
@@ -220,7 +225,8 @@ class AddonOptions(CoreSysAttributes):
         # Make sure it is a dict
         if not isinstance(data_dict, dict):
             raise vol.Invalid(
-                f"Invalid dict for option '{key}' in {self._name} ({self._slug})"
+                f"Invalid dict for option '{key}' in {self.addon.name} "
+                f"({self.addon.slug})"
             ) from None
 
         # Process dict
@@ -228,7 +234,10 @@ class AddonOptions(CoreSysAttributes):
             # Ignore unknown options / remove from list
             if c_key not in typ:
                 _LOGGER.warning(
-                    "Unknown option '%s' for %s (%s)", c_key, self._name, self._slug
+                    "Unknown option '%s' for %s (%s)",
+                    c_key,
+                    self.addon.name,
+                    self.addon.slug,
                 )
                 continue
 
@@ -267,7 +276,8 @@ class AddonOptions(CoreSysAttributes):
                 continue
 
             raise vol.Invalid(
-                f"Missing option '{miss_opt}' in {root} in {self._name} ({self._slug})"
+                f"Missing option '{miss_opt}' in {root} in {self.addon.name} "
+                f"({self.addon.slug})"
             ) from None
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
See this issue for more details on the behavior I am trying to enable along with an example: https://github.com/home-assistant/supervisor/issues/4606

I believe that if a nested dictionary is in the `schema` but not in the `options` and therefore hidden by default from the configuration UI, it should be optional, and I consider this a bug because you can hide it.

I know I need to refactor tests significantly for this change, but I wanted to get a sense of whether I am headed in the right direction before I continue.

I also attempted to improve the error message because I noticed that the `key` that failed validation is not always part of the message which makes it confusing.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4606
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
