### PR TITLE
Minimize D-Bus requirements for tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -313,7 +313,7 @@ jobs:
       - name: Install additional system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libpulse0 libudev1 dbus dbus-x11
+          sudo apt-get install -y --no-install-recommends libpulse0 libudev1 dbus-daemon
       - name: Register Python problem matcher
         run: |
           echo "::add-matcher::.github/workflows/matchers/python.json"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This PR minimizes the D-Bus requirements for tests. It does this by using dbus-daemon directly instead of dbus-launch. The latter is meant for graphical applications and therefor has X11 dependencies. It also leaves the D-Bus daemon running after the tests are done. This will accumulate dbus-daemon processes over time which is not ideal.

I've also considered using dbus-run-session since it is meant to launch processes with a private D-Bus session. For Python tests one could launch it like so:
dbus-run-session -- python3 -m pytest ...

Then `DBUS_SESSION_BUS_ADDRESS` would be used automatically by the `MessageBus` class. However, to keep the current behavior of the tests, launching the D-Bus daemon manually is the better option.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints of add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `dbus_session` function to return a session address, improving connection capabilities to the D-Bus session.
	- Updated the `dbus_session` function for asynchronous execution, optimizing resource management.
- **Bug Fixes**
	- Corrected dependency installation in the CI workflow for improved environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->