### PR TITLE
Mount manager reload mounts all failed mounts

### DIFF
--- a/tests/mounts/test_manager.py
+++ b/tests/mounts/test_manager.py
@@ -595,10 +595,6 @@ async def test_reload_mounts(
     assert len(coresys.resolution.suggestions_for_issue(mount.failed_issue)) == 2
     assert len(systemd_service.ReloadOrRestartUnit.calls) == 1
 
-    # This shouldn't reload the mount again since this isn't a new failure
-    await coresys.mounts.reload()
-    assert len(systemd_service.ReloadOrRestartUnit.calls) == 1
-
     # This should now remove the issue from the list
     systemd_unit_service.active_state = "active"
     await coresys.mounts.reload()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Mount manager reload is currently called every 15 minutes to get an update on the state of all mounts. Currently it only attempts to reload or mount a failed mount on first failure, after that it pops a repair and leaves it up to the user to fix.

Now it will attempt reload of all failures anytime it is reloaded. This will help users that don't run a NAS 24/7 and turn it off on certain times and days. Currently if those users happen to reboot or update supervisor at that time they have to manually fix it after turning on their NAS, now Supervisor will fix it for them eventually (15 minutes max).

The downside here is there will be a lot more logging. If a NAS is actually down long-term and the mount is still configured in Supervisor it will keep trying and logging the failure every 15 minutes. But considering we have a good number of requests from users in the first situation, it seems like a worthwhile trade off.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
