### PR TITLE
Return cursor of the first host logs entry via headers

### DIFF
--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -262,7 +262,7 @@ async def test_advaced_logs_query_parameters(
         range_header=DEFAULT_RANGE,
         accept=LogFormat.JOURNAL,
     )
-    journal_logs_reader.assert_called_with(ANY, LogFormatter.VERBOSE)
+    journal_logs_reader.assert_called_with(ANY, LogFormatter.VERBOSE, ANY)
 
     journal_logs_reader.reset_mock()
     journald_logs.reset_mock()
@@ -280,7 +280,7 @@ async def test_advaced_logs_query_parameters(
         range_header="entries=:-53:",
         accept=LogFormat.JOURNAL,
     )
-    journal_logs_reader.assert_called_with(ANY, LogFormatter.VERBOSE)
+    journal_logs_reader.assert_called_with(ANY, LogFormatter.VERBOSE, ANY)
 
 
 async def test_advanced_logs_boot_id_offset(
@@ -333,24 +333,24 @@ async def test_advanced_logs_formatters(
     """Test advanced logs formatters varying on Accept header."""
 
     await api_client.get("/host/logs")
-    journal_logs_reader.assert_called_once_with(ANY, LogFormatter.VERBOSE)
+    journal_logs_reader.assert_called_once_with(ANY, LogFormatter.VERBOSE, ANY)
 
     journal_logs_reader.reset_mock()
 
     headers = {"Accept": "text/x-log"}
     await api_client.get("/host/logs", headers=headers)
-    journal_logs_reader.assert_called_once_with(ANY, LogFormatter.VERBOSE)
+    journal_logs_reader.assert_called_once_with(ANY, LogFormatter.VERBOSE, ANY)
 
     journal_logs_reader.reset_mock()
 
     await api_client.get("/host/logs/identifiers/test")
-    journal_logs_reader.assert_called_once_with(ANY, LogFormatter.PLAIN)
+    journal_logs_reader.assert_called_once_with(ANY, LogFormatter.PLAIN, ANY)
 
     journal_logs_reader.reset_mock()
 
     headers = {"Accept": "text/x-log"}
     await api_client.get("/host/logs/identifiers/test", headers=headers)
-    journal_logs_reader.assert_called_once_with(ANY, LogFormatter.VERBOSE)
+    journal_logs_reader.assert_called_once_with(ANY, LogFormatter.VERBOSE, ANY)
 
 
 async def test_advanced_logs_errors(api_client: TestClient):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Return first entry's cursor via custom `X-First-Cursor` header that can be consumed by the client and used for continual requesting of the historic logs. Once the first fetch returns data, the cursor can be supplied as the first argument to the Range header in another call, fetching accurate slice of the journal with the previous log entries using the `Range: entries=cursor[[:num_skip]:num_entries]` syntax.

Let's say we fetch logs with the Range header `entries=:-19:20` (to fetch very last 20 lines of the logs, see below why not `entries:-20:20`) and we get `cursor50` as the reply (the actual value will be much more complex and with no guaranteed format). To fetch previous slice of the logs, we use `entries=cursor50:-20:20`, which would return 20 lines previous to `cursor50` and `cursor30` in the cursor header. This way we can go all the way back to the history.

One problem with the cursor is that it's not possible to determine when the negative num_skip points beyond the first log entry. In that case the client either needs to know what the first entry is (via `entries=:0:1`) or can iterate naively and stop once two subsequent requests return the same first cursor.

Another caveat, even though it's unlikely it will be hit in real usage, is that it's not possible to fetch the last line only - if no cursor is provided, negative num_skip argument is needed, and in that case we're pointing one record back from the current cursor, which is the previous record. The least we can return without knowing any cursor is thus `entries=:-1:2` (where the `2` can be omitted, however with `entries=:-1:1` we would lose the last line). This also explains why different `num_skip` and `num_entries` must be used for the first fetch.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: TBD
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
