### PR TITLE
Expand docker version evaluation.

### DIFF
--- a/supervisor/docker/manager.py
+++ b/supervisor/docker/manager.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Final
 
 import attr
-from awesomeversion import AwesomeVersion, AwesomeVersionCompareException
+from awesomeversion import AwesomeVersion
 from docker import errors as docker_errors
 from docker.api.client import APIClient
 from docker.client import DockerClient
@@ -35,8 +35,6 @@ from .monitor import DockerMonitor
 from .network import DockerNetwork
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
-
-MIN_SUPPORTED_DOCKER: Final = AwesomeVersion("20.10.1")
 DOCKER_NETWORK_HOST: Final = "host"
 
 
@@ -66,14 +64,6 @@ class DockerInfo:
             data.get("LoggingDriver", "unknown"),
             data.get("CgroupVersion", "1"),
         )
-
-    @property
-    def supported_version(self) -> bool:
-        """Return true, if docker version is supported."""
-        try:
-            return self.version >= MIN_SUPPORTED_DOCKER
-        except AwesomeVersionCompareException:
-            return False
 
     @property
     def support_cpu_realtime(self) -> bool:

--- a/supervisor/resolution/evaluations/docker_version.py
+++ b/supervisor/resolution/evaluations/docker_version.py
@@ -1,5 +1,7 @@
 """Evaluation class for docker version."""
 
+from awesomeversion import AwesomeVersion, AwesomeVersionCompareException
+
 from ...const import CoreState
 from ...coresys import CoreSys
 from ..const import UnsupportedReason
@@ -14,6 +16,17 @@ def setup(coresys: CoreSys) -> EvaluateBase:
 class EvaluateDockerVersion(EvaluateBase):
     """Evaluate Docker version."""
 
+    def __init__(self, coresys):
+        """Initialize check with known bad versions of docker."""
+        super().__init__(coresys)
+        self.min_supported_version = AwesomeVersion("20.10.1")
+        self.broken_versions = {
+            AwesomeVersion(
+                "25.0.0"
+            ): "network IP range evaluation is overly strict and does not allow supervisor/observer/etc to bind intended IPs;\n See: https://github.com/moby/moby/issues/47120.\nDowngrade to 24 or upgrade to 25.0.1+ if released"
+        }
+        self.specific_reason = "it seems to be missing or malformed?"
+
     @property
     def reason(self) -> UnsupportedReason:
         """Return a UnsupportedReason enum."""
@@ -22,7 +35,7 @@ class EvaluateDockerVersion(EvaluateBase):
     @property
     def on_failure(self) -> str:
         """Return a string that is printed when self.evaluate is True."""
-        return f"Docker version '{self.sys_docker.info.version}' is not supported by the Supervisor!"
+        return f"Docker version '{self.sys_docker.info.version}' is not supported by the Supervisor!: {self.specific_reason}"
 
     @property
     def states(self) -> list[CoreState]:
@@ -31,4 +44,16 @@ class EvaluateDockerVersion(EvaluateBase):
 
     async def evaluate(self):
         """Run evaluation."""
-        return not self.sys_docker.info.supported_version
+        try:
+            if self.sys_docker.info.version < self.min_supported_version:
+                self.specific_reason = "It is much too old. Please upgrade."
+                return True
+
+            for bad_version, why_bad in self.broken_versions.items():
+                if self.sys_docker.info.version == bad_version:
+                    self.specific_reason = why_bad
+                    return True
+        except AwesomeVersionCompareException:
+            return True
+
+        return False

--- a/tests/resolution/evaluation/test_evaluate_docker_version.py
+++ b/tests/resolution/evaluation/test_evaluate_docker_version.py
@@ -1,26 +1,69 @@
-"""Test evaluation base."""
-# pylint: disable=import-error,protected-access
+"""Test evaluation of docker version."""
+
+import random
 from unittest.mock import patch
+
+# pylint: disable=import-error,protected-access
+from awesomeversion import AwesomeVersion
 
 from supervisor.const import CoreState
 from supervisor.coresys import CoreSys
 from supervisor.resolution.evaluations.docker_version import EvaluateDockerVersion
 
 
-async def test_evaluation(coresys: CoreSys):
-    """Test evaluation."""
+async def test_evaluation_supported(coresys: CoreSys):
+    """Test real evaluation with a current docker daemon."""
+    docker_version = EvaluateDockerVersion(coresys)
+    coresys.core.state = CoreState.INITIALIZE
+    coresys.docker.info.version = AwesomeVersion("24.0.7")
+
+    assert docker_version.reason not in coresys.resolution.unsupported
+
+    await docker_version()
+
+    assert docker_version.reason not in coresys.resolution.unsupported
+
+
+async def test_evaluation_below_min_version(coresys: CoreSys):
+    """Test handling of too-low docker versions."""
     docker_version = EvaluateDockerVersion(coresys)
     coresys.core.state = CoreState.INITIALIZE
 
     assert docker_version.reason not in coresys.resolution.unsupported
 
-    coresys.docker.info.supported_version = False
+    minv = docker_version.min_supported_version
+    coresys.docker.info.version = AwesomeVersion(f"{int(minv.major) - 1}.0.0")
     await docker_version()
     assert docker_version.reason in coresys.resolution.unsupported
 
-    coresys.docker.info.supported_version = True
+    coresys.resolution.unsupported = []
+    coresys.docker.info.version = AwesomeVersion(
+        f"{minv.major}.{minv.minor}.{int(minv.patch) - 1}"
+    )
+    await docker_version()
+    assert docker_version.reason in coresys.resolution.unsupported
+
+
+async def test_evaluation_at_min_version(coresys: CoreSys):
+    """Test handling of just-too-low docker versions."""
+    docker_version = EvaluateDockerVersion(coresys)
+    coresys.core.state = CoreState.INITIALIZE
+
+    coresys.docker.info.version = docker_version.min_supported_version
     await docker_version()
     assert docker_version.reason not in coresys.resolution.unsupported
+
+
+async def test_evaluation_known_broken_version(coresys: CoreSys):
+    """Test handling of a known-bad docker versions."""
+    docker_version = EvaluateDockerVersion(coresys)
+    coresys.core.state = CoreState.INITIALIZE
+
+    coresys.docker.info.version = random.choice(
+        list(docker_version.broken_versions.keys())
+    )
+    await docker_version()
+    assert docker_version.reason in coresys.resolution.unsupported
 
 
 async def test_did_run(coresys: CoreSys):


### PR DESCRIPTION
**EDIT:** apparently contrary to my impression of their plans, they cut a docker 25.0.1 this morning, so this is kinda for no one now. The broader idea _could_ still be helpful in future, but lmk if just want to close

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

1. Expand the `EvaluateDockerVersion` to include both a minimum version check and a list of known bad versions for poor supervised-installer users. (I would also accept, even perhaps prefer e.g. a constraint in https://github.com/home-assistant/supervised-installer/blob/main/homeassistant-supervised/DEBIAN/control but this is already here)

2. expand test suite accordingly

3. do away with the apparently otherwise unused `supported_version` property of DockerInfo, concentrating that logic in the evaluation itself




<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issues: 
    - #4827 ; and by extension at least
    - home-assistant/supervised-installer#349
    - home-assistant/supervised-installer#351
    - home-assistant/supervised-installer#352

As I discussed at https://github.com/home-assistant/supervisor/issues/4827#issuecomment-1907090382

there is already a fix landed upstream in moby for this ~bug but they are not interested in fast-tracking a patch release apparently.

Ditto is perhaps foolish to suspect a supervisor release would be forthcoming either, but I'd already spent ~5 hours struggling with debugging this issue myself (errantly over-focalizing on pyudev getting denied on `udev_monitor_new_from_netlink`... for some reason), so figured might as well spend 2 hours more closing the loop

- Link to documentation pull request: [... there should perhaps be one for https://www.home-assistant.io/more-info/unsupported/docker_version, but I'll let reviewer have say first ]

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.

    I have verified that the additions do not hamper supervisor (and enough else for the setup wizard to showup at `http://localhost:9123`) startup on docker 24.0.7 in devcontainer (running under orbstack on an M1 MacBook air). 
    
    I have not yet investigated exact behavior/ordering of failures during startup under docker-ce 25.0.0

- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast supervisor tests`)
- [x] Tests have been added to verify that the new code works.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
