### PR TITLE
Check password early on backup restore

### DIFF
--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -687,10 +687,12 @@ class BackupManager(FileConfiguration, JobGroup):
                 f"{backup.slug} is only a partial backup!", _LOGGER.error
             )
 
-        if backup.protected and not backup.set_password(password):
-            raise BackupInvalidError(
-                f"Invalid password for backup {backup.slug}", _LOGGER.error
-            )
+        if backup.protected:
+            backup.set_password(password)
+            if not await backup.validate_password():
+                raise BackupInvalidError(
+                    f"Invalid password for backup {backup.slug}", _LOGGER.error
+                )
 
         if backup.supervisor_version > self.sys_supervisor.version:
             raise BackupInvalidError(
@@ -755,10 +757,12 @@ class BackupManager(FileConfiguration, JobGroup):
             folder_list.remove(FOLDER_HOMEASSISTANT)
             homeassistant = True
 
-        if backup.protected and not backup.set_password(password):
-            raise BackupInvalidError(
-                f"Invalid password for backup {backup.slug}", _LOGGER.error
-            )
+        if backup.protected:
+            backup.set_password(password)
+            if not await backup.validate_password():
+                raise BackupInvalidError(
+                    f"Invalid password for backup {backup.slug}", _LOGGER.error
+                )
 
         if backup.homeassistant is None and homeassistant:
             raise BackupInvalidError(

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -478,7 +478,7 @@ async def test_restore_immediate_errors(
 
     with (
         patch.object(Backup, "protected", new=PropertyMock(return_value=True)),
-        patch.object(Backup, "set_password", return_value=False),
+        patch.object(Backup, "validate_password", return_value=False),
     ):
         resp = await api_client.post(
             f"/backups/{mock_partial_backup.slug}/restore/partial",

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -209,6 +209,7 @@ async def test_do_restore_full(coresys: CoreSys, full_backup_mock, install_addon
     manager = BackupManager(coresys)
 
     backup_instance = full_backup_mock.return_value
+    backup_instance.protected = False
     backup_instance.sys_addons = coresys.addons
     backup_instance.remove_delta_addons = partial(
         Backup.remove_delta_addons, backup_instance
@@ -241,6 +242,7 @@ async def test_do_restore_full_different_addon(
     manager = BackupManager(coresys)
 
     backup_instance = full_backup_mock.return_value
+    backup_instance.protected = False
     backup_instance.addon_list = ["differentslug"]
     backup_instance.sys_addons = coresys.addons
     backup_instance.remove_delta_addons = partial(
@@ -273,6 +275,7 @@ async def test_do_restore_partial_minimal(
     manager = BackupManager(coresys)
 
     backup_instance = partial_backup_mock.return_value
+    backup_instance.protected = False
     assert await manager.do_restore_partial(backup_instance, homeassistant=False)
 
     backup_instance.restore_homeassistant.assert_not_called()
@@ -297,6 +300,7 @@ async def test_do_restore_partial_maximal(coresys: CoreSys, partial_backup_mock)
     manager = BackupManager(coresys)
 
     backup_instance = partial_backup_mock.return_value
+    backup_instance.protected = False
     assert await manager.do_restore_partial(
         backup_instance,
         addons=[TEST_ADDON_SLUG],
@@ -330,7 +334,7 @@ async def test_fail_invalid_full_backup(
 
     backup_instance = full_backup_mock.return_value
     backup_instance.protected = True
-    backup_instance.set_password.return_value = False
+    backup_instance.validate_password = AsyncMock(return_value=False)
 
     with pytest.raises(BackupInvalidError):
         await manager.do_restore_full(backup_instance)
@@ -359,7 +363,7 @@ async def test_fail_invalid_partial_backup(
 
     backup_instance = partial_backup_mock.return_value
     backup_instance.protected = True
-    backup_instance.set_password.return_value = False
+    backup_instance.validate_password = AsyncMock(return_value=False)
 
     with pytest.raises(BackupInvalidError):
         await manager.do_restore_partial(backup_instance)
@@ -407,6 +411,7 @@ async def test_restore_error(
     coresys.homeassistant.core.start = AsyncMock(return_value=None)
 
     backup_instance = full_backup_mock.return_value
+    backup_instance.protected = False
     backup_instance.restore_dockerconfig.side_effect = BackupError()
     with pytest.raises(BackupError):
         await coresys.backups.do_restore_full(backup_instance)
@@ -1818,6 +1823,7 @@ async def test_monitoring_after_full_restore(
     manager = BackupManager(coresys)
 
     backup_instance = full_backup_mock.return_value
+    backup_instance.protected = False
     assert await manager.do_restore_full(backup_instance)
 
     backup_instance.restore_addons.assert_called_once_with([TEST_ADDON_SLUG])
@@ -1835,6 +1841,7 @@ async def test_monitoring_after_partial_restore(
     manager = BackupManager(coresys)
 
     backup_instance = partial_backup_mock.return_value
+    backup_instance.protected = False
     assert await manager.do_restore_partial(backup_instance, addons=[TEST_ADDON_SLUG])
 
     backup_instance.restore_addons.assert_called_once_with([TEST_ADDON_SLUG])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Introduce a validate password method which only peaks into the archive to validate the password before starting the actual restore process. This makes sure that a wrong password returns an error even when restoring the backup in background.

This implements what has been added in Core with https://github.com/home-assistant/core/pull/133647.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added an asynchronous password validation method for backups.
	- Enhanced backup password management functionality.

- **Bug Fixes**
	- Improved error handling for backup password validation.
	- Refined backup restoration process with more precise password checks.

- **Refactor**
	- Updated password validation mechanism in backup and restore processes.
	- Modified test cases to align with new password validation approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->