### PR TITLE
Improve error handling when mounts fail

### DIFF
--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -607,6 +607,10 @@ class BackupInvalidError(BackupError):
     """Raise if backup or password provided is invalid."""
 
 
+class BackupMountDownError(BackupError):
+    """Raise if mount specified for backup is down."""
+
+
 class BackupJobError(BackupError, JobException):
     """Raise on Backup job error."""
 

--- a/supervisor/mounts/const.py
+++ b/supervisor/mounts/const.py
@@ -8,6 +8,7 @@ FILE_CONFIG_MOUNTS = PurePath("mounts.json")
 ATTR_DEFAULT_BACKUP_MOUNT = "default_backup_mount"
 ATTR_MOUNTS = "mounts"
 ATTR_PATH = "path"
+ATTR_READ_ONLY = "read_only"
 ATTR_SERVER = "server"
 ATTR_SHARE = "share"
 ATTR_USAGE = "usage"

--- a/supervisor/mounts/manager.py
+++ b/supervisor/mounts/manager.py
@@ -297,6 +297,7 @@ class MountManager(FileConfiguration, CoreSysAttributes):
                 name=f"{'emergency' if emergency else 'bind'}_{mount.name}",
                 path=path,
                 where=where,
+                read_only=emergency,
             ),
             emergency=emergency,
         )

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -90,13 +90,14 @@ async def test_backup_to_location(
 
     coresys.core.state = CoreState.RUNNING
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
-    resp = await api_client.post(
-        "/backups/new/full",
-        json={
-            "name": "Mount test",
-            "location": location,
-        },
-    )
+    with patch("supervisor.mounts.mount.Path.is_mount", return_value=True):
+        resp = await api_client.post(
+            "/backups/new/full",
+            json={
+                "name": "Mount test",
+                "location": location,
+            },
+        )
     result = await resp.json()
     assert result["result"] == "ok"
     slug = result["data"]["slug"]
@@ -134,10 +135,11 @@ async def test_backup_to_default(
 
     coresys.core.state = CoreState.RUNNING
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
-    resp = await api_client.post(
-        "/backups/new/full",
-        json={"name": "Mount test"},
-    )
+    with patch("supervisor.mounts.mount.Path.is_mount", return_value=True):
+        resp = await api_client.post(
+            "/backups/new/full",
+            json={"name": "Mount test"},
+        )
     result = await resp.json()
     assert result["result"] == "ok"
     slug = result["data"]["slug"]

--- a/tests/mounts/test_manager.py
+++ b/tests/mounts/test_manager.py
@@ -311,7 +311,7 @@ async def test_mount_failed_during_load(
         "mnt-data-supervisor-media-media_test.mount",
         "fail",
         [
-            ["Options", Variant("s", "bind")],
+            ["Options", Variant("s", "ro,bind")],
             [
                 "Description",
                 Variant("s", "Supervisor bind mount: emergency_media_test"),
@@ -498,6 +498,7 @@ async def test_save_data(
                 "share": "backups",
                 "username": "admin",
                 "password": "password",
+                "read_only": False,
             }
         ]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

When we fail to mount a media or share type mount it is supposed to mount a read-only file in that spot. This ensures that attempts to write to that folder will fail and report rather then essentially silently fail by writing locally (and then creating other issues later). This logic did not work because it relied on user permissions and all docker containers in the Home Assistant ecosystem run as `root`. This changes the bind mount itself to use the read-only option which causes write failures even for `root`.

Since there was a feature request to create mounts of type media and share as read-only this was extended into a feature. Users can now make read-only mounts of type media and share.

As for backup type mounts, we expected that if the user tried to make a backup on a downed mount they would get a timeout. It appears that instead it writes the file locally instead. This causes impossible to fix errors next startup as we cannot mount over a non-empty folder and users can't see these folders without going into the supervisor container.

So if the user tries to make a backup in a mount we first check that the folder is in fact a mountpoint using [Path.is_mount](https://docs.python.org/3/library/pathlib.html#pathlib.Path.is_mount). In testing this only returns true if the folder is a mountpoint and if that connection is active. If this returns false we raise an error immediately and exit.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4856
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2071
- Link to cli pull request: https://github.com/home-assistant/cli/pull/451

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
