### PR TITLE
Add X-Accel-Buffering to disable buffers in proxies

### DIFF
--- a/supervisor/api/host.py
+++ b/supervisor/api/host.py
@@ -258,6 +258,7 @@ class APIHost(CoreSysAttributes):
                     if not headers_returned:
                         if cursor:
                             response.headers["X-First-Cursor"] = cursor
+                        response.headers["X-Accel-Buffering"] = "no"
                         await response.prepare(request)
                         headers_returned = True
                     # When client closes the connection while reading busy logs, we

--- a/supervisor/api/ingress.py
+++ b/supervisor/api/ingress.py
@@ -277,6 +277,7 @@ class APIIngress(CoreSysAttributes):
             response.content_type = content_type
 
             try:
+                response.headers["X-Accel-Buffering"] = "no"
                 await response.prepare(request)
                 async for data in result.content.iter_chunked(4096):
                     await response.write(data)

--- a/supervisor/api/proxy.py
+++ b/supervisor/api/proxy.py
@@ -95,6 +95,7 @@ class APIProxy(CoreSysAttributes):
             response = web.StreamResponse()
             response.content_type = request.headers.get(CONTENT_TYPE)
             try:
+                response.headers["X-Accel-Buffering"] = "no"
                 await response.prepare(request)
                 async for data in client.content:
                     await response.write(data)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some proxies, notable NGINX, seem to buffer responses by default. For the long running log requests this is not helpful: The user won't see logs since the proxy is buffering the response.

It seems that using http2 or explicit `proxy_buffering: no`` in the proxy configuration disables the buffering. However, better yet is to explicitly add the `X-Accel-Buffering: no`` header to the log responses.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5509
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced log streaming performance by modifying server response headers to prevent buffering, optimizing data transmission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->