### PR TITLE
Improve json performance by porting core orjson utils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ docker==7.0.0
 faust-cchardet==2.1.19
 gitpython==3.1.41
 jinja2==3.1.3
+orjson==3.9.10
 pulsectl==23.5.2
 pyudev==0.24.1
 PyYAML==6.0.1

--- a/supervisor/api/auth.py
+++ b/supervisor/api/auth.py
@@ -11,6 +11,7 @@ from ..addons.addon import Addon
 from ..const import ATTR_PASSWORD, ATTR_USERNAME, REQUEST_FROM
 from ..coresys import CoreSysAttributes
 from ..exceptions import APIForbidden
+from ..utils.json import json_loads
 from .const import CONTENT_TYPE_JSON, CONTENT_TYPE_URL
 from .utils import api_process, api_validate
 
@@ -67,7 +68,7 @@ class APIAuth(CoreSysAttributes):
 
         # Json
         if request.headers.get(CONTENT_TYPE) == CONTENT_TYPE_JSON:
-            data = await request.json()
+            data = await request.json(loads=json_loads)
             return await self._process_dict(request, addon, data)
 
         # URL encoded

--- a/supervisor/api/utils.py
+++ b/supervisor/api/utils.py
@@ -22,7 +22,7 @@ from ..const import (
 from ..coresys import CoreSys
 from ..exceptions import APIError, APIForbidden, DockerAPIError, HassioError
 from ..utils import check_exception_chain, get_message_from_exception_chain
-from ..utils.json import JSONEncoder
+from ..utils.json import json_dumps, json_loads as json_loads_util
 from ..utils.log_format import format_message
 from .const import CONTENT_TYPE_BINARY
 
@@ -48,7 +48,7 @@ def json_loads(data: Any) -> dict[str, Any]:
     if not data:
         return {}
     try:
-        return json.loads(data)
+        return json_loads_util(data)
     except json.JSONDecodeError as err:
         raise APIError("Invalid json") from err
 
@@ -130,7 +130,7 @@ def api_return_error(
             JSON_MESSAGE: message or "Unknown error, see supervisor",
         },
         status=400,
-        dumps=lambda x: json.dumps(x, cls=JSONEncoder),
+        dumps=json_dumps,
     )
 
 
@@ -138,7 +138,7 @@ def api_return_ok(data: dict[str, Any] | None = None) -> web.Response:
     """Return an API ok answer."""
     return web.json_response(
         {JSON_RESULT: RESULT_OK, JSON_DATA: data or {}},
-        dumps=lambda x: json.dumps(x, cls=JSONEncoder),
+        dumps=json_dumps,
     )
 
 

--- a/supervisor/utils/json.py
+++ b/supervisor/utils/json.py
@@ -53,7 +53,7 @@ def write_json_file(jsonfile: Path, data: Any) -> None:
             fp.write(
                 orjson.dumps(  # pylint: disable=no-member
                     data,
-                    option=orjson.OPT_INDENT_2
+                    option=orjson.OPT_INDENT_2  # pylint: disable=no-member
                     | orjson.OPT_NON_STR_KEYS,  # pylint: disable=no-member
                     default=json_encoder_default,
                 ).decode("utf-8")

--- a/supervisor/utils/json.py
+++ b/supervisor/utils/json.py
@@ -35,12 +35,15 @@ if TYPE_CHECKING:
 
 else:
     json_bytes = partial(
-        orjson.dumps, option=orjson.OPT_NON_STR_KEYS, default=json_encoder_default
+        orjson.dumps,  # pylint: disable=no-member
+        option=orjson.OPT_NON_STR_KEYS,  # pylint: disable=no-member
+        default=json_encoder_default,
     )
     """Dump json bytes."""
 
 
-json_loads = orjson.loads
+# pylint - https://github.com/ijl/orjson/issues/248
+json_loads = orjson.loads  # pylint: disable=no-member
 
 
 def write_json_file(jsonfile: Path, data: Any) -> None:
@@ -48,9 +51,10 @@ def write_json_file(jsonfile: Path, data: Any) -> None:
     try:
         with atomic_write(jsonfile, overwrite=True) as fp:
             fp.write(
-                orjson.dumps(
+                orjson.dumps(  # pylint: disable=no-member
                     data,
-                    option=orjson.OPT_INDENT_2 | orjson.OPT_NON_STR_KEYS,
+                    option=orjson.OPT_INDENT_2
+                    | orjson.OPT_NON_STR_KEYS,  # pylint: disable=no-member
                     default=json_encoder_default,
                 ).decode("utf-8")
             )

--- a/supervisor/utils/json.py
+++ b/supervisor/utils/json.py
@@ -1,40 +1,59 @@
 """Tools file for Supervisor."""
-from datetime import datetime
-import json
+from functools import partial
 import logging
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from atomicwrites import atomic_write
+import orjson
 
 from ..exceptions import JsonFileError
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
-class JSONEncoder(json.JSONEncoder):
-    """JSONEncoder that supports Supervisor objects."""
+def json_dumps(data: Any) -> str:
+    """Dump json string."""
+    return json_bytes(data).decode("utf-8")
 
-    def default(self, o: Any) -> Any:
-        """Convert Supervisor special objects.
 
-        Hand other objects to the original method.
-        """
-        if isinstance(o, datetime):
-            return o.isoformat()
-        if isinstance(o, set):
-            return list(o)
-        if isinstance(o, Path):
-            return o.as_posix()
+def json_encoder_default(obj: Any) -> Any:
+    """Convert Supervisor special objects."""
+    if isinstance(obj, (set, tuple)):
+        return list(obj)
+    if isinstance(obj, float):
+        return float(obj)
+    if isinstance(obj, Path):
+        return obj.as_posix()
+    raise TypeError
 
-        return super().default(o)
+
+if TYPE_CHECKING:
+
+    def json_bytes(obj: Any) -> bytes:
+        """Dump json bytes."""
+
+else:
+    json_bytes = partial(
+        orjson.dumps, option=orjson.OPT_NON_STR_KEYS, default=json_encoder_default
+    )
+    """Dump json bytes."""
+
+
+json_loads = orjson.loads
 
 
 def write_json_file(jsonfile: Path, data: Any) -> None:
     """Write a JSON file."""
     try:
         with atomic_write(jsonfile, overwrite=True) as fp:
-            fp.write(json.dumps(data, indent=2, cls=JSONEncoder))
+            fp.write(
+                orjson.dumps(
+                    data,
+                    option=orjson.OPT_INDENT_2 | orjson.OPT_NON_STR_KEYS,
+                    default=json_encoder_default,
+                ).decode("utf-8")
+            )
         jsonfile.chmod(0o600)
     except (OSError, ValueError, TypeError) as err:
         raise JsonFileError(
@@ -45,7 +64,7 @@ def write_json_file(jsonfile: Path, data: Any) -> None:
 def read_json_file(jsonfile: Path) -> Any:
     """Read a JSON file and return a dict."""
     try:
-        return json.loads(jsonfile.read_text())
+        return json_loads(jsonfile.read_bytes())
     except (OSError, ValueError, TypeError, UnicodeDecodeError) as err:
         raise JsonFileError(
             f"Can't read json from {jsonfile!s}: {err!s}", _LOGGER.error

--- a/tests/utils/test_json.py
+++ b/tests/utils/test_json.py
@@ -1,5 +1,11 @@
 """test json."""
-from supervisor.utils.json import write_json_file
+import json
+import time
+from typing import NamedTuple
+
+import pytest
+
+from supervisor.utils.json import json_dumps, json_loads, write_json_file
 
 
 def test_file_permissions(tmp_path):
@@ -18,3 +24,50 @@ def test_new_file_permissions(tmp_path):
 
     write_json_file(tempfile, {"test": "data"})
     assert oct(tempfile.stat().st_mode)[-3:] == "600"
+
+
+async def test_loading_derived_class():
+    """Test loading data from classes derived from str."""
+
+    class MyStr(str):
+        pass
+
+    class MyBytes(bytes):
+        pass
+
+    assert json_loads('"abc"') == "abc"
+    assert json_loads(MyStr('"abc"')) == "abc"
+
+    assert json_loads(b'"abc"') == "abc"
+    with pytest.raises(json.JSONDecodeError):
+        assert json_loads(MyBytes(b'"abc"')) == "abc"
+
+
+def test_json_dumps_float_subclass() -> None:
+    """Test the json dumps a float subclass."""
+
+    class FloatSubclass(float):
+        """A float subclass."""
+
+    assert json_dumps({"c": FloatSubclass(1.2)}) == '{"c":1.2}'
+
+
+def test_json_dumps_tuple_subclass() -> None:
+    """Test the json dumps a tuple subclass."""
+
+    tt = time.struct_time((1999, 3, 17, 32, 44, 55, 2, 76, 0))
+
+    assert json_dumps(tt) == "[1999,3,17,32,44,55,2,76,0]"
+
+
+def test_json_dumps_named_tuple_subclass() -> None:
+    """Test the json dumps a tuple subclass."""
+
+    class NamedTupleSubclass(NamedTuple):
+        """A NamedTuple subclass."""
+
+        name: str
+
+    nts = NamedTupleSubclass("a")
+
+    assert json_dumps(nts) == '["a"]'

--- a/tests/utils/test_json.py
+++ b/tests/utils/test_json.py
@@ -5,7 +5,12 @@ from typing import NamedTuple
 
 import pytest
 
-from supervisor.utils.json import json_dumps, json_loads, write_json_file
+from supervisor.utils.json import (
+    json_dumps,
+    json_loads,
+    read_json_file,
+    write_json_file,
+)
 
 
 def test_file_permissions(tmp_path):
@@ -24,6 +29,15 @@ def test_new_file_permissions(tmp_path):
 
     write_json_file(tempfile, {"test": "data"})
     assert oct(tempfile.stat().st_mode)[-3:] == "600"
+
+
+def test_file_round_trip(tmp_path):
+    """Test file permissions."""
+    tempfile = tmp_path / "test.json"
+    write_json_file(tempfile, {"test": "data"})
+    assert tempfile.is_file()
+    assert oct(tempfile.stat().st_mode)[-3:] == "600"
+    assert read_json_file(tempfile) == {"test": "data"}
 
 
 async def test_loading_derived_class():

--- a/tests/utils/test_json.py
+++ b/tests/utils/test_json.py
@@ -1,16 +1,8 @@
 """test json."""
-import json
 import time
 from typing import NamedTuple
 
-import pytest
-
-from supervisor.utils.json import (
-    json_dumps,
-    json_loads,
-    read_json_file,
-    write_json_file,
-)
+from supervisor.utils.json import json_dumps, read_json_file, write_json_file
 
 
 def test_file_permissions(tmp_path):
@@ -38,23 +30,6 @@ def test_file_round_trip(tmp_path):
     assert tempfile.is_file()
     assert oct(tempfile.stat().st_mode)[-3:] == "600"
     assert read_json_file(tempfile) == {"test": "data"}
-
-
-async def test_loading_derived_class():
-    """Test loading data from classes derived from str."""
-
-    class MyStr(str):
-        pass
-
-    class MyBytes(bytes):
-        pass
-
-    assert json_loads('"abc"') == "abc"
-    assert json_loads(MyStr('"abc"')) == "abc"
-
-    assert json_loads(b'"abc"') == "abc"
-    with pytest.raises(json.JSONDecodeError):
-        assert json_loads(MyBytes(b'"abc"')) == "abc"
 
 
 def test_json_dumps_float_subclass() -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improve json performance by porting core orjson utils

core has to wait for supervisor to build and reply to its api requests before startup can proceed which slows down core startup a bit since everything is core depends on hassio when its in use

Additionally there is a noticeable by humans improvement in the load times of applications running through ingress.


## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
