### PR TITLE
Avoid reordering add-on repositories on Backup load

### DIFF
--- a/supervisor/backups/backup.py
+++ b/supervisor/backups/backup.py
@@ -162,12 +162,12 @@ class Backup(JobGroup):
 
     @property
     def repositories(self) -> list[str]:
-        """Return backup date."""
+        """Return add-on store repositories."""
         return self._data[ATTR_REPOSITORIES]
 
     @repositories.setter
     def repositories(self, value: list[str]) -> None:
-        """Set backup date."""
+        """Set add-on store repositories."""
         self._data[ATTR_REPOSITORIES] = value
 
     @property
@@ -286,7 +286,7 @@ class Backup(JobGroup):
                 or k not in other._data
                 or self._data[k] != other._data[k]
             ):
-                _LOGGER.debug(
+                _LOGGER.info(
                     "Backup %s and %s not equal because %s field has different value: %s and %s",
                     self.slug,
                     other.slug,

--- a/supervisor/store/validate.py
+++ b/supervisor/store/validate.py
@@ -28,6 +28,15 @@ SCHEMA_REPOSITORY_CONFIG = vol.Schema(
 )
 
 
+def ensure_builtin_repositories(addon_repositories: list[str]) -> list[str]:
+    """Ensure builtin repositories are in list.
+
+    Note: This should not be used in validation as the resulting list is not
+    stable. This can have side effects when comparing data later on.
+    """
+    return list(set(addon_repositories) | BUILTIN_REPOSITORIES)
+
+
 def validate_repository(repository: str) -> str:
     """Validate a valid repository."""
     if repository in [StoreType.CORE, StoreType.LOCAL]:
@@ -44,13 +53,7 @@ def validate_repository(repository: str) -> str:
     return repository
 
 
-def ensure_builtin_repositories(addon_repositories: list[str]) -> list[str]:
-    """Ensure builtin repositories are in list."""
-    return list(set(addon_repositories) | BUILTIN_REPOSITORIES)
-
-
-# pylint: disable=no-value-for-parameter
-repositories = vol.All([validate_repository], vol.Unique(), ensure_builtin_repositories)
+repositories = vol.All([validate_repository], vol.Unique())
 
 SCHEMA_STORE_FILE = vol.Schema(
     {

--- a/tests/backups/test_backup.py
+++ b/tests/backups/test_backup.py
@@ -64,7 +64,10 @@ async def test_consolidate(
     await unc_backup.load()
 
     enc_backup.consolidate(unc_backup)
-    assert f"Backup in backup_test and None both have slug d9c48f8b but are not the same!" not in caplog.text
+    assert (
+        f"Backup in backup_test and None both have slug d9c48f8b but are not the same!"
+        not in caplog.text
+    )
     assert enc_backup.all_locations == {
         None: {"path": enc_tar, "protected": True},
         "backup_test": {"path": unc_tar, "protected": False},

--- a/tests/backups/test_backup.py
+++ b/tests/backups/test_backup.py
@@ -65,7 +65,7 @@ async def test_consolidate(
 
     enc_backup.consolidate(unc_backup)
     assert (
-        f"Backup in backup_test and None both have slug d9c48f8b but are not the same!"
+        "Backup in backup_test and None both have slug d9c48f8b but are not the same!"
         not in caplog.text
     )
     assert enc_backup.all_locations == {

--- a/tests/backups/test_backup.py
+++ b/tests/backups/test_backup.py
@@ -45,3 +45,27 @@ async def test_consolidate_conflict_varied_encryption(
         in caplog.text
     )
     assert enc_backup.all_locations == {None: {"path": unc_tar, "protected": False}}
+
+
+async def test_consolidate(
+    coresys: CoreSys,
+    tmp_path: Path,
+    tmp_supervisor_data: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test consolidate with two backups in different location and varied encryption."""
+    (mount_dir := coresys.config.path_mounts / "backup_test").mkdir()
+    enc_tar = Path(copy(get_fixture_path("test_consolidate.tar"), tmp_path))
+    enc_backup = Backup(coresys, enc_tar, "test", None)
+    await enc_backup.load()
+
+    unc_tar = Path(copy(get_fixture_path("test_consolidate_unc.tar"), mount_dir))
+    unc_backup = Backup(coresys, unc_tar, "test", "backup_test")
+    await unc_backup.load()
+
+    enc_backup.consolidate(unc_backup)
+    assert f"Backup in backup_test and None both have slug d9c48f8b but are not the same!" not in caplog.text
+    assert enc_backup.all_locations == {
+        None: {"path": enc_tar, "protected": True},
+        "backup_test": {"path": unc_tar, "protected": False},
+    }

--- a/tests/store/test_validate.py
+++ b/tests/store/test_validate.py
@@ -1,12 +1,10 @@
 """Test schema validation."""
 
-from typing import Any
 
 import pytest
 from voluptuous import Invalid
 
-from supervisor.const import ATTR_REPOSITORIES
-from supervisor.store.validate import SCHEMA_STORE_FILE, repositories
+from supervisor.store.validate import repositories
 
 
 @pytest.mark.parametrize(

--- a/tests/store/test_validate.py
+++ b/tests/store/test_validate.py
@@ -18,7 +18,6 @@ from supervisor.store.validate import repositories
 async def test_repository_validate(repo_list: list[str], valid: bool):
     """Test repository list validate."""
     if valid:
-        processed = repositories(repo_list)
         assert repositories(repo_list) == repo_list
     else:
         with pytest.raises(Invalid):

--- a/tests/store/test_validate.py
+++ b/tests/store/test_validate.py
@@ -19,8 +19,7 @@ async def test_repository_validate(repo_list: list[str], valid: bool):
     """Test repository list validate."""
     if valid:
         processed = repositories(repo_list)
-        assert len(processed) == len(repo_list)
-        assert set(repositories(repo_list)) == set(repo_list)
+        assert repositories(repo_list) == repo_list
     else:
         with pytest.raises(Invalid):
             repositories(repo_list)

--- a/tests/store/test_validate.py
+++ b/tests/store/test_validate.py
@@ -10,36 +10,8 @@ from supervisor.store.validate import SCHEMA_STORE_FILE, repositories
 
 
 @pytest.mark.parametrize(
-    "config",
-    [
-        {},
-        {ATTR_REPOSITORIES: []},
-        {ATTR_REPOSITORIES: ["https://github.com/esphome/home-assistant-addon"]},
-    ],
-)
-async def test_default_config(config: dict[Any]):
-    """Test built-ins included by default."""
-    conf = SCHEMA_STORE_FILE(config)
-    assert ATTR_REPOSITORIES in conf
-    assert "core" in conf[ATTR_REPOSITORIES]
-    assert "local" in conf[ATTR_REPOSITORIES]
-    assert "https://github.com/hassio-addons/repository" in conf[ATTR_REPOSITORIES]
-    assert (
-        len(
-            [
-                repo
-                for repo in conf[ATTR_REPOSITORIES]
-                if repo == "https://github.com/esphome/home-assistant-addon"
-            ]
-        )
-        == 1
-    )
-
-
-@pytest.mark.parametrize(
     "repo_list,valid",
     [
-        ([], True),
         (["core", "local"], True),
         (["https://github.com/hassio-addons/repository"], True),
         (["not_a_url"], False),
@@ -50,14 +22,8 @@ async def test_repository_validate(repo_list: list[str], valid: bool):
     """Test repository list validate."""
     if valid:
         processed = repositories(repo_list)
-        assert len(processed) == 5
-        assert set(repositories(repo_list)) == {
-            "core",
-            "local",
-            "https://github.com/hassio-addons/repository",
-            "https://github.com/esphome/home-assistant-addon",
-            "https://github.com/music-assistant/home-assistant-addon",
-        }
+        assert len(processed) == len(repo_list)
+        assert set(repositories(repo_list)) == set(repo_list)
     else:
         with pytest.raises(Invalid):
             repositories(repo_list)

--- a/tests/store/test_validate.py
+++ b/tests/store/test_validate.py
@@ -1,6 +1,5 @@
 """Test schema validation."""
 
-
 import pytest
 from voluptuous import Invalid
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The `ensure_builtin_repositories` function uses a set to deduplicate items, which sometimes led to a change of order in elements. This is problematic when deduplicating Backups.

Simply avoid mangling the list of add-on repositories on load. Instead rely on `update_repositories` which uses the same function to ensure built-in repositories when loading the store configuration and restoring a backup file.


<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for repositories property in Backup class to clarify its purpose.
	- Improved clarity of repository-related method descriptions.

- **New Features**
	- Added a new function to ensure built-in repositories are included in addon repositories list.

- **Logging**
	- Modified logging level in backup equality check method from debug to info.

- **Tests**
	- Introduced a new asynchronous test for consolidating backups with varied encryption settings.
	- Updated validation tests to allow for flexible input repository list validation.
	- Removed the test for default configuration of repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->