### PR TITLE
Revert Home Assistant configuration to `/config`

### DIFF
--- a/supervisor/docker/addon.py
+++ b/supervisor/docker/addon.py
@@ -365,7 +365,7 @@ class DockerAddon(DockerInterface):
                     )
                 )
 
-            # Map Home Assistant config in new way
+            # Map Home Assistant config using the new mapping to /config still
             if MAP_HOMEASSISTANT_CONFIG in addon_mapping:
                 mounts.append(
                     Mount(

--- a/supervisor/docker/addon.py
+++ b/supervisor/docker/addon.py
@@ -360,7 +360,7 @@ class DockerAddon(DockerInterface):
                     Mount(
                         type=MountType.BIND,
                         source=self.addon.path_extern_config.as_posix(),
-                        target="/config",
+                        target="/addon_config",
                         read_only=addon_mapping[MAP_ADDON_CONFIG],
                     )
                 )
@@ -371,7 +371,7 @@ class DockerAddon(DockerInterface):
                     Mount(
                         type=MountType.BIND,
                         source=self.sys_config.path_extern_homeassistant.as_posix(),
-                        target="/homeassistant",
+                        target="/config",
                         read_only=addon_mapping[MAP_HOMEASSISTANT_CONFIG],
                     )
                 )

--- a/tests/docker/test_addon.py
+++ b/tests/docker/test_addon.py
@@ -149,12 +149,12 @@ def test_addon_map_homeassistant_folder(
     config["map"].append("homeassistant_config")
     docker_addon = get_docker_addon(coresys, addonsdata_system, config)
 
-    # Home Assistant config folder mounted to /homeassistant, not /config
+    # Home Assistant config folder still mounted to /config
     assert (
         Mount(
             type="bind",
             source=coresys.config.path_extern_homeassistant.as_posix(),
-            target="/homeassistant",
+            target="/config",
             read_only=True,
         )
         in docker_addon.mounts
@@ -194,7 +194,7 @@ def test_addon_map_addon_config_folder(
         Mount(
             type="bind",
             source=docker_addon.addon.path_extern_config.as_posix(),
-            target="/config",
+            target="/addon_config",
             read_only=True,
         )
         in docker_addon.mounts


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
With the new add-on config feature the intention is to provide a good location for add-on specific configurations. Currently, add-ons such as Node RED or ESPHome use the Home Assistant config directory because this location is accessible to the user (via Samba VSCode add-on etc.).

To make it clear to add-on developer that the new intention is to use add-on specific config, the implementation now bind mounts the add-on configuration directory to `/config`. And since some add-ons still need access to the Home Assistant configuration, its config folder is mounted to `/homeassistant` under the new scheme.

However, users do *know* and use the path `/config`, and edit things e.g. through the SSH or VS Code add-on. Also `/config` is still the directory from inside the Core container. The path is also in documentations and how-to's.

For SSH/VS Code add-on we could work around using a symlink (pointing `/config` -> `/homeassistant` e.g. as suggested in https://github.com/home-assistant/addons/pull/3304), but that only works as long as these add-ons don't have a add-on config themselfs.

This all has very high confusion potential, for not much gain. The renaming is mainly "developer friendly", but not really user friendly.

Let's minimize potential confusion, and keep things where they are. The Home Assistant config directory stays at `/config, in all cases, everywhere.

Map the new add-on configuration directory to `/addon_config`.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
