### PR TITLE
Don't remove add-on conifg on add-on removal

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -602,10 +602,6 @@ class Addon(AddonModel):
             _LOGGER.info("Removing add-on data folder %s", self.path_data)
             await remove_data(self.path_data)
 
-        if self.path_config.is_dir():
-            _LOGGER.info("Removing add-on config folder %s", self.path_config)
-            await remove_data(self.path_config)
-
     @Job(
         name="addon_install",
         limit=JobExecutionLimit.GROUP_ONCE,

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -1420,9 +1420,12 @@ async def test_restore_preserves_data_config(
     (test_config := install_addon_example.path_config / "config.yaml").touch()
 
     backup: Backup = await coresys.backups.do_backup_partial(addons=["local_example"])
+    (test_config2 := install_addon_example.path_config / "config2.yaml").touch()
+
     await coresys.addons.uninstall("local_example")
     assert not install_addon_example.path_data.exists()
-    assert not install_addon_example.path_config.exists()
+    assert install_addon_example.path_config.exists()
+    assert test_config2.exists()
 
     with patch.object(AddonModel, "_validate_availability"), patch.object(
         DockerAddon, "attach"
@@ -1433,6 +1436,7 @@ async def test_restore_preserves_data_config(
 
     assert test_data.exists()
     assert test_config.exists()
+    assert not test_config2.exists()
 
 
 async def test_backup_to_mount_bypasses_free_space_condition(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Do not remove the add-on config when the add-on gets uninstalled. The add-on config directory contains user configuration which the user might like to retain even when uninstalling the add-on. The user can easily delete the directory on his own since it is user can access the directory.

In the future we should consider adding an option at uninstall time to offer removing this directory. But meanwhile not removing it is the better default.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
