### PR TITLE
Add hard-coded image fallback for plugins for offline start

### DIFF
--- a/supervisor/plugins/audio.py
+++ b/supervisor/plugins/audio.py
@@ -2,6 +2,7 @@
 
 Code: https://github.com/home-assistant/plugin-audio
 """
+
 import errno
 import logging
 from pathlib import Path, PurePath
@@ -73,7 +74,9 @@ class PluginAudio(PluginBase):
     @property
     def default_image(self) -> str:
         """Return default image for audio plugin."""
-        return self.sys_updater.image_audio
+        if self.sys_updater.image_audio:
+            return self.sys_updater.image_audio
+        return super().default_image
 
     @property
     def latest_version(self) -> AwesomeVersion | None:

--- a/supervisor/plugins/cli.py
+++ b/supervisor/plugins/cli.py
@@ -2,6 +2,7 @@
 
 Code: https://github.com/home-assistant/plugin-cli
 """
+
 from collections.abc import Awaitable
 import logging
 import secrets
@@ -42,7 +43,9 @@ class PluginCli(PluginBase):
     @property
     def default_image(self) -> str:
         """Return default image for cli plugin."""
-        return self.sys_updater.image_cli
+        if self.sys_updater.image_cli:
+            return self.sys_updater.image_cli
+        return super().default_image
 
     @property
     def latest_version(self) -> AwesomeVersion | None:

--- a/supervisor/plugins/dns.py
+++ b/supervisor/plugins/dns.py
@@ -2,6 +2,7 @@
 
 Code: https://github.com/home-assistant/plugin-dns
 """
+
 import asyncio
 from contextlib import suppress
 import errno
@@ -111,7 +112,9 @@ class PluginDns(PluginBase):
     @property
     def default_image(self) -> str:
         """Return default image for dns plugin."""
-        return self.sys_updater.image_dns
+        if self.sys_updater.image_dns:
+            return self.sys_updater.image_dns
+        return super().default_image
 
     @property
     def latest_version(self) -> AwesomeVersion | None:

--- a/supervisor/plugins/multicast.py
+++ b/supervisor/plugins/multicast.py
@@ -2,6 +2,7 @@
 
 Code: https://github.com/home-assistant/plugin-multicast
 """
+
 import logging
 
 from awesomeversion import AwesomeVersion
@@ -44,7 +45,9 @@ class PluginMulticast(PluginBase):
     @property
     def default_image(self) -> str:
         """Return default image for multicast plugin."""
-        return self.sys_updater.image_multicast
+        if self.sys_updater.image_multicast:
+            return self.sys_updater.image_multicast
+        return super().default_image
 
     @property
     def latest_version(self) -> AwesomeVersion | None:

--- a/supervisor/plugins/observer.py
+++ b/supervisor/plugins/observer.py
@@ -2,6 +2,7 @@
 
 Code: https://github.com/home-assistant/plugin-observer
 """
+
 import logging
 import secrets
 
@@ -47,7 +48,9 @@ class PluginObserver(PluginBase):
     @property
     def default_image(self) -> str:
         """Return default image for observer plugin."""
-        return self.sys_updater.image_observer
+        if self.sys_updater.image_observer:
+            return self.sys_updater.image_observer
+        return super().default_image
 
     @property
     def latest_version(self) -> AwesomeVersion | None:

--- a/tests/plugins/test_plugin_base.py
+++ b/tests/plugins/test_plugin_base.py
@@ -1,4 +1,5 @@
 """Test base plugin functionality."""
+
 import asyncio
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
@@ -60,14 +61,17 @@ async def fixture_plugin(
 )
 async def test_plugin_watchdog(coresys: CoreSys, plugin: PluginBase) -> None:
     """Test plugin watchdog works correctly."""
-    with patch.object(type(plugin.instance), "attach"), patch.object(
-        type(plugin.instance), "is_running", return_value=True
+    with (
+        patch.object(type(plugin.instance), "attach"),
+        patch.object(type(plugin.instance), "is_running", return_value=True),
     ):
         await plugin.load()
 
-    with patch.object(type(plugin), "rebuild") as rebuild, patch.object(
-        type(plugin), "start"
-    ) as start, patch.object(type(plugin.instance), "current_state") as current_state:
+    with (
+        patch.object(type(plugin), "rebuild") as rebuild,
+        patch.object(type(plugin), "start") as start,
+        patch.object(type(plugin.instance), "current_state") as current_state,
+    ):
         current_state.return_value = ContainerState.UNHEALTHY
         coresys.bus.fire_event(
             BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
@@ -168,9 +172,10 @@ async def test_plugin_watchdog_max_failed_attempts(
 
     container.status = "stopped"
     container.attrs = {"State": {"ExitCode": 1}}
-    with patch("supervisor.plugins.base.WATCHDOG_RETRY_SECONDS", 0), patch.object(
-        type(plugin), "start", side_effect=error
-    ) as start:
+    with (
+        patch("supervisor.plugins.base.WATCHDOG_RETRY_SECONDS", 0),
+        patch.object(type(plugin), "start", side_effect=error) as start,
+    ):
         await plugin.watchdog_container(
             DockerContainerStateEvent(
                 name=plugin.instance.name,
@@ -198,17 +203,18 @@ async def test_plugin_load_running_container(
 ) -> None:
     """Test plugins load and attach to a running container."""
     test_version = AwesomeVersion("2022.7.3")
-    with patch.object(
-        type(coresys.bus), "register_event"
-    ) as register_event, patch.object(
-        type(plugin.instance), "attach"
-    ) as attach, patch.object(type(plugin), "install") as install, patch.object(
-        type(plugin), "start"
-    ) as start, patch.object(
-        type(plugin.instance),
-        "get_latest_version",
-        return_value=test_version,
-    ), patch.object(type(plugin.instance), "is_running", return_value=True):
+    with (
+        patch.object(type(coresys.bus), "register_event") as register_event,
+        patch.object(type(plugin.instance), "attach") as attach,
+        patch.object(type(plugin), "install") as install,
+        patch.object(type(plugin), "start") as start,
+        patch.object(
+            type(plugin.instance),
+            "get_latest_version",
+            return_value=test_version,
+        ),
+        patch.object(type(plugin.instance), "is_running", return_value=True),
+    ):
         await plugin.load()
         register_event.assert_any_call(
             BusEvent.DOCKER_CONTAINER_STATE_CHANGE, plugin.watchdog_container
@@ -230,17 +236,18 @@ async def test_plugin_load_stopped_container(
 ) -> None:
     """Test plugins load and start existing container."""
     test_version = AwesomeVersion("2022.7.3")
-    with patch.object(
-        type(coresys.bus), "register_event"
-    ) as register_event, patch.object(
-        type(plugin.instance), "attach"
-    ) as attach, patch.object(type(plugin), "install") as install, patch.object(
-        type(plugin), "start"
-    ) as start, patch.object(
-        type(plugin.instance),
-        "get_latest_version",
-        return_value=test_version,
-    ), patch.object(type(plugin.instance), "is_running", return_value=False):
+    with (
+        patch.object(type(coresys.bus), "register_event") as register_event,
+        patch.object(type(plugin.instance), "attach") as attach,
+        patch.object(type(plugin), "install") as install,
+        patch.object(type(plugin), "start") as start,
+        patch.object(
+            type(plugin.instance),
+            "get_latest_version",
+            return_value=test_version,
+        ),
+        patch.object(type(plugin.instance), "is_running", return_value=False),
+    ):
         await plugin.load()
         register_event.assert_any_call(
             BusEvent.DOCKER_CONTAINER_STATE_CHANGE, plugin.watchdog_container
@@ -262,17 +269,20 @@ async def test_plugin_load_missing_container(
 ) -> None:
     """Test plugins load and create and start container."""
     test_version = AwesomeVersion("2022.7.3")
-    with patch.object(
-        type(coresys.bus), "register_event"
-    ) as register_event, patch.object(
-        type(plugin.instance), "attach", side_effect=DockerError()
-    ) as attach, patch.object(type(plugin), "install") as install, patch.object(
-        type(plugin), "start"
-    ) as start, patch.object(
-        type(plugin.instance),
-        "get_latest_version",
-        return_value=test_version,
-    ), patch.object(type(plugin.instance), "is_running", return_value=False):
+    with (
+        patch.object(type(coresys.bus), "register_event") as register_event,
+        patch.object(
+            type(plugin.instance), "attach", side_effect=DockerError()
+        ) as attach,
+        patch.object(type(plugin), "install") as install,
+        patch.object(type(plugin), "start") as start,
+        patch.object(
+            type(plugin.instance),
+            "get_latest_version",
+            return_value=test_version,
+        ),
+        patch.object(type(plugin.instance), "is_running", return_value=False),
+    ):
         await plugin.load()
         register_event.assert_any_call(
             BusEvent.DOCKER_CONTAINER_STATE_CHANGE, plugin.watchdog_container
@@ -301,9 +311,12 @@ async def test_update_fails_if_out_of_date(
     """Test update of plugins fail when supervisor is out of date."""
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
 
-    with patch.object(
-        type(coresys.supervisor), "need_update", new=PropertyMock(return_value=True)
-    ), pytest.raises(error):
+    with (
+        patch.object(
+            type(coresys.supervisor), "need_update", new=PropertyMock(return_value=True)
+        ),
+        pytest.raises(error),
+    ):
         await plugin.update()
 
 
@@ -316,10 +329,14 @@ async def test_repair_failed(
     coresys: CoreSys, capture_exception: Mock, plugin: PluginBase
 ):
     """Test repair failed."""
-    with patch.object(DockerInterface, "exists", return_value=False), patch.object(
-        DockerInterface, "arch", new=PropertyMock(return_value=CpuArch.AMD64)
-    ), patch(
-        "supervisor.security.module.cas_validate", side_effect=CodeNotaryUntrusted
+    with (
+        patch.object(DockerInterface, "exists", return_value=False),
+        patch.object(
+            DockerInterface, "arch", new=PropertyMock(return_value=CpuArch.AMD64)
+        ),
+        patch(
+            "supervisor.security.module.cas_validate", side_effect=CodeNotaryUntrusted
+        ),
     ):
         await plugin.repair()
 
@@ -360,3 +377,16 @@ async def test_load_with_incorrect_image(
         platform="linux/amd64",
     )
     assert plugin.image == correct_image
+
+
+@pytest.mark.parametrize(
+    "plugin",
+    [PluginAudio, PluginCli, PluginDns, PluginMulticast, PluginObserver],
+    indirect=True,
+)
+async def test_default_image_fallback(
+    coresys: CoreSys, container: MagicMock, plugin: PluginBase
+):
+    """Test default image falls back to hard-coded constant if we fail to fetch version file."""
+    assert getattr(coresys.updater, f"image_{plugin.slug}") is None
+    assert plugin.default_image == f"ghcr.io/home-assistant/amd64-hassio-{plugin.slug}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Plugins need a hard-coded string to use as a fallback. That way when an HAOS system is first started offline it can function and get to the landing page even though we cannot fetch the latest versions file with all the image names and latest versions.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the default image retrieval process across multiple plugins to ensure more robust handling of unavailable images.
	- Added a test case to verify the fallback mechanism for the default image.

- **Bug Fixes**
	- Improved error handling by implementing conditional checks in the default image property across various plugins to prevent returning invalid values.

- **Tests**
	- Refactored test cases for better readability and maintainability.
	- Introduced new tests to ensure the correct functionality of the updated default image logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->