### PR TITLE
Avoid test failure by not checking exact size of backup

### DIFF
--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -1035,12 +1035,13 @@ async def test_protected_backup(
     assert body["data"]["backups"][0]["location"] is None
     assert body["data"]["backups"][0]["locations"] == [None]
     assert body["data"]["backups"][0]["protected"] is True
-    assert body["data"]["backups"][0]["location_attributes"] == {
-        ".local": {
-            "protected": True,
-            "size_bytes": 10240,
-        }
-    }
+    assert (
+        body["data"]["backups"][0]["location_attributes"][".local"]["protected"] is True
+    )
+    # NOTE: It is not safe to check size exactly here, as order of keys in
+    # `homeassistant.json` and potentially other random data (e.g. isntance UUID,
+    # backup slug) does change the size of the backup (due to gzip).
+    assert body["data"]["backups"][0]["location_attributes"][".local"]["size_bytes"] > 0
 
     resp = await api_client.get(f"/backups/{slug}/info")
     assert resp.status == 200
@@ -1048,12 +1049,10 @@ async def test_protected_backup(
     assert body["data"]["location"] is None
     assert body["data"]["locations"] == [None]
     assert body["data"]["protected"] is True
-    assert body["data"]["location_attributes"] == {
-        ".local": {
-            "protected": True,
-            "size_bytes": 10240,
-        }
-    }
+    assert (
+        body["data"]["backups"][0]["location_attributes"][".local"]["protected"] is True
+    )
+    assert body["data"]["backups"][0]["location_attributes"][".local"]["size_bytes"] > 0
 
 
 @pytest.mark.usefixtures(

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -1049,10 +1049,8 @@ async def test_protected_backup(
     assert body["data"]["location"] is None
     assert body["data"]["locations"] == [None]
     assert body["data"]["protected"] is True
-    assert (
-        body["data"]["backups"][0]["location_attributes"][".local"]["protected"] is True
-    )
-    assert body["data"]["backups"][0]["location_attributes"][".local"]["size_bytes"] > 0
+    assert body["data"]["location_attributes"][".local"]["protected"] is True
+    assert body["data"]["location_attributes"][".local"]["size_bytes"] > 0
 
 
 @pytest.mark.usefixtures(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This is a workaround for the fact that the backup size is not exactly the same every time. This is due to the fact that the inner gziped tar file can vary in size due to difference in json file (key order) and potentially also different field values (UUID, backup slug).

It seems that sorting the keys makes the actual difference today, but this has runtime overhead and might not catch all cases.

Simply check if size property is there and a number bigger than 0 instead.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated backup size verification in tests to check for non-zero size instead of exact value
	- Improved test assertions to accommodate dynamic backup content variations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->