### PR TITLE
Fix addon in wrong state after restore

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -1343,11 +1343,11 @@ class Addon(AddonModel):
                         )
                         raise AddonsError() from err
 
+            finally:
                 # Is add-on loaded
                 if not self.loaded:
                     await self.load()
 
-            finally:
                 # Run add-on
                 if data[ATTR_STATE] == AddonState.STARTED:
                     wait_for_start = await self.start()

--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -345,9 +345,6 @@ class Core(CoreSysAttributes):
         if self.state == CoreState.RUNNING:
             self.state = CoreState.SHUTDOWN
 
-        # Stop docker monitoring
-        await self.sys_docker.unload()
-
         # Shutdown Application Add-ons, using Home Assistant API
         await self.sys_addons.shutdown(AddonStartup.APPLICATION)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Full restore currently stops the docker events listener before it begins as part of `shutdown`. It is not restarted afterwards leaving the addons in completely unknown states beyond that point. This PR fixes that issue, the docker monitor is no longer stopped.

It also fixes a minor possible issue where addons were not loaded prior to being restarted during a restore due to an exception. The first is the real cause of these "unknown state after restore" issues though. 

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured add-ons are properly loaded before running by moving the check to a `finally` block.

- **Improvements**
  - Improved system shutdown process by removing unnecessary stopping of docker monitoring.

- **Tests**
  - Added tests to verify addon state monitoring after full and partial restore operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->