### PR TITLE
Wait until mount unit is deactivated on unmount

### DIFF
--- a/supervisor/mounts/mount.py
+++ b/supervisor/mounts/mount.py
@@ -192,7 +192,7 @@ class Mount(CoreSysAttributes, ABC):
             capture_exception(err)
             raise MountError(f"Could not get mount unit due to: {err!s}") from err
 
-        self.update_state()
+        await self.update_state()
 
         # If active, dismiss corresponding failed mount issue if found
         if (

--- a/supervisor/mounts/mount.py
+++ b/supervisor/mounts/mount.py
@@ -201,7 +201,7 @@ class Mount(CoreSysAttributes, ABC):
         ):
             self.sys_resolution.dismiss_issue(self.failed_issue)
 
-    async def _update_state_await_deactivated(self, expected_state: UnitActiveState):
+    async def _update_state_await(self, expected_state: UnitActiveState) -> None:
         """Update state info about mount from dbus. Wait up to 30 seconds for the state to appear."""
         for i in range(5):
             await self.update_state()

--- a/tests/api/test_mounts.py
+++ b/tests/api/test_mounts.py
@@ -142,7 +142,7 @@ async def test_api_create_dbus_error_mount_not_added(
         "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
     ]
     systemd_service.response_start_transient_unit = "/org/freedesktop/systemd1/job/7623"
-    systemd_unit_service.active_state = "failed"
+    systemd_unit_service.active_state = ["failed", "failed", "inactive"]
 
     resp = await api_client.post(
         "/mounts",
@@ -219,8 +219,15 @@ async def test_api_create_mount_fails_missing_mount_propagation(
     )
 
 
-async def test_api_update_mount(api_client: TestClient, coresys: CoreSys, mount):
+async def test_api_update_mount(
+    api_client: TestClient,
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock],
+    mount,
+):
     """Test updating a mount via API."""
+    systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
+    systemd_unit_service.active_state = ["active", "inactive", "active"]
     resp = await api_client.put(
         "/mounts/backup_test",
         json={
@@ -280,6 +287,7 @@ async def test_api_update_dbus_error_mount_remains(
     """Test mount remains in list with unsuccessful state if dbus error occurs during update."""
     systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
+    systemd_unit_service.active_state = ["failed", "inactive"]
     systemd_service.response_get_unit = [
         "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
         DBusError("org.freedesktop.systemd1.NoSuchUnit", "error"),
@@ -321,7 +329,13 @@ async def test_api_update_dbus_error_mount_remains(
         "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
     ]
     systemd_service.response_start_transient_unit = "/org/freedesktop/systemd1/job/7623"
-    systemd_unit_service.active_state = "failed"
+    systemd_unit_service.active_state = [
+        "failed",
+        "inactive",
+        "inactive",
+        "failed",
+        "inactive",
+    ]
 
     resp = await api_client.put(
         "/mounts/backup_test",
@@ -385,8 +399,15 @@ async def test_api_reload_error_mount_missing(
     )
 
 
-async def test_api_delete_mount(api_client: TestClient, coresys: CoreSys, mount):
+async def test_api_delete_mount(
+    api_client: TestClient,
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock],
+    mount,
+):
     """Test deleting a mount via API."""
+    systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
+    systemd_unit_service.active_state = ["active", "inactive"]
     resp = await api_client.delete("/mounts/backup_test")
     result = await resp.json()
     assert result["result"] == "ok"
@@ -455,9 +476,25 @@ async def test_api_create_backup_mount_sets_default(
 
 
 async def test_update_backup_mount_changes_default(
-    api_client: TestClient, coresys: CoreSys, mount
+    api_client: TestClient,
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock],
+    mount,
 ):
     """Test updating a backup mount may unset the default."""
+    systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
+    systemd_unit_service.active_state = [
+        "active",
+        "active",
+        "inactive",
+        "active",
+        "active",
+        "active",
+        "inactive",
+        "active",
+        "active",
+    ]
+
     # Make another backup mount for testing
     resp = await api_client.post(
         "/mounts",
@@ -502,9 +539,21 @@ async def test_update_backup_mount_changes_default(
 
 
 async def test_delete_backup_mount_changes_default(
-    api_client: TestClient, coresys: CoreSys, mount
+    api_client: TestClient,
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock],
+    mount,
 ):
     """Test deleting a backup mount may unset the default."""
+    systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
+    systemd_unit_service.active_state = [
+        "active",
+        "active",
+        "inactive",
+        "active",
+        "inactive",
+    ]
+
     # Make another backup mount for testing
     resp = await api_client.post(
         "/mounts",
@@ -535,11 +584,35 @@ async def test_delete_backup_mount_changes_default(
 async def test_backup_mounts_reload_backups(
     api_client: TestClient,
     coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock],
     tmp_supervisor_data,
     path_extern,
     mount_propagation,
 ):
     """Test actions on a backup mount reload backups."""
+    systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
+    systemd_unit_service.active_state = [
+        "active",
+        "active",
+        "active",
+        "active",
+        "inactive",
+        "active",
+        "inactive",
+        "active",
+        "active",
+        "active",
+        "inactive",
+        "active",
+        "active",
+        "active",
+        "active",
+        "inactive",
+        "active",
+        "inactive",
+        "active",
+        "inactive",
+    ]
     await coresys.mounts.load()
 
     with patch.object(BackupManager, "reload") as reload:

--- a/tests/api/test_mounts.py
+++ b/tests/api/test_mounts.py
@@ -226,8 +226,9 @@ async def test_api_update_mount(
     mount,
 ):
     """Test updating a mount via API."""
+    systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
-    systemd_unit_service.active_state = ["active", "inactive", "active"]
+    systemd_service.mock_systemd_unit = systemd_unit_service
     resp = await api_client.put(
         "/mounts/backup_test",
         json={
@@ -406,8 +407,9 @@ async def test_api_delete_mount(
     mount,
 ):
     """Test deleting a mount via API."""
+    systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
-    systemd_unit_service.active_state = ["active", "inactive"]
+    systemd_service.mock_systemd_unit = systemd_unit_service
     resp = await api_client.delete("/mounts/backup_test")
     result = await resp.json()
     assert result["result"] == "ok"
@@ -483,17 +485,8 @@ async def test_update_backup_mount_changes_default(
 ):
     """Test updating a backup mount may unset the default."""
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
-    systemd_unit_service.active_state = [
-        "active",
-        "active",
-        "inactive",
-        "active",
-        "active",
-        "active",
-        "inactive",
-        "active",
-        "active",
-    ]
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_service.mock_systemd_unit = systemd_unit_service
 
     # Make another backup mount for testing
     resp = await api_client.post(
@@ -546,13 +539,8 @@ async def test_delete_backup_mount_changes_default(
 ):
     """Test deleting a backup mount may unset the default."""
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
-    systemd_unit_service.active_state = [
-        "active",
-        "active",
-        "inactive",
-        "active",
-        "inactive",
-    ]
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_service.mock_systemd_unit = systemd_unit_service
 
     # Make another backup mount for testing
     resp = await api_client.post(
@@ -591,28 +579,8 @@ async def test_backup_mounts_reload_backups(
 ):
     """Test actions on a backup mount reload backups."""
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
-    systemd_unit_service.active_state = [
-        "active",
-        "active",
-        "active",
-        "active",
-        "inactive",
-        "active",
-        "inactive",
-        "active",
-        "active",
-        "active",
-        "inactive",
-        "active",
-        "active",
-        "active",
-        "active",
-        "inactive",
-        "active",
-        "inactive",
-        "active",
-        "inactive",
-    ]
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_service.mock_systemd_unit = systemd_unit_service
     await coresys.mounts.load()
 
     with patch.object(BackupManager, "reload") as reload:

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -30,10 +30,8 @@ from supervisor.utils.json import read_json_file, write_json_file
 
 from tests.const import TEST_ADDON_SLUG
 from tests.dbus_service_mocks.base import DBusServiceMock
-from tests.dbus_service_mocks.systemd import (
-    Systemd as SystemdService,
-    SystemdUnit as SystemdUnitService,
-)
+from tests.dbus_service_mocks.systemd import Systemd as SystemdService
+from tests.dbus_service_mocks.systemd_unit import SystemdUnit as SystemdUnitService
 
 
 async def test_do_backup_full(coresys: CoreSys, backup_mock, install_addon_ssh):

--- a/tests/dbus_service_mocks/systemd.py
+++ b/tests/dbus_service_mocks/systemd.py
@@ -4,6 +4,7 @@ from dbus_fast import DBusError
 from dbus_fast.service import PropertyAccess, dbus_property
 
 from .base import DBusServiceMock, dbus_method
+from .systemd_unit import SystemdUnit
 
 BUS_NAME = "org.freedesktop.systemd1"
 
@@ -40,6 +41,7 @@ class Systemd(DBusServiceMock):
     response_start_transient_unit: str | DBusError = (
         "/org/freedesktop/systemd1/job/7623"
     )
+    mock_systemd_unit: SystemdUnit | None = None
 
     @dbus_property(access=PropertyAccess.READ)
     def Version(self) -> "s":
@@ -658,6 +660,8 @@ class Systemd(DBusServiceMock):
     @dbus_method()
     def StartUnit(self, name: "s", mode: "s") -> "o":
         """Start a service unit."""
+        if self.mock_systemd_unit:
+            self.mock_systemd_unit.active_state = "active"
         return "/org/freedesktop/systemd1/job/7623"
 
     @dbus_method()
@@ -665,6 +669,8 @@ class Systemd(DBusServiceMock):
         """Stop a service unit."""
         if isinstance(self.response_stop_unit, DBusError):
             raise self.response_stop_unit
+        if self.mock_systemd_unit:
+            self.mock_systemd_unit.active_state = "inactive"
         return self.response_stop_unit
 
     @dbus_method()
@@ -672,11 +678,15 @@ class Systemd(DBusServiceMock):
         """Reload or restart a service unit."""
         if isinstance(self.response_reload_or_restart_unit, DBusError):
             raise self.response_reload_or_restart_unit
+        if self.mock_systemd_unit:
+            self.mock_systemd_unit.active_state = "active"
         return self.response_reload_or_restart_unit
 
     @dbus_method()
     def RestartUnit(self, name: "s", mode: "s") -> "o":
         """Restart a service unit."""
+        if self.mock_systemd_unit:
+            self.mock_systemd_unit.active_state = "active"
         return "/org/freedesktop/systemd1/job/7623"
 
     @dbus_method()
@@ -686,11 +696,15 @@ class Systemd(DBusServiceMock):
         """Start a transient service unit."""
         if isinstance(self.response_start_transient_unit, DBusError):
             raise self.response_start_transient_unit
+        if self.mock_systemd_unit:
+            self.mock_systemd_unit.active_state = "active"
         return self.response_start_transient_unit
 
     @dbus_method()
     def ResetFailedUnit(self, name: "s") -> None:
         """Reset a failed unit."""
+        if self.mock_systemd_unit:
+            self.mock_systemd_unit.active_state = "inactive"
 
     @dbus_method()
     def GetUnit(self, name: "s") -> "s":

--- a/tests/mounts/test_manager.py
+++ b/tests/mounts/test_manager.py
@@ -584,6 +584,15 @@ async def test_reload_mounts(
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
     systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_service.ReloadOrRestartUnit.calls.clear()
+    systemd_unit_service.active_state = [
+        "active",
+        "active",
+        "inactive",
+        "active",
+        "failed",
+        "failed",
+        "active",
+    ]
 
     await coresys.mounts.load()
 

--- a/tests/mounts/test_manager.py
+++ b/tests/mounts/test_manager.py
@@ -372,14 +372,7 @@ async def test_update_mount(
     """Test updating a mount."""
     systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
-    systemd_unit_service.active_state = [
-        "active",
-        "inactive",
-        "active",
-        "inactive",
-        "active",
-        "active",
-    ]
+    systemd_service.mock_systemd_unit = systemd_unit_service
     systemd_service.StartTransientUnit.calls.clear()
     systemd_service.StopUnit.calls.clear()
 
@@ -584,17 +577,6 @@ async def test_reload_mounts(
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
     systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_service.ReloadOrRestartUnit.calls.clear()
-    systemd_unit_service.active_state = [
-        "active",
-        "active",
-        "inactive",
-        "active",
-        "failed",
-        "failed",
-        "active",
-    ]
-
-    await coresys.mounts.load()
 
     assert mount.state == UnitActiveState.ACTIVE
     assert mount.failed_issue not in coresys.resolution.issues

--- a/tests/mounts/test_manager.py
+++ b/tests/mounts/test_manager.py
@@ -371,6 +371,15 @@ async def test_update_mount(
 ):
     """Test updating a mount."""
     systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
+    systemd_unit_service.active_state = [
+        "active",
+        "inactive",
+        "active",
+        "inactive",
+        "active",
+        "active",
+    ]
     systemd_service.StartTransientUnit.calls.clear()
     systemd_service.StopUnit.calls.clear()
 
@@ -429,6 +438,8 @@ async def test_remove_mount(
 ):
     """Test removing a mount."""
     systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
+    systemd_unit_service.active_state = ["active", "inactive", "active", "inactive"]
     systemd_service.StopUnit.calls.clear()
 
     # Remove the mount
@@ -549,7 +560,7 @@ async def test_create_mount_activation_failure(
         "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
         "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
     ]
-    systemd_unit_service.active_state = "failed"
+    systemd_unit_service.active_state = ["failed", "failed", "inactive"]
 
     await coresys.mounts.load()
 

--- a/tests/mounts/test_manager.py
+++ b/tests/mounts/test_manager.py
@@ -560,7 +560,7 @@ async def test_create_mount_activation_failure(
         "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
         "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
     ]
-    systemd_unit_service.active_state = ["failed", "failed", "inactive"]
+    systemd_unit_service.active_state = ["failed", "failed", "failed"]
 
     await coresys.mounts.load()
 

--- a/tests/mounts/test_mount.py
+++ b/tests/mounts/test_mount.py
@@ -52,6 +52,7 @@ async def test_cifs_mount(
 ):
     """Test CIFS mount."""
     systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
     systemd_service.StartTransientUnit.calls.clear()
 
     mount_data = {
@@ -130,6 +131,7 @@ async def test_cifs_mount(
     assert not cred_stat.st_mode & stat.S_IRGRP
     assert not cred_stat.st_mode & stat.S_IROTH
 
+    systemd_unit_service.active_state = ["active", "inactive"]
     await mount.unmount()
     assert not mount.path_credentials.exists()
 
@@ -289,6 +291,7 @@ async def test_unmount(
 ):
     """Test unmounting."""
     systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
     systemd_service.StopUnit.calls.clear()
 
     mount: CIFSMount = Mount.from_dict(
@@ -306,6 +309,7 @@ async def test_unmount(
     assert mount.unit is not None
     assert mount.state == UnitActiveState.ACTIVE
 
+    systemd_unit_service.active_state = ["active", "inactive"]
     await mount.unmount()
 
     assert mount.unit is None

--- a/tests/resolution/fixup/test_mount_execute_remove.py
+++ b/tests/resolution/fixup/test_mount_execute_remove.py
@@ -6,7 +6,10 @@ from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.fixups.mount_execute_remove import FixupMountExecuteRemove
 
 from tests.dbus_service_mocks.base import DBusServiceMock
-from tests.dbus_service_mocks.systemd import Systemd as SystemdService
+from tests.dbus_service_mocks.systemd import (
+    Systemd as SystemdService,
+    SystemdUnit as SystemdUnitService,
+)
 
 
 async def test_fixup(
@@ -17,6 +20,7 @@ async def test_fixup(
 ):
     """Test fixup."""
     systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
     systemd_service.StopUnit.calls.clear()
 
     mount_execute_remove = FixupMountExecuteRemove(coresys)
@@ -42,6 +46,8 @@ async def test_fixup(
         reference="test",
         suggestions=[SuggestionType.EXECUTE_RELOAD, SuggestionType.EXECUTE_REMOVE],
     )
+
+    systemd_unit_service.active_state = ["active", "inactive"]
     await mount_execute_remove()
 
     assert coresys.resolution.issues == []

--- a/tests/resolution/fixup/test_mount_execute_remove.py
+++ b/tests/resolution/fixup/test_mount_execute_remove.py
@@ -6,10 +6,8 @@ from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.fixups.mount_execute_remove import FixupMountExecuteRemove
 
 from tests.dbus_service_mocks.base import DBusServiceMock
-from tests.dbus_service_mocks.systemd import (
-    Systemd as SystemdService,
-    SystemdUnit as SystemdUnitService,
-)
+from tests.dbus_service_mocks.systemd import Systemd as SystemdService
+from tests.dbus_service_mocks.systemd_unit import SystemdUnit as SystemdUnitService
 
 
 async def test_fixup(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The current code does not wait until the (bind) mount unit has been actually deactivated (state "inactive"). This is especially problematic when restoring a backup, where we deactivate all bind mounts before restoring the target folder. Before the tarball is actually restored, we delete all contents of the target folder. This lead to the situation where the "rm -rf" command got executed before the bind mount actually got unmounted.

The current code polls the state using an exponentially increasing delay. Wait up to 30s for the bind mount to actually deactivate.

Fixes: #4711, #4726

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
