### PR TITLE
Fix serialization issue adding error to job

### DIFF
--- a/supervisor/jobs/__init__.py
+++ b/supervisor/jobs/__init__.py
@@ -201,8 +201,11 @@ class JobManager(FileConfiguration, CoreSysAttributes):
         self, job: SupervisorJob, attribute: Attribute, value: Any
     ) -> None:
         """Notify Home Assistant of a change to a job and bus on job start/end."""
+        if attribute.name == "errors":
+            value = [err.as_dict() for err in value]
+
         self.sys_homeassistant.websocket.supervisor_event(
-            WSEvent.JOB, job.as_dict() | {attribute.alias: value}
+            WSEvent.JOB, job.as_dict() | {attribute.name: value}
         )
 
         if attribute.name == "done":

--- a/tests/jobs/test_job_manager.py
+++ b/tests/jobs/test_job_manager.py
@@ -175,6 +175,32 @@ async def test_notify_on_change(coresys: CoreSys):
             }
         )
 
+        job.capture_error()
+        await asyncio.sleep(0)
+        coresys.homeassistant.websocket._client.async_send_command.assert_called_with(
+            {
+                "type": "supervisor/event",
+                "data": {
+                    "event": "job",
+                    "data": {
+                        "name": TEST_JOB,
+                        "reference": "test",
+                        "uuid": ANY,
+                        "progress": 50,
+                        "stage": "test",
+                        "done": False,
+                        "parent_id": None,
+                        "errors": [
+                            {
+                                "type": "HassioError",
+                                "message": "Unknown error, see supervisor logs",
+                            }
+                        ],
+                    },
+                },
+            }
+        )
+
     await asyncio.sleep(0)
     coresys.homeassistant.websocket._client.async_send_command.assert_called_with(
         {
@@ -189,7 +215,12 @@ async def test_notify_on_change(coresys: CoreSys):
                     "stage": "test",
                     "done": True,
                     "parent_id": None,
-                    "errors": [],
+                    "errors": [
+                        {
+                            "type": "HassioError",
+                            "message": "Unknown error, see supervisor logs",
+                        }
+                    ],
                 },
             },
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Changes to jobs are immediately reported to Home Assistant via websockets. When the change is to the `errors` field we are attempting to pass the instance of `SupervisorJobError` which is not serializable, causing this:

```
24-01-29 21:58:44 ERROR (MainThread) [asyncio] Task exception was never retrieved                                                                                                                                                                                                                                             
future: <Task finished name='Task-5951' coro=<HomeAssistantWebSocket.async_supervisor_event() done, defined at /usr/src/supervisor/supervisor/homeassistant/websocket.py:318> exception=TypeError('Object of type SupervisorJobError is not JSON serializable')>                                                              
Traceback (most recent call last):                                                                                                                                                                                                                                                                                            
  File "/usr/src/supervisor/supervisor/homeassistant/websocket.py", line 323, in async_supervisor_event                                                                                                                                                                                                                       
    await self.async_send_message(                                                                                                                                                                                                                                                                                            
  File "/usr/src/supervisor/supervisor/homeassistant/websocket.py", line 263, in async_send_message                                                                                                                                                                                                                           
    await self._client.async_send_command(message)                                                                                                                                                                                                                                                                            
  File "/usr/src/supervisor/supervisor/homeassistant/websocket.py", line 88, in async_send_command                                                                                                                                                                                                                            
    await self._client.send_json(message)                                                                                                                                                                                                                                                                                     
  File "/usr/local/lib/python3.12/site-packages/aiohttp/client_ws.py", line 179, in send_json                                                                                                                                                                                                                                 
    await self.send_str(dumps(data), compress=compress)                                                                                                                                                                                                                                                                       
                        ^^^^^^^^^^^                                                                                                                                                                                                                                                                                           
  File "/usr/local/lib/python3.12/json/__init__.py", line 231, in dumps                                                                                                                                                                                                                                                       
    return _default_encoder.encode(obj)                                                                                                                                                                                                                                                                                       
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                                                                       
  File "/usr/local/lib/python3.12/json/encoder.py", line 200, in encode                                                                                                                                                                                                                                                       
    chunks = self.iterencode(o, _one_shot=True)                                                                                                                                                                                                                                                                               
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                                                               
  File "/usr/local/lib/python3.12/json/encoder.py", line 258, in iterencode                                                                                                                                                                                                                                                   
    return _iterencode(o, 0)                                                                                                                                                                                                                                                                                                  
           ^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                                                                                  
  File "/usr/local/lib/python3.12/json/encoder.py", line 180, in default                                                                                                                                                                                                                                                      
    raise TypeError(f'Object of type {o.__class__.__name__} '                                                                                                                                                                                                                                                                 
TypeError: Object of type SupervisorJobError is not JSON serializable
```

We need to call `as_dict` first to get the dictionary representation of each error instead.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
