### PR TITLE
Increase DNS timeout for CoreDNS users

### DIFF
--- a/supervisor/docker/manager.py
+++ b/supervisor/docker/manager.py
@@ -181,7 +181,7 @@ class DockerAPI:
             # However, the default timeout of glibc and musl is 5s. Increase
             # default timeout to make sure CoreDNS fallback is working
             # on first query.
-            kwargs["dns_opt"] = "timeout:10"
+            kwargs["dns_opt"] = ["timeout:10"]
             if hostname:
                 kwargs["domainname"] = DNS_SUFFIX
 

--- a/supervisor/docker/manager.py
+++ b/supervisor/docker/manager.py
@@ -177,6 +177,11 @@ class DockerAPI:
         if dns:
             kwargs["dns"] = [str(self.network.dns)]
             kwargs["dns_search"] = [DNS_SUFFIX]
+            # CoreDNS forward plug-in fails in ~6s, then fallback triggers.
+            # However, the default timeout of glibc and musl is 5s. Increase
+            # default timeout to make sure CoreDNS fallback is working
+            # on first query.
+            kwargs["dns_opt"] = "timeout:10"
             if hostname:
                 kwargs["domainname"] = DNS_SUFFIX
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
CoreDNS forward plug-in fails in ~6s, then fallback triggers. However, the default timeout of glibc and musl is 5s. Increase default timeout to make sure CoreDNS fallback is working on first query.

Background: Default timeout of libc (getaddrinfo`):
 * [musl in src/network/resolvconf.c](https://git.musl-libc.org/cgit/musl/tree/src/network/resolvconf.c#n17) 
 * [glibc resolv/resolv.h](https://elixir.bootlin.com/glibc/glibc-2.39/source/resolv/resolv.h#L68)

The option `timeout` allows to configure this timeout.

Note that there is also an option `attempts`, which is 2 by default. From observation, these attempts are done within the 5s window. This means that even the second attempt of the C library will fail. When the local (forwarded) DNS server did not respond, and CoreDNS used the fallback, this leads to a first attempt to fail, and an immediate second attempt to succeed (because the DNS caching):

```
homeassistant:/config# ping www.google.ch
ping: bad address 'www.google.ch'
homeassistant:/config# ping www.google.ch
PING www.google.ch (2a00:1450:400a:808::2003): 56 data bytes
64 bytes from 2a00:1450:400a:808::2003: seq=0 ttl=112 time=2.810 ms
```

With this change, the first resolving attempt already succeeds, after ~6s (CoreDNS forward timeout).


<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
