### PR TITLE
Ignore failure to query wireless strength.

### DIFF
--- a/supervisor/host/configuration.py
+++ b/supervisor/host/configuration.py
@@ -191,7 +191,7 @@ class Interface:
             mode = WifiMode(inet.settings.wireless.mode)
 
         # Signal
-        if inet.wireless:
+        if inet.wireless and inet.wireless.active:
             signal = inet.wireless.active.strength
         else:
             signal = None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This patch silently ignores queuing wireless strength from nm when that attribute doesn't exist. 

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change 

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

I'm running home assistant supervised on Arch Linux .

I found on my installation of home assistant that most functions relating to supervisor were suddenly failing. 
The initial most visible issue was the settings / add-ons page was unable to load, just showing the loading spinner forever.

In the home assistant system log I was seeing entries like: 
```
Logger: homeassistant.components.hassio.handler
Source: components/hassio/handler.py:618
integration: Home Assistant Supervisor (documentation, issues)
First occurred: July 11, 2024 at 10:49:05 PM (35 occurrences)
Last logged: 12:49:06 AM

Client error on /network/info request 0, message='Attempt to decode JSON with unexpected mimetype: text/plain; charset=utf-8', url=URL('http://172.30.32.2/network/info')
```

Checking the supervisor docker logs I found long exception tracebacks ending in: 
```
  File "/usr/src/supervisor/supervisor/host/netwo
rk.py", line 73, in interfaces
    interfaces.append(Interface.from_dbus_interfa
ce(inet))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
^^^^^^^^
  File "/usr/src/supervisor/supervisor/host/confi
guration.py", line 135, in from_dbus_interface
    Interface._map_nm_wifi(inet),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/supervisor/supervisor/host/confi
guration.py", line 195, in _map_nm_wifi
    signal = inet.wireless.active.strength
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribut
e 'strength'
```

I'm not too sure why this is failing, though my wifi adaptor in not actively used (rely on wired connection) so it might be simply because it's not connected to an AP?
```
[corona@Telie ~]$ nmcli
wlp1s0: connecting (need authentication) to Supervisor wlp1s0
        "Qualcomm Atheros AR93xx"
        wifi (ath9k), 64:70:02:16:5F:2A, hw, mtu 1500
```

With this patch applied and the supervisor docker image restarted the -ons page loads again correctly.

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - Improved error handling for wireless signal strength measurement, ensuring the app does not crash if the signal strength attribute is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->