### PR TITLE
Fix doc and changelog API response for orphaned addons

### DIFF
--- a/supervisor/api/store.py
+++ b/supervisor/api/store.py
@@ -249,7 +249,12 @@ class APIStore(CoreSysAttributes):
     @api_process_raw(CONTENT_TYPE_TEXT)
     async def addons_addon_changelog(self, request: web.Request) -> str:
         """Return changelog from add-on."""
-        addon = self._extract_addon(request)
+        # Frontend can't handle error response here, need to return 200 and error as text for now
+        try:
+            addon = self._extract_addon(request)
+        except APIError as err:
+            return str(err)
+
         if not addon.with_changelog:
             return f"No changelog found for add-on {addon.slug}!"
 
@@ -259,9 +264,14 @@ class APIStore(CoreSysAttributes):
     @api_process_raw(CONTENT_TYPE_TEXT)
     async def addons_addon_documentation(self, request: web.Request) -> str:
         """Return documentation from add-on."""
-        addon = self._extract_addon(request)
+        # Frontend can't handle error response here, need to return 200 and error as text for now
+        try:
+            addon = self._extract_addon(request)
+        except APIError as err:
+            return str(err)
+
         if not addon.with_documentation:
-            raise APIError(f"No documentation found for add-on {addon.slug}!")
+            return f"No documentation found for add-on {addon.slug}!"
 
         with addon.path_documentation.open("r") as documentation:
             return documentation.read()

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -209,14 +209,14 @@ async def test_api_store_addons_no_changelog(
 
 
 @pytest.mark.parametrize("resource", ["store/addons", "addons"])
-async def test_api_orphaned_addon_changelog(
+async def test_api_detached_addon_changelog(
     api_client: TestClient,
     coresys: CoreSys,
     install_addon_ssh: Addon,
     tmp_supervisor_data: Path,
     resource: str,
 ):
-    """Test /store/addons/{addon}/changelog for an orphaned addon.
+    """Test /store/addons/{addon}/changelog for an detached addon.
 
     Currently the frontend expects a valid body even in the error case. Make sure that is
     what the API returns.
@@ -253,14 +253,14 @@ async def test_api_store_addons_no_documentation(
 
 
 @pytest.mark.parametrize("resource", ["store/addons", "addons"])
-async def test_api_orphaned_addon_documentation(
+async def test_api_detached_addon_documentation(
     api_client: TestClient,
     coresys: CoreSys,
     install_addon_ssh: Addon,
     tmp_supervisor_data: Path,
     resource: str,
 ):
-    """Test /store/addons/{addon}/changelog for an orphaned addon.
+    """Test /store/addons/{addon}/changelog for an detached addon.
 
     Currently the frontend expects a valid body even in the error case. Make sure that is
     what the API returns.

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -1,6 +1,7 @@
 """Test Store API."""
 
 import asyncio
+from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from aiohttp.test_utils import TestClient
@@ -8,6 +9,7 @@ import pytest
 
 from supervisor.addons.addon import Addon
 from supervisor.arch import CpuArch
+from supervisor.config import CoreConfig
 from supervisor.const import AddonState
 from supervisor.coresys import CoreSys
 from supervisor.docker.addon import DockerAddon
@@ -199,7 +201,80 @@ async def test_api_store_addons_no_changelog(
     Currently the frontend expects a valid body even in the error case. Make sure that is
     what the API returns.
     """
+    assert store_addon.with_changelog is False
     resp = await api_client.get(f"/{resource}/{store_addon.slug}/changelog")
     assert resp.status == 200
     result = await resp.text()
     assert result == "No changelog found for add-on test_store_addon!"
+
+
+@pytest.mark.parametrize("resource", ["store/addons", "addons"])
+async def test_api_orphaned_addon_changelog(
+    api_client: TestClient,
+    coresys: CoreSys,
+    install_addon_ssh: Addon,
+    tmp_supervisor_data: Path,
+    resource: str,
+):
+    """Test /store/addons/{addon}/changelog for an orphaned addon.
+
+    Currently the frontend expects a valid body even in the error case. Make sure that is
+    what the API returns.
+    """
+    (addons_dir := tmp_supervisor_data / "addons" / "local").mkdir()
+    with patch.object(
+        CoreConfig, "path_addons_local", new=PropertyMock(return_value=addons_dir)
+    ):
+        await coresys.store.load()
+
+    assert install_addon_ssh.is_detached is True
+    assert install_addon_ssh.with_changelog is False
+
+    resp = await api_client.get(f"/{resource}/{install_addon_ssh.slug}/changelog")
+    assert resp.status == 200
+    result = await resp.text()
+    assert result == "Addon local_ssh with version latest does not exist in the store"
+
+
+@pytest.mark.parametrize("resource", ["store/addons", "addons"])
+async def test_api_store_addons_no_documentation(
+    api_client: TestClient, coresys: CoreSys, store_addon: AddonStore, resource: str
+):
+    """Test /store/addons/{addon}/documentation REST API.
+
+    Currently the frontend expects a valid body even in the error case. Make sure that is
+    what the API returns.
+    """
+    assert store_addon.with_documentation is False
+    resp = await api_client.get(f"/{resource}/{store_addon.slug}/documentation")
+    assert resp.status == 200
+    result = await resp.text()
+    assert result == "No documentation found for add-on test_store_addon!"
+
+
+@pytest.mark.parametrize("resource", ["store/addons", "addons"])
+async def test_api_orphaned_addon_documentation(
+    api_client: TestClient,
+    coresys: CoreSys,
+    install_addon_ssh: Addon,
+    tmp_supervisor_data: Path,
+    resource: str,
+):
+    """Test /store/addons/{addon}/changelog for an orphaned addon.
+
+    Currently the frontend expects a valid body even in the error case. Make sure that is
+    what the API returns.
+    """
+    (addons_dir := tmp_supervisor_data / "addons" / "local").mkdir()
+    with patch.object(
+        CoreConfig, "path_addons_local", new=PropertyMock(return_value=addons_dir)
+    ):
+        await coresys.store.load()
+
+    assert install_addon_ssh.is_detached is True
+    assert install_addon_ssh.with_documentation is False
+
+    resp = await api_client.get(f"/{resource}/{install_addon_ssh.slug}/documentation")
+    assert resp.status == 200
+    result = await resp.text()
+    assert result == "Addon local_ssh with version latest does not exist in the store"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Follow-up to #5064 . It appears orphaned addons return 400 responses to `/changelog` that the frontend cannot interpret. While digging I noticed that the `/documentation` API has the same problem, it just hasn't come up yet (probably because `update` entities do not hit it in the background like they do with the changelog).

Changed both these APIs so they go back to returning 200 responses with the error as text. As noted in the other PR, we should really handle this differently. Although in this case I'm not sure a 404 makes sense since this is a bit odd. Still it would be nice to have the API correctly report an error and the frontend show the appropriate text rather then having supervisor return error text to display to users.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5076
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
