### PR TITLE
Addon devs can block auto update for breaking versions

### DIFF
--- a/supervisor/addons/const.py
+++ b/supervisor/addons/const.py
@@ -28,6 +28,7 @@ class MappingType(StrEnum):
 
 
 ATTR_BACKUP = "backup"
+ATTR_BREAKING_VERSIONS = "breaking_versions"
 ATTR_CODENOTARY = "codenotary"
 ATTR_READ_ONLY = "read_only"
 ATTR_PATH = "path"

--- a/supervisor/addons/model.py
+++ b/supervisor/addons/model.py
@@ -90,6 +90,7 @@ from ..utils import version_is_new_enough
 from .configuration import FolderMapping
 from .const import (
     ATTR_BACKUP,
+    ATTR_BREAKING_VERSIONS,
     ATTR_CODENOTARY,
     ATTR_PATH,
     ATTR_READ_ONLY,
@@ -619,6 +620,11 @@ class AddonModel(JobGroup, ABC):
     def codenotary(self) -> str | None:
         """Return Signer email address for CAS."""
         return self.data.get(ATTR_CODENOTARY)
+
+    @property
+    def breaking_versions(self) -> list[AwesomeVersion]:
+        """Return breaking versions of addon."""
+        return self.data[ATTR_BREAKING_VERSIONS]
 
     def validate_availability(self) -> None:
         """Validate if addon is available for current system."""

--- a/supervisor/addons/validate.py
+++ b/supervisor/addons/validate.py
@@ -112,6 +112,7 @@ from ..validate import (
 )
 from .const import (
     ATTR_BACKUP,
+    ATTR_BREAKING_VERSIONS,
     ATTR_CODENOTARY,
     ATTR_PATH,
     ATTR_READ_ONLY,
@@ -422,6 +423,7 @@ _SCHEMA_ADDON_CONFIG = vol.Schema(
             vol.Coerce(int), vol.Range(min=10, max=300)
         ),
         vol.Optional(ATTR_JOURNALD, default=False): vol.Boolean(),
+        vol.Optional(ATTR_BREAKING_VERSIONS, default=list): [version_tag],
     },
     extra=vol.REMOVE_EXTRA,
 )

--- a/supervisor/misc/tasks.py
+++ b/supervisor/misc/tasks.py
@@ -95,6 +95,14 @@ class Tasks(CoreSysAttributes):
             # Evaluate available updates
             if not addon.need_update:
                 continue
+            if not addon.auto_update_available:
+                _LOGGER.debug(
+                    "Not updating add-on %s from %s to %s as that would cross a known breaking version",
+                    addon.slug,
+                    addon.version,
+                    addon.latest_version,
+                )
+                continue
             if not addon.test_update_schema():
                 _LOGGER.warning(
                     "Add-on %s will be ignored, schema tests failed", addon.slug

--- a/tests/fixtures/addons/local/example/config.yaml
+++ b/tests/fixtures/addons/local/example/config.yaml
@@ -20,3 +20,6 @@ schema:
   message: "str?"
 ingress: true
 ingress_port: 0
+breaking_versions:
+  - test
+  - 1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Provide addon developers with a way to list breaking versions of their addons. This way we can block auto-updates which would cross one of these breaking versions and prevent bad situations like what happened recently with Nginx Proxy Manager.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2056
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
