### PR TITLE
Mount status checks look at connection

### DIFF
--- a/supervisor/dbus/const.py
+++ b/supervisor/dbus/const.py
@@ -36,12 +36,14 @@ DBUS_IFACE_RAUC_INSTALLER = "de.pengutronix.rauc.Installer"
 DBUS_IFACE_RESOLVED_MANAGER = "org.freedesktop.resolve1.Manager"
 DBUS_IFACE_SETTINGS_CONNECTION = "org.freedesktop.NetworkManager.Settings.Connection"
 DBUS_IFACE_SYSTEMD_MANAGER = "org.freedesktop.systemd1.Manager"
+DBUS_IFACE_SYSTEMD_UNIT = "org.freedesktop.systemd1.Unit"
 DBUS_IFACE_TIMEDATE = "org.freedesktop.timedate1"
 DBUS_IFACE_UDISKS2_MANAGER = "org.freedesktop.UDisks2.Manager"
 
 DBUS_SIGNAL_NM_CONNECTION_ACTIVE_CHANGED = (
     "org.freedesktop.NetworkManager.Connection.Active.StateChanged"
 )
+DBUS_SIGNAL_PROPERTIES_CHANGED = "org.freedesktop.DBus.Properties.PropertiesChanged"
 DBUS_SIGNAL_RAUC_INSTALLER_COMPLETED = "de.pengutronix.rauc.Installer.Completed"
 
 DBUS_OBJECT_BASE = "/"
@@ -64,6 +66,7 @@ DBUS_OBJECT_UDISKS2 = "/org/freedesktop/UDisks2/Manager"
 DBUS_ATTR_ACTIVE_ACCESSPOINT = "ActiveAccessPoint"
 DBUS_ATTR_ACTIVE_CONNECTION = "ActiveConnection"
 DBUS_ATTR_ACTIVE_CONNECTIONS = "ActiveConnections"
+DBUS_ATTR_ACTIVE_STATE = "ActiveState"
 DBUS_ATTR_ACTIVITY_LED = "ActivityLED"
 DBUS_ATTR_ADDRESS_DATA = "AddressData"
 DBUS_ATTR_BITRATE = "Bitrate"

--- a/supervisor/dbus/systemd.py
+++ b/supervisor/dbus/systemd.py
@@ -13,6 +13,7 @@ from ..exceptions import (
     DBusServiceUnkownError,
     DBusSystemdNoSuchUnit,
 )
+from ..utils.dbus import DBusSignalWrapper
 from .const import (
     DBUS_ATTR_FINISH_TIMESTAMP,
     DBUS_ATTR_FIRMWARE_TIMESTAMP_MONOTONIC,
@@ -23,6 +24,7 @@ from .const import (
     DBUS_IFACE_SYSTEMD_MANAGER,
     DBUS_NAME_SYSTEMD,
     DBUS_OBJECT_SYSTEMD,
+    DBUS_SIGNAL_PROPERTIES_CHANGED,
     StartUnitMode,
     StopUnitMode,
     UnitActiveState,
@@ -63,6 +65,11 @@ class SystemdUnit(DBusInterface):
     async def get_active_state(self) -> UnitActiveState:
         """Get active state of the unit."""
         return await self.dbus.Unit.get_active_state()
+
+    @dbus_connected
+    def properties_changed(self) -> DBusSignalWrapper:
+        """Return signal wrapper for properties changed."""
+        return self.dbus.signal(DBUS_SIGNAL_PROPERTIES_CHANGED)
 
 
 class Systemd(DBusInterfaceProxy):

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -71,6 +71,7 @@ async def test_backup_to_location(
     tmp_supervisor_data: Path,
     path_extern,
     mount_propagation,
+    mock_is_mount,
 ):
     """Test making a backup to a specific location with default mount."""
     await coresys.mounts.load()
@@ -90,14 +91,13 @@ async def test_backup_to_location(
 
     coresys.core.state = CoreState.RUNNING
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
-    with patch("supervisor.mounts.mount.Path.is_mount", return_value=True):
-        resp = await api_client.post(
-            "/backups/new/full",
-            json={
-                "name": "Mount test",
-                "location": location,
-            },
-        )
+    resp = await api_client.post(
+        "/backups/new/full",
+        json={
+            "name": "Mount test",
+            "location": location,
+        },
+    )
     result = await resp.json()
     assert result["result"] == "ok"
     slug = result["data"]["slug"]
@@ -116,6 +116,7 @@ async def test_backup_to_default(
     tmp_supervisor_data,
     path_extern,
     mount_propagation,
+    mock_is_mount,
 ):
     """Test making backup to default mount."""
     await coresys.mounts.load()
@@ -135,11 +136,10 @@ async def test_backup_to_default(
 
     coresys.core.state = CoreState.RUNNING
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
-    with patch("supervisor.mounts.mount.Path.is_mount", return_value=True):
-        resp = await api_client.post(
-            "/backups/new/full",
-            json={"name": "Mount test"},
-        )
+    resp = await api_client.post(
+        "/backups/new/full",
+        json={"name": "Mount test"},
+    )
     result = await resp.json()
     assert result["result"] == "ok"
     slug = result["data"]["slug"]

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -431,20 +431,21 @@ async def test_backup_media_with_mounts(
     (test_file_2 := coresys.config.path_media / "test" / "inner.txt").touch()
 
     # Add a media mount
-    await coresys.mounts.load()
-    await coresys.mounts.create_mount(
-        Mount.from_dict(
-            coresys,
-            {
-                "name": "media_test",
-                "usage": "media",
-                "type": "cifs",
-                "server": "test.local",
-                "share": "test",
-            },
+    with patch("supervisor.mounts.mount.Path.is_mount", return_value=True):
+        await coresys.mounts.load()
+        await coresys.mounts.create_mount(
+            Mount.from_dict(
+                coresys,
+                {
+                    "name": "media_test",
+                    "usage": "media",
+                    "type": "cifs",
+                    "server": "test.local",
+                    "share": "test",
+                },
+            )
         )
-    )
-    assert (mount_dir := coresys.config.path_media / "media_test").is_dir()
+        assert (mount_dir := coresys.config.path_media / "media_test").is_dir()
 
     # Make a partial backup
     coresys.core.state = CoreState.RUNNING
@@ -488,19 +489,20 @@ async def test_backup_media_with_mounts_retains_files(
     ]
 
     # Add a media mount
-    await coresys.mounts.load()
-    await coresys.mounts.create_mount(
-        Mount.from_dict(
-            coresys,
-            {
-                "name": "media_test",
-                "usage": "media",
-                "type": "cifs",
-                "server": "test.local",
-                "share": "test",
-            },
+    with patch("supervisor.mounts.mount.Path.is_mount", return_value=True):
+        await coresys.mounts.load()
+        await coresys.mounts.create_mount(
+            Mount.from_dict(
+                coresys,
+                {
+                    "name": "media_test",
+                    "usage": "media",
+                    "type": "cifs",
+                    "server": "test.local",
+                    "share": "test",
+                },
+            )
         )
-    )
 
     # Make a partial backup
     coresys.core.state = CoreState.RUNNING
@@ -553,20 +555,21 @@ async def test_backup_share_with_mounts(
     (test_file_2 := coresys.config.path_share / "test" / "inner.txt").touch()
 
     # Add a media mount
-    await coresys.mounts.load()
-    await coresys.mounts.create_mount(
-        Mount.from_dict(
-            coresys,
-            {
-                "name": "share_test",
-                "usage": "share",
-                "type": "cifs",
-                "server": "test.local",
-                "share": "test",
-            },
+    with patch("supervisor.mounts.mount.Path.is_mount", return_value=True):
+        await coresys.mounts.load()
+        await coresys.mounts.create_mount(
+            Mount.from_dict(
+                coresys,
+                {
+                    "name": "share_test",
+                    "usage": "share",
+                    "type": "cifs",
+                    "server": "test.local",
+                    "share": "test",
+                },
+            )
         )
-    )
-    assert (mount_dir := coresys.config.path_share / "share_test").is_dir()
+        assert (mount_dir := coresys.config.path_share / "share_test").is_dir()
 
     # Make a partial backup
     coresys.core.state = CoreState.RUNNING
@@ -1574,23 +1577,23 @@ async def test_backup_to_mount_bypasses_free_space_condition(
     ]
 
     # Add a backup mount
-    await coresys.mounts.load()
-    await coresys.mounts.create_mount(
-        Mount.from_dict(
-            coresys,
-            {
-                "name": "backup_test",
-                "usage": "backup",
-                "type": "cifs",
-                "server": "test.local",
-                "share": "test",
-            },
-        )
-    )
-    mount = coresys.mounts.get("backup_test")
-
-    # These succeed because local free space does not matter when using a mount
     with patch("supervisor.mounts.mount.Path.is_mount", return_value=True):
+        await coresys.mounts.load()
+        await coresys.mounts.create_mount(
+            Mount.from_dict(
+                coresys,
+                {
+                    "name": "backup_test",
+                    "usage": "backup",
+                    "type": "cifs",
+                    "server": "test.local",
+                    "share": "test",
+                },
+            )
+        )
+        mount = coresys.mounts.get("backup_test")
+
+        # These succeed because local free space does not matter when using a mount
         await coresys.backups.do_backup_full(location=mount)
         await coresys.backups.do_backup_partial(folders=["media"], location=mount)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -711,3 +711,10 @@ def mock_aarch64_arch_supported(coresys: CoreSys) -> None:
     """Mock aarch64 arch as supported."""
     with patch.object(coresys.arch, "_supported_set", {"aarch64"}):
         yield
+
+
+@pytest.fixture
+def mock_is_mount() -> MagicMock:
+    """Mock is_mount in mounts."""
+    with patch("supervisor.mounts.mount.Path.is_mount", return_value=True) as is_mount:
+        yield is_mount

--- a/tests/mounts/test_manager.py
+++ b/tests/mounts/test_manager.py
@@ -3,6 +3,7 @@
 import json
 import os
 from pathlib import Path
+from unittest.mock import patch
 
 from dbus_fast import DBusError, ErrorType, Variant
 from dbus_fast.aio.message_bus import MessageBus
@@ -57,8 +58,9 @@ async def fixture_mount(
     """Add an initial mount and load mounts."""
     mount = Mount.from_dict(coresys, MEDIA_TEST_DATA)
     coresys.mounts._mounts = {"media_test": mount}  # pylint: disable=protected-access
-    await coresys.mounts.load()
-    yield mount
+    with patch("supervisor.mounts.mount.Path.is_mount", return_value=True):
+        await coresys.mounts.load()
+        yield mount
 
 
 async def test_load(
@@ -350,7 +352,8 @@ async def test_create_mount(
         ERROR_NO_UNIT,
         "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
     ]
-    await coresys.mounts.create_mount(mount)
+    with patch("supervisor.mounts.mount.Path.is_mount", return_value=True):
+        await coresys.mounts.create_mount(mount)
 
     assert mount.state == UnitActiveState.ACTIVE
     assert mount in coresys.mounts
@@ -661,7 +664,8 @@ async def test_create_share_mount(
         ERROR_NO_UNIT,
         "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
     ]
-    await coresys.mounts.create_mount(mount)
+    with patch("supervisor.mounts.mount.Path.is_mount", return_value=True):
+        await coresys.mounts.create_mount(mount)
 
     assert mount.state == UnitActiveState.ACTIVE
     assert mount in coresys.mounts

--- a/tests/resolution/fixup/test_mount_execute_reload.py
+++ b/tests/resolution/fixup/test_mount_execute_reload.py
@@ -1,8 +1,14 @@
 """Test fixup mount reload."""
 
+from unittest.mock import patch
+
+import pytest
+
 from supervisor.coresys import CoreSys
+from supervisor.exceptions import MountActivationError
 from supervisor.mounts.mount import Mount
 from supervisor.resolution.const import ContextType, IssueType, SuggestionType
+from supervisor.resolution.data import Issue
 from supervisor.resolution.fixups.mount_execute_reload import FixupMountExecuteReload
 
 from tests.dbus_service_mocks.base import DBusServiceMock
@@ -23,26 +29,27 @@ async def test_fixup(
 
     assert mount_execute_reload.auto is False
 
-    await coresys.mounts.create_mount(
-        Mount.from_dict(
-            coresys,
-            {
-                "name": "test",
-                "usage": "backup",
-                "type": "cifs",
-                "server": "test.local",
-                "share": "test",
-            },
+    with patch("supervisor.mounts.mount.Path.is_mount", return_value=True):
+        await coresys.mounts.create_mount(
+            Mount.from_dict(
+                coresys,
+                {
+                    "name": "test",
+                    "usage": "backup",
+                    "type": "cifs",
+                    "server": "test.local",
+                    "share": "test",
+                },
+            )
         )
-    )
 
-    coresys.resolution.create_issue(
-        IssueType.MOUNT_FAILED,
-        ContextType.MOUNT,
-        reference="test",
-        suggestions=[SuggestionType.EXECUTE_RELOAD, SuggestionType.EXECUTE_REMOVE],
-    )
-    await mount_execute_reload()
+        coresys.resolution.create_issue(
+            IssueType.MOUNT_FAILED,
+            ContextType.MOUNT,
+            reference="test",
+            suggestions=[SuggestionType.EXECUTE_RELOAD, SuggestionType.EXECUTE_REMOVE],
+        )
+        await mount_execute_reload()
 
     assert coresys.resolution.issues == []
     assert coresys.resolution.suggestions == []
@@ -50,3 +57,43 @@ async def test_fixup(
     assert systemd_service.ReloadOrRestartUnit.calls == [
         ("mnt-data-supervisor-mounts-test.mount", "fail")
     ]
+
+
+async def test_fixup_error_after_reload(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock],
+    path_extern,
+    mount_propagation,
+):
+    """Test fixup."""
+    mount_execute_reload = FixupMountExecuteReload(coresys)
+    with patch("supervisor.mounts.mount.Path.is_mount", return_value=True):
+        await coresys.mounts.create_mount(
+            Mount.from_dict(
+                coresys,
+                {
+                    "name": "test",
+                    "usage": "backup",
+                    "type": "cifs",
+                    "server": "test.local",
+                    "share": "test",
+                },
+            )
+        )
+
+    coresys.resolution.create_issue(
+        IssueType.MOUNT_FAILED,
+        ContextType.MOUNT,
+        reference="test",
+        suggestions=[SuggestionType.EXECUTE_RELOAD, SuggestionType.EXECUTE_REMOVE],
+    )
+    with patch(
+        "supervisor.mounts.mount.Path.is_mount", return_value=False
+    ), pytest.raises(MountActivationError):
+        await mount_execute_reload()
+
+    # Since is_mount is false, issue remains
+    assert (
+        Issue(IssueType.MOUNT_FAILED, ContextType.MOUNT, reference="test")
+        in coresys.resolution.issues
+    )

--- a/tests/resolution/fixup/test_mount_execute_remove.py
+++ b/tests/resolution/fixup/test_mount_execute_remove.py
@@ -15,6 +15,7 @@ async def test_fixup(
     all_dbus_services: dict[str, DBusServiceMock],
     path_extern,
     mount_propagation,
+    mock_is_mount,
 ):
     """Test fixup."""
     systemd_service: SystemdService = all_dbus_services["systemd"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

All mount status checks only looked at the state reported by the systemd unit. If that was `active` they assumed the connection was live. This state does not actually reflect this though, it just tells us whether the mount process is live. To check if the the connection is actually working, you need to use something like `mountpoint` or `pathlib.Path.is_mount`.

This check now happens in all major mount processes (mount, load, reload, and update). If it does not succeed then an error is reported to the user. And if the user was attempting to fix the "mount not working" repair, it should only dismiss if the connection is intact.

Additionally improved the state checking process to use signals instead of polling dbus.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
