### PR TITLE
Check/get ingress port on add-on load

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -184,6 +184,7 @@ class Addon(AddonModel):
             )
         )
 
+        await self._check_ingress_port()
         with suppress(DockerError):
             await self.instance.attach(version=self.version)
 
@@ -640,8 +641,6 @@ class Addon(AddonModel):
             self.sys_addons.data.uninstall(self)
             raise AddonsError() from err
 
-        await self._check_ingress_port()
-
         # Add to addon manager
         self.sys_addons.local[self.slug] = self
 
@@ -769,7 +768,6 @@ class Addon(AddonModel):
                 raise AddonsError() from err
 
             self.sys_addons.data.update(self.addon_store)
-            await self._check_ingress_port()
             _LOGGER.info("Add-on '%s' successfully rebuilt", self.slug)
 
         finally:

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -683,3 +683,16 @@ async def test_local_example_start(
     await install_addon_example.start()
 
     assert addon_config_dir.is_dir()
+
+
+async def test_local_example_ingress_port_set(
+    coresys: CoreSys,
+    container: MagicMock,
+    tmp_supervisor_data: Path,
+    install_addon_example: Addon,
+):
+    """Test start of an addon."""
+    install_addon_example.path_data.mkdir()
+    await install_addon_example.load()
+
+    assert install_addon_example.ingress_port != 0

--- a/tests/fixtures/addons/local/example/config.yaml
+++ b/tests/fixtures/addons/local/example/config.yaml
@@ -18,3 +18,5 @@ options:
   message: "Hello world..."
 schema:
   message: "str?"
+ingress: true
+ingress_port: 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Instead of setting the ingress port on install, make sure to set the port when the add-on gets loaded (on Supervisor startup and before installation). This is necessary since a dynamic ingress port is not stored as part of the add-on data storage themself but in the ingress data store. So on every Supervisor start the port needs to be transferred to the add-on model.

Note that we still need to check the port on add-on update since the add-on potentially added (dynamic) ingress on update. Same applies to add-on restore (the restored version might use a dynamic ingress port).

This addresses the following issue seen on the dev channel:
```
23-12-06 10:11:36 ERROR (MainThread) [aiohttp.server] Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/aiohttp/web_protocol.py", line 452, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/aiohttp/web_app.py", line 543, in _handle
    resp = await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/aiohttp/web_middlewares.py", line 114, in impl
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/supervisor/supervisor/api/middleware/security.py", line 186, in block_bad_requests
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/supervisor/supervisor/api/middleware/security.py", line 202, in system_validation
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/supervisor/supervisor/api/middleware/security.py", line 269, in token_validation
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/supervisor/supervisor/api/middleware/security.py", line 280, in core_proxy
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/supervisor/supervisor/api/utils.py", line 62, in wrap_api
    answer = await method(api, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/supervisor/supervisor/api/__init__.py", line 456, in addons_addon_info
    return await api_addons.info(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/supervisor/supervisor/api/addons.py", line 253, in info
    ATTR_INGRESS_PORT: addon.ingress_port,
                       ^^^^^^^^^^^^^^^^^^
  File "/usr/src/supervisor/supervisor/addons/addon.py", line 399, in ingress_port
    raise RuntimeError(f"No port set for add-on {self.slug}")
RuntimeError: No port set for add-on 8675bb79_rt_test
```


## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4677
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
