### PR TITLE
Revert "Bump orjson from 3.10.12 to 3.10.13"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ docker==7.1.0
 faust-cchardet==2.1.19
 gitpython==3.1.44
 jinja2==3.1.5
-orjson==3.10.13
+orjson==3.10.12
 pulsectl==24.12.0
 pyudev==0.24.3
 PyYAML==6.0.2


### PR DESCRIPTION
Reverts home-assistant/supervisor#5514

Revert orjson to 3.10.12. This unblocks Python 3.13 builds. 3.10.12 is what is currently used in Core, and we have wheels built for Python 3.13.