### PR TITLE
Ensure empty body responses never generate an invalid chunked response

### DIFF
--- a/supervisor/api/ingress.py
+++ b/supervisor/api/ingress.py
@@ -256,17 +256,15 @@ class APIIngress(CoreSysAttributes):
             # Simple request
             code = result.status
             if (
-                (
-                    hdrs.CONTENT_LENGTH in result.headers
-                    and int(result.headers.get(hdrs.CONTENT_LENGTH, 0)) < 4_194_000
-                )
                 # empty body responses should not be streamed,
                 # otherwise aiohttp < 3.9.0 may generate
                 # an invalid "0\r\n\r\n" chunk instead of an empty response.
                 #
                 # The below is from
                 # https://github.com/aio-libs/aiohttp/blob/8ae650bee4add9f131d49b96a0a150311ea58cd1/aiohttp/helpers.py#L1061
-                or must_be_empty_body(request.method, code)
+                must_be_empty_body(request.method, code)
+                or hdrs.CONTENT_LENGTH in result.headers
+                and int(result.headers.get(hdrs.CONTENT_LENGTH, 0)) < 4_194_000
             ):
                 # Return Response
                 body = await result.read()

--- a/supervisor/api/ingress.py
+++ b/supervisor/api/ingress.py
@@ -254,7 +254,6 @@ class APIIngress(CoreSysAttributes):
             else:
                 content_type = result.content_type
             # Simple request
-            code = result.status
             if (
                 # empty body responses should not be streamed,
                 # otherwise aiohttp < 3.9.0 may generate
@@ -262,7 +261,7 @@ class APIIngress(CoreSysAttributes):
                 #
                 # The below is from
                 # https://github.com/aio-libs/aiohttp/blob/8ae650bee4add9f131d49b96a0a150311ea58cd1/aiohttp/helpers.py#L1061
-                must_be_empty_body(request.method, code)
+                must_be_empty_body(request.method, result.status)
                 or hdrs.CONTENT_LENGTH in result.headers
                 and int(result.headers.get(hdrs.CONTENT_LENGTH, 0)) < 4_194_000
             ):
@@ -270,13 +269,13 @@ class APIIngress(CoreSysAttributes):
                 body = await result.read()
                 return web.Response(
                     headers=headers,
-                    status=code,
+                    status=result.status,
                     content_type=content_type,
                     body=body,
                 )
 
             # Stream response
-            response = web.StreamResponse(status=code, headers=headers)
+            response = web.StreamResponse(status=result.status, headers=headers)
             response.content_type = content_type
 
             try:

--- a/supervisor/api/ingress.py
+++ b/supervisor/api/ingress.py
@@ -258,9 +258,6 @@ class APIIngress(CoreSysAttributes):
                 # empty body responses should not be streamed,
                 # otherwise aiohttp < 3.9.0 may generate
                 # an invalid "0\r\n\r\n" chunk instead of an empty response.
-                #
-                # The below is from
-                # https://github.com/aio-libs/aiohttp/blob/8ae650bee4add9f131d49b96a0a150311ea58cd1/aiohttp/helpers.py#L1061
                 must_be_empty_body(request.method, result.status)
                 or hdrs.CONTENT_LENGTH in result.headers
                 and int(result.headers.get(hdrs.CONTENT_LENGTH, 0)) < 4_194_000


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

aiohttp < 3.9.0 (fixed in https://github.com/aio-libs/aiohttp/pull/7756) will generate an invalid chunked response aka `"0\r\n\r\n"` instead of an actual empty body if we reached the streaming handler for 204, 304, and a few other cases. Additionally its inefficient to send a `StreamResponse` when a normal `Response` will do in these cases.

I tested this changed with core running aiohttp 3.9.0rc0 and 3.8.5, and supervisor running aiohttp 3.8.6 and 3.9.0rc0

When we upgrade to 3.9.0 we should replace this check with the aiohttp `must_be_empty_body` helper:
https://github.com/aio-libs/aiohttp/blob/8ae650bee4add9f131d49b96a0a150311ea58cd1/aiohttp/helpers.py#L1061

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
