### PR TITLE
Keep shared images on addon uninstall

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -763,10 +763,12 @@ class Addon(AddonModel):
         limit=JobExecutionLimit.GROUP_ONCE,
         on_condition=AddonsJobError,
     )
-    async def uninstall(self, *, remove_config: bool) -> None:
+    async def uninstall(
+        self, *, remove_config: bool, remove_image: bool = True
+    ) -> None:
         """Uninstall and cleanup this addon."""
         try:
-            await self.instance.remove()
+            await self.instance.remove(remove_image=remove_image)
         except DockerError as err:
             raise AddonsError() from err
 

--- a/supervisor/addons/manager.py
+++ b/supervisor/addons/manager.py
@@ -185,7 +185,15 @@ class AddonManager(CoreSysAttributes):
             _LOGGER.warning("Add-on %s is not installed", slug)
             return
 
-        await self.local[slug].uninstall(remove_config=remove_config)
+        shared_image = any(
+            self.local[slug].image == addon.image
+            and self.local[slug].version == addon.version
+            for addon in self.installed
+            if addon.slug != slug
+        )
+        await self.local[slug].uninstall(
+            remove_config=remove_config, remove_image=not shared_image
+        )
 
         _LOGGER.info("Add-on '%s' successfully removed", slug)
 

--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -429,15 +429,17 @@ class DockerInterface(JobGroup):
         limit=JobExecutionLimit.GROUP_ONCE,
         on_condition=DockerJobError,
     )
-    async def remove(self) -> None:
+    async def remove(self, *, remove_image: bool = True) -> None:
         """Remove Docker images."""
         # Cleanup container
         with suppress(DockerError):
             await self.stop()
 
-        await self.sys_run_in_executor(
-            self.sys_docker.remove_image, self.image, self.version
-        )
+        if remove_image:
+            await self.sys_run_in_executor(
+                self.sys_docker.remove_image, self.image, self.version
+            )
+
         self._meta = None
 
     @Job(

--- a/tests/addons/test_manager.py
+++ b/tests/addons/test_manager.py
@@ -1,6 +1,7 @@
 """Test addon manager."""
 
 import asyncio
+from copy import deepcopy
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, Mock, PropertyMock, patch
 
@@ -24,6 +25,7 @@ from supervisor.exceptions import (
     DockerNotFound,
 )
 from supervisor.plugins.dns import PluginDns
+from supervisor.store.addon import AddonStore
 from supervisor.store.repository import Repository
 from supervisor.utils import check_exception_chain
 from supervisor.utils.common import write_json_file
@@ -454,3 +456,38 @@ async def test_watchdog_runs_during_update(
         await asyncio.sleep(0)
         start.assert_called_once()
         restart.assert_not_called()
+
+
+async def test_shared_image_kept_on_uninstall(
+    coresys: CoreSys, install_addon_example: Addon
+):
+    """Test if two addons share an image it is not removed on uninstall."""
+    # Clone example to a new mock copy so two share an image
+    store = AddonStore(
+        coresys, "local_example2", deepcopy(coresys.addons.store["local_example"].data)
+    )
+    coresys.addons.data.install(store)
+    # pylint: disable-next=protected-access
+    coresys.addons.data._data = coresys.addons.data._schema(coresys.addons.data._data)
+
+    example_2 = Addon(coresys, store.slug)
+    coresys.addons.local[example_2.slug] = example_2
+
+    image = f"{install_addon_example.image}:{install_addon_example.version}"
+    latest = f"{install_addon_example.image}:latest"
+
+    await coresys.addons.uninstall("local_example2")
+    coresys.docker.images.remove.assert_not_called()
+    assert not coresys.addons.get("local_example2", local_only=True)
+
+    await coresys.addons.uninstall("local_example")
+    assert coresys.docker.images.remove.call_count == 2
+    assert coresys.docker.images.remove.call_args_list[0].kwargs == {
+        "image": latest,
+        "force": True,
+    }
+    assert coresys.docker.images.remove.call_args_list[1].kwargs == {
+        "image": image,
+        "force": True,
+    }
+    assert not coresys.addons.get("local_example", local_only=True)

--- a/tests/addons/test_manager.py
+++ b/tests/addons/test_manager.py
@@ -463,9 +463,9 @@ async def test_shared_image_kept_on_uninstall(
 ):
     """Test if two addons share an image it is not removed on uninstall."""
     # Clone example to a new mock copy so two share an image
-    store = AddonStore(
-        coresys, "local_example2", deepcopy(coresys.addons.store["local_example"].data)
-    )
+    store_data = deepcopy(coresys.addons.store["local_example"].data)
+    store = AddonStore(coresys, "local_example2", store_data)
+    coresys.addons.store["local_example2"] = store
     coresys.addons.data.install(store)
     # pylint: disable-next=protected-access
     coresys.addons.data._data = coresys.addons.data._schema(coresys.addons.data._data)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

It's possible that two addons share the same image, particularly when the addon dev publishes a separate beta version of the addon. If a user uninstalls an addon Supervisor needs to check if another addon is removing the image before removing it.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5244
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced uninstallation process for add-ons, allowing users to specify whether to remove associated Docker images.
	- Improved logic to prevent removal of shared images during the uninstallation of add-ons.

- **Tests**
	- Added a new test case to verify that shared Docker images are retained when one add-on is uninstalled while another references the same image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->