### PR TITLE
Revert "Bump dbus-fast from 2.28.0 to 2.29.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,6 @@ securetar==2024.11.0
 sentry-sdk==2.20.0
 setuptools==75.8.0
 voluptuous==0.15.2
-dbus-fast==2.29.0
+dbus-fast==2.28.0
 typing_extensions==4.12.2
 zlib-fast==0.2.0


### PR DESCRIPTION
Reverts home-assistant/supervisor#5551

Revert dbus-fast to 2.28.0. This unblocks Python 3.13 builds. 2.28.0 is what is currently used in Core, and we have wheels built for Python 3.13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Downgraded `dbus-fast` package version from 2.29.0 to 2.28.0 in project dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->