### PR TITLE
Revert "Revert Home Assistant configuration to `/config`"

### DIFF
--- a/supervisor/docker/addon.py
+++ b/supervisor/docker/addon.py
@@ -360,18 +360,18 @@ class DockerAddon(DockerInterface):
                     Mount(
                         type=MountType.BIND,
                         source=self.addon.path_extern_config.as_posix(),
-                        target="/addon_config",
+                        target="/config",
                         read_only=addon_mapping[MAP_ADDON_CONFIG],
                     )
                 )
 
-            # Map Home Assistant config using the new mapping to /config still
+            # Map Home Assistant config in new way
             if MAP_HOMEASSISTANT_CONFIG in addon_mapping:
                 mounts.append(
                     Mount(
                         type=MountType.BIND,
                         source=self.sys_config.path_extern_homeassistant.as_posix(),
-                        target="/config",
+                        target="/homeassistant",
                         read_only=addon_mapping[MAP_HOMEASSISTANT_CONFIG],
                     )
                 )

--- a/tests/docker/test_addon.py
+++ b/tests/docker/test_addon.py
@@ -149,12 +149,12 @@ def test_addon_map_homeassistant_folder(
     config["map"].append("homeassistant_config")
     docker_addon = get_docker_addon(coresys, addonsdata_system, config)
 
-    # Home Assistant config folder still mounted to /config
+    # Home Assistant config folder mounted to /homeassistant, not /config
     assert (
         Mount(
             type="bind",
             source=coresys.config.path_extern_homeassistant.as_posix(),
-            target="/config",
+            target="/homeassistant",
             read_only=True,
         )
         in docker_addon.mounts
@@ -194,7 +194,7 @@ def test_addon_map_addon_config_folder(
         Mount(
             type="bind",
             source=docker_addon.addon.path_extern_config.as_posix(),
-            target="/addon_config",
+            target="/config",
             read_only=True,
         )
         in docker_addon.mounts


### PR DESCRIPTION
Reverts home-assistant/supervisor#4697

As discussed, reverting this change.

Reasoning:

- `/config` will always point to the active config in the matching container. The Home Assistant container will have its config in `/config`, all plugins have their config in `/config` and add-ons will now have their config in `/config` too.
- `/homeassistant` is where other containers can access the Home Assistant configuration (if needed, but in general, their should not need it).

The above will add consistency to the developer experience (as part of the original intention was for this specific case).

For user-facing add-ons (like ssh, samba, vscode, file editor, e.d.), they will be adopted that they map `config` to `/homeassistant`, so that the change is transparent/non-breaking from the user experience.

