### PR TITLE
Improve WiFi settings error handling

### DIFF
--- a/supervisor/dbus/network/setting/generate.py
+++ b/supervisor/dbus/network/setting/generate.py
@@ -199,15 +199,17 @@ def get_connection_from_interface(
     elif interface.type == InterfaceType.WIRELESS:
         wireless = {
             CONF_ATTR_802_WIRELESS_ASSIGNED_MAC: Variant("s", "preserve"),
-            CONF_ATTR_802_WIRELESS_SSID: Variant(
-                "ay", interface.wifi.ssid.encode("UTF-8")
-            ),
             CONF_ATTR_802_WIRELESS_MODE: Variant("s", "infrastructure"),
             CONF_ATTR_802_WIRELESS_POWERSAVE: Variant("i", 1),
         }
+        if interface.wifi and interface.wifi.ssid:
+            wireless[CONF_ATTR_802_WIRELESS_SSID] = Variant(
+                "ay", interface.wifi.ssid.encode("UTF-8")
+            )
+
         conn[CONF_ATTR_802_WIRELESS] = wireless
 
-        if interface.wifi.auth != "open":
+        if interface.wifi and interface.wifi.auth != "open":
             wireless["security"] = Variant("s", CONF_ATTR_802_WIRELESS_SECURITY)
             wireless_security = {}
             if interface.wifi.auth == "wep":

--- a/supervisor/host/network.py
+++ b/supervisor/host/network.py
@@ -238,7 +238,7 @@ class NetworkManager(CoreSysAttributes):
         # Remove config from interface
         elif inet and not interface.enabled:
             if not inet.settings:
-                # It was and is disabled, that is fine
+                _LOGGER.debug("Interface %s is already disabled.", interface.name)
                 return
             try:
                 await inet.settings.delete()

--- a/supervisor/host/network.py
+++ b/supervisor/host/network.py
@@ -236,7 +236,10 @@ class NetworkManager(CoreSysAttributes):
                 ) from err
 
         # Remove config from interface
-        elif inet and inet.settings and not interface.enabled:
+        elif inet and not interface.enabled:
+            if not inet.settings:
+                # It was and is disabled, that is fine
+                return
             try:
                 await inet.settings.delete()
             except DBusError as err:

--- a/tests/api/test_network.py
+++ b/tests/api/test_network.py
@@ -234,7 +234,7 @@ async def test_api_network_interface_update_ethernet(
 
 
 async def test_api_network_interface_update_wifi(api_client: TestClient):
-    """Test network manager api."""
+    """Test network interface WiFi API."""
     resp = await api_client.post(
         f"/network/interface/{TEST_INTERFACE_WLAN_NAME}/update",
         json={
@@ -250,6 +250,30 @@ async def test_api_network_interface_update_wifi(api_client: TestClient):
     )
     result = await resp.json()
     assert result["result"] == "ok"
+
+
+async def test_api_network_interface_update_wifi_error(api_client: TestClient):
+    """Test network interface WiFi API error handling."""
+    # Simulate frontend WiFi interface edit where the user did not select
+    # a WiFi SSID.
+    resp = await api_client.post(
+        f"/network/interface/{TEST_INTERFACE_WLAN_NAME}/update",
+        json={
+            "enabled": True,
+            "ipv4": {
+                "method": "auto",
+            },
+            "ipv6": {
+                "method": "auto",
+            },
+        },
+    )
+    result = await resp.json()
+    assert result["result"] == "error"
+    assert (
+        result["message"]
+        == "Can't create config and activate wlan0: A 'wireless' setting with a valid SSID is required if no AP path was given."
+    )
 
 
 async def test_api_network_interface_update_remove(api_client: TestClient):

--- a/tests/dbus_service_mocks/network_manager.py
+++ b/tests/dbus_service_mocks/network_manager.py
@@ -1,5 +1,6 @@
 """Mock of Network Manager service."""
 
+from dbus_fast import DBusError
 from dbus_fast.service import PropertyAccess, dbus_property, signal
 
 from .base import DBusServiceMock, dbus_method
@@ -227,6 +228,18 @@ class NetworkManager(DBusServiceMock):
         self, connection: "a{sa{sv}}", device: "o", speciic_object: "o"
     ) -> "oo":
         """Do AddAndActivateConnection method."""
+        if connection["connection"]["type"].value == "802-11-wireless":
+            if "802-11-wireless" not in connection:
+                raise DBusError(
+                    "org.freedesktop.NetworkManager.Device.InvalidConnection",
+                    "A 'wireless' setting is required if no AP path was given.",
+                )
+            if "ssid" not in connection["802-11-wireless"]:
+                raise DBusError(
+                    "org.freedesktop.NetworkManager.Device.InvalidConnection",
+                    "A 'wireless' setting with a valid SSID is required if no AP path was given.",
+                )
+
         return [
             "/org/freedesktop/NetworkManager/Settings/1",
             "/org/freedesktop/NetworkManager/ActiveConnection/1",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Currently, the frontend potentially provides no WiFi settings dictionary but still tries to update other (IP address) settings on the interface. This leads to a stack trace since network manager is not able to fetch the WiFi settings from the settings dictionary. This change simply only sets the field we can and let NetworkManager provide an error.

Also allow to disable a network interface which has no configuration. This avoids an error when switching to auto and back to disabled then press save on a new wireless network interface.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5216, #5271
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of wireless interface configurations to prevent errors related to undefined properties.
	- Enhanced error handling for wireless settings, ensuring attributes are assigned only when valid data is available.
	- Added validation for WiFi connection parameters to prevent misconfigurations.

- **Performance Improvements**
	- Streamlined logic in network interface management to enhance clarity and reduce unnecessary operations.

- **Tests**
	- Updated tests for WiFi functionality to improve clarity and coverage of error handling scenarios.
	- Introduced new tests to ensure proper error handling when required parameters are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->