### PR TITLE
Add support for offline DB migration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -361,7 +361,9 @@ async def coresys(
     )
 
     # WebSocket
-    coresys_obj.homeassistant.api.get_api_state = AsyncMock(return_value=APIState("RUNNING", False))
+    coresys_obj.homeassistant.api.get_api_state = AsyncMock(
+        return_value=APIState("RUNNING", False)
+    )
     coresys_obj.homeassistant._websocket._client = AsyncMock(
         ha_version=AwesomeVersion("2021.2.4")
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ from supervisor.coresys import CoreSys
 from supervisor.dbus.network import NetworkManager
 from supervisor.docker.manager import DockerAPI
 from supervisor.docker.monitor import DockerMonitor
+from supervisor.homeassistant.api import APIState
 from supervisor.host.logs import LogsControl
 from supervisor.os.manager import OSManager
 from supervisor.store.addon import AddonStore
@@ -360,7 +361,7 @@ async def coresys(
     )
 
     # WebSocket
-    coresys_obj.homeassistant.api.get_api_state = AsyncMock(return_value="RUNNING")
+    coresys_obj.homeassistant.api.get_api_state = AsyncMock(return_value=APIState("RUNNING", False))
     coresys_obj.homeassistant._websocket._client = AsyncMock(
         ha_version=AwesomeVersion("2021.2.4")
     )

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -322,6 +322,7 @@ async def test_api_check_database_migration(
 ):
     """Test attempts to contact the API timeout."""
     calls = []
+
     def mock_api_state(*args):
         calls.append(None)
         if len(calls) > 50:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for offline DB migration:
- Watchdog will not bark during DB migration
- `HomeAssistantCore._block_till_run` will not time out during DB migration

To test this change with core, checkout core PR https://github.com/home-assistant/core/pull/122399, then apply the following stash:
```diff
commit 0e98b5b00f05a41c3b41122dfd701bc386cb106c
Merge: 22d494bc7d8 49ea61c8f78
Author: Erik <erik@montnemery.com>
Date:   Tue Jul 23 10:36:23 2024 +0200

    WIP on recorder_non_live_migration: 22d494bc7d8 Update test

diff --cc homeassistant/components/recorder/db_schema.py
index 8d4cc29d9be,8d4cc29d9be..dd293ed6bc2
--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@@ -77,7 -77,7 +77,7 @@@ class LegacyBase(DeclarativeBase)
      """Base class for tables, used for schema migration."""


--SCHEMA_VERSION = 44
++SCHEMA_VERSION = 45

  _LOGGER = logging.getLogger(__name__)

diff --cc homeassistant/components/recorder/migration.py
index f32a91b8b02,f32a91b8b02..80d08f87e91
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@@ -8,7 -8,7 +8,7 @@@ import contextli
  from dataclasses import dataclass, replace as dataclass_replace
  from datetime import timedelta
  import logging
--from time import time
++from time import sleep, time
  from typing import TYPE_CHECKING, Any, cast, final
  from uuid import UUID

@@@ -122,7 -122,7 +122,7 @@@ if TYPE_CHECKING
  # Live schema migration supported starting from schema version 42 or newer
  # Schema version 41 was introduced in HA Core 2023.4
  # Schema version 42 was introduced in HA Core 2023.11
--LIVE_MIGRATION_MIN_SCHEMA_VERSION = 42
++LIVE_MIGRATION_MIN_SCHEMA_VERSION = 45
  _EMPTY_ENTITY_ID = "missing.entity_id"
  _EMPTY_EVENT_TYPE = "missing_event_type"

@@@ -1512,6 -1512,6 +1512,14 @@@ class _SchemaVersion44Migrator(_SchemaV
          )


++class _SchemaVersion45Migrator(_SchemaVersionMigrator, target_version=45):
++    def _apply_update(self) -> None:
++        """Version specific update method."""
++        _LOGGER.error("START SLEEP %s", self.hass.state.value)
++        sleep(3600)
++        _LOGGER.error("DONE SLEEP")
++
++
  def _migrate_statistics_columns_to_timestamp_removing_duplicates(
      hass: HomeAssistant,
      instance: Recorder,
```

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced API state representation with a structured `APIState` class.
	- Introduced a timeout for database migration, improving system responsiveness during startup.

- **Bug Fixes**
	- Improved checks for API operational status to handle database migration scenarios more effectively.

- **Tests**
	- Added a new test for validating the Home Assistant API behavior during database migrations, increasing coverage and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->