### PR TITLE
Allow adoption of existing data disk

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -198,6 +198,12 @@ class Addon(AddonModel):
         with suppress(DockerError):
             await self.instance.attach(version=self.version)
 
+        with suppress(DockerError):
+            await self.instance.check_image(
+                self.version, self._image(self.data), self.arch
+            )
+            self.persist[ATTR_IMAGE] = self.instance.image
+
     @property
     def ip_address(self) -> IPv4Address:
         """Return IP of add-on instance."""

--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -199,10 +199,9 @@ class Addon(AddonModel):
             await self.instance.attach(version=self.version)
 
         with suppress(DockerError):
-            await self.instance.check_image(
-                self.version, self._image(self.data), self.arch
-            )
-            self.persist[ATTR_IMAGE] = self.instance.image
+            image = self._image(self.data)
+            await self.instance.check_image(self.version, image, self.arch)
+            self.persist[ATTR_IMAGE] = image
 
     @property
     def ip_address(self) -> IPv4Address:

--- a/supervisor/addons/build.py
+++ b/supervisor/addons/build.py
@@ -102,11 +102,11 @@ class AddonBuild(FileConfiguration, CoreSysAttributes):
         except HassioArchNotFound:
             return False
 
-    def get_docker_args(self, version: AwesomeVersion):
+    def get_docker_args(self, version: AwesomeVersion, image: str | None = None):
         """Create a dict with Docker build arguments."""
         args = {
             "path": str(self.addon.path_location),
-            "tag": f"{self.addon.image}:{version!s}",
+            "tag": f"{image or self.addon.image}:{version!s}",
             "dockerfile": str(self.dockerfile),
             "pull": True,
             "forcerm": not self.sys_dev,

--- a/supervisor/api/homeassistant.py
+++ b/supervisor/api/homeassistant.py
@@ -93,6 +93,9 @@ class APIHomeAssistant(CoreSysAttributes):
 
         if ATTR_IMAGE in body:
             self.sys_homeassistant.image = body[ATTR_IMAGE]
+            self.sys_homeassistant.override_image = (
+                self.sys_homeassistant.image != self.sys_homeassistant.default_image
+            )
 
         if ATTR_BOOT in body:
             self.sys_homeassistant.boot = body[ATTR_BOOT]

--- a/supervisor/docker/addon.py
+++ b/supervisor/docker/addon.py
@@ -641,11 +641,11 @@ class DockerAddon(DockerInterface):
     ) -> None:
         """Pull Docker image or build it."""
         if need_build is None and self.addon.need_build or need_build:
-            await self._build(version)
+            await self._build(version, image)
         else:
             await super().install(version, image, latest, arch)
 
-    async def _build(self, version: AwesomeVersion) -> None:
+    async def _build(self, version: AwesomeVersion, image: str | None = None) -> None:
         """Build a Docker container."""
         build_env = AddonBuild(self.coresys, self.addon)
         if not build_env.is_valid:
@@ -657,7 +657,7 @@ class DockerAddon(DockerInterface):
             image, log = await self.sys_run_in_executor(
                 self.sys_docker.images.build,
                 use_config_proxy=False,
-                **build_env.get_docker_args(version),
+                **build_env.get_docker_args(version, image),
             )
 
             _LOGGER.debug("Build %s:%s done: %s", self.image, version, log)

--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -455,25 +455,22 @@ class DockerInterface(JobGroup):
         image_name = f"{expected_image}:{version!s}"
         if self.image == expected_image:
             try:
-                image: Image | None = await self.sys_run_in_executor(
+                image: Image = await self.sys_run_in_executor(
                     self.sys_docker.images.get, image_name
                 )
-            except docker.errors.ImageNotFound:
-                image = None
             except (docker.errors.DockerException, requests.RequestException) as err:
                 raise DockerError(
                     f"Could not get {image_name} for check due to: {err!s}",
                     _LOGGER.error,
                 ) from err
 
-            if image:
-                image_arch = f"{image.attrs['Os']}/{image.attrs['Architecture']}"
-                if "Variant" in image.attrs:
-                    image_arch = f"{image_arch}/{image.attrs['Variant']}"
+            image_arch = f"{image.attrs['Os']}/{image.attrs['Architecture']}"
+            if "Variant" in image.attrs:
+                image_arch = f"{image_arch}/{image.attrs['Variant']}"
 
-                # If we have an image and its the right arch, all set
-                if MAP_ARCH[expected_arch] == image_arch:
-                    return
+            # If we have an image and its the right arch, all set
+            if MAP_ARCH[expected_arch] == image_arch:
+                return
 
         # We're missing the image we need. Stop and clean up what we have then pull the right one
         with suppress(DockerError):

--- a/supervisor/homeassistant/const.py
+++ b/supervisor/homeassistant/const.py
@@ -6,6 +6,7 @@ from awesomeversion import AwesomeVersion
 
 from ..const import CoreState
 
+ATTR_OVERRIDE_IMAGE = "override_image"
 LANDINGPAGE: AwesomeVersion = AwesomeVersion("landingpage")
 WATCHDOG_RETRY_SECONDS = 10
 WATCHDOG_MAX_ATTEMPTS = 5

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -89,6 +89,11 @@ class HomeAssistantCore(JobGroup):
             await self.instance.attach(
                 version=self.sys_homeassistant.version, skip_state_event_if_down=True
             )
+
+            # Check that that the image found is correct for this system
+            await self.instance.check_image(
+                self.sys_homeassistant.version, self.sys_homeassistant.default_image
+            )
         except DockerError:
             _LOGGER.info(
                 "No Home Assistant Docker image %s found.", self.sys_homeassistant.image

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -90,10 +90,12 @@ class HomeAssistantCore(JobGroup):
                 version=self.sys_homeassistant.version, skip_state_event_if_down=True
             )
 
-            # Check that that the image found is correct for this system
-            await self.instance.check_image(
-                self.sys_homeassistant.version, self.sys_homeassistant.default_image
-            )
+            # Ensure we are using correct image for this system (unless user has overridden it)
+            if not self.sys_homeassistant.override_image:
+                await self.instance.check_image(
+                    self.sys_homeassistant.version, self.sys_homeassistant.default_image
+                )
+                self.sys_homeassistant.image = self.sys_homeassistant.default_image
         except DockerError:
             _LOGGER.info(
                 "No Home Assistant Docker image %s found.", self.sys_homeassistant.image

--- a/supervisor/homeassistant/module.py
+++ b/supervisor/homeassistant/module.py
@@ -171,11 +171,16 @@ class HomeAssistant(FileConfiguration, CoreSysAttributes):
         return self.sys_updater.version_homeassistant
 
     @property
+    def default_image(self) -> str:
+        """Return the default image for this system."""
+        return f"ghcr.io/home-assistant/{self.sys_machine}-homeassistant"
+
+    @property
     def image(self) -> str:
         """Return image name of the Home Assistant container."""
         if self._data.get(ATTR_IMAGE):
             return self._data[ATTR_IMAGE]
-        return f"ghcr.io/home-assistant/{self.sys_machine}-homeassistant"
+        return self.default_image
 
     @image.setter
     def image(self, value: str | None) -> None:

--- a/supervisor/homeassistant/module.py
+++ b/supervisor/homeassistant/module.py
@@ -48,7 +48,7 @@ from ..utils import remove_folder
 from ..utils.common import FileConfiguration
 from ..utils.json import read_json_file, write_json_file
 from .api import HomeAssistantAPI
-from .const import WSType
+from .const import ATTR_OVERRIDE_IMAGE, WSType
 from .core import HomeAssistantCore
 from .secrets import HomeAssistantSecrets
 from .validate import SCHEMA_HASS_CONFIG
@@ -186,6 +186,16 @@ class HomeAssistant(FileConfiguration, CoreSysAttributes):
     def image(self, value: str | None) -> None:
         """Set image name of Home Assistant container."""
         self._data[ATTR_IMAGE] = value
+
+    @property
+    def override_image(self) -> bool:
+        """Return if user has overridden the image to use for Home Assistant."""
+        return self._data[ATTR_OVERRIDE_IMAGE]
+
+    @override_image.setter
+    def override_image(self, value: bool) -> None:
+        """Enable/disable image override."""
+        self._data[ATTR_OVERRIDE_IMAGE] = value
 
     @property
     def version(self) -> AwesomeVersion | None:

--- a/supervisor/homeassistant/validate.py
+++ b/supervisor/homeassistant/validate.py
@@ -18,6 +18,7 @@ from ..const import (
     ATTR_WATCHDOG,
 )
 from ..validate import docker_image, network_port, token, uuid_match, version_tag
+from .const import ATTR_OVERRIDE_IMAGE
 
 # pylint: disable=no-value-for-parameter
 SCHEMA_HASS_CONFIG = vol.Schema(
@@ -34,6 +35,7 @@ SCHEMA_HASS_CONFIG = vol.Schema(
         vol.Optional(ATTR_AUDIO_OUTPUT, default=None): vol.Maybe(str),
         vol.Optional(ATTR_AUDIO_INPUT, default=None): vol.Maybe(str),
         vol.Optional(ATTR_BACKUPS_EXCLUDE_DATABASE, default=False): vol.Boolean(),
+        vol.Optional(ATTR_OVERRIDE_IMAGE, default=False): vol.Boolean(),
     },
     extra=vol.REMOVE_EXTRA,
 )

--- a/supervisor/os/data_disk.py
+++ b/supervisor/os/data_disk.py
@@ -123,9 +123,9 @@ class DataDisk(CoreSysAttributes):
             vendor="",
             model="",
             serial="",
-            id=self.sys_dbus.agent.datadisk.current_device,
+            id=self.sys_dbus.agent.datadisk.current_device.as_posix(),
             size=0,
-            device_path=self.sys_dbus.agent.datadisk.current_device,
+            device_path=self.sys_dbus.agent.datadisk.current_device.as_posix(),
             object_path="",
             device_object_path="",
         )

--- a/supervisor/plugins/base.py
+++ b/supervisor/plugins/base.py
@@ -177,7 +177,7 @@ class PluginBase(ABC, FileConfiguration, CoreSysAttributes):
                 await self.install()
         else:
             self.version = self.instance.version
-            self.image = self.instance.image
+            self.image = self.default_image
             self.save_data()
 
         # Run plugin
@@ -206,7 +206,7 @@ class PluginBase(ABC, FileConfiguration, CoreSysAttributes):
 
         _LOGGER.info("%s plugin now installed", self.slug)
         self.version = self.instance.version
-        self.image = self.instance.image
+        self.image = self.default_image
         self.save_data()
 
     async def update(self, version: str | None = None) -> None:
@@ -222,7 +222,7 @@ class PluginBase(ABC, FileConfiguration, CoreSysAttributes):
 
         await self.instance.update(version, image=self.default_image)
         self.version = self.instance.version
-        self.image = self.instance.image
+        self.image = self.default_image
         self.save_data()
 
         # Cleanup

--- a/supervisor/resolution/checks/multiple_data_disks.py
+++ b/supervisor/resolution/checks/multiple_data_disks.py
@@ -27,7 +27,10 @@ class CheckMultipleDataDisks(CheckBase):
                     IssueType.MULTIPLE_DATA_DISKS,
                     ContextType.SYSTEM,
                     reference=block_device.device.as_posix(),
-                    suggestions=[SuggestionType.RENAME_DATA_DISK],
+                    suggestions=[
+                        SuggestionType.RENAME_DATA_DISK,
+                        SuggestionType.ADOPT_DATA_DISK,
+                    ],
                 )
 
     async def approve_check(self, reference: str | None = None) -> bool:

--- a/supervisor/resolution/checks/multiple_data_disks.py
+++ b/supervisor/resolution/checks/multiple_data_disks.py
@@ -61,4 +61,4 @@ class CheckMultipleDataDisks(CheckBase):
     @property
     def states(self) -> list[CoreState]:
         """Return a list of valid states when this check can run."""
-        return [CoreState.RUNNING, CoreState.STARTUP]
+        return [CoreState.RUNNING, CoreState.SETUP]

--- a/supervisor/resolution/const.py
+++ b/supervisor/resolution/const.py
@@ -96,6 +96,7 @@ class IssueType(StrEnum):
 class SuggestionType(StrEnum):
     """Sugestion type."""
 
+    ADOPT_DATA_DISK = "adopt_data_disk"
     CLEAR_FULL_BACKUP = "clear_full_backup"
     CREATE_FULL_BACKUP = "create_full_backup"
     EXECUTE_INTEGRITY = "execute_integrity"

--- a/supervisor/resolution/fixups/system_adopt_data_disk.py
+++ b/supervisor/resolution/fixups/system_adopt_data_disk.py
@@ -37,7 +37,7 @@ class FixupSystemAdoptDataDisk(FixupBase):
             not current
             or not (
                 resolved := await self.sys_dbus.udisks2.resolve_device(
-                    DeviceSpecification(path=current.as_posix())
+                    DeviceSpecification(path=current)
                 )
             )
             or not resolved[0].filesystem

--- a/supervisor/resolution/fixups/system_adopt_data_disk.py
+++ b/supervisor/resolution/fixups/system_adopt_data_disk.py
@@ -1,0 +1,90 @@
+"""Adopt data disk fixup."""
+
+import logging
+from pathlib import Path
+
+from ...coresys import CoreSys
+from ...dbus.udisks2.data import DeviceSpecification
+from ...exceptions import DBusError, HostError, ResolutionFixupError
+from ...os.const import FILESYSTEM_LABEL_OLD_DATA_DISK
+from ..const import ContextType, IssueType, SuggestionType
+from .base import FixupBase
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+def setup(coresys: CoreSys) -> FixupBase:
+    """Check setup function."""
+    return FixupSystemAdoptDataDisk(coresys)
+
+
+class FixupSystemAdoptDataDisk(FixupBase):
+    """Storage class for fixup."""
+
+    async def process_fixup(self, reference: str | None = None) -> None:
+        """Initialize the fixup class."""
+        if not await self.sys_dbus.udisks2.resolve_device(
+            DeviceSpecification(path=Path(reference))
+        ):
+            _LOGGER.info(
+                "Data disk at %s with name conflict was removed, skipping adopt",
+                reference,
+            )
+            return
+
+        current = self.sys_dbus.agent.datadisk.current_device
+        if (
+            not current
+            or not (
+                resolved := await self.sys_dbus.udisks2.resolve_device(
+                    DeviceSpecification(path=current.as_posix())
+                )
+            )
+            or not resolved[0].filesystem
+        ):
+            raise ResolutionFixupError(
+                "Cannot resolve current data disk for rename", _LOGGER.error
+            )
+
+        _LOGGER.info(
+            "Renaming current data disk at %s to %s so new data disk at %s becomes primary ",
+            self.sys_dbus.agent.datadisk.current_device,
+            FILESYSTEM_LABEL_OLD_DATA_DISK,
+            reference,
+        )
+        try:
+            await resolved[0].filesystem.set_label(FILESYSTEM_LABEL_OLD_DATA_DISK)
+        except DBusError as err:
+            raise ResolutionFixupError(
+                f"Could not rename filesystem at {current.as_posix()}: {err!s}",
+                _LOGGER.error,
+            ) from err
+
+        _LOGGER.info("Rebooting the host to finish adoption")
+        try:
+            await self.sys_host.control.reboot()
+        except (HostError, DBusError) as err:
+            _LOGGER.warning(
+                "Could not reboot host to finish data disk adoption, manual reboot required to finish process: %s",
+                err,
+            )
+            self.sys_resolution.create_issue(
+                IssueType.REBOOT_REQUIRED,
+                ContextType.SYSTEM,
+                suggestions=[SuggestionType.EXECUTE_REBOOT],
+            )
+
+    @property
+    def suggestion(self) -> SuggestionType:
+        """Return a SuggestionType enum."""
+        return SuggestionType.ADOPT_DATA_DISK
+
+    @property
+    def context(self) -> ContextType:
+        """Return a ContextType enum."""
+        return ContextType.SYSTEM
+
+    @property
+    def issues(self) -> list[IssueType]:
+        """Return a IssueType enum list."""
+        return [IssueType.MULTIPLE_DATA_DISKS]

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from awesomeversion import AwesomeVersion
-from docker.errors import DockerException, NotFound
+from docker.errors import DockerException, ImageNotFound, NotFound
 import pytest
 from securetar import SecureTarFile
 
@@ -763,3 +763,57 @@ async def test_paths_cache(coresys: CoreSys, install_addon_ssh: Addon):
         assert install_addon_ssh.with_icon
         assert install_addon_ssh.with_changelog
         assert install_addon_ssh.with_documentation
+
+
+async def test_addon_loads_wrong_image(
+    coresys: CoreSys,
+    install_addon_ssh: Addon,
+    container: MagicMock,
+    mock_amd64_arch_supported,
+):
+    """Test addon is loaded with incorrect image for architecture."""
+    install_addon_ssh.persist["image"] = "local/aarch64-addon-ssh"
+    assert install_addon_ssh.image == "local/aarch64-addon-ssh"
+
+    with patch("pathlib.Path.is_file", return_value=True):
+        await install_addon_ssh.load()
+
+    container.remove.assert_called_once_with(force=True)
+    assert coresys.docker.images.remove.call_args_list[0].kwargs == {
+        "image": "local/aarch64-addon-ssh:latest",
+        "force": True,
+    }
+    assert coresys.docker.images.remove.call_args_list[1].kwargs == {
+        "image": "local/aarch64-addon-ssh:9.2.1",
+        "force": True,
+    }
+    coresys.docker.images.build.assert_called_once()
+    assert (
+        coresys.docker.images.build.call_args.kwargs["tag"]
+        == "local/amd64-addon-ssh:9.2.1"
+    )
+    assert coresys.docker.images.build.call_args.kwargs["platform"] == "linux/amd64"
+    assert install_addon_ssh.image == "local/amd64-addon-ssh"
+
+
+async def test_addon_loads_missing_image(
+    coresys: CoreSys,
+    install_addon_ssh: Addon,
+    container: MagicMock,
+    mock_amd64_arch_supported,
+):
+    """Test addon corrects a missing image on load."""
+    coresys.docker.images.get.side_effect = ImageNotFound("missing")
+
+    with patch("pathlib.Path.is_file", return_value=True):
+        await install_addon_ssh.load()
+
+    container.remove.assert_called_once()
+    assert coresys.docker.images.remove.call_count == 2
+    coresys.docker.images.build.assert_called_once()
+    assert (
+        coresys.docker.images.build.call_args.kwargs["tag"]
+        == "local/amd64-addon-ssh:9.2.1"
+    )
+    assert coresys.docker.images.build.call_args.kwargs["platform"] == "linux/amd64"
+    assert install_addon_ssh.image == "local/amd64-addon-ssh"

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -772,6 +772,7 @@ async def test_addon_loads_wrong_image(
     mock_amd64_arch_supported,
 ):
     """Test addon is loaded with incorrect image for architecture."""
+    coresys.addons.data.save_data.reset_mock()
     install_addon_ssh.persist["image"] = "local/aarch64-addon-ssh"
     assert install_addon_ssh.image == "local/aarch64-addon-ssh"
 
@@ -794,6 +795,7 @@ async def test_addon_loads_wrong_image(
     )
     assert coresys.docker.images.build.call_args.kwargs["platform"] == "linux/amd64"
     assert install_addon_ssh.image == "local/amd64-addon-ssh"
+    coresys.addons.data.save_data.assert_called_once()
 
 
 async def test_addon_loads_missing_image(
@@ -808,8 +810,6 @@ async def test_addon_loads_missing_image(
     with patch("pathlib.Path.is_file", return_value=True):
         await install_addon_ssh.load()
 
-    container.remove.assert_called_once()
-    assert coresys.docker.images.remove.call_count == 2
     coresys.docker.images.build.assert_called_once()
     assert (
         coresys.docker.images.build.call_args.kwargs["tag"]

--- a/tests/addons/test_manager.py
+++ b/tests/addons/test_manager.py
@@ -86,7 +86,7 @@ async def test_image_added_removed_on_update(
         DockerAddon, "_build"
     ) as build:
         await coresys.addons.update(TEST_ADDON_SLUG)
-        build.assert_called_once_with(AwesomeVersion("11.0.0"))
+        build.assert_called_once_with(AwesomeVersion("11.0.0"), "local/amd64-addon-ssh")
         install.assert_not_called()
 
 

--- a/tests/api/test_homeassistant.py
+++ b/tests/api/test_homeassistant.py
@@ -62,3 +62,33 @@ async def test_api_set_options(api_client: TestClient, coresys: CoreSys):
     result = await resp.json()
     assert result["data"]["watchdog"] is False
     assert result["data"]["backups_exclude_database"] is True
+
+
+async def test_api_set_image(api_client: TestClient, coresys: CoreSys):
+    """Test changing the image for homeassistant."""
+    assert (
+        coresys.homeassistant.image == "ghcr.io/home-assistant/qemux86-64-homeassistant"
+    )
+    assert coresys.homeassistant.override_image is False
+
+    with patch.object(HomeAssistant, "save_data"):
+        resp = await api_client.post(
+            "/homeassistant/options",
+            json={"image": "test_image"},
+        )
+
+    assert resp.status == 200
+    assert coresys.homeassistant.image == "test_image"
+    assert coresys.homeassistant.override_image is True
+
+    with patch.object(HomeAssistant, "save_data"):
+        resp = await api_client.post(
+            "/homeassistant/options",
+            json={"image": "ghcr.io/home-assistant/qemux86-64-homeassistant"},
+        )
+
+    assert resp.status == 200
+    assert (
+        coresys.homeassistant.image == "ghcr.io/home-assistant/qemux86-64-homeassistant"
+    )
+    assert coresys.homeassistant.override_image is False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -723,15 +723,15 @@ async def container(docker: DockerAPI) -> MagicMock:
 @pytest.fixture
 def mock_amd64_arch_supported(coresys: CoreSys) -> None:
     """Mock amd64 arch as supported."""
-    with patch.object(coresys.arch, "_supported_set", {"amd64"}):
-        yield
+    coresys.arch._supported_arch = ["amd64"]
+    coresys.arch._supported_set = {"amd64"}
 
 
 @pytest.fixture
 def mock_aarch64_arch_supported(coresys: CoreSys) -> None:
     """Mock aarch64 arch as supported."""
-    with patch.object(coresys.arch, "_supported_set", {"aarch64"}):
-        yield
+    coresys.arch._supported_arch = ["amd64"]
+    coresys.arch._supported_set = {"amd64"}
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,8 @@ async def supervisor_name() -> None:
 async def docker() -> DockerAPI:
     """Mock DockerAPI."""
     images = [MagicMock(tags=["ghcr.io/home-assistant/amd64-hassio-supervisor:latest"])]
+    image = MagicMock()
+    image.attrs = {"Os": "linux", "Architecture": "amd64"}
 
     with patch(
         "supervisor.docker.manager.DockerClient", return_value=MagicMock()
@@ -86,6 +88,8 @@ async def docker() -> DockerAPI:
         "supervisor.docker.manager.DockerAPI.containers", return_value=MagicMock()
     ), patch(
         "supervisor.docker.manager.DockerAPI.api", return_value=MagicMock()
+    ), patch(
+        "supervisor.docker.manager.DockerAPI.images.get", return_value=image
     ), patch(
         "supervisor.docker.manager.DockerAPI.images.list", return_value=images
     ), patch(
@@ -317,6 +321,9 @@ async def coresys(
     coresys_obj._mounts.save_data = MagicMock()
 
     # Mock test client
+    coresys_obj._supervisor.instance._meta = {
+        "Config": {"Labels": {"io.hass.arch": "amd64"}}
+    }
     coresys_obj.arch._default_arch = "amd64"
     coresys_obj.arch._supported_set = {"amd64"}
     coresys_obj._machine = "qemux86-64"

--- a/tests/homeassistant/test_module.py
+++ b/tests/homeassistant/test_module.py
@@ -22,6 +22,8 @@ async def test_load(
 
     # Unwrap read_secrets to prevent throttling between tests
     with patch.object(DockerInterface, "attach") as attach, patch.object(
+        DockerInterface, "check_image"
+    ) as check_image, patch.object(
         HomeAssistantSecrets,
         "_read_secrets",
         new=HomeAssistantSecrets._read_secrets.__wrapped__,
@@ -29,6 +31,7 @@ async def test_load(
         await coresys.homeassistant.load()
 
         attach.assert_called_once()
+        check_image.assert_called_once()
 
     assert coresys.homeassistant.secrets.secrets == {"hello": "world"}
 

--- a/tests/resolution/check/test_check_multiple_data_disks.py
+++ b/tests/resolution/check/test_check_multiple_data_disks.py
@@ -53,7 +53,10 @@ async def test_check(coresys: CoreSys, sda1_block_service: BlockService):
     assert coresys.resolution.suggestions == [
         Suggestion(
             SuggestionType.RENAME_DATA_DISK, ContextType.SYSTEM, reference="/dev/sda1"
-        )
+        ),
+        Suggestion(
+            SuggestionType.ADOPT_DATA_DISK, ContextType.SYSTEM, reference="/dev/sda1"
+        ),
     ]
 
 

--- a/tests/resolution/fixup/test_system_adopt_data_disk.py
+++ b/tests/resolution/fixup/test_system_adopt_data_disk.py
@@ -1,0 +1,158 @@
+"""Test system fixup adopt data disk."""
+
+from dbus_fast import DBusError, ErrorType, Variant
+import pytest
+
+from supervisor.coresys import CoreSys
+from supervisor.resolution.const import ContextType, IssueType, SuggestionType
+from supervisor.resolution.data import Issue, Suggestion
+from supervisor.resolution.fixups.system_adopt_data_disk import FixupSystemAdoptDataDisk
+
+from tests.dbus_service_mocks.base import DBusServiceMock
+from tests.dbus_service_mocks.logind import Logind as LogindService
+from tests.dbus_service_mocks.udisks2_filesystem import Filesystem as FilesystemService
+from tests.dbus_service_mocks.udisks2_manager import (
+    UDisks2Manager as UDisks2ManagerService,
+)
+
+
+@pytest.fixture(name="sda1_filesystem_service")
+async def fixture_sda1_filesystem_service(
+    udisks2_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+) -> FilesystemService:
+    """Return sda1 filesystem service."""
+    return udisks2_services["udisks2_filesystem"][
+        "/org/freedesktop/UDisks2/block_devices/sda1"
+    ]
+
+
+@pytest.fixture(name="mmcblk1p3_filesystem_service")
+async def fixture_mmcblk1p3_filesystem_service(
+    udisks2_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+) -> FilesystemService:
+    """Return mmcblk1p3 filesystem service."""
+    return udisks2_services["udisks2_filesystem"][
+        "/org/freedesktop/UDisks2/block_devices/mmcblk1p3"
+    ]
+
+
+@pytest.fixture(name="udisks2_service")
+async def fixture_udisks2_service(
+    udisks2_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+) -> UDisks2ManagerService:
+    """Return udisks2 manager service."""
+    return udisks2_services["udisks2_manager"]
+
+
+@pytest.fixture(name="logind_service")
+async def fixture_logind_service(
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+) -> LogindService:
+    """Return logind service."""
+    return all_dbus_services["logind"]
+
+
+async def test_fixup(
+    coresys: CoreSys,
+    mmcblk1p3_filesystem_service: FilesystemService,
+    udisks2_service: UDisks2ManagerService,
+    logind_service: LogindService,
+):
+    """Test fixup."""
+    mmcblk1p3_filesystem_service.SetLabel.calls.clear()
+    logind_service.Reboot.calls.clear()
+    system_adopt_data_disk = FixupSystemAdoptDataDisk(coresys)
+
+    assert not system_adopt_data_disk.auto
+
+    coresys.resolution.suggestions = Suggestion(
+        SuggestionType.ADOPT_DATA_DISK, ContextType.SYSTEM, reference="/dev/sda1"
+    )
+    coresys.resolution.issues = Issue(
+        IssueType.MULTIPLE_DATA_DISKS, ContextType.SYSTEM, reference="/dev/sda1"
+    )
+    udisks2_service.resolved_devices = [
+        "/org/freedesktop/UDisks2/block_devices/mmcblk1p3"
+    ]
+
+    await system_adopt_data_disk()
+
+    assert mmcblk1p3_filesystem_service.SetLabel.calls == [
+        ("hassos-data-old", {"auth.no_user_interaction": Variant("b", True)})
+    ]
+    assert len(coresys.resolution.suggestions) == 0
+    assert len(coresys.resolution.issues) == 0
+    assert logind_service.Reboot.calls == [(False,)]
+
+
+async def test_fixup_device_removed(
+    coresys: CoreSys,
+    mmcblk1p3_filesystem_service: FilesystemService,
+    udisks2_service: UDisks2ManagerService,
+    logind_service: LogindService,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test fixup when device removed."""
+    mmcblk1p3_filesystem_service.SetLabel.calls.clear()
+    logind_service.Reboot.calls.clear()
+    system_adopt_data_disk = FixupSystemAdoptDataDisk(coresys)
+
+    assert not system_adopt_data_disk.auto
+
+    coresys.resolution.suggestions = Suggestion(
+        SuggestionType.ADOPT_DATA_DISK, ContextType.SYSTEM, reference="/dev/sda1"
+    )
+    coresys.resolution.issues = Issue(
+        IssueType.MULTIPLE_DATA_DISKS, ContextType.SYSTEM, reference="/dev/sda1"
+    )
+
+    udisks2_service.resolved_devices = []
+    await system_adopt_data_disk()
+
+    assert len(coresys.resolution.suggestions) == 0
+    assert len(coresys.resolution.issues) == 0
+    assert "Data disk at /dev/sda1 with name conflict was removed" in caplog.text
+    assert mmcblk1p3_filesystem_service.SetLabel.calls == []
+    assert logind_service.Reboot.calls == []
+
+
+async def test_fixup_reboot_failed(
+    coresys: CoreSys,
+    mmcblk1p3_filesystem_service: FilesystemService,
+    udisks2_service: UDisks2ManagerService,
+    logind_service: LogindService,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test fixup when reboot fails."""
+    mmcblk1p3_filesystem_service.SetLabel.calls.clear()
+    logind_service.side_effect_reboot = DBusError(ErrorType.SERVICE_ERROR, "error")
+    system_adopt_data_disk = FixupSystemAdoptDataDisk(coresys)
+
+    assert not system_adopt_data_disk.auto
+
+    coresys.resolution.suggestions = Suggestion(
+        SuggestionType.ADOPT_DATA_DISK, ContextType.SYSTEM, reference="/dev/sda1"
+    )
+    coresys.resolution.issues = Issue(
+        IssueType.MULTIPLE_DATA_DISKS, ContextType.SYSTEM, reference="/dev/sda1"
+    )
+    udisks2_service.resolved_devices = [
+        "/org/freedesktop/UDisks2/block_devices/mmcblk1p3"
+    ]
+
+    await system_adopt_data_disk()
+
+    assert mmcblk1p3_filesystem_service.SetLabel.calls == [
+        ("hassos-data-old", {"auth.no_user_interaction": Variant("b", True)})
+    ]
+    assert len(coresys.resolution.suggestions) == 1
+    assert (
+        Suggestion(SuggestionType.EXECUTE_REBOOT, ContextType.SYSTEM)
+        in coresys.resolution.suggestions
+    )
+    assert len(coresys.resolution.issues) == 1
+    assert (
+        Issue(IssueType.REBOOT_REQUIRED, ContextType.SYSTEM)
+        in coresys.resolution.issues
+    )
+    assert "Could not reboot host to finish data disk adoption" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

When a user plugs in an existing data disk from another system we encourage them to rename it otherwise it causes a race condition at startup. However users often expect another option - to use it as their data disk. For example if they just purchased a new system they might expect to move the external data disk from one to the other and have it keep working.

This adds that option. It largely works as is. However at startup we now check all the images to see if we have the right ones for the current machine/architecture. Because if you move a data disk from one system to another we may need to get all new images depending on what changed.

PR in core to add translation strings and support for this new repair: https://github.com/home-assistant/core/pull/114891

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
