### PR TITLE
Fix submounts of /dev being read-only with Docker 25+

### DIFF
--- a/supervisor/docker/const.py
+++ b/supervisor/docker/const.py
@@ -74,6 +74,7 @@ MOUNT_DBUS = Mount(
     type=MountType.BIND, source="/run/dbus", target="/run/dbus", read_only=True
 )
 MOUNT_DEV = Mount(type=MountType.BIND, source="/dev", target="/dev", read_only=True)
+MOUNT_DEV.setdefault("BindOptions", {})["ReadOnlyNonRecursive"] = True
 MOUNT_DOCKER = Mount(
     type=MountType.BIND,
     source="/run/docker.sock",

--- a/tests/docker/__init__.py
+++ b/tests/docker/__init__.py
@@ -1,1 +1,6 @@
 """Docker tests."""
+from docker.types import Mount
+
+# dev mount with equivalent of bind-recursive=writable specified via dict value
+DEV_MOUNT = Mount(type="bind", source="/dev", target="/dev", read_only=True)
+DEV_MOUNT["BindOptions"] = {"ReadOnlyNonRecursive": True}

--- a/tests/docker/test_addon.py
+++ b/tests/docker/test_addon.py
@@ -19,6 +19,7 @@ from supervisor.resolution.const import ContextType, IssueType
 from supervisor.resolution.data import Issue
 
 from ..common import load_json_fixture
+from . import DEV_MOUNT
 
 
 @pytest.fixture(name="addonsdata_system")
@@ -66,11 +67,8 @@ def test_base_volumes_included(
         coresys, addonsdata_system, "basic-addon-config.json"
     )
 
-    # Dev added as ro
-    assert (
-        Mount(type="bind", source="/dev", target="/dev", read_only=True)
-        in docker_addon.mounts
-    )
+    # Dev added as ro with bind-recursive=writable option
+    assert DEV_MOUNT in docker_addon.mounts
 
     # Data added as rw
     assert (

--- a/tests/docker/test_audio.py
+++ b/tests/docker/test_audio.py
@@ -9,6 +9,8 @@ from docker.types import Mount
 from supervisor.coresys import CoreSys
 from supervisor.docker.manager import DockerAPI
 
+from . import DEV_MOUNT
+
 
 async def test_start(coresys: CoreSys, tmp_supervisor_data: Path, path_extern):
     """Test starting audio plugin."""
@@ -26,8 +28,9 @@ async def test_start(coresys: CoreSys, tmp_supervisor_data: Path, path_extern):
         assert run.call_args.kwargs["ulimits"] == [
             {"Name": "rtprio", "Soft": 10, "Hard": 10}
         ]
+
         assert run.call_args.kwargs["mounts"] == [
-            Mount(type="bind", source="/dev", target="/dev", read_only=True),
+            DEV_MOUNT,
             Mount(
                 type="bind",
                 source=coresys.config.path_extern_audio.as_posix(),

--- a/tests/docker/test_homeassistant.py
+++ b/tests/docker/test_homeassistant.py
@@ -12,6 +12,8 @@ from supervisor.docker.homeassistant import DockerHomeAssistant
 from supervisor.docker.manager import DockerAPI
 from supervisor.homeassistant.const import LANDINGPAGE
 
+from . import DEV_MOUNT
+
 
 async def test_homeassistant_start(
     coresys: CoreSys, tmp_supervisor_data: Path, path_extern
@@ -42,7 +44,7 @@ async def test_homeassistant_start(
             "HASSIO_TOKEN": ANY,
         }
         assert run.call_args.kwargs["mounts"] == [
-            Mount(type="bind", source="/dev", target="/dev", read_only=True),
+            DEV_MOUNT,
             Mount(type="bind", source="/run/dbus", target="/run/dbus", read_only=True),
             Mount(type="bind", source="/run/udev", target="/run/udev", read_only=True),
             Mount(
@@ -128,7 +130,7 @@ async def test_landingpage_start(
             "HASSIO_TOKEN": ANY,
         }
         assert run.call_args.kwargs["mounts"] == [
-            Mount(type="bind", source="/dev", target="/dev", read_only=True),
+            DEV_MOUNT,
             Mount(type="bind", source="/run/dbus", target="/run/dbus", read_only=True),
             Mount(type="bind", source="/run/udev", target="/run/udev", read_only=True),
             Mount(


### PR DESCRIPTION
## Proposed change

As described in #4996, Docker 25+ changes made sub-mounts of the /dev filesystem to be mounted read-only. Revert to the previous behavior by adjusting the ReadOnlyNonRecursive option. Cleaner way would be to upstream support for setting this option via Mount class arguments, so this change is meant to be rather a hotfix for the issue. Even better approach would be mounting /dev non-recursively, and taking care of creating all necessary filesystems when creating containers in Supervisor.

This change was also tested on HAOS 12.0 with Docker 24.0.7 - it just ignores the extra option without any fuss in logs.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4996
- This PR is related to issue: #4827
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
