### PR TITLE
Fix no changelog API response

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -697,7 +697,6 @@ class RestAPI(CoreSysAttributes):
                 web.get("/store", api_store.store_info),
                 web.get("/store/addons", api_store.addons_list),
                 web.get("/store/addons/{addon}", api_store.addons_addon_info),
-                web.get("/store/addons/{addon}/{version}", api_store.addons_addon_info),
                 web.get("/store/addons/{addon}/icon", api_store.addons_addon_icon),
                 web.get("/store/addons/{addon}/logo", api_store.addons_addon_logo),
                 web.get(
@@ -719,6 +718,8 @@ class RestAPI(CoreSysAttributes):
                     "/store/addons/{addon}/update/{version}",
                     api_store.addons_addon_update,
                 ),
+                # Must be below others since it has a wildcard in resource path
+                web.get("/store/addons/{addon}/{version}", api_store.addons_addon_info),
                 web.post("/store/reload", api_store.reload),
                 web.get("/store/repositories", api_store.repositories_list),
                 web.get(

--- a/supervisor/api/store.py
+++ b/supervisor/api/store.py
@@ -251,7 +251,7 @@ class APIStore(CoreSysAttributes):
         """Return changelog from add-on."""
         addon = self._extract_addon(request)
         if not addon.with_changelog:
-            raise APIError(f"No changelog found for add-on {addon.slug}!")
+            return f"No changelog found for add-on {addon.slug}!"
 
         with addon.path_changelog.open("r") as changelog:
             return changelog.read()

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -194,7 +194,11 @@ async def test_api_store_update_healthcheck(
 async def test_api_store_addons_no_changelog(
     api_client: TestClient, coresys: CoreSys, store_addon: AddonStore, resource: str
 ):
-    """Test /store/addons/{addon}/changelog REST API."""
+    """Test /store/addons/{addon}/changelog REST API.
+    
+    Currently the frontend expects a valid body even in the error case. Make sure that is
+    what the API returns.
+    """
     resp = await api_client.get(f"/{resource}/{store_addon.slug}/changelog")
     assert resp.status == 200
     result = await resp.text()

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -188,3 +188,14 @@ async def test_api_store_update_healthcheck(
     assert resp.status == 200
 
     await _container_events_task
+
+
+@pytest.mark.parametrize("resource", ["store/addons", "addons"])
+async def test_api_store_addons_no_changelog(
+    api_client: TestClient, coresys: CoreSys, store_addon: AddonStore, resource: str
+):
+    """Test /store/addons/{addon}/changelog REST API."""
+    resp = await api_client.get(f"/{resource}/{store_addon.slug}/changelog")
+    assert resp.status == 200
+    result = await resp.text()
+    assert result == "No changelog found for add-on test_store_addon!"

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -195,7 +195,7 @@ async def test_api_store_addons_no_changelog(
     api_client: TestClient, coresys: CoreSys, store_addon: AddonStore, resource: str
 ):
     """Test /store/addons/{addon}/changelog REST API.
-    
+
     Currently the frontend expects a valid body even in the error case. Make sure that is
     what the API returns.
     """


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The status code of the changelog API when an addon had no changelog was accidently chnaged in #4972 . This PR changes it back to a 200 in this case and adds a unit test. It also fixes the `/store/addons/{slug}/changelog` API as it appears that hasn't worked for a long time (frontend is still using the supposedly deprecated `/addons/{slug}/changelog` and that did work).

As an aside this feels very hacky. We should simply return a 404 and the frontend should have the text to display in that case with localization. Supervisor should not be returning the message presented directly to users in this case.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/116470
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
