### PR TITLE
Use longer timeouts for API checks before trigger a rollback

### DIFF
--- a/supervisor/homeassistant/api.py
+++ b/supervisor/homeassistant/api.py
@@ -131,7 +131,7 @@ class HomeAssistantAPI(CoreSysAttributes):
         return await self._get_json("api/core/state")
 
     async def get_api_state(self) -> str | None:
-        """Return True if Home Assistant Core is up and running."""
+        """Return state of Home Assistant Core or None."""
         # Skip check on landingpage
         if (
             self.sys_homeassistant.version is None

--- a/supervisor/homeassistant/api.py
+++ b/supervisor/homeassistant/api.py
@@ -130,7 +130,7 @@ class HomeAssistantAPI(CoreSysAttributes):
         """Return Home Assistant core state."""
         return await self._get_json("api/core/state")
 
-    async def check_api_state(self) -> bool:
+    async def check_api_state(self, check_running: bool = True) -> bool:
         """Return True if Home Assistant up and running."""
         # Skip check on landingpage
         if (
@@ -157,7 +157,9 @@ class HomeAssistantAPI(CoreSysAttributes):
             else:
                 data = await self.get_config()
             # Older versions of home assistant does not expose the state
-            if data and data.get("state", "RUNNING") == "RUNNING":
+            if data:
+                if check_running:
+                    return data.get("state", "RUNNING") == "RUNNING"
                 return True
 
         return False

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -450,7 +450,7 @@ class HomeAssistantCore(JobGroup):
                 break
 
             # 2: Check if API response
-            if await self.sys_homeassistant.api.check_api_state():
+            if await self.sys_homeassistant.api.check_api_state(check_running=False):
                 _LOGGER.info("Detect a running Home Assistant instance")
                 self._error_state = False
                 return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -354,6 +354,7 @@ async def coresys(
 
     # WebSocket
     coresys_obj.homeassistant.api.check_api_state = AsyncMock(return_value=True)
+    coresys_obj.homeassistant.api.get_api_state = AsyncMock(return_value="RUNNING")
     coresys_obj.homeassistant._websocket._client = AsyncMock(
         ha_version=AwesomeVersion("2021.2.4")
     )

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -275,7 +275,7 @@ async def test_api_check_timeout(
     """Test attempts to contact the API timeout."""
     container.status = "stopped"
     coresys.homeassistant.version = AwesomeVersion("2023.9.0")
-    coresys.homeassistant.api.check_api_state.return_value = False
+    coresys.homeassistant.api.get_api_state.return_value = None
 
     async def mock_instance_start(*_):
         container.status = "running"
@@ -294,8 +294,7 @@ async def test_api_check_timeout(
         ), pytest.raises(HomeAssistantCrashError):
             await coresys.homeassistant.core.start()
 
-    assert coresys.homeassistant.api.check_api_state.call_count == 5
+    assert coresys.homeassistant.api.get_api_state.call_count == 3
     assert (
-        "No API response in 5 minutes, assuming core has had a fatal startup error"
-        in caplog.text
+        "No Home Assistant Core response, assuming a fatal startup error" in caplog.text
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Currently we check for Core API access and that the state is running. If this is not fulfilled within 5 minutes, we rollback to the previous version.

It can take quite a while until Home Assistant Core is in state running. In fact, after going through bootstrap, it can theoretically take indefinitely (as in there is no timeout from Core side).

~~So to trigger rollback, rather than check the state to be running, just check if the API is accessible in this case. This prevents spurious rollbacks.~~

However, we can almost guarantee that with all timeouts added up, and some margin, the Core should be up in all but the most obscure setups.

Use a two step method, where we check the API responding first before checking the state. This allows to better understand why the Supervisor chose to rollback, and rolls back the system faster in case there is a serious problem.


<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4655
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
