### PR TITLE
Improve error handling in backup restore

### DIFF
--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -593,6 +593,10 @@ class HomeAssistantBackupError(BackupError, HomeAssistantError):
     """Raise if an error during Home Assistant Core backup is happening."""
 
 
+class BackupInvalidError(BackupError):
+    """Raise if backup or password provided is invalid."""
+
+
 class BackupJobError(BackupError, JobException):
     """Raise on Backup job error."""
 

--- a/supervisor/homeassistant/module.py
+++ b/supervisor/homeassistant/module.py
@@ -481,7 +481,8 @@ class HomeAssistant(FileConfiguration, CoreSysAttributes):
                 ATTR_REFRESH_TOKEN,
                 ATTR_WATCHDOG,
             ):
-                self._data[attr] = data[attr]
+                if attr in data:
+                    self._data[attr] = data[attr]
 
     @Job(
         name="home_assistant_get_users",

--- a/tests/backups/conftest.py
+++ b/tests/backups/conftest.py
@@ -21,9 +21,9 @@ def fixture_backup_mock():
         backup_instance.store_folders = AsyncMock(return_value=None)
         backup_instance.store_homeassistant = AsyncMock(return_value=None)
         backup_instance.store_addons = AsyncMock(return_value=None)
-        backup_instance.restore_folders = AsyncMock(return_value=None)
+        backup_instance.restore_folders = AsyncMock(return_value=True)
         backup_instance.restore_homeassistant = AsyncMock(return_value=None)
-        backup_instance.restore_addons = AsyncMock(return_value=None)
+        backup_instance.restore_addons = AsyncMock(return_value=(True, []))
         backup_instance.restore_repositories = AsyncMock(return_value=None)
 
         yield backup_mock


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

When something goes wrong in restore users often have no idea since all we do is log a warning or error. When we do return an error all the UI says is "something went wrong, check the logs". This is particularly egregious during onboarding since the users can't even check supervisor logs.

This PR changes it so we raise an exception with what went wrong if the restore process did not begin due to invalid input or if restore was halted with an exception. If restore proceeded to the end but something went wrong along the way we always return `False` to tell users to check the logs to see what worked and what didn't.

The last part is not ideal but currently we have no other option. Restore can be partially successful, we don't have a good way to inform and display the details of what happened in the UI in this case. And if restore stopped Home Assistant then the UI can't actually display the response at all since it lost its connection to Supervisor. There are additional improvements to be made here that we'll follow up on in another PR.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
