### PR TITLE
Revert "Bump aiohttp to 3.9.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiodns==3.1.1
-aiohttp==3.9.0
+aiohttp==3.8.6
 aiohttp-fast-url-dispatcher==0.1.1
 async_timeout==4.0.3
 atomicwrites-homeassistant==1.4.1

--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -68,7 +68,7 @@ class RestAPI(CoreSysAttributes):
         attach_fast_url_dispatcher(self.webapp, FastUrlDispatcher())
 
         # service stuff
-        self._runner: web.AppRunner = web.AppRunner(self.webapp, shutdown_timeout=5)
+        self._runner: web.AppRunner = web.AppRunner(self.webapp)
         self._site: web.TCPSite | None = None
 
     async def load(self) -> None:
@@ -673,7 +673,9 @@ class RestAPI(CoreSysAttributes):
     async def start(self) -> None:
         """Run RESTful API webserver."""
         await self._runner.setup()
-        self._site = web.TCPSite(self._runner, host="0.0.0.0", port=80)
+        self._site = web.TCPSite(
+            self._runner, host="0.0.0.0", port=80, shutdown_timeout=5
+        )
 
         try:
             await self._site.start()


### PR DESCRIPTION
Reverts home-assistant/supervisor#4714 due to https://github.com/aio-libs/aiohttp/issues/7864