### PR TITLE
Avoid backup size difference by sorting JSON keys

### DIFF
--- a/supervisor/utils/json.py
+++ b/supervisor/utils/json.py
@@ -55,7 +55,8 @@ def write_json_file(jsonfile: Path, data: Any) -> None:
                 orjson.dumps(  # pylint: disable=no-member
                     data,
                     option=orjson.OPT_INDENT_2  # pylint: disable=no-member
-                    | orjson.OPT_NON_STR_KEYS,  # pylint: disable=no-member
+                    | orjson.OPT_NON_STR_KEYS  # pylint: disable=no-member
+                    | orjson.OPT_SORT_KEYS,  # pylint: disable=no-member
                     default=json_encoder_default,
                 ).decode("utf-8")
             )

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -1036,8 +1036,9 @@ async def test_protected_backup(
     assert body["data"]["backups"][0]["locations"] == [None]
     assert body["data"]["backups"][0]["protected"] is True
 
-    # NOTE: Maybe it is not safe to compare size here, as random data in the
-    # backup might change the size (due to gzip).
+    # NOTE: It might not be safe to check size here, as random data in the
+    # backup (e.g. isntance UUID, backup slug) might change the size (due
+    # to gzip).
     assert body["data"]["backups"][0]["location_attributes"] == {
         ".local": {
             "protected": True,

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -1035,6 +1035,9 @@ async def test_protected_backup(
     assert body["data"]["backups"][0]["location"] is None
     assert body["data"]["backups"][0]["locations"] == [None]
     assert body["data"]["backups"][0]["protected"] is True
+
+    # NOTE: Maybe it is not safe to compare size here, as random data in the
+    # backup might change the size (due to gzip).
     assert body["data"]["backups"][0]["location_attributes"] == {
         ".local": {
             "protected": True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
It seems that the order of keys in the `homeassistant.json` file leads to a different homeassistant.tar.gz size, which in turn leads to a different overall backup size. It seems that running the full test suite compared to run tests individually lead to a different order of keys in the JSON file.

This PR sorts the keys when dumping the JSON. With that change, the backup size is consistent.

Note that in theory, the size of the gzip still could change since there is random data in the json file. It may compress to different sizes. Currently that doesn't seem to be a problem, but in case it is, we either need to get rid of the random data or just drop the size check from pytest.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated JSON serialization to include key sorting
	- Added a comment in backup test to clarify potential size variation considerations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->