### PR TITLE
Capture exception if image is missing on run

### DIFF
--- a/supervisor/docker/addon.py
+++ b/supervisor/docker/addon.py
@@ -501,24 +501,16 @@ class DockerAddon(DockerInterface):
     )
     async def run(self) -> None:
         """Run Docker image."""
-        if await self.is_running():
-            return
-
         # Security check
         if not self.addon.protected:
             _LOGGER.warning("%s running with disabled protected mode!", self.addon.name)
-
-        # Cleanup
-        await self.stop()
 
         # Don't set a hostname if no separate UTS namespace is used
         hostname = None if self.uts_mode else self.addon.hostname
 
         # Create & Run container
         try:
-            docker_container = await self.sys_run_in_executor(
-                self.sys_docker.run,
-                self.image,
+            await self._run(
                 tag=str(self.addon.version),
                 name=self.name,
                 hostname=hostname,
@@ -549,7 +541,6 @@ class DockerAddon(DockerInterface):
             )
             raise
 
-        self._meta = docker_container.attrs
         _LOGGER.info(
             "Starting Docker add-on %s with version %s", self.image, self.version
         )

--- a/supervisor/docker/audio.py
+++ b/supervisor/docker/audio.py
@@ -92,16 +92,7 @@ class DockerAudio(DockerInterface, CoreSysAttributes):
     )
     async def run(self) -> None:
         """Run Docker image."""
-        if await self.is_running():
-            return
-
-        # Cleanup
-        await self.stop()
-
-        # Create & Run container
-        docker_container = await self.sys_run_in_executor(
-            self.sys_docker.run,
-            self.image,
+        await self._run(
             tag=str(self.sys_plugins.audio.version),
             init=False,
             ipv4=self.sys_docker.network.audio,
@@ -118,8 +109,6 @@ class DockerAudio(DockerInterface, CoreSysAttributes):
             },
             mounts=self.mounts,
         )
-
-        self._meta = docker_container.attrs
         _LOGGER.info(
             "Starting Audio %s with version %s - %s",
             self.image,

--- a/supervisor/docker/cli.py
+++ b/supervisor/docker/cli.py
@@ -33,16 +33,7 @@ class DockerCli(DockerInterface, CoreSysAttributes):
     )
     async def run(self) -> None:
         """Run Docker image."""
-        if await self.is_running():
-            return
-
-        # Cleanup
-        await self.stop()
-
-        # Create & Run container
-        docker_container = await self.sys_run_in_executor(
-            self.sys_docker.run,
-            self.image,
+        await self._run(
             entrypoint=["/init"],
             tag=str(self.sys_plugins.cli.version),
             init=False,
@@ -60,8 +51,6 @@ class DockerCli(DockerInterface, CoreSysAttributes):
                 ENV_TOKEN: self.sys_plugins.cli.supervisor_token,
             },
         )
-
-        self._meta = docker_container.attrs
         _LOGGER.info(
             "Starting CLI %s with version %s - %s",
             self.image,

--- a/supervisor/docker/dns.py
+++ b/supervisor/docker/dns.py
@@ -35,16 +35,7 @@ class DockerDNS(DockerInterface, CoreSysAttributes):
     )
     async def run(self) -> None:
         """Run Docker image."""
-        if await self.is_running():
-            return
-
-        # Cleanup
-        await self.stop()
-
-        # Create & Run container
-        docker_container = await self.sys_run_in_executor(
-            self.sys_docker.run,
-            self.image,
+        await self._run(
             tag=str(self.sys_plugins.dns.version),
             init=False,
             dns=False,
@@ -65,8 +56,6 @@ class DockerDNS(DockerInterface, CoreSysAttributes):
             ],
             oom_score_adj=-300,
         )
-
-        self._meta = docker_container.attrs
         _LOGGER.info(
             "Starting DNS %s with version %s - %s",
             self.image,

--- a/supervisor/docker/homeassistant.py
+++ b/supervisor/docker/homeassistant.py
@@ -152,16 +152,7 @@ class DockerHomeAssistant(DockerInterface):
     )
     async def run(self) -> None:
         """Run Docker image."""
-        if await self.is_running():
-            return
-
-        # Cleanup
-        await self.stop()
-
-        # Create & Run container
-        docker_container = await self.sys_run_in_executor(
-            self.sys_docker.run,
-            self.image,
+        await self._run(
             tag=(self.sys_homeassistant.version),
             name=self.name,
             hostname=self.name,
@@ -186,8 +177,6 @@ class DockerHomeAssistant(DockerInterface):
             tmpfs={"/tmp": ""},
             oom_score_adj=-300,
         )
-
-        self._meta = docker_container.attrs
         _LOGGER.info(
             "Starting Home Assistant %s with version %s", self.image, self.version
         )

--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -377,6 +377,31 @@ class DockerInterface(JobGroup):
         """Run Docker image."""
         raise NotImplementedError()
 
+    async def _run(self, **kwargs) -> None:
+        """Run Docker image with retry inf necessary."""
+        if await self.is_running():
+            return
+
+        # Cleanup
+        await self.stop()
+
+        # Create & Run container
+        try:
+            docker_container = await self.sys_run_in_executor(
+                self.sys_docker.run, self.image, **kwargs
+            )
+        except DockerNotFound as err:
+            # If image is missing, capture the exception as this shouldn't happen
+            # Try to keep things working for user by pulling image and retrying once
+            capture_exception(err)
+            await self.install(self.version)
+            docker_container = await self.sys_run_in_executor(
+                self.sys_docker.run, self.image, **kwargs
+            )
+
+        # Store metadata
+        self._meta = docker_container.attrs
+
     @Job(
         name="docker_interface_stop",
         limit=JobExecutionLimit.GROUP_ONCE,

--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -392,12 +392,8 @@ class DockerInterface(JobGroup):
             )
         except DockerNotFound as err:
             # If image is missing, capture the exception as this shouldn't happen
-            # Try to keep things working for user by pulling image and retrying once
             capture_exception(err)
-            await self.install(self.version)
-            docker_container = await self.sys_run_in_executor(
-                self.sys_docker.run, self.image, **kwargs
-            )
+            raise
 
         # Store metadata
         self._meta = docker_container.attrs

--- a/supervisor/docker/multicast.py
+++ b/supervisor/docker/multicast.py
@@ -38,16 +38,7 @@ class DockerMulticast(DockerInterface, CoreSysAttributes):
     )
     async def run(self) -> None:
         """Run Docker image."""
-        if await self.is_running():
-            return
-
-        # Cleanup
-        await self.stop()
-
-        # Create & Run container
-        docker_container = await self.sys_run_in_executor(
-            self.sys_docker.run,
-            self.image,
+        await self._run(
             tag=str(self.sys_plugins.multicast.version),
             init=False,
             name=self.name,
@@ -59,8 +50,6 @@ class DockerMulticast(DockerInterface, CoreSysAttributes):
             extra_hosts={"supervisor": self.sys_docker.network.supervisor},
             environment={ENV_TIME: self.sys_timezone},
         )
-
-        self._meta = docker_container.attrs
         _LOGGER.info(
             "Starting Multicast %s with version %s - Host", self.image, self.version
         )

--- a/supervisor/docker/observer.py
+++ b/supervisor/docker/observer.py
@@ -35,16 +35,7 @@ class DockerObserver(DockerInterface, CoreSysAttributes):
     )
     async def run(self) -> None:
         """Run Docker image."""
-        if await self.is_running():
-            return
-
-        # Cleanup
-        await self.stop()
-
-        # Create & Run container
-        docker_container = await self.sys_run_in_executor(
-            self.sys_docker.run,
-            self.image,
+        await self._run(
             tag=str(self.sys_plugins.observer.version),
             init=False,
             ipv4=self.sys_docker.network.observer,
@@ -63,8 +54,6 @@ class DockerObserver(DockerInterface, CoreSysAttributes):
             ports={"80/tcp": 4357},
             oom_score_adj=-300,
         )
-
-        self._meta = docker_container.attrs
         _LOGGER.info(
             "Starting Observer %s with version %s - %s",
             self.image,

--- a/supervisor/resolution/fixups/addon_execute_repair.py
+++ b/supervisor/resolution/fixups/addon_execute_repair.py
@@ -1,0 +1,57 @@
+"""Helper to fix missing image for addon."""
+
+import logging
+
+from ...coresys import CoreSys
+from ..const import ContextType, IssueType, SuggestionType
+from .base import FixupBase
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+def setup(coresys: CoreSys) -> FixupBase:
+    """Check setup function."""
+    return FixupAddonExecuteRepair(coresys)
+
+
+class FixupAddonExecuteRepair(FixupBase):
+    """Storage class for fixup."""
+
+    async def process_fixup(self, reference: str | None = None) -> None:
+        """Pull the addons image."""
+        addon = self.sys_addons.get(reference, local_only=True)
+        if not addon:
+            _LOGGER.info(
+                "Cannot repair addon %s as it is not installed, dismissing suggestion",
+                reference,
+            )
+            return
+
+        if await addon.instance.exists():
+            _LOGGER.info(
+                "Addon %s does not need repair, dismissing suggestion", reference
+            )
+            return
+
+        _LOGGER.info("Installing image for addon %s")
+        await addon.instance.install(addon.version)
+
+    @property
+    def suggestion(self) -> SuggestionType:
+        """Return a SuggestionType enum."""
+        return SuggestionType.EXECUTE_REPAIR
+
+    @property
+    def context(self) -> ContextType:
+        """Return a ContextType enum."""
+        return ContextType.ADDON
+
+    @property
+    def issues(self) -> list[IssueType]:
+        """Return a IssueType enum list."""
+        return [IssueType.MISSING_IMAGE]
+
+    @property
+    def auto(self) -> bool:
+        """Return if a fixup can be apply as auto fix."""
+        return True

--- a/tests/docker/test_addon.py
+++ b/tests/docker/test_addon.py
@@ -39,13 +39,6 @@ def fixture_addonsdata_user() -> dict[str, Data]:
         yield mock
 
 
-@pytest.fixture(name="os_environ")
-def fixture_os_environ():
-    """Mock os.environ."""
-    with patch("supervisor.config.os.environ") as mock:
-        yield mock
-
-
 def get_docker_addon(
     coresys: CoreSys, addonsdata_system: dict[str, Data], config_file: str
 ):
@@ -60,7 +53,7 @@ def get_docker_addon(
 
 
 def test_base_volumes_included(
-    coresys: CoreSys, addonsdata_system: dict[str, Data], os_environ
+    coresys: CoreSys, addonsdata_system: dict[str, Data], path_extern
 ):
     """Dev and data volumes always included."""
     docker_addon = get_docker_addon(
@@ -86,7 +79,7 @@ def test_base_volumes_included(
 
 
 def test_addon_map_folder_defaults(
-    coresys: CoreSys, addonsdata_system: dict[str, Data], os_environ
+    coresys: CoreSys, addonsdata_system: dict[str, Data], path_extern
 ):
     """Validate defaults for mapped folders in addons."""
     docker_addon = get_docker_addon(
@@ -143,7 +136,7 @@ def test_addon_map_folder_defaults(
 
 
 def test_journald_addon(
-    coresys: CoreSys, addonsdata_system: dict[str, Data], os_environ
+    coresys: CoreSys, addonsdata_system: dict[str, Data], path_extern
 ):
     """Validate volume for journald option."""
     docker_addon = get_docker_addon(
@@ -171,7 +164,7 @@ def test_journald_addon(
 
 
 def test_not_journald_addon(
-    coresys: CoreSys, addonsdata_system: dict[str, Data], os_environ
+    coresys: CoreSys, addonsdata_system: dict[str, Data], path_extern
 ):
     """Validate journald option defaults off."""
     docker_addon = get_docker_addon(
@@ -182,9 +175,7 @@ def test_not_journald_addon(
 
 
 async def test_addon_run_docker_error(
-    coresys: CoreSys,
-    addonsdata_system: dict[str, Data],
-    os_environ,
+    coresys: CoreSys, addonsdata_system: dict[str, Data], path_extern
 ):
     """Test docker error when addon is run."""
     await coresys.dbus.timedate.connect(coresys.dbus.bus)
@@ -195,7 +186,7 @@ async def test_addon_run_docker_error(
 
     with patch.object(DockerAddon, "stop"), patch.object(
         AddonOptions, "validate", new=PropertyMock(return_value=lambda _: None)
-    ), patch.object(DockerAddon, "install"), pytest.raises(DockerNotFound):
+    ), pytest.raises(DockerNotFound):
         await docker_addon.run()
 
     assert (
@@ -208,7 +199,7 @@ async def test_addon_run_add_host_error(
     coresys: CoreSys,
     addonsdata_system: dict[str, Data],
     capture_exception: Mock,
-    os_environ,
+    path_extern,
 ):
     """Test error adding host when addon is run."""
     await coresys.dbus.timedate.connect(coresys.dbus.bus)

--- a/tests/docker/test_addon.py
+++ b/tests/docker/test_addon.py
@@ -184,7 +184,6 @@ def test_not_journald_addon(
 async def test_addon_run_docker_error(
     coresys: CoreSys,
     addonsdata_system: dict[str, Data],
-    capture_exception: Mock,
     os_environ,
 ):
     """Test docker error when addon is run."""
@@ -196,14 +195,13 @@ async def test_addon_run_docker_error(
 
     with patch.object(DockerAddon, "stop"), patch.object(
         AddonOptions, "validate", new=PropertyMock(return_value=lambda _: None)
-    ), pytest.raises(DockerNotFound):
+    ), patch.object(DockerAddon, "install"), pytest.raises(DockerNotFound):
         await docker_addon.run()
 
     assert (
         Issue(IssueType.MISSING_IMAGE, ContextType.ADDON, reference="test_addon")
         in coresys.resolution.issues
     )
-    capture_exception.assert_not_called()
 
 
 async def test_addon_run_add_host_error(

--- a/tests/docker/test_interface.py
+++ b/tests/docker/test_interface.py
@@ -242,5 +242,5 @@ async def test_run_missing_image(
         await install_addon_ssh.instance.run()
         install.assert_called_once_with(AwesomeVersion("9.2.1"), None, False, None)
 
-    coresys.docker.containers.create.call_count == 2
+    assert coresys.docker.containers.create.call_count == 2
     capture_exception.assert_called_once()

--- a/tests/resolution/fixup/test_addon_execute_repair.py
+++ b/tests/resolution/fixup/test_addon_execute_repair.py
@@ -1,0 +1,73 @@
+"""Test fixup core execute repair."""
+
+from unittest.mock import MagicMock, patch
+
+from docker.errors import NotFound
+
+from supervisor.addons.addon import Addon
+from supervisor.coresys import CoreSys
+from supervisor.docker.addon import DockerAddon
+from supervisor.docker.interface import DockerInterface
+from supervisor.docker.manager import DockerAPI
+from supervisor.resolution.const import ContextType, IssueType, SuggestionType
+from supervisor.resolution.fixups.addon_execute_repair import FixupAddonExecuteRepair
+
+
+async def test_fixup(docker: DockerAPI, coresys: CoreSys, install_addon_ssh: Addon):
+    """Test fixup rebuilds addon's container."""
+    docker.images.get.side_effect = NotFound("missing")
+    install_addon_ssh.data["image"] = "test_image"
+
+    addon_execute_repair = FixupAddonExecuteRepair(coresys)
+    assert addon_execute_repair.auto is True
+
+    coresys.resolution.create_issue(
+        IssueType.MISSING_IMAGE,
+        ContextType.ADDON,
+        reference="local_ssh",
+        suggestions=[SuggestionType.EXECUTE_REPAIR],
+    )
+    with patch.object(DockerInterface, "install") as install:
+        await addon_execute_repair()
+        install.assert_called_once()
+
+    assert not coresys.resolution.issues
+    assert not coresys.resolution.suggestions
+
+
+async def test_fixup_no_addon(coresys: CoreSys):
+    """Test fixup dismisses if addon is missing."""
+    addon_execute_repair = FixupAddonExecuteRepair(coresys)
+    assert addon_execute_repair.auto is True
+
+    coresys.resolution.create_issue(
+        IssueType.MISSING_IMAGE,
+        ContextType.ADDON,
+        reference="local_ssh",
+        suggestions=[SuggestionType.EXECUTE_REPAIR],
+    )
+
+    with patch.object(DockerAddon, "install") as install:
+        await addon_execute_repair()
+        install.assert_not_called()
+
+
+async def test_fixup_image_exists(
+    docker: DockerAPI, coresys: CoreSys, install_addon_ssh: Addon
+):
+    """Test fixup dismisses if image exists."""
+    docker.images.get.return_value = MagicMock()
+
+    addon_execute_repair = FixupAddonExecuteRepair(coresys)
+    assert addon_execute_repair.auto is True
+
+    coresys.resolution.create_issue(
+        IssueType.MISSING_IMAGE,
+        ContextType.ADDON,
+        reference="local_ssh",
+        suggestions=[SuggestionType.EXECUTE_REPAIR],
+    )
+
+    with patch.object(DockerAddon, "install") as install:
+        await addon_execute_repair()
+        install.assert_not_called()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Follow-up to #4619 . Although we believe #4610 should be fixed now, we don't have explicit confirmation that the race condition is the source. In addition there are edge cases where the image can go missing unexpectedly (failure/outtage in the middle of an `ha supervisor repair`, docker update clearing out images, user pruning images with docker cli, etc.)

~~"{x} cannot be started because the image doesn't exist" is not an error we should ever really be showing users. There is nothing they can do about this except submit an issue here and be told to run `ha supervisor repair`. There is however, more supervisor can do to prevent them from ever seeing this error. Namely we can do exactly what `docker run` does - if the image with the specified tag cannot be found locally, pull it.~~

~~This PR adds a retry step to the `run` for all docker objects to handle `ImageNotFound`. Since this should not happen it first reports the error to sentry so we know there is an issue to address. But it tries to handle this issue for users and only let them know if we also fail to pull the image at that time.~~

EDIT: No longer re-pulling and retrying on run. For now we are just capturing the exception and reporting it to sentry. Although the fixup for image missing is still implemented and marked autofix. So while users will see the error, it will at least try to fix itself afterwards.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
