### PR TITLE
Avoid Watchdog starting Core before Supervisor is in startup

### DIFF
--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -86,7 +86,9 @@ class HomeAssistantCore(JobGroup):
                     await self.instance.get_latest_version()
                 )
 
-            await self.instance.attach(version=self.sys_homeassistant.version)
+            await self.instance.attach(
+                version=self.sys_homeassistant.version, skip_state_event_if_down=True
+            )
         except DockerError:
             _LOGGER.info(
                 "No Home Assistant Docker image %s found.", self.sys_homeassistant.image
@@ -115,7 +117,9 @@ class HomeAssistantCore(JobGroup):
         """Install a landing page."""
         # Try to use a preinstalled landingpage
         try:
-            await self.instance.attach(version=LANDINGPAGE)
+            await self.instance.attach(
+                version=LANDINGPAGE, skip_state_event_if_down=True
+            )
         except DockerError:
             pass
         else:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

If core had failed immediately prior to an OS shutdown or while supervisor is restarting then its watchdog will cause it to start immediately during the `SETUP` phase of supervisor. Instead of waiting until Supervisor normally starts it in the `STARTUP` phase.

We need to skip processing this initial on attach event like we do for plugins and let supervisor always start Home Assistant as normal during `STARTUP`

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
