### PR TITLE
Add Exception handling when processing udev devices

### DIFF
--- a/supervisor/hardware/manager.py
+++ b/supervisor/hardware/manager.py
@@ -101,7 +101,7 @@ class HardwareManager(CoreSysAttributes):
         self._devices.clear()
 
         # Exctract all devices
-        for device in self._udev.list_devices():            
+        for device in self._udev.list_devices():
             # Skip devices without mapping
             try:
                 if not device.device_node or self.helper.hide_virtual_device(device):

--- a/supervisor/hardware/manager.py
+++ b/supervisor/hardware/manager.py
@@ -103,8 +103,12 @@ class HardwareManager(CoreSysAttributes):
         # Exctract all devices
         for device in self._udev.list_devices():
             # Skip devices without mapping
-            if not device.device_node or self.helper.hide_virtual_device(device):
-                continue
+            try:
+              if not device.device_node or self.helper.hide_virtual_device(device):
+                  continue
+            except:
+              continue
+                
             self._devices[device.sys_name] = Device.import_udev(device)
 
     async def load(self) -> None:

--- a/supervisor/hardware/manager.py
+++ b/supervisor/hardware/manager.py
@@ -104,11 +104,18 @@ class HardwareManager(CoreSysAttributes):
         for device in self._udev.list_devices():
             # Skip devices without mapping
             try:
-              if not device.device_node or self.helper.hide_virtual_device(device):
+              if not device.device_node:
                   continue
             except:
-               _LOGGER.exception("Exception : UDEV name does not appear to be a string - ignoring and continuing")
+               _LOGGER.exception("Exception : UDEV passed bad data")
               continue
+
+            try: 
+              if self.helper.hide_virtual_device(device):
+                continue
+            except:      
+                _LOGGER.exception("Exception: Could not parse virtual device")
+                continue
                 
             self._devices[device.sys_name] = Device.import_udev(device)
 

--- a/supervisor/hardware/manager.py
+++ b/supervisor/hardware/manager.py
@@ -107,6 +107,7 @@ class HardwareManager(CoreSysAttributes):
               if not device.device_node or self.helper.hide_virtual_device(device):
                   continue
             except:
+               _LOGGER.exception("Exception : UDEV name does not appear to be a string - ignoring and continuing")
               continue
                 
             self._devices[device.sys_name] = Device.import_udev(device)

--- a/supervisor/hardware/manager.py
+++ b/supervisor/hardware/manager.py
@@ -104,19 +104,13 @@ class HardwareManager(CoreSysAttributes):
         for device in self._udev.list_devices():            
             # Skip devices without mapping
             try:
-              if self.helper.hide_virtual_device(device):  
-                  continue
-            except:
-              _LOGGER.exception("Exception:")
-              continue
-
-            try:
-              if not device.device_node:
-                  continue
-            except:
-              _LOGGER.exception("Exception:")
-              continue
-                
+                if not device.device_node or self.helper.hide_virtual_device(device):
+                    continue
+            except UnicodeDecodeError as err:
+                # Some udev properties have an unkown/different encoding. This is a general
+                # problem with pyudev, see https://github.com/pyudev/pyudev/pull/230
+                _LOGGER.warning("Ignoring udev device due to error: %s", err)
+                continue
             self._devices[device.sys_name] = Device.import_udev(device)
 
     async def load(self) -> None:

--- a/supervisor/hardware/manager.py
+++ b/supervisor/hardware/manager.py
@@ -101,21 +101,21 @@ class HardwareManager(CoreSysAttributes):
         self._devices.clear()
 
         # Exctract all devices
-        for device in self._udev.list_devices():
+        for device in self._udev.list_devices():            
             # Skip devices without mapping
             try:
               if not device.device_node:
                   continue
             except:
-               _LOGGER.exception("Exception : UDEV passed bad data")
+              _LOGGER.exception("Exception:")
               continue
 
-            try: 
+            try:
               if self.helper.hide_virtual_device(device):
-                continue
-            except:      
-                _LOGGER.exception("Exception: Could not parse virtual device")
-                continue
+                  continue
+            except:
+              _LOGGER.exception("Exception:")
+              continue
                 
             self._devices[device.sys_name] = Device.import_udev(device)
 

--- a/supervisor/hardware/manager.py
+++ b/supervisor/hardware/manager.py
@@ -104,14 +104,14 @@ class HardwareManager(CoreSysAttributes):
         for device in self._udev.list_devices():            
             # Skip devices without mapping
             try:
-              if not device.device_node:
+              if self.helper.hide_virtual_device(device):  
                   continue
             except:
               _LOGGER.exception("Exception:")
               continue
 
             try:
-              if self.helper.hide_virtual_device(device):
+              if not device.device_node:
                   continue
             except:
               _LOGGER.exception("Exception:")


### PR DESCRIPTION
Khadas VIM4 UDEV returns something that python crapps its pants about. The exception just allows it to continue.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  VIM4 UDEV passes something that makes python string parsing go bad! Added EXception handling to allow it to continue.

```2024-05-17 19:33:01.620 INFO (MainThread) [supervisor.api] Starting API on 172.30.32.2
2024-05-17 19:33:01.831 CRITICAL (MainThread) [supervisor.core] Fatal error happening on load Task <coroutine object HardwareManager.load at 0x7f8dad5780>: 'utf-8' codec can't decode byte 0x9f in position 7: invalid start byte
2024-05-17 19:33:01.836 INFO (MainThread) [supervisor.dbus.manager] Connected to system D-Bus.```
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5092 
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device processing by handling `UnicodeDecodeError` exceptions, ensuring smoother operation and logging warning messages for better diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->