### PR TITLE
Always pass explicit architecture of installed add-ons

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -718,7 +718,7 @@ class Addon(AddonModel):
         store = self.addon_store.clone()
 
         try:
-            await self.instance.update(store.version, store.image)
+            await self.instance.update(store.version, store.image, arch=self.arch)
         except DockerError as err:
             raise AddonsError() from err
 

--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -1209,12 +1209,14 @@ class Addon(AddonModel):
                             await self.instance.import_image(image_file)
                     else:
                         with suppress(DockerError):
-                            await self.instance.install(version, restore_image)
+                            await self.instance.install(
+                                version, restore_image, self.arch
+                            )
                             await self.instance.cleanup()
                 elif self.instance.version != version or self.legacy:
                     _LOGGER.info("Restore/Update of image for addon %s", self.slug)
                     with suppress(DockerError):
-                        await self.instance.update(version, restore_image)
+                        await self.instance.update(version, restore_image, self.arch)
                 self._check_ingress_port()
 
                 # Restore data and config

--- a/supervisor/docker/addon.py
+++ b/supervisor/docker/addon.py
@@ -602,7 +602,11 @@ class DockerAddon(DockerInterface):
         on_condition=DockerJobError,
     )
     async def update(
-        self, version: AwesomeVersion, image: str | None = None, latest: bool = False
+        self,
+        version: AwesomeVersion,
+        image: str | None = None,
+        latest: bool = False,
+        arch: CpuArch | None = None,
     ) -> None:
         """Update a docker image."""
         image = image or self.image
@@ -613,7 +617,11 @@ class DockerAddon(DockerInterface):
 
         # Update docker image
         await self.install(
-            version, image=image, latest=latest, need_build=self.addon.latest_need_build
+            version,
+            image=image,
+            latest=latest,
+            arch=arch,
+            need_build=self.addon.latest_need_build,
         )
 
     @Job(

--- a/tests/addons/test_manager.py
+++ b/tests/addons/test_manager.py
@@ -68,7 +68,7 @@ async def test_image_added_removed_on_update(
         await coresys.addons.update(TEST_ADDON_SLUG)
         build.assert_not_called()
         install.assert_called_once_with(
-            AwesomeVersion("10.0.0"), "test/amd64-my-ssh-addon", False, None
+            AwesomeVersion("10.0.0"), "test/amd64-my-ssh-addon", False, "amd64"
         )
 
     assert install_addon_ssh.need_update is False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
When using multi-architecture container images, the architecture of the add-on is not passed to Docker in all cases. This causes the architecture of the Supervisor container to be used, which potentially is not supported by the add-on in question.

This commit passes the architecture of the add-on to Docker, so that the correct image is pulled.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4402
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
