### PR TITLE
Add support for addon target path

### DIFF
--- a/supervisor/addons/model.py
+++ b/supervisor/addons/model.py
@@ -538,15 +538,22 @@ class AddonModel(JobGroup, ABC):
         return ATTR_IMAGE not in self.data
 
     @property
-    def map_volumes(self) -> dict[str, bool]:
-        """Return a dict of {volume: read-only} from add-on."""
+    def map_volumes(self) -> dict[str, dict]:
+        """Return a dict of {volume: dict} from add-on."""
         volumes = {}
         for volume in self.data[ATTR_MAP]:
-            result = RE_VOLUME.match(volume)
-            if not result:
-                continue
-            volumes[result.group(1)] = result.group(2) != "rw"
-
+            if type(volume) is dict:
+                result = RE_VOLUME.match(volume.get("name"))
+                if not result:
+                    continue
+                volumes[result.group(1)]["read_only"] = result.group(2) != "rw"
+                volumes[result.group(1)]["target"] = volume.get("target")
+            else:
+                result = RE_VOLUME.match(volume)
+                if not result:
+                    continue
+                volumes[result.group(1)]["read_only"] = result.group(2) != "rw"
+            
         return volumes
 
     @property

--- a/supervisor/addons/validate.py
+++ b/supervisor/addons/validate.py
@@ -118,7 +118,7 @@ from .options import RE_SCHEMA_ELEMENT
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 RE_VOLUME = re.compile(
-    r"^(config|ssl|addons|backup|share|media|homeassistant_config|all_addon_configs|addon_config)(?::(rw|ro))?$"
+    r"^(data|config|ssl|addons|backup|share|media|homeassistant_config|all_addon_configs|addon_config)(?::(rw|ro))?$"
 )
 RE_SERVICE = re.compile(r"^(?P<service>mqtt|mysql):(?P<rights>provide|want|need)$")
 
@@ -265,8 +265,22 @@ def _migrate_addon_config(protocol=False):
                     name,
                 )
 
+        # setup config mappings
+        if MAP_CONFIG in addon_mapping or next((m.get("name") == MAP_CONFIG for m in addon_mapping if type(m) is dict), False):
+            mounts.append(
+                Mount(
+                    type=MountType.BIND,
+                    source=self.sys_config.path_extern_homeassistant.as_posix(),
+                    target=next((m.get("target", "/config") for m in addon_mapping if type(m) is dict and m.get("name") == MAP_CONFIG)),
+                    read_only=next((m.get("read_only", addon_mapping[MAP_CONFIG]) for m in addon_mapping if type(m) is dict and m.get("name") == MAP_CONFIG))
+                )
+            )
+
+
         # 2023-10 "config" became "homeassistant" so /config can be used for addon's public config
-        volumes = [RE_VOLUME.match(entry) for entry in config.get(ATTR_MAP, [])]
+        volumes = [RE_VOLUME.match(entry) for entry in config.get(ATTR_MAP, []) if type(entry) is not dict]
+        volumes.extend([RE_VOLUME.match(entry.get("name")) for entry in config.get(ATTR_MAP, []) if type(entry) is dict])
+
         if any(volume and volume.group(1) for volume in volumes):
             if any(
                 volume
@@ -336,7 +350,17 @@ _SCHEMA_ADDON_CONFIG = vol.Schema(
         vol.Optional(ATTR_DEVICES): [str],
         vol.Optional(ATTR_UDEV, default=False): vol.Boolean(),
         vol.Optional(ATTR_TMPFS, default=False): vol.Boolean(),
-        vol.Optional(ATTR_MAP, default=list): [vol.Match(RE_VOLUME)],
+        vol.Optional(ATTR_MAP, default=list): [
+            vol.Any(
+                vol.Match(RE_VOLUME),
+                vol.Schema(
+                    {
+                        vol.Required('name'): str,
+                        vol.Optional('target'): str
+                    }
+                )
+            )
+        ],
         vol.Optional(ATTR_ENVIRONMENT): {vol.Match(r"\w*"): str},
         vol.Optional(ATTR_PRIVILEGED): [vol.Coerce(Capabilities)],
         vol.Optional(ATTR_APPARMOR, default=True): vol.Boolean(),

--- a/supervisor/const.py
+++ b/supervisor/const.py
@@ -346,6 +346,7 @@ NEED_SERVICE = "need"
 WANT_SERVICE = "want"
 
 
+MAP_DATA = "data"
 MAP_CONFIG = "config"
 MAP_SSL = "ssl"
 MAP_ADDONS = "addons"

--- a/supervisor/docker/addon.py
+++ b/supervisor/docker/addon.py
@@ -18,6 +18,7 @@ from ..addons.build import AddonBuild
 from ..bus import EventListener
 from ..const import (
     DOCKER_CPU_RUNTIME_ALLOCATION,
+    MAP_DATA,
     MAP_ADDON_CONFIG,
     MAP_ADDONS,
     MAP_ALL_ADDON_CONFIGS,
@@ -337,7 +338,7 @@ class DockerAddon(DockerInterface):
             Mount(
                 type=MountType.BIND,
                 source=self.addon.path_extern_data.as_posix(),
-                target="/data",
+                target=addon_mapping.get(MAP_DATA, {}).get("target", "/data"),
                 read_only=False,
             ),
         ]
@@ -348,8 +349,8 @@ class DockerAddon(DockerInterface):
                 Mount(
                     type=MountType.BIND,
                     source=self.sys_config.path_extern_homeassistant.as_posix(),
-                    target="/config",
-                    read_only=addon_mapping[MAP_CONFIG],
+                    target=addon_mapping[MAP_CONFIG].get("target", "/config"),
+                    read_only=addon_mapping[MAP_CONFIG]["read_only"],
                 )
             )
 
@@ -360,8 +361,8 @@ class DockerAddon(DockerInterface):
                     Mount(
                         type=MountType.BIND,
                         source=self.addon.path_extern_config.as_posix(),
-                        target="/config",
-                        read_only=addon_mapping[MAP_ADDON_CONFIG],
+                        target=addon_mapping[MAP_ADDON_CONFIG].get("target", "/config"),
+                        read_only=addon_mapping[MAP_ADDON_CONFIG]["read_only"],
                     )
                 )
 
@@ -372,7 +373,7 @@ class DockerAddon(DockerInterface):
                         type=MountType.BIND,
                         source=self.sys_config.path_extern_homeassistant.as_posix(),
                         target="/homeassistant",
-                        read_only=addon_mapping[MAP_HOMEASSISTANT_CONFIG],
+                        read_only=addon_mapping[MAP_HOMEASSISTANT_CONFIG]["read_only"],
                     )
                 )
 
@@ -382,7 +383,7 @@ class DockerAddon(DockerInterface):
                     type=MountType.BIND,
                     source=self.sys_config.path_extern_addon_configs.as_posix(),
                     target="/addon_configs",
-                    read_only=addon_mapping[MAP_ALL_ADDON_CONFIGS],
+                    read_only=addon_mapping[MAP_ALL_ADDON_CONFIGS]["read_only"],
                 )
             )
 
@@ -392,7 +393,7 @@ class DockerAddon(DockerInterface):
                     type=MountType.BIND,
                     source=self.sys_config.path_extern_ssl.as_posix(),
                     target="/ssl",
-                    read_only=addon_mapping[MAP_SSL],
+                    read_only=addon_mapping[MAP_SSL]["read_only"],
                 )
             )
 
@@ -402,7 +403,7 @@ class DockerAddon(DockerInterface):
                     type=MountType.BIND,
                     source=self.sys_config.path_extern_addons_local.as_posix(),
                     target="/addons",
-                    read_only=addon_mapping[MAP_ADDONS],
+                    read_only=addon_mapping[MAP_ADDONS]["read_only"],
                 )
             )
 
@@ -412,7 +413,7 @@ class DockerAddon(DockerInterface):
                     type=MountType.BIND,
                     source=self.sys_config.path_extern_backup.as_posix(),
                     target="/backup",
-                    read_only=addon_mapping[MAP_BACKUP],
+                    read_only=addon_mapping[MAP_BACKUP]["read_only"],
                 )
             )
 
@@ -422,7 +423,7 @@ class DockerAddon(DockerInterface):
                     type=MountType.BIND,
                     source=self.sys_config.path_extern_share.as_posix(),
                     target="/share",
-                    read_only=addon_mapping[MAP_SHARE],
+                    read_only=addon_mapping[MAP_SHARE]["read_only"],
                     propagation=PropagationMode.RSLAVE,
                 )
             )
@@ -433,7 +434,7 @@ class DockerAddon(DockerInterface):
                     type=MountType.BIND,
                     source=self.sys_config.path_extern_media.as_posix(),
                     target="/media",
-                    read_only=addon_mapping[MAP_MEDIA],
+                    read_only=addon_mapping[MAP_MEDIA]["read_only"],
                     propagation=PropagationMode.RSLAVE,
                 )
             )

--- a/tests/docker/test_addon.py
+++ b/tests/docker/test_addon.py
@@ -201,6 +201,68 @@ def test_addon_map_addon_config_folder(
     )
 
 
+def test_addon_map_addon_config_folder_with_custom_target(
+    coresys: CoreSys, addonsdata_system: dict[str, Data], path_extern
+):
+    """Test mounts for addon which maps its own config folder and sets target path."""
+    config = load_json_fixture("addon-config-map-addon_config.json")
+    config["map"].remove("addon_config")
+    config["map"].append({ "name":"addon_config:rw", "target":"/custom/target/path" })
+    docker_addon = get_docker_addon(coresys, addonsdata_system, config)
+
+    # Addon config folder included
+    assert (
+        Mount(
+            type="bind",
+            source=docker_addon.addon.path_extern_config.as_posix(),
+            target="/custom/target/path",
+            read_only=False,
+        )
+        in docker_addon.mounts
+    )
+
+
+def test_addon_map_data_folder_with_custom_target(
+    coresys: CoreSys, addonsdata_system: dict[str, Data], path_extern
+):
+    """Test mounts for addon which sets target path for data folder."""
+    config = load_json_fixture("addon-config-map-addon_config.json")
+    config["map"].append({ "name":"data", "target":"/custom/data/path" })
+    docker_addon = get_docker_addon(coresys, addonsdata_system, config)
+
+    # Addon config folder included
+    assert (
+        Mount(
+            type="bind",
+            source=docker_addon.addon.path_extern_data.as_posix(),
+            target="/custom/data/path",
+            read_only=False,
+        )
+        in docker_addon.mounts
+    )
+
+
+def test_addon_map_addon_config_folder_with_custom_target(
+    coresys: CoreSys, addonsdata_system: dict[str, Data], path_extern
+):
+    """Test mounts for addon which maps its own config folder and sets target path."""
+    config = load_json_fixture("addon-config-map-addon_config.json")
+    config["map"].remove("addon_config")
+    config["map"].append({ "name":"addon_config:rw", "target":"/custom/config/path" })
+    docker_addon = get_docker_addon(coresys, addonsdata_system, config)
+
+    # Addon config folder included
+    assert (
+        Mount(
+            type="bind",
+            source=docker_addon.addon.path_extern_config.as_posix(),
+            target="/custom/config/path",
+            read_only=False,
+        )
+        in docker_addon.mounts
+    )
+
+
 def test_addon_ignore_on_config_map(
     coresys: CoreSys, addonsdata_system: dict[str, Data], path_extern
 ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change
This change is to add support for configuring the target path for custom addons. In order to persist data outside of the addon container certain paths need to be bound. Currently there are several options to bind path into an addon (data, config, share, etc) but the paths inside the container are set.

Some applications and existing docker images have default storage paths that are not easily changed (if at all). Being able to configre these paths will allow simple integration with these applications. I have created a feature request in the Home Assistant Community Forum that provides some more detail:

https://community.home-assistant.io/t/ability-to-configure-container-target-path-for-custom-addon-such-as-wordpress/635615

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1974
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [X] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [X] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
