### PR TITLE
Remove race with watchdog during backup, restore and update

### DIFF
--- a/supervisor/addons/__init__.py
+++ b/supervisor/addons/__init__.py
@@ -315,12 +315,13 @@ class AddonManager(CoreSysAttributes):
             await addon.install_apparmor()
 
         finally:
-            # restore state
-            return (
+            # restore state. Return awaitable for caller if no exception
+            out = (
                 await addon.start()
                 if last_state in {AddonState.STARTED, AddonState.STARTUP}
                 else None
             )
+        return out
 
     @Job(
         name="addon_manager_rebuild",

--- a/supervisor/addons/__init__.py
+++ b/supervisor/addons/__init__.py
@@ -292,16 +292,16 @@ class AddonManager(CoreSysAttributes):
         # Cache data to prevent races with other updates to global
         store = store.clone()
 
+        try:
+            await addon.instance.update(store.version, store.image)
+        except DockerError as err:
+            raise AddonsError() from err
+
         # Stop the addon if running
         if (last_state := addon.state) in {AddonState.STARTED, AddonState.STARTUP}:
             await addon.stop()
 
         try:
-            try:
-                await addon.instance.update(store.version, store.image)
-            except DockerError as err:
-                raise AddonsError() from err
-
             _LOGGER.info("Add-on '%s' successfully updated", slug)
             self.data.update(store)
 

--- a/supervisor/docker/addon.py
+++ b/supervisor/docker/addon.py
@@ -580,10 +580,6 @@ class DockerAddon(DockerInterface):
             version, image=image, latest=latest, need_build=self.addon.latest_need_build
         )
 
-        # Stop container & cleanup
-        with suppress(DockerError):
-            await self.stop()
-
     @Job(
         name="docker_addon_install",
         limit=JobExecutionLimit.GROUP_ONCE,

--- a/supervisor/plugins/base.py
+++ b/supervisor/plugins/base.py
@@ -119,10 +119,7 @@ class PluginBase(ABC, FileConfiguration, CoreSysAttributes):
                     state,
                 )
                 try:
-                    if state == ContainerState.STOPPED and attempts == 0:
-                        await self.start()
-                    else:
-                        await self.rebuild()
+                    await self.rebuild()
                 except PluginError as err:
                     attempts = attempts + 1
                     _LOGGER.error("Watchdog restart of %s plugin failed!", self.slug)

--- a/supervisor/plugins/base.py
+++ b/supervisor/plugins/base.py
@@ -105,11 +105,7 @@ class PluginBase(ABC, FileConfiguration, CoreSysAttributes):
         if not (event.name == self.instance.name):
             return
 
-        if event.state in [
-            ContainerState.FAILED,
-            ContainerState.STOPPED,
-            ContainerState.UNHEALTHY,
-        ]:
+        if event.state in {ContainerState.FAILED, ContainerState.UNHEALTHY}:
             await self._restart_after_problem(event.state)
 
     async def _restart_after_problem(self, state: ContainerState):

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -39,10 +39,6 @@ def _fire_test_event(coresys: CoreSys, name: str, state: ContainerState):
     )
 
 
-async def mock_stop() -> None:
-    """Mock for stop method."""
-
-
 def test_options_merge(coresys: CoreSys, install_addon_ssh: Addon) -> None:
     """Test options merge."""
     addon = coresys.addons.get(TEST_ADDON_SLUG)
@@ -148,7 +144,7 @@ async def test_addon_watchdog(coresys: CoreSys, install_addon_ssh: Addon) -> Non
 
         # Rebuild if it failed
         current_state.return_value = ContainerState.FAILED
-        with patch.object(DockerAddon, "stop", return_value=mock_stop()) as stop:
+        with patch.object(DockerAddon, "stop") as stop:
             _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.FAILED)
             await asyncio.sleep(0)
             stop.assert_called_once_with(remove_container=True)
@@ -183,7 +179,7 @@ async def test_watchdog_on_stop(coresys: CoreSys, install_addon_ssh: Addon) -> N
         DockerAddon,
         "current_state",
         return_value=ContainerState.STOPPED,
-    ), patch.object(DockerAddon, "stop", return_value=mock_stop()):
+    ), patch.object(DockerAddon, "stop"):
         # Do not restart when addon stopped by user
         _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
         await asyncio.sleep(0)

--- a/tests/plugins/test_plugin_base.py
+++ b/tests/plugins/test_plugin_base.py
@@ -98,7 +98,7 @@ async def test_plugin_watchdog(coresys: CoreSys, plugin: PluginBase) -> None:
         start.assert_not_called()
 
         rebuild.reset_mock()
-        # Plugins are restarted anytime they stop, not just on failure
+        # Stop should be ignored as it means an update or system shutdown, plugins don't stop otherwise
         current_state.return_value = ContainerState.STOPPED
         coresys.bus.fire_event(
             BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
@@ -111,9 +111,8 @@ async def test_plugin_watchdog(coresys: CoreSys, plugin: PluginBase) -> None:
         )
         await asyncio.sleep(0)
         rebuild.assert_not_called()
-        start.assert_called_once()
+        start.assert_not_called()
 
-        start.reset_mock()
         # Do not process event if container state has changed since fired
         current_state.return_value = ContainerState.HEALTHY
         coresys.bus.fire_event(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Currently backup, restore and update has a race condition with watchdog. Watchdog will see that the addon has stopped and it will not be marked as a manual stop so it believes it is unexpected. This will cause it to try and reanimate it which can cause issues with the process being run. Block this from happening by treating it as a manual stop as it was initiated by the user.

This situation can also occur with plugin updates currently. The PR stops that as well by having watchdog ignore successful stops of the container as that will only occur during plugin updates or system shutdowns, watchdog should not try to reanimate during either of these events.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
