### PR TITLE
Small speed up to arch is_supported

### DIFF
--- a/supervisor/arch.py
+++ b/supervisor/arch.py
@@ -28,6 +28,7 @@ class CpuArch(CoreSysAttributes):
         """Initialize CPU Architecture handler."""
         self.coresys = coresys
         self._supported_arch: list[str] = []
+        self._supported_set: set[str] = set()
         self._default_arch: str
 
     @property
@@ -70,9 +71,11 @@ class CpuArch(CoreSysAttributes):
         if native_support not in self._supported_arch:
             self._supported_arch.append(native_support)
 
+        self._supported_set = set(self._supported_arch)
+
     def is_supported(self, arch_list: list[str]) -> bool:
         """Return True if there is a supported arch by this platform."""
-        return not set(self.supported).isdisjoint(set(arch_list))
+        return not self._supported_set.isdisjoint(arch_list)
 
     def match(self, arch_list: list[str]) -> str:
         """Return best match for this CPU/Platform."""

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -12,7 +12,6 @@ from securetar import SecureTarFile
 from supervisor.addons.addon import Addon
 from supervisor.addons.const import AddonBackupMode
 from supervisor.addons.model import AddonModel
-from supervisor.arch import CpuArch
 from supervisor.const import AddonState, BusEvent
 from supervisor.coresys import CoreSys
 from supervisor.docker.addon import DockerAddon
@@ -197,12 +196,14 @@ async def test_watchdog_on_stop(coresys: CoreSys, install_addon_ssh: Addon) -> N
         restart.assert_called_once()
 
 
-async def test_listener_attached_on_install(coresys: CoreSys, repository):
+async def test_listener_attached_on_install(
+    coresys: CoreSys, mock_x86_64_arch_supported: None, repository
+):
     """Test events listener attached on addon install."""
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     container_collection = MagicMock()
     container_collection.get.side_effect = DockerException()
-    with patch("supervisor.arch.CpuArch._supported_set", {"amd64"}), patch(
+    with patch(
         "supervisor.docker.manager.DockerAPI.containers",
         new=PropertyMock(return_value=container_collection),
     ), patch("pathlib.Path.is_dir", return_value=True), patch(
@@ -552,6 +553,7 @@ async def test_restore(
     status: str,
     tmp_supervisor_data,
     path_extern,
+    mock_aarch64_arch_supported: None,
 ) -> None:
     """Test restoring an addon."""
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
@@ -559,9 +561,7 @@ async def test_restore(
     await install_addon_ssh.load()
 
     tarfile = SecureTarFile(get_fixture_path(f"backup_local_ssh_{status}.tar.gz"), "r")
-    with patch.object(DockerAddon, "is_running", return_value=False), patch.object(
-        CpuArch, "supported", new=PropertyMock(return_value=["aarch64"])
-    ):
+    with patch.object(DockerAddon, "is_running", return_value=False):
         start_task = await coresys.addons.restore(TEST_ADDON_SLUG, tarfile)
 
     assert bool(start_task) is (status == "running")
@@ -573,6 +573,7 @@ async def test_restore_while_running(
     container: MagicMock,
     tmp_supervisor_data,
     path_extern,
+    mock_aarch64_arch_supported: None,
 ):
     """Test restore of a running addon."""
     container.status = "running"
@@ -582,8 +583,8 @@ async def test_restore_while_running(
 
     tarfile = SecureTarFile(get_fixture_path("backup_local_ssh_stopped.tar.gz"), "r")
     with patch.object(DockerAddon, "is_running", return_value=True), patch.object(
-        CpuArch, "supported", new=PropertyMock(return_value=["aarch64"])
-    ), patch.object(Ingress, "update_hass_panel"):
+        Ingress, "update_hass_panel"
+    ):
         start_task = await coresys.addons.restore(TEST_ADDON_SLUG, tarfile)
 
     assert bool(start_task) is False
@@ -596,6 +597,7 @@ async def test_restore_while_running_with_watchdog(
     container: MagicMock,
     tmp_supervisor_data,
     path_extern,
+    mock_aarch64_arch_supported: None,
 ):
     """Test restore of a running addon with watchdog interference."""
     container.status = "running"
@@ -615,8 +617,6 @@ async def test_restore_while_running_with_watchdog(
     with patch.object(Addon, "start") as start, patch.object(
         Addon, "restart"
     ) as restart, patch.object(DockerAddon, "stop", new=mock_stop), patch.object(
-        CpuArch, "supported", new=PropertyMock(return_value=["aarch64"])
-    ), patch.object(
         Ingress, "update_hass_panel"
     ):
         await coresys.addons.restore(TEST_ADDON_SLUG, tarfile)
@@ -646,7 +646,11 @@ async def test_start_when_running(
 
 
 async def test_install(
-    coresys: CoreSys, container: MagicMock, tmp_supervisor_data: Path, repository
+    coresys: CoreSys,
+    container: MagicMock,
+    tmp_supervisor_data: Path,
+    repository,
+    mock_aarch64_arch_supported: None,
 ):
     """Test install of an addon."""
     assert not (
@@ -656,9 +660,7 @@ async def test_install(
         config_dir := tmp_supervisor_data / "addon_configs" / "local_example"
     ).exists()
 
-    with patch.object(
-        CpuArch, "supported", new=PropertyMock(return_value=["aarch64"])
-    ), patch.object(DockerAddon, "install") as install:
+    with patch.object(DockerAddon, "install") as install:
         await coresys.addons.install("local_example")
         install.assert_called_once()
 

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -197,7 +197,7 @@ async def test_watchdog_on_stop(coresys: CoreSys, install_addon_ssh: Addon) -> N
 
 
 async def test_listener_attached_on_install(
-    coresys: CoreSys, mock_x86_64_arch_supported: None, repository
+    coresys: CoreSys, mock_amd64_arch_supported: None, repository
 ):
     """Test events listener attached on addon install."""
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -202,14 +202,10 @@ async def test_listener_attached_on_install(coresys: CoreSys, repository):
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     container_collection = MagicMock()
     container_collection.get.side_effect = DockerException()
-    with patch(
-        "supervisor.arch.CpuArch.supported", new=PropertyMock(return_value=["amd64"])
-    ), patch(
+    with patch("supervisor.arch.CpuArch._supported_set", {"amd64"}), patch(
         "supervisor.docker.manager.DockerAPI.containers",
         new=PropertyMock(return_value=container_collection),
-    ), patch(
-        "pathlib.Path.is_dir", return_value=True
-    ), patch(
+    ), patch("pathlib.Path.is_dir", return_value=True), patch(
         "supervisor.addons.addon.Addon.need_build", new=PropertyMock(return_value=False)
     ), patch(
         "supervisor.addons.model.AddonModel.with_ingress",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -320,6 +320,7 @@ async def coresys(
 
     # Mock test client
     coresys_obj.arch._default_arch = "amd64"
+    coresys_obj.arch._supported_set = {"amd64"}
     coresys_obj._machine = "qemux86-64"
     coresys_obj._machine_id = uuid4()
 
@@ -698,9 +699,9 @@ async def container(docker: DockerAPI) -> MagicMock:
 
 
 @pytest.fixture
-def mock_x86_64_arch_supported(coresys: CoreSys) -> None:
-    """Mock x86_64 arch as supported."""
-    with patch.object(coresys.arch, "_supported_set", {"x86_64"}):
+def mock_amd64_arch_supported(coresys: CoreSys) -> None:
+    """Mock amd64 arch as supported."""
+    with patch.object(coresys.arch, "_supported_set", {"amd64"}):
         yield
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -695,3 +695,17 @@ async def container(docker: DockerAPI) -> MagicMock:
     addon.status = "stopped"
     addon.attrs = {"State": {"ExitCode": 0}}
     yield addon
+
+
+@pytest.fixture
+def mock_x86_64_arch_supported(coresys: CoreSys) -> None:
+    """Mock x86_64 arch as supported."""
+    with patch.object(coresys.arch, "_supported_set", {"x86_64"}):
+        yield
+
+
+@pytest.fixture
+def mock_aarch64_arch_supported(coresys: CoreSys) -> None:
+    """Mock aarch64 arch as supported."""
+    with patch.object(coresys.arch, "_supported_set", {"aarch64"}):
+        yield

--- a/tests/test_arch.py
+++ b/tests/test_arch.py
@@ -111,6 +111,10 @@ async def test_yellow_arch(coresys, sys_machine, sys_supervisor):
 
     assert coresys.arch.default == "aarch64"
     assert coresys.arch.supported == ["aarch64", "armv7", "armhf"]
+    assert coresys.arch.is_supported(["aarch64"]) is True
+    assert coresys.arch.is_supported(["armv7"]) is True
+    assert coresys.arch.is_supported(["armhf"]) is True
+    assert coresys.arch.is_supported(["x86_64", "i386"]) is False
 
 
 async def test_green_arch(coresys, sys_machine, sys_supervisor):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Small speed up to arch is_supported by avoiding building two sets every time its called

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
