### PR TITLE
Create add-on config folder on add-on start

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -903,7 +903,7 @@ class Addon(AddonModel):
             self.path_config.mkdir()
 
         if self.addon_config_used:
-            self.sys_run_in_executor(_check_addon_config_dir)
+            await self.sys_run_in_executor(_check_addon_config_dir)
 
         # Start Add-on
         self._startup_event.clear()

--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -622,12 +622,6 @@ class Addon(AddonModel):
             )
             self.path_data.mkdir()
 
-        if self.addon_config_used and not self.path_config.is_dir():
-            _LOGGER.info(
-                "Creating Home Assistant add-on config folder %s", self.path_config
-            )
-            self.path_config.mkdir()
-
         # Setup/Fix AppArmor profile
         await self.install_apparmor()
 
@@ -898,6 +892,18 @@ class Addon(AddonModel):
         # Sound
         if self.with_audio:
             self.write_pulse()
+
+        def _check_addon_config_dir():
+            if self.path_config.is_dir():
+                return
+
+            _LOGGER.info(
+                "Creating Home Assistant add-on config folder %s", self.path_config
+            )
+            self.path_config.mkdir()
+
+        if self.addon_config_used:
+            self.sys_run_in_executor(_check_addon_config_dir)
 
         # Start Add-on
         self._startup_event.clear()

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -649,15 +649,12 @@ async def test_start_when_running(
     assert "local_ssh is already running" in caplog.text
 
 
-async def test_install(
+async def test_local_example_install(
     coresys: CoreSys, container: MagicMock, tmp_supervisor_data: Path, repository
 ):
     """Test install of an addon."""
     assert not (
         data_dir := tmp_supervisor_data / "addons" / "data" / "local_example"
-    ).exists()
-    assert not (
-        config_dir := tmp_supervisor_data / "addon_configs" / "local_example"
     ).exists()
 
     with patch.object(
@@ -667,4 +664,24 @@ async def test_install(
         install.assert_called_once()
 
     assert data_dir.is_dir()
-    assert config_dir.is_dir()
+
+
+async def test_local_example_start(
+    coresys: CoreSys,
+    container: MagicMock,
+    tmp_supervisor_data: Path,
+    install_addon_example: Addon,
+):
+    """Test start of an addon."""
+    install_addon_example.path_data.mkdir()
+    await install_addon_example.load()
+    await asyncio.sleep(0)
+    assert install_addon_example.state == AddonState.STOPPED
+
+    assert not (
+        addon_config_dir := tmp_supervisor_data / "addon_configs" / "local_example"
+    ).exists()
+
+    await install_addon_example.start()
+
+    assert addon_config_dir.is_dir()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
An add-on update could start to make use of the add-on config. However, at this point the add-on config directory doesn't exist, which leads to an error. Instead of creating the folder on add-on installation, create the folder on add-on startup to make sure it exists in any case.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4689
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
