### PR TITLE
Ignore dns-data field in network settings update

### DIFF
--- a/supervisor/dbus/network/setting/__init__.py
+++ b/supervisor/dbus/network/setting/__init__.py
@@ -44,6 +44,7 @@ IPV4_6_IGNORE_FIELDS = [
     "addresses",
     "address-data",
     "dns",
+    "dns-data",
     "gateway",
     "method",
 ]

--- a/tests/dbus/network/setting/test_init.py
+++ b/tests/dbus/network/setting/test_init.py
@@ -67,6 +67,7 @@ async def test_update(
     assert settings["ipv4"]["method"] == Variant("s", "auto")
     assert "gateway" not in settings["ipv4"]
     assert "dns" not in settings["ipv4"]
+    assert "dns-data" not in settings["ipv4"]
     assert "address-data" not in settings["ipv4"]
     assert "addresses" not in settings["ipv4"]
     assert len(settings["ipv4"]["route-data"].value) == 1
@@ -83,6 +84,7 @@ async def test_update(
     assert settings["ipv6"]["method"] == Variant("s", "auto")
     assert "gateway" not in settings["ipv6"]
     assert "dns" not in settings["ipv6"]
+    assert "dns-data" not in settings["ipv6"]
     assert "address-data" not in settings["ipv6"]
     assert "addresses" not in settings["ipv6"]
     assert settings["ipv6"]["addr-gen-mode"] == Variant("i", 0)

--- a/tests/dbus_service_mocks/network_connection_settings.py
+++ b/tests/dbus_service_mocks/network_connection_settings.py
@@ -31,6 +31,7 @@ SETTINGS_FIXTURE: dict[str, dict[str, Variant]] = {
         ),
         "addresses": Variant("aau", [[2483202240, 24, 16951488]]),
         "dns": Variant("au", [16951488]),
+        "dns-data": Variant("as", ["192.168.2.1"]),
         "dns-search": Variant("as", []),
         "gateway": Variant("s", "192.168.2.1"),
         "method": Variant("s", "auto"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The `dns-data` field replaces the now deprecated `dns` field in [Network Manager's connection settings](https://networkmanager.dev/docs/api/latest/settings-ipv4.html). As with the other `-data` fields both the new and the old get populated automatically no matter which you use. So also like the others, it needs to be added to our ignore list when generating the object for the dbus call so the old value does not get merged in.

This would appear to be a problem for disabling an ipv4 or ipv6 interface though so far we only have a report on ipv6. I think it's relatively new as `dns-data` wasn't in our test fixture which was generated from the dbus calls directly. I think it was added when we updated NM a couple OS releases ago which happened after the fixtures were made.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5132
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `dns-data` in network settings, enhancing DNS configuration capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->