### PR TITLE
Fix number of lines returned with host logs' query argument

### DIFF
--- a/supervisor/api/host.py
+++ b/supervisor/api/host.py
@@ -61,7 +61,7 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 IDENTIFIER = "identifier"
 BOOTID = "bootid"
-DEFAULT_RANGE = 100
+DEFAULT_LINES = 100
 
 SCHEMA_OPTIONS = vol.Schema({vol.Optional(ATTR_HOSTNAME): str})
 
@@ -226,13 +226,24 @@ class APIHost(CoreSysAttributes):
             log_formatter = LogFormatter.VERBOSE
 
         if "lines" in request.query:
-            lines = request.query.get("lines", DEFAULT_RANGE)
+            lines = request.query.get("lines", DEFAULT_LINES)
+            try:
+                lines = int(lines)
+            except ValueError:
+                # If the user passed a non-integer value, just use the default instead of error.
+                lines = DEFAULT_LINES
+            finally:
+                # We can't use the entries= Range header syntax to refer to the last 1 line,
+                # and passing 1 to the calculation below would return the 1st line of the logs
+                # instead. Since this is really an edge case that doesn't matter much, we'll just
+                # return 2 lines at minimum.
+                lines = max(2, lines)
             # entries=cursor[[:num_skip]:num_entries]
-            range_header = f"entries=:-{lines}:"
+            range_header = f"entries=:-{lines-1}:{lines}"
         elif RANGE in request.headers:
             range_header = request.headers.get(RANGE)
         else:
-            range_header = f"entries=:-{DEFAULT_RANGE}:"
+            range_header = f"entries=:-{DEFAULT_LINES-1}:{DEFAULT_LINES}"
 
         async with self.sys_host.logs.journald_logs(
             params=params, range_header=range_header, accept=LogFormat.JOURNAL

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -6,7 +6,7 @@ from aiohttp.test_utils import TestClient
 
 from supervisor.host.const import LogFormat
 
-DEFAULT_LOG_RANGE = "entries=:-100:"
+DEFAULT_LOG_RANGE = "entries=:-99:100"
 
 
 async def common_test_api_advanced_logs(

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -14,7 +14,7 @@ from supervisor.host.control import SystemControl
 from tests.dbus_service_mocks.base import DBusServiceMock
 from tests.dbus_service_mocks.systemd import Systemd as SystemdService
 
-DEFAULT_RANGE = "entries=:-100:"
+DEFAULT_RANGE = "entries=:-99:100"
 # pylint: disable=protected-access
 
 
@@ -249,7 +249,7 @@ async def test_advaced_logs_query_parameters(
     await api_client.get("/host/logs?lines=53")
     journald_logs.assert_called_once_with(
         params={"SYSLOG_IDENTIFIER": coresys.host.logs.default_identifiers},
-        range_header="entries=:-53:",
+        range_header="entries=:-52:53",
         accept=LogFormat.JOURNAL,
     )
 
@@ -277,7 +277,7 @@ async def test_advaced_logs_query_parameters(
     )
     journald_logs.assert_called_once_with(
         params={"SYSLOG_IDENTIFIER": coresys.host.logs.default_identifiers},
-        range_header="entries=:-53:",
+        range_header="entries=:-52:53",
         accept=LogFormat.JOURNAL,
     )
     journal_logs_reader.assert_called_with(ANY, LogFormatter.VERBOSE)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

If no cursor is specified and negative num_skip is used, we're pointing one record back from the last one, so host logs always returned 101 lines as the default. This was also the case of the lines query argument that used the number directly as num_skip. Instead of doing that, point N-1 records to the back and then get N records. Handle 1 record and invalid numbers silently to avoid the need for error handling in unpractical edge cases.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced log retrieval functionality with improved handling of line counts.
	- Minimum number of lines returned is now enforced to be at least 2.

- **Bug Fixes**
	- Adjusted range header logic to ensure consistent behavior with user input.

- **Tests**
	- Updated test cases to reflect changes in log entry range handling and ensure accurate assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->