### PR TITLE
Adjust "retry in ..." log messages to avoid confusion

### DIFF
--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -129,7 +129,7 @@ class HomeAssistantCore(JobGroup):
         while True:
             if not self.sys_updater.image_homeassistant:
                 _LOGGER.warning(
-                    "Found no information about Home Assistant. Retry in 30sec"
+                    "Found no information about Home Assistant. Retrying in 30sec"
                 )
                 await asyncio.sleep(30)
                 await self.sys_updater.reload()
@@ -145,7 +145,7 @@ class HomeAssistantCore(JobGroup):
             except Exception as err:  # pylint: disable=broad-except
                 capture_exception(err)
 
-            _LOGGER.warning("Fails install landingpage, retry after 30sec")
+            _LOGGER.warning("Failed to install landingpage, retrying after 30sec")
             await asyncio.sleep(30)
 
         self.sys_homeassistant.version = LANDINGPAGE
@@ -177,7 +177,7 @@ class HomeAssistantCore(JobGroup):
                 except Exception as err:  # pylint: disable=broad-except
                     capture_exception(err)
 
-            _LOGGER.warning("Error on Home Assistant installation. Retry in 30sec")
+            _LOGGER.warning("Error on Home Assistant installation. Retrying in 30sec")
             await asyncio.sleep(30)
 
         _LOGGER.info("Home Assistant docker now installed")

--- a/supervisor/plugins/cli.py
+++ b/supervisor/plugins/cli.py
@@ -66,7 +66,7 @@ class PluginCli(PluginBase):
                         image=self.sys_updater.image_cli,
                     )
                     break
-            _LOGGER.warning("Error on install cli plugin. Retry in 30sec")
+            _LOGGER.warning("Error on install cli plugin. Retrying in 30sec")
             await asyncio.sleep(30)
 
         _LOGGER.info("CLI plugin is now installed")

--- a/supervisor/plugins/dns.py
+++ b/supervisor/plugins/dns.py
@@ -175,7 +175,7 @@ class PluginDns(PluginBase):
                         self.latest_version, image=self.sys_updater.image_dns
                     )
                     break
-            _LOGGER.warning("Error on install CoreDNS plugin. Retry in 30sec")
+            _LOGGER.warning("Error on install CoreDNS plugin. Retrying in 30sec")
             await asyncio.sleep(30)
 
         _LOGGER.info("CoreDNS plugin now installed")

--- a/supervisor/plugins/multicast.py
+++ b/supervisor/plugins/multicast.py
@@ -62,7 +62,7 @@ class PluginMulticast(PluginBase):
                         self.latest_version, image=self.sys_updater.image_multicast
                     )
                     break
-            _LOGGER.warning("Error on install Multicast plugin. Retry in 30sec")
+            _LOGGER.warning("Error on install Multicast plugin. Retrying in 30sec")
             await asyncio.sleep(30)
 
         _LOGGER.info("Multicast plugin is now installed")

--- a/supervisor/plugins/observer.py
+++ b/supervisor/plugins/observer.py
@@ -70,7 +70,7 @@ class PluginObserver(PluginBase):
                         self.latest_version, image=self.sys_updater.image_observer
                     )
                     break
-            _LOGGER.warning("Error on install observer plugin. Retry in 30sec")
+            _LOGGER.warning("Error on install observer plugin. Retrying in 30sec")
             await asyncio.sleep(30)
 
         _LOGGER.info("observer plugin now installed")

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -65,7 +65,7 @@ async def test_install_landingpage_docker_error(
         await coresys.homeassistant.core.install_landingpage()
         sleep.assert_awaited_once_with(30)
 
-    assert "Fails install landingpage, retry after 30sec" in caplog.text
+    assert "Failed to install landingpage, retrying after 30sec" in caplog.text
     capture_exception.assert_not_called()
 
 
@@ -87,7 +87,7 @@ async def test_install_landingpage_other_error(
         await coresys.homeassistant.core.install_landingpage()
         sleep.assert_awaited_once_with(30)
 
-    assert "Fails install landingpage, retry after 30sec" in caplog.text
+    assert "Failed to install landingpage, retrying after 30sec" in caplog.text
     capture_exception.assert_called_once_with(err)
 
 
@@ -113,7 +113,7 @@ async def test_install_docker_error(
         await coresys.homeassistant.core.install()
         sleep.assert_awaited_once_with(30)
 
-    assert "Error on Home Assistant installation. Retry in 30sec" in caplog.text
+    assert "Error on Home Assistant installation. Retrying in 30sec" in caplog.text
     capture_exception.assert_not_called()
 
 
@@ -137,7 +137,7 @@ async def test_install_other_error(
         await coresys.homeassistant.core.install()
         sleep.assert_awaited_once_with(30)
 
-    assert "Error on Home Assistant installation. Retry in 30sec" in caplog.text
+    assert "Error on Home Assistant installation. Retrying in 30sec" in caplog.text
     capture_exception.assert_called_once_with(err)
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As shown in home-assistant/operating-system#3007, error messages printed to logs when container installation fails can cause some confusion, because they are sometimes printed to the log on the landing page. Adjust all wordings of "retry in" to "retrying in" to make it obvious this happens automatically.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/operating-system#3007
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
