### PR TITLE
Support CGroup v2 on Supervised with manual addon restarts

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -148,6 +148,9 @@ class Addon(AddonModel):
         self._boot_failed_issue = Issue(
             IssueType.BOOT_FAIL, ContextType.ADDON, reference=self.slug
         )
+        self._device_access_missing_issue = Issue(
+            IssueType.DEVICE_ACCESS_MISSING, ContextType.ADDON, reference=self.slug
+        )
 
     def __repr__(self) -> str:
         """Return internal representation."""
@@ -157,6 +160,11 @@ class Addon(AddonModel):
     def boot_failed_issue(self) -> Issue:
         """Get issue used if start on boot failed."""
         return self._boot_failed_issue
+
+    @property
+    def device_access_missing_issue(self) -> Issue:
+        """Get issue used if device access is missing and can't be automatically added."""
+        return self._device_access_missing_issue
 
     @property
     def state(self) -> AddonState:
@@ -181,6 +189,13 @@ class Addon(AddonModel):
             and self.boot_failed_issue in self.sys_resolution.issues
         ):
             self.sys_resolution.dismiss_issue(self.boot_failed_issue)
+
+        # Dismiss device access missing issue if present and we stopped
+        if (
+            new_state == AddonState.STOPPED
+            and self.device_access_missing_issue in self.sys_resolution.issues
+        ):
+            self.sys_resolution.dismiss_issue(self.device_access_missing_issue)
 
         self.sys_homeassistant.websocket.send_message(
             {

--- a/supervisor/docker/addon.py
+++ b/supervisor/docker/addon.py
@@ -10,6 +10,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from attr import evolve
 from awesomeversion import AwesomeVersion
 import docker
 from docker.types import Mount
@@ -40,7 +41,7 @@ from ..hardware.const import PolicyGroup
 from ..hardware.data import Device
 from ..jobs.const import JobCondition, JobExecutionLimit
 from ..jobs.decorator import Job
-from ..resolution.const import ContextType, IssueType, SuggestionType
+from ..resolution.const import CGROUP_V2_VERSION, ContextType, IssueType, SuggestionType
 from ..utils.sentry import capture_exception
 from .const import (
     ENV_TIME,
@@ -787,6 +788,13 @@ class DockerAddon(DockerInterface):
 
         await super().stop(remove_container)
 
+        # If there is a device access issue and the container is removed, clear it
+        if (
+            remove_container
+            and self.addon.device_access_missing_issue in self.sys_resolution.issues
+        ):
+            self.sys_resolution.dismiss_issue(self.addon.device_access_missing_issue)
+
     async def _validate_trust(
         self, image_id: str, image: str, version: AwesomeVersion
     ) -> None:
@@ -823,6 +831,16 @@ class DockerAddon(DockerInterface):
             raise DockerError(
                 f"Can't process Hardware Event on {self.name}: {err!s}", _LOGGER.error
             ) from err
+
+        if (
+            self.sys_docker.info.cgroup == CGROUP_V2_VERSION
+            and not self.sys_os.available
+        ):
+            self.sys_resolution.add_issue(
+                evolve(self.addon.device_access_missing_issue),
+                suggestions=[SuggestionType.EXECUTE_RESTART],
+            )
+            return
 
         permission = self.sys_hardware.policy.get_cgroups_rule(device)
         try:

--- a/supervisor/resolution/const.py
+++ b/supervisor/resolution/const.py
@@ -15,6 +15,9 @@ MINIMUM_FULL_BACKUPS = 2
 DNS_CHECK_HOST = "_checkdns.home-assistant.io"
 DNS_ERROR_NO_DATA = 1
 
+CGROUP_V1_VERSION = "1"
+CGROUP_V2_VERSION = "2"
+
 
 class ContextType(StrEnum):
     """Place where somethings was happening."""
@@ -77,6 +80,7 @@ class IssueType(StrEnum):
     CORRUPT_FILESYSTEM = "corrupt_filesystem"
     DETACHED_ADDON_MISSING = "detached_addon_missing"
     DETACHED_ADDON_REMOVED = "detached_addon_removed"
+    DEVICE_ACCESS_MISSING = "device_access_missing"
     DISABLED_DATA_DISK = "disabled_data_disk"
     DNS_LOOP = "dns_loop"
     DNS_SERVER_FAILED = "dns_server_failed"
@@ -112,6 +116,7 @@ class SuggestionType(StrEnum):
     EXECUTE_REMOVE = "execute_remove"
     EXECUTE_REPAIR = "execute_repair"
     EXECUTE_RESET = "execute_reset"
+    EXECUTE_RESTART = "execute_restart"
     EXECUTE_START = "execute_start"
     EXECUTE_STOP = "execute_stop"
     EXECUTE_UPDATE = "execute_update"

--- a/supervisor/resolution/evaluations/cgroup.py
+++ b/supervisor/resolution/evaluations/cgroup.py
@@ -2,11 +2,8 @@
 
 from ...const import CoreState
 from ...coresys import CoreSys
-from ..const import UnsupportedReason
+from ..const import CGROUP_V1_VERSION, CGROUP_V2_VERSION, UnsupportedReason
 from .base import EvaluateBase
-
-CGROUP_V1_VERSION = "1"
-CGROUP_V2_VERSION = "2"
 
 
 def setup(coresys: CoreSys) -> EvaluateBase:
@@ -20,9 +17,7 @@ class EvaluateCGroupVersion(EvaluateBase):
     @property
     def expected_versions(self) -> set[str]:
         """Return expected cgroup versions."""
-        if self.coresys.os.available:
-            return {CGROUP_V1_VERSION, CGROUP_V2_VERSION}
-        return {CGROUP_V1_VERSION}
+        return {CGROUP_V1_VERSION, CGROUP_V2_VERSION}
 
     @property
     def reason(self) -> UnsupportedReason:

--- a/supervisor/resolution/fixups/addon_execute_restart.py
+++ b/supervisor/resolution/fixups/addon_execute_restart.py
@@ -1,0 +1,60 @@
+"""Helpers to fix addon by restarting it."""
+
+import logging
+
+from ...coresys import CoreSys
+from ...exceptions import AddonsError, ResolutionFixupError
+from ..const import ContextType, IssueType, SuggestionType
+from .base import FixupBase
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+def setup(coresys: CoreSys) -> FixupBase:
+    """Check setup function."""
+    return FixupAddonExecuteRestart(coresys)
+
+
+class FixupAddonExecuteRestart(FixupBase):
+    """Storage class for fixup."""
+
+    async def process_fixup(self, reference: str | None = None) -> None:
+        """Initialize the fixup class."""
+        if not (addon := self.sys_addons.get(reference, local_only=True)):
+            _LOGGER.info("Cannot restart addon %s as it does not exist", reference)
+            return
+
+        # Stop addon
+        try:
+            await addon.stop()
+        except AddonsError as err:
+            _LOGGER.error("Could not stop %s due to %s", reference, err)
+            raise ResolutionFixupError() from None
+
+        # Start addon
+        # Removing the container has already fixed the issue and dismissed it
+        # So any errors on startup are just logged. We won't wait on the startup task either
+        try:
+            await addon.start()
+        except AddonsError as err:
+            _LOGGER.error("Could not restart %s due to %s", reference, err)
+
+    @property
+    def suggestion(self) -> SuggestionType:
+        """Return a SuggestionType enum."""
+        return SuggestionType.EXECUTE_RESTART
+
+    @property
+    def context(self) -> ContextType:
+        """Return a ContextType enum."""
+        return ContextType.ADDON
+
+    @property
+    def issues(self) -> list[IssueType]:
+        """Return a IssueType enum list."""
+        return [IssueType.DEVICE_ACCESS_MISSING]
+
+    @property
+    def auto(self) -> bool:
+        """Return if a fixup can be apply as auto fix."""
+        return False

--- a/tests/resolution/evaluation/test_evaluate_cgroup.py
+++ b/tests/resolution/evaluation/test_evaluate_cgroup.py
@@ -26,7 +26,7 @@ async def test_evaluation(coresys: CoreSys):
 
     coresys.docker.info.cgroup = CGROUP_V2_VERSION
     await cgroup_version()
-    assert cgroup_version.reason in coresys.resolution.unsupported
+    assert cgroup_version.reason not in coresys.resolution.unsupported
     coresys.resolution.unsupported.clear()
 
     coresys.docker.info.cgroup = CGROUP_V1_VERSION

--- a/tests/resolution/fixup/test_addon_execute_restart.py
+++ b/tests/resolution/fixup/test_addon_execute_restart.py
@@ -1,0 +1,120 @@
+"""Test fixup addon execute restart."""
+
+from unittest.mock import patch
+
+import pytest
+
+from supervisor.addons.addon import Addon
+from supervisor.const import AddonState
+from supervisor.coresys import CoreSys
+from supervisor.docker.addon import DockerAddon
+from supervisor.docker.interface import DockerInterface
+from supervisor.exceptions import DockerError
+from supervisor.resolution.const import ContextType, IssueType, SuggestionType
+from supervisor.resolution.data import Issue, Suggestion
+from supervisor.resolution.fixups.addon_execute_restart import FixupAddonExecuteRestart
+
+from tests.const import TEST_ADDON_SLUG
+
+DEVICE_ACCESS_MISSING_ISSUE = Issue(
+    IssueType.DEVICE_ACCESS_MISSING,
+    ContextType.ADDON,
+    reference=TEST_ADDON_SLUG,
+)
+EXECUTE_RESTART_SUGGESTION = Suggestion(
+    SuggestionType.EXECUTE_RESTART, ContextType.ADDON, reference="local_ssh"
+)
+
+
+@pytest.mark.usefixtures("path_extern")
+async def test_fixup(coresys: CoreSys, install_addon_ssh: Addon):
+    """Test fixup restarts addon."""
+    install_addon_ssh.state = AddonState.STARTED
+    addon_execute_restart = FixupAddonExecuteRestart(coresys)
+    assert addon_execute_restart.auto is False
+
+    async def mock_stop(*args, **kwargs):
+        install_addon_ssh.state = AddonState.STOPPED
+
+    coresys.resolution.add_issue(
+        DEVICE_ACCESS_MISSING_ISSUE,
+        suggestions=[SuggestionType.EXECUTE_RESTART],
+    )
+    with (
+        patch.object(DockerInterface, "stop") as stop,
+        patch.object(DockerAddon, "run") as run,
+        patch.object(Addon, "_wait_for_startup"),
+        patch.object(Addon, "write_options"),
+    ):
+        await addon_execute_restart()
+        stop.assert_called_once()
+        run.assert_called_once()
+
+    assert not coresys.resolution.issues
+    assert not coresys.resolution.suggestions
+
+
+@pytest.mark.usefixtures("path_extern")
+async def test_fixup_stop_error(
+    coresys: CoreSys, install_addon_ssh: Addon, caplog: pytest.LogCaptureFixture
+):
+    """Test fixup fails on stop addon failure."""
+    install_addon_ssh.state = AddonState.STARTED
+    addon_execute_start = FixupAddonExecuteRestart(coresys)
+
+    coresys.resolution.add_issue(
+        DEVICE_ACCESS_MISSING_ISSUE,
+        suggestions=[SuggestionType.EXECUTE_RESTART],
+    )
+    with (
+        patch.object(DockerInterface, "stop", side_effect=DockerError),
+        patch.object(DockerAddon, "run") as run,
+    ):
+        await addon_execute_start()
+        run.assert_not_called()
+
+    assert DEVICE_ACCESS_MISSING_ISSUE in coresys.resolution.issues
+    assert EXECUTE_RESTART_SUGGESTION in coresys.resolution.suggestions
+    assert "Could not stop local_ssh" in caplog.text
+
+
+@pytest.mark.usefixtures("path_extern")
+async def test_fixup_start_error(
+    coresys: CoreSys, install_addon_ssh: Addon, caplog: pytest.LogCaptureFixture
+):
+    """Test fixup logs a start addon failure."""
+    install_addon_ssh.state = AddonState.STARTED
+    addon_execute_start = FixupAddonExecuteRestart(coresys)
+
+    coresys.resolution.add_issue(
+        DEVICE_ACCESS_MISSING_ISSUE,
+        suggestions=[SuggestionType.EXECUTE_RESTART],
+    )
+    with (
+        patch.object(DockerInterface, "stop") as stop,
+        patch.object(DockerAddon, "run", side_effect=DockerError),
+        patch.object(Addon, "write_options"),
+    ):
+        await addon_execute_start()
+        stop.assert_called_once()
+
+    assert DEVICE_ACCESS_MISSING_ISSUE not in coresys.resolution.issues
+    assert EXECUTE_RESTART_SUGGESTION not in coresys.resolution.suggestions
+    assert "Could not restart local_ssh" in caplog.text
+
+
+async def test_fixup_no_addon(coresys: CoreSys, caplog: pytest.LogCaptureFixture):
+    """Test fixup dismisses if addon is missing."""
+    addon_execute_start = FixupAddonExecuteRestart(coresys)
+
+    coresys.resolution.add_issue(
+        DEVICE_ACCESS_MISSING_ISSUE,
+        suggestions=[SuggestionType.EXECUTE_RESTART],
+    )
+    with patch.object(DockerAddon, "stop") as stop:
+        await addon_execute_start()
+        stop.assert_not_called()
+
+    assert not coresys.resolution.issues
+    assert not coresys.resolution.suggestions
+    assert "Cannot restart addon local_ssh as it does not exist" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

CGroup v2 does not support the ability to add device access on the fly to a container like we could with CGroup v1. It does not appear we are going to get that support and CGroup v1 support is completely dropped at this point so we will use a workaround on Supervised systems.

CGroup v2 will no longer be marked as unsupported on Supervised systems. If a device is hotplugged and we need to add access to a running addon we will instead create a repair asking the user to restart the addon. This will not be automatic, users will have to restart the addon manually in order for it to access the device.

Note that this only applies to Supervised systems with CGroup v2. HAOS uses a patched version of CGroup v2 with the ability to add device access on the fly so users on HAOS systems will never see this repair or have to restart addons for device access.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request: https://github.com/home-assistant-libs/python-supervisor-client/pull/29

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced enhanced error handling for device access issues in add-ons.
  - Added a mechanism to suggest restarting add-ons when device access is missing.

- **Bug Fixes**
  - Improved management of device access issues during add-on state transitions.
  - Updated logic to handle cgroup versions more effectively.

- **Tests**
  - Expanded testing framework for Docker add-ons, including new scenarios for device management and error handling.
  - Added unit tests for the add-on restart functionality, covering various operational states and error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->