### PR TITLE
Eliminate possible addon data race condition during update

### DIFF
--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -449,12 +449,17 @@ class DockerInterface(JobGroup):
         return b""
 
     @Job(name="docker_interface_cleanup", limit=JobExecutionLimit.GROUP_WAIT)
-    def cleanup(self, old_image: str | None = None) -> Awaitable[None]:
+    def cleanup(
+        self,
+        old_image: str | None = None,
+        image: str | None = None,
+        version: AwesomeVersion | None = None,
+    ) -> Awaitable[None]:
         """Check if old version exists and cleanup."""
         return self.sys_run_in_executor(
             self.sys_docker.cleanup_old_images,
-            self.image,
-            self.version,
+            image or self.image,
+            version or self.version,
             {old_image} if old_image else None,
         )
 

--- a/supervisor/store/addon.py
+++ b/supervisor/store/addon.py
@@ -1,4 +1,6 @@
 """Init file for Supervisor add-ons."""
+
+from copy import deepcopy
 import logging
 
 from ..addons.model import AddonModel, Data
@@ -9,6 +11,8 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 class AddonStore(AddonModel):
     """Hold data for add-on inside Supervisor."""
 
+    _data: Data | None = None
+
     def __repr__(self) -> str:
         """Return internal representation."""
         return f"<Store: {self.slug}>"
@@ -16,7 +20,7 @@ class AddonStore(AddonModel):
     @property
     def data(self) -> Data:
         """Return add-on data/config."""
-        return self.sys_store.data.addons[self.slug]
+        return self._data or self.sys_store.data.addons[self.slug]
 
     @property
     def is_installed(self) -> bool:
@@ -27,3 +31,9 @@ class AddonStore(AddonModel):
     def is_detached(self) -> bool:
         """Return True if add-on is detached."""
         return False
+
+    def clone(self) -> "AddonStore":
+        """Return a copy that includes data and does not use global store data."""
+        addon = AddonStore(self.coresys, self.slug)
+        addon._data = deepcopy(self.data)
+        return addon

--- a/supervisor/store/addon.py
+++ b/supervisor/store/addon.py
@@ -2,10 +2,10 @@
 
 from copy import deepcopy
 import logging
-
-from supervisor.coresys import CoreSys
+from typing import Self
 
 from ..addons.model import AddonModel, Data
+from ..coresys import CoreSys
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -37,6 +37,6 @@ class AddonStore(AddonModel):
         """Return True if add-on is detached."""
         return False
 
-    def clone(self) -> "AddonStore":
+    def clone(self) -> Self:
         """Return a copy that includes data and does not use global store data."""
-        return AddonStore(self.coresys, self.slug, deepcopy(self.data))
+        return type(self)(self.coresys, self.slug, deepcopy(self.data))

--- a/supervisor/store/addon.py
+++ b/supervisor/store/addon.py
@@ -3,6 +3,8 @@
 from copy import deepcopy
 import logging
 
+from supervisor.coresys import CoreSys
+
 from ..addons.model import AddonModel, Data
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -11,7 +13,10 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 class AddonStore(AddonModel):
     """Hold data for add-on inside Supervisor."""
 
-    _data: Data | None = None
+    def __init__(self, coresys: CoreSys, slug: str, data: Data | None = None):
+        """Initialize object."""
+        super().__init__(coresys, slug)
+        self._data: Data | None = data
 
     def __repr__(self) -> str:
         """Return internal representation."""
@@ -34,6 +39,4 @@ class AddonStore(AddonModel):
 
     def clone(self) -> "AddonStore":
         """Return a copy that includes data and does not use global store data."""
-        addon = AddonStore(self.coresys, self.slug)
-        addon._data = deepcopy(self.data)
-        return addon
+        return AddonStore(self.coresys, self.slug, deepcopy(self.data))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Currently addon update has a possible race condition with the global addon data. This can be triggered as follows:

1. An addon update is initiated
2. While waiting for the new image to download, store data is updated (possibly due to scheduled task)
3. The config of the addon being updated has changed. Specifically if a new version came out or the image was changed

In this situation Supervisor ends up pulling one image but telling the addon a completely different image is in use. And then promptly removing the image it just pulled as it believes it is stale.

The unit test reproduces this race condition by simulating with asyncio events prior to the code change. It is not reproducible afterwards. I believe this change to be the solution to #4610 . Although we can't be certain as we have no logs or steps to reproduce clearly showing what is occurring on these systems. Still it seems likely as the steps I outlined above would result in that exact error.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4610
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
