### PR TITLE
Improve D-Bus error handling for NetworkManager

### DIFF
--- a/supervisor/dbus/agent/__init__.py
+++ b/supervisor/dbus/agent/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 from awesomeversion import AwesomeVersion
 from dbus_fast.aio.message_bus import MessageBus
 
-from ...exceptions import DBusError, DBusInterfaceError
+from ...exceptions import DBusError, DBusInterfaceError, DBusServiceUnkownError
 from ..const import (
     DBUS_ATTR_DIAGNOSTICS,
     DBUS_ATTR_VERSION,
@@ -99,7 +99,7 @@ class OSAgent(DBusInterfaceProxy):
             await asyncio.gather(*[dbus.connect(bus) for dbus in self.all])
         except DBusError:
             _LOGGER.warning("Can't connect to OS-Agent")
-        except DBusInterfaceError:
+        except (DBusServiceUnkownError, DBusInterfaceError):
             _LOGGER.warning(
                 "No OS-Agent support on the host. Some Host functions have been disabled."
             )

--- a/supervisor/dbus/hostname.py
+++ b/supervisor/dbus/hostname.py
@@ -3,7 +3,7 @@ import logging
 
 from dbus_fast.aio.message_bus import MessageBus
 
-from ..exceptions import DBusError, DBusInterfaceError
+from ..exceptions import DBusError, DBusInterfaceError, DBusServiceUnkownError
 from .const import (
     DBUS_ATTR_CHASSIS,
     DBUS_ATTR_DEPLOYMENT,
@@ -39,7 +39,7 @@ class Hostname(DBusInterfaceProxy):
             await super().connect(bus)
         except DBusError:
             _LOGGER.warning("Can't connect to systemd-hostname")
-        except DBusInterfaceError:
+        except (DBusServiceUnkownError, DBusInterfaceError):
             _LOGGER.warning(
                 "No hostname support on the host. Hostname functions have been disabled."
             )

--- a/supervisor/dbus/logind.py
+++ b/supervisor/dbus/logind.py
@@ -29,7 +29,7 @@ class Logind(DBusInterface):
         except DBusError:
             _LOGGER.warning("Can't connect to systemd-logind")
         except (DBusServiceUnkownError, DBusInterfaceError):
-            _LOGGER.info("No systemd-logind support on the host.")
+            _LOGGER.warning("No systemd-logind support on the host.")
 
     @dbus_connected
     async def reboot(self) -> None:

--- a/supervisor/dbus/logind.py
+++ b/supervisor/dbus/logind.py
@@ -3,7 +3,7 @@ import logging
 
 from dbus_fast.aio.message_bus import MessageBus
 
-from ..exceptions import DBusError, DBusInterfaceError
+from ..exceptions import DBusError, DBusInterfaceError, DBusServiceUnkownError
 from .const import DBUS_NAME_LOGIND, DBUS_OBJECT_LOGIND
 from .interface import DBusInterface
 from .utils import dbus_connected
@@ -28,7 +28,7 @@ class Logind(DBusInterface):
             await super().connect(bus)
         except DBusError:
             _LOGGER.warning("Can't connect to systemd-logind")
-        except DBusInterfaceError:
+        except (DBusServiceUnkownError, DBusInterfaceError):
             _LOGGER.info("No systemd-logind support on the host.")
 
     @dbus_connected

--- a/supervisor/dbus/network/__init__.py
+++ b/supervisor/dbus/network/__init__.py
@@ -215,11 +215,10 @@ class NetworkManager(DBusInterfaceProxy):
                 except (
                     DBusNoReplyError,
                     DBusServiceUnkownError,
-                ) as err:  # pylint: disable=broad-except
-                    # This typically means that NetworkManager disappeared.
-                    # Give up immeaditly.
-                    _LOGGER.exception(
-                        "NetworkManager not respondiing while processing %s: %s. Giving up.",
+                ) as err:
+                    # This typically means that NetworkManager disappeared. Give up immeaditly.
+                    _LOGGER.error(
+                        "NetworkManager not responding while processing %s: %s. Giving up.",
                         device,
                         err,
                     )

--- a/supervisor/dbus/network/__init__.py
+++ b/supervisor/dbus/network/__init__.py
@@ -263,7 +263,6 @@ class NetworkManager(DBusInterfaceProxy):
             curr_devices[device].shutdown()
 
         self._interfaces = interfaces
-        DBusServiceUnkownError
 
     def shutdown(self) -> None:
         """Shutdown the object and disconnect from D-Bus.

--- a/supervisor/dbus/network/dns.py
+++ b/supervisor/dbus/network/dns.py
@@ -12,7 +12,7 @@ from ...const import (
     ATTR_PRIORITY,
     ATTR_VPN,
 )
-from ...exceptions import DBusError, DBusInterfaceError
+from ...exceptions import DBusError, DBusInterfaceError, DBusServiceUnkownError
 from ..const import (
     DBUS_ATTR_CONFIGURATION,
     DBUS_ATTR_MODE,
@@ -67,7 +67,7 @@ class NetworkManagerDNS(DBusInterfaceProxy):
             await super().connect(bus)
         except DBusError:
             _LOGGER.warning("Can't connect to DnsManager")
-        except DBusInterfaceError:
+        except (DBusServiceUnkownError, DBusInterfaceError):
             _LOGGER.warning(
                 "No DnsManager support on the host. Local DNS functions have been disabled."
             )

--- a/supervisor/dbus/network/settings.py
+++ b/supervisor/dbus/network/settings.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from dbus_fast.aio.message_bus import MessageBus
 
-from ...exceptions import DBusError, DBusInterfaceError
+from ...exceptions import DBusError, DBusInterfaceError, DBusServiceUnkownError
 from ..const import DBUS_NAME_NM, DBUS_OBJECT_SETTINGS
 from ..interface import DBusInterface
 from ..network.setting import NetworkSetting
@@ -28,7 +28,7 @@ class NetworkManagerSettings(DBusInterface):
             await super().connect(bus)
         except DBusError:
             _LOGGER.warning("Can't connect to Network Manager Settings")
-        except DBusInterfaceError:
+        except (DBusServiceUnkownError, DBusInterfaceError):
             _LOGGER.warning(
                 "No Network Manager Settings support on the host. Local network functions have been disabled."
             )

--- a/supervisor/dbus/rauc.py
+++ b/supervisor/dbus/rauc.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from dbus_fast.aio.message_bus import MessageBus
 
-from ..exceptions import DBusError, DBusInterfaceError
+from ..exceptions import DBusError, DBusInterfaceError, DBusServiceUnkownError
 from ..utils.dbus import DBusSignalWrapper
 from .const import (
     DBUS_ATTR_BOOT_SLOT,
@@ -49,7 +49,7 @@ class Rauc(DBusInterfaceProxy):
             await super().connect(bus)
         except DBusError:
             _LOGGER.warning("Can't connect to rauc")
-        except DBusInterfaceError:
+        except (DBusServiceUnkownError, DBusInterfaceError):
             _LOGGER.warning("Host has no rauc support. OTA updates have been disabled.")
 
     @property

--- a/supervisor/dbus/resolved.py
+++ b/supervisor/dbus/resolved.py
@@ -5,7 +5,7 @@ import logging
 
 from dbus_fast.aio.message_bus import MessageBus
 
-from ..exceptions import DBusError, DBusInterfaceError
+from ..exceptions import DBusError, DBusInterfaceError, DBusServiceUnkownError
 from .const import (
     DBUS_ATTR_CACHE_STATISTICS,
     DBUS_ATTR_CURRENT_DNS_SERVER,
@@ -59,7 +59,7 @@ class Resolved(DBusInterfaceProxy):
             await super().connect(bus)
         except DBusError:
             _LOGGER.warning("Can't connect to systemd-resolved.")
-        except DBusInterfaceError:
+        except (DBusServiceUnkownError, DBusInterfaceError):
             _LOGGER.warning(
                 "Host has no systemd-resolved support. DNS will not work correctly."
             )

--- a/supervisor/dbus/systemd.py
+++ b/supervisor/dbus/systemd.py
@@ -10,6 +10,7 @@ from ..exceptions import (
     DBusError,
     DBusFatalError,
     DBusInterfaceError,
+    DBusServiceUnkownError,
     DBusSystemdNoSuchUnit,
 )
 from .const import (
@@ -86,7 +87,7 @@ class Systemd(DBusInterfaceProxy):
             await super().connect(bus)
         except DBusError:
             _LOGGER.warning("Can't connect to systemd")
-        except DBusInterfaceError:
+        except (DBusServiceUnkownError, DBusInterfaceError):
             _LOGGER.warning(
                 "No systemd support on the host. Host control has been disabled."
             )

--- a/supervisor/dbus/timedate.py
+++ b/supervisor/dbus/timedate.py
@@ -4,7 +4,7 @@ import logging
 
 from dbus_fast.aio.message_bus import MessageBus
 
-from ..exceptions import DBusError, DBusInterfaceError
+from ..exceptions import DBusError, DBusInterfaceError, DBusServiceUnkownError
 from ..utils.dt import utc_from_timestamp
 from .const import (
     DBUS_ATTR_NTP,
@@ -63,7 +63,7 @@ class TimeDate(DBusInterfaceProxy):
             await super().connect(bus)
         except DBusError:
             _LOGGER.warning("Can't connect to systemd-timedate")
-        except DBusInterfaceError:
+        except (DBusServiceUnkownError, DBusInterfaceError):
             _LOGGER.warning(
                 "No timedate support on the host. Time/Date functions have been disabled."
             )

--- a/supervisor/dbus/udisks2/__init__.py
+++ b/supervisor/dbus/udisks2/__init__.py
@@ -6,7 +6,12 @@ from typing import Any
 from awesomeversion import AwesomeVersion
 from dbus_fast.aio import MessageBus
 
-from ...exceptions import DBusError, DBusInterfaceError, DBusObjectError
+from ...exceptions import (
+    DBusError,
+    DBusInterfaceError,
+    DBusObjectError,
+    DBusServiceUnkownError,
+)
 from ..const import (
     DBUS_ATTR_SUPPORTED_FILESYSTEMS,
     DBUS_ATTR_VERSION,
@@ -45,7 +50,7 @@ class UDisks2(DBusInterfaceProxy):
             await super().connect(bus)
         except DBusError:
             _LOGGER.warning("Can't connect to udisks2")
-        except DBusInterfaceError:
+        except (DBusServiceUnkownError, DBusInterfaceError):
             _LOGGER.warning(
                 "No udisks2 support on the host. Host control has been disabled."
             )

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -335,6 +335,10 @@ class DBusNotConnectedError(HostNotSupportedError):
     """D-Bus is not connected and call a method."""
 
 
+class DBusServiceUnkownError(HassioNotSupportedError):
+    """D-Bus service was not available."""
+
+
 class DBusInterfaceError(HassioNotSupportedError):
     """D-Bus interface not connected."""
 
@@ -361,6 +365,10 @@ class DBusParseError(DBusError):
 
 class DBusTimeoutError(DBusError):
     """D-Bus call timed out."""
+
+
+class DBusNoReplyError(DBusError):
+    """D-Bus remote didn't reply/disconnected."""
 
 
 class DBusFatalError(DBusError):

--- a/supervisor/utils/dbus.py
+++ b/supervisor/utils/dbus.py
@@ -15,10 +15,11 @@ from dbus_fast import (
 )
 from dbus_fast.aio.message_bus import MessageBus
 from dbus_fast.aio.proxy_object import ProxyInterface, ProxyObject
-from dbus_fast.errors import DBusError
+from dbus_fast.errors import DBusError as DBusFastDBusError
 from dbus_fast.introspection import Node
 
 from ..exceptions import (
+    DBusError,
     DBusFatalError,
     DBusInterfaceError,
     DBusInterfaceMethodError,
@@ -64,7 +65,7 @@ class DBus:
         return self
 
     @staticmethod
-    def from_dbus_error(err: DBusError) -> HassioNotSupportedError | DBusError:
+    def from_dbus_error(err: DBusFastDBusError) -> HassioNotSupportedError | DBusError:
         """Return correct dbus error based on type."""
         if err.type == ErrorType.SERVICE_UNKNOWN.value:
             return DBusServiceUnkownError(err.text)
@@ -111,7 +112,7 @@ class DBus:
                     *args, unpack_variants=True
                 )
             return await getattr(proxy_interface, method)(*args)
-        except DBusError as err:
+        except DBusFastDBusError as err:
             raise DBus.from_dbus_error(err)
         except Exception as err:  # pylint: disable=broad-except
             capture_exception(err)
@@ -135,7 +136,7 @@ class DBus:
                 raise DBusParseError(
                     f"Can't parse introspect data: {err}", _LOGGER.error
                 ) from err
-            except DBusError as err:
+            except DBusFastDBusError as err:
                 raise DBus.from_dbus_error(err)
             except (EOFError, TimeoutError):
                 _LOGGER.warning(

--- a/supervisor/utils/dbus.py
+++ b/supervisor/utils/dbus.py
@@ -66,25 +66,28 @@ class DBus:
     @staticmethod
     def from_dbus_error(err: DBusError) -> HassioNotSupportedError | DBusError:
         """Return correct dbus error based on type."""
-        if err.type == ErrorType.SERVICE_UNKNOWN:
+        if err.type == ErrorType.SERVICE_UNKNOWN.value:
             return DBusServiceUnkownError(err.text)
-        if err.type == ErrorType.UNKNOWN_INTERFACE:
+        if err.type == ErrorType.UNKNOWN_INTERFACE.value:
             return DBusInterfaceError(err.text)
         if err.type in {
-            ErrorType.UNKNOWN_METHOD,
-            ErrorType.INVALID_SIGNATURE,
-            ErrorType.INVALID_ARGS,
+            ErrorType.UNKNOWN_METHOD.value,
+            ErrorType.INVALID_SIGNATURE.value,
+            ErrorType.INVALID_ARGS.value,
         }:
             return DBusInterfaceMethodError(err.text)
-        if err.type == ErrorType.UNKNOWN_OBJECT:
+        if err.type == ErrorType.UNKNOWN_OBJECT.value:
             return DBusObjectError(err.text)
-        if err.type in {ErrorType.UNKNOWN_PROPERTY, ErrorType.PROPERTY_READ_ONLY}:
+        if err.type in {
+            ErrorType.UNKNOWN_PROPERTY.value,
+            ErrorType.PROPERTY_READ_ONLY.value,
+        }:
             return DBusInterfacePropertyError(err.text)
-        if err.type == ErrorType.DISCONNECTED:
+        if err.type == ErrorType.DISCONNECTED.value:
             return DBusNotConnectedError(err.text)
-        if err.type == ErrorType.TIMEOUT:
+        if err.type == ErrorType.TIMEOUT.value:
             return DBusTimeoutError(err.text)
-        if err.type == ErrorType.NO_REPLY:
+        if err.type == ErrorType.NO_REPLY.value:
             return DBusNoReplyError(err.text)
         return DBusFatalError(err.text, type_=err.type)
 

--- a/supervisor/utils/dbus.py
+++ b/supervisor/utils/dbus.py
@@ -67,28 +67,25 @@ class DBus:
     @staticmethod
     def from_dbus_error(err: DBusFastDBusError) -> HassioNotSupportedError | DBusError:
         """Return correct dbus error based on type."""
-        if err.type == ErrorType.SERVICE_UNKNOWN.value:
+        if err.type == ErrorType.SERVICE_UNKNOWN:
             return DBusServiceUnkownError(err.text)
-        if err.type == ErrorType.UNKNOWN_INTERFACE.value:
+        if err.type == ErrorType.UNKNOWN_INTERFACE:
             return DBusInterfaceError(err.text)
         if err.type in {
-            ErrorType.UNKNOWN_METHOD.value,
-            ErrorType.INVALID_SIGNATURE.value,
-            ErrorType.INVALID_ARGS.value,
+            ErrorType.UNKNOWN_METHOD,
+            ErrorType.INVALID_SIGNATURE,
+            ErrorType.INVALID_ARGS,
         }:
             return DBusInterfaceMethodError(err.text)
-        if err.type == ErrorType.UNKNOWN_OBJECT.value:
+        if err.type == ErrorType.UNKNOWN_OBJECT:
             return DBusObjectError(err.text)
-        if err.type in {
-            ErrorType.UNKNOWN_PROPERTY.value,
-            ErrorType.PROPERTY_READ_ONLY.value,
-        }:
+        if err.type in {ErrorType.UNKNOWN_PROPERTY, ErrorType.PROPERTY_READ_ONLY}:
             return DBusInterfacePropertyError(err.text)
-        if err.type == ErrorType.DISCONNECTED.value:
+        if err.type == ErrorType.DISCONNECTED:
             return DBusNotConnectedError(err.text)
-        if err.type == ErrorType.TIMEOUT.value:
+        if err.type == ErrorType.TIMEOUT:
             return DBusTimeoutError(err.text)
-        if err.type == ErrorType.NO_REPLY.value:
+        if err.type == ErrorType.NO_REPLY:
             return DBusNoReplyError(err.text)
         return DBusFatalError(err.text, type_=err.type)
 

--- a/tests/dbus/agent/test_agent.py
+++ b/tests/dbus/agent/test_agent.py
@@ -5,11 +5,12 @@ import pytest
 
 from supervisor.dbus.agent import OSAgent
 
+from tests.common import mock_dbus_services
 from tests.dbus_service_mocks.base import DBusServiceMock
 from tests.dbus_service_mocks.os_agent import OSAgent as OSAgentService
 
 
-@pytest.fixture(name="os_agent_service", autouse=True)
+@pytest.fixture(name="os_agent_service")
 async def fixture_os_agent_service(
     os_agent_services: dict[str, DBusServiceMock]
 ) -> OSAgentService:
@@ -39,3 +40,36 @@ async def test_dbus_osagent(
     await os_agent_service.ping()
     await os_agent_service.ping()
     assert os_agent.diagnostics is True
+
+
+@pytest.mark.parametrize(
+    "skip_service",
+    [
+        "os_agent",
+        "agent_apparmor",
+        "agent_datadisk",
+    ],
+)
+async def test_dbus_osagent_connect_error(
+    skip_service: str, dbus_session_bus: MessageBus, caplog: pytest.LogCaptureFixture
+):
+    """Test OS Agent errors during connect."""
+    os_agent_services = {
+        "os_agent": None,
+        "agent_apparmor": None,
+        "agent_cgroup": None,
+        "agent_datadisk": None,
+        "agent_system": None,
+        "agent_boards": None,
+        "agent_boards_yellow": None,
+    }
+    os_agent_services.pop(skip_service)
+    await mock_dbus_services(
+        os_agent_services,
+        dbus_session_bus,
+    )
+
+    os_agent = OSAgent()
+    await os_agent.connect(dbus_session_bus)
+
+    assert "No OS-Agent support on the host" in caplog.text

--- a/tests/dbus/network/test_dns.py
+++ b/tests/dbus/network/test_dns.py
@@ -12,7 +12,7 @@ from tests.common import mock_dbus_services
 from tests.dbus_service_mocks.network_dns_manager import DnsManager as DnsManagerService
 
 
-@pytest.fixture(name="dns_manager_service", autouse=True)
+@pytest.fixture(name="dns_manager_service")
 async def fixture_dns_manager_service(
     dbus_session_bus: MessageBus,
 ) -> DnsManagerService:
@@ -49,3 +49,12 @@ async def test_dns(
     await dns_manager_service.ping()
     await dns_manager_service.ping()
     assert dns_manager.mode == "default"
+
+
+async def test_dbus_dns_connect_error(
+    dbus_session_bus: MessageBus, caplog: pytest.LogCaptureFixture
+):
+    """Test connecting to dns error."""
+    dns_manager = NetworkManagerDNS()
+    await dns_manager.connect(dbus_session_bus)
+    assert "No DnsManager support on the host" in caplog.text

--- a/tests/dbus/network/test_network_manager.py
+++ b/tests/dbus/network/test_network_manager.py
@@ -161,7 +161,7 @@ async def test_handling_bad_devices(
         await network_manager.update(
             {"Devices": [device := "/org/freedesktop/NetworkManager/Devices/102"]}
         )
-        assert f"Error while processing {device}" in caplog.text
+        assert f"Unkown error while processing {device}" in caplog.text
         capture_exception.assert_called_once_with(err)
 
     # We should be able to debug these situations if necessary

--- a/tests/dbus/network/test_settings.py
+++ b/tests/dbus/network/test_settings.py
@@ -11,7 +11,7 @@ from tests.dbus_service_mocks.network_connection_settings import SETTINGS_FIXTUR
 from tests.dbus_service_mocks.network_settings import Settings as SettingsService
 
 
-@pytest.fixture(name="settings_service", autouse=True)
+@pytest.fixture(name="settings_service")
 async def fixture_settings_service(dbus_session_bus: MessageBus) -> SettingsService:
     """Mock Settings service."""
     yield (
@@ -55,3 +55,12 @@ async def test_reload_connections(
 
     assert await settings.reload_connections() is True
     assert settings_service.ReloadConnections.calls == [tuple()]
+
+
+async def test_dbus_network_settings_connect_error(
+    dbus_session_bus: MessageBus, caplog: pytest.LogCaptureFixture
+):
+    """Test connecting to network settings error."""
+    settings = NetworkManagerSettings()
+    await settings.connect(dbus_session_bus)
+    assert "No Network Manager Settings support on the host" in caplog.text

--- a/tests/dbus/test_hostname.py
+++ b/tests/dbus/test_hostname.py
@@ -10,7 +10,7 @@ from tests.common import mock_dbus_services
 from tests.dbus_service_mocks.hostname import Hostname as HostnameService
 
 
-@pytest.fixture(name="hostname_service", autouse=True)
+@pytest.fixture(name="hostname_service")
 async def fixture_hostname_service(dbus_session_bus: MessageBus) -> HostnameService:
     """Mock hostname dbus service."""
     yield (await mock_dbus_services({"hostname": None}, dbus_session_bus))["hostname"]
@@ -61,3 +61,12 @@ async def test_dbus_sethostname(
     assert hostname_service.SetStaticHostname.calls == [("StarWars", False)]
     await hostname_service.ping()
     assert hostname.hostname == "StarWars"
+
+
+async def test_dbus_hostname_connect_error(
+    dbus_session_bus: MessageBus, caplog: pytest.LogCaptureFixture
+):
+    """Test connecting to hostname error."""
+    hostname = Hostname()
+    await hostname.connect(dbus_session_bus)
+    assert "No hostname support on the host" in caplog.text

--- a/tests/dbus/test_login.py
+++ b/tests/dbus/test_login.py
@@ -10,7 +10,7 @@ from tests.common import mock_dbus_services
 from tests.dbus_service_mocks.logind import Logind as LogindService
 
 
-@pytest.fixture(name="logind_service", autouse=True)
+@pytest.fixture(name="logind_service")
 async def fixture_logind_service(dbus_session_bus: MessageBus) -> LogindService:
     """Mock logind dbus service."""
     yield (await mock_dbus_services({"logind": None}, dbus_session_bus))["logind"]
@@ -42,3 +42,12 @@ async def test_power_off(logind_service: LogindService, dbus_session_bus: Messag
 
     assert await logind.power_off() is None
     assert logind_service.PowerOff.calls == [(False,)]
+
+
+async def test_dbus_logind_connect_error(
+    dbus_session_bus: MessageBus, caplog: pytest.LogCaptureFixture
+):
+    """Test connecting to logind error."""
+    logind = Logind()
+    await logind.connect(dbus_session_bus)
+    assert "No systemd-logind support on the host" in caplog.text

--- a/tests/dbus/test_resolved.py
+++ b/tests/dbus/test_resolved.py
@@ -19,7 +19,7 @@ from tests.common import mock_dbus_services
 from tests.dbus_service_mocks.resolved import Resolved as ResolvedService
 
 
-@pytest.fixture(name="resolved_service", autouse=True)
+@pytest.fixture(name="resolved_service")
 async def fixture_resolved_service(dbus_session_bus: MessageBus) -> ResolvedService:
     """Mock resolved dbus service."""
     yield (await mock_dbus_services({"resolved": None}, dbus_session_bus))["resolved"]
@@ -102,3 +102,12 @@ async def test_dbus_resolved_info(
     await resolved_service.ping()
     await resolved_service.ping()  # To process the follow-up get all properties call
     assert resolved.llmnr_hostname == "homeassistant"
+
+
+async def test_dbus_resolved_connect_error(
+    dbus_session_bus: MessageBus, caplog: pytest.LogCaptureFixture
+):
+    """Test connecting to resolved error."""
+    resolved = Resolved()
+    await resolved.connect(dbus_session_bus)
+    assert "Host has no systemd-resolved support" in caplog.text

--- a/tests/dbus/test_timedate.py
+++ b/tests/dbus/test_timedate.py
@@ -12,7 +12,7 @@ from tests.common import mock_dbus_services
 from tests.dbus_service_mocks.timedate import TimeDate as TimeDateService
 
 
-@pytest.fixture(name="timedate_service", autouse=True)
+@pytest.fixture(name="timedate_service")
 async def fixture_timedate_service(dbus_session_bus: MessageBus) -> TimeDateService:
     """Mock timedate dbus service."""
     yield (await mock_dbus_services({"timedate": None}, dbus_session_bus))["timedate"]
@@ -81,3 +81,12 @@ async def test_dbus_setntp(
     assert timedate_service.SetNTP.calls == [(False, False)]
     await timedate_service.ping()
     assert timedate.ntp is False
+
+
+async def test_dbus_timedate_connect_error(
+    dbus_session_bus: MessageBus, caplog: pytest.LogCaptureFixture
+):
+    """Test connecting to timedate error."""
+    timedate = TimeDate()
+    await timedate.connect(dbus_session_bus)
+    assert "No timedate support on the host" in caplog.text

--- a/tests/utils/test_dbus.py
+++ b/tests/utils/test_dbus.py
@@ -2,12 +2,18 @@
 
 from unittest.mock import AsyncMock, Mock, patch
 
+from dbus_fast import ErrorType
 from dbus_fast.aio.message_bus import MessageBus
+from dbus_fast.errors import DBusError as DBusFastDBusError
 from dbus_fast.service import method, signal
 import pytest
 
 from supervisor.dbus.const import DBUS_OBJECT_BASE
-from supervisor.exceptions import DBusFatalError, DBusInterfaceError
+from supervisor.exceptions import (
+    DBusFatalError,
+    DBusInterfaceError,
+    DBusServiceUnkownError,
+)
 from supervisor.utils.dbus import DBus
 
 from tests.common import load_fixture
@@ -172,3 +178,12 @@ async def test_init_proxy(test_service: TestInterface, dbus_session_bus: Message
     test_service.signal_test()
     await test_service.ping()
     assert callback_count == 0
+
+
+def test_from_dbus_error():
+    """Test converting DBus fast errors to Supervisor specific errors."""
+    dbus_fast_error = DBusFastDBusError(
+        ErrorType.SERVICE_UNKNOWN, "The name is not activatable"
+    )
+
+    assert type(DBus.from_dbus_error(dbus_fast_error)) is DBusServiceUnkownError


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
There are quite some errors captured which are related by seemingly a suddenly missing NetworkManager. Errors appear as: 

```
23-11-21 17:42:50 ERROR (MainThread) [supervisor.dbus.network] Error while processing /org/freedesktop/NetworkManager/Devices/10: Remote peer disconnected
...
23-11-21 17:42:50 ERROR (MainThread) [supervisor.dbus.network] Error while processing /org/freedesktop/NetworkManager/Devices/35: The name is not activatable
```

Both errors seem to already happen at introspection time, however the current code doesn't converts these errors to Supervisor issues. This PR uses the already existing `DBus.from_dbus_error()`.

Furthermore this adds a new Exception `DBusNoReplyError` for the `ErrorType.NO_REPLY` (or `org.freedesktop.DBus.Error.NoReply` in D-Bus terms, which is the type of the first of the two issues above).

And finally it separates the `ErrorType.SERVICE_UNKNOWN` (or `org.freedesktop.DBus.Error.ServiceUnknown` in D-Bus terms, which is the second of the above issue) from `DBusInterfaceError` into a new `DBusServiceUnkownError`.

This allows to handle errors more specifically.

To avoid too much churn, all instances where `DBusInterfaceError` got handled, we are now also handling `DBusServiceUnkownError`.

The `DBusNoReplyError` and `DBusServiceUnkownError` appear when the NetworkManager service stops or crashes. Instead of retrying every interface we know, just give up if one of these issues appear. This should significantly lower error messages users are seeing and Sentry events.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
