### PR TITLE
Fix WiFi WEP configuration

### DIFF
--- a/supervisor/dbus/network/setting/generate.py
+++ b/supervisor/dbus/network/setting/generate.py
@@ -148,8 +148,8 @@ def get_connection_from_interface(
             wireless["security"] = Variant("s", CONF_ATTR_802_WIRELESS_SECURITY)
             wireless_security = {}
             if interface.wifi.auth == "wep":
-                wireless_security["auth-alg"] = Variant("s", "none")
-                wireless_security["key-mgmt"] = Variant("s", "open")
+                wireless_security["auth-alg"] = Variant("s", "open")
+                wireless_security["key-mgmt"] = Variant("s", "none")
             elif interface.wifi.auth == "wpa-psk":
                 wireless_security["auth-alg"] = Variant("s", "open")
                 wireless_security["key-mgmt"] = Variant("s", "wpa-psk")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
It seems that the values for auth-alg and key-mgmt got mixed up. Trying to safe a WEP configuration currently leads to the error:
```
23-12-19 10:56:37 ERROR (MainThread) [supervisor.host.network] Can't create config and activate wlan0: 802-11-wireless-security.key-mgmt: 'open' is not a valid value for the property
```

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/105879
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
