### PR TITLE
Persist currently selected slot on successful boot

### DIFF
--- a/supervisor/os/manager.py
+++ b/supervisor/os/manager.py
@@ -366,11 +366,19 @@ class OSManager(CoreSysAttributes):
     async def mark_healthy(self) -> None:
         """Set booted partition as good for rauc."""
         try:
-            response = await self.sys_dbus.rauc.mark(RaucState.GOOD, "booted")
+            responses = [
+                await self.sys_dbus.rauc.mark(RaucState.ACTIVE, "booted"),
+                await self.sys_dbus.rauc.mark(RaucState.GOOD, "booted"),
+            ]
         except DBusError:
-            _LOGGER.error("Can't mark booted partition as healthy!")
+            _LOGGER.exception("Can't mark booted partition as healthy!")
         else:
-            _LOGGER.info("Rauc: %s - %s", self.sys_dbus.rauc.boot_slot, response[1])
+            _LOGGER.info(
+                "Rauc: slot %s - %s, %s",
+                self.sys_dbus.rauc.boot_slot,
+                responses[0][1],
+                responses[1][1],
+            )
             await self.reload()
 
     @Job(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

When boot slot is selected manually in GRUB, the system boots into this slot and marks it as good. However, the boot order is not changed, so in the next boot (after an explicit or unexpected reboot) HAOS returns to the version in the other slot. This might be confusing because if the system has been running for some time, the user can forget they have changed the boot slot to fix issue they had.

This gets more confusing if the "other" boot slot is selected manually three times in a row. Let's say we have ORDER="A B". This means that every time GRUB starts, it wants to boot slot A. If the slot B is selected instead, only A_TRY is incremented, system boots into slot B and marks slot B as good (B_OK=1, B_TRY=0). On another boot, this repeats, yet A_TRY is incremented again. Until it reaches 3, the slot A would be always chosen automatically, only after that it would boot to slot B, presuming slot A is dead. The ORDER variable will be still unchanged though.

This commit only makes sure that when the system is marked as healthy, the slot is both marked as good AND active, updating the ORDER variable as well. Because the X_TRY counter is incremented by GRUB, if we want the other slot not to be marked as bad, we need to adjust the logic in OS's grub.cfg as well, because Supervisor can't know whether it's apppropriate to change other slot's state or not.

I also took the courtesy to adjust the logging a bit, to include the stack trace in the error log if marking the slot fails somehow.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `mark_healthy` functionality to allow marking multiple states for the booted partition, improving operational flexibility.
	
- **Bug Fixes**
	- Improved error handling by using more appropriate logging for exceptions, enhancing debugging capabilities.

- **Improvements**
	- Expanded logging for successful operations to include detailed feedback on state changes, providing better visibility into the system's status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->