### PR TITLE
Always validate Backup before restoring

### DIFF
--- a/supervisor/backups/backup.py
+++ b/supervisor/backups/backup.py
@@ -386,7 +386,7 @@ class Backup(JobGroup):
                     None,
                 )
                 if not test_tar_name:
-                    _LOGGER.warning("No tar file found to validate password with")
+                    # From Supervisor perspective, a metadata only backup only is valid.
                     return
 
                 test_tar_file = backup.extractfile(test_tar_name)

--- a/supervisor/backups/backup.py
+++ b/supervisor/backups/backup.py
@@ -373,7 +373,7 @@ class Backup(JobGroup):
         """
         backup_file: Path = self.all_locations[location][ATTR_PATH]
 
-        def _validate_file() -> bool:
+        def _validate_file() -> None:
             ending = f".tar{'.gz' if self.compressed else ''}"
 
             with tarfile.open(backup_file, "r:") as backup:
@@ -399,14 +399,14 @@ class Backup(JobGroup):
                         fileobj=test_tar_file,
                     ):
                         # If we can read the tar file, the password is correct
-                        return True
+                        return
                 except tarfile.ReadError as ex:
                     raise BackupInvalidError(
                         f"Invalid password for backup {backup.slug}", _LOGGER.error
                     ) from ex
 
         try:
-            return await self.sys_run_in_executor(_validate_file)
+            await self.sys_run_in_executor(_validate_file)
         except FileNotFoundError as err:
             self.sys_create_task(self.sys_backups.reload(location))
             raise BackupFileNotFoundError(

--- a/tests/backups/conftest.py
+++ b/tests/backups/conftest.py
@@ -42,6 +42,7 @@ def partial_backup_mock(backup_mock):
     backup_instance.supervisor_version = "9999.09.9.dev9999"
     backup_instance.location = None
     backup_instance.all_locations = {None: {"protected": False}}
+    backup_instance.validate_backup = AsyncMock()
     yield backup_mock
 
 
@@ -55,6 +56,7 @@ def full_backup_mock(backup_mock):
     backup_instance.supervisor_version = "9999.09.9.dev9999"
     backup_instance.location = None
     backup_instance.all_locations = {None: {"protected": False}}
+    backup_instance.validate_backup = AsyncMock()
     yield backup_mock
 
 

--- a/tests/backups/test_backup.py
+++ b/tests/backups/test_backup.py
@@ -11,7 +11,7 @@ import pytest
 from supervisor.backups.backup import Backup
 from supervisor.backups.const import BackupType
 from supervisor.coresys import CoreSys
-from supervisor.exceptions import BackupFileNotFoundError
+from supervisor.exceptions import BackupFileNotFoundError, BackupInvalidError
 
 from tests.common import get_fixture_path
 
@@ -79,20 +79,19 @@ async def test_consolidate(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "tarfile_side_effect, securetar_side_effect, expected_result, expect_exception",
+    "tarfile_side_effect, securetar_side_effect, expected_exception",
     [
-        (None, None, True, False),  # Successful validation
-        (FileNotFoundError, None, None, True),  # File not found
-        (None, tarfile.ReadError, False, False),  # Invalid password
+        (None, None, None),  # Successful validation
+        (FileNotFoundError, None, BackupFileNotFoundError),  # File not found
+        (None, tarfile.ReadError, BackupInvalidError),  # Invalid password
     ],
 )
-async def test_validate_password(
+async def test_validate_backup(
     coresys: CoreSys,
     tmp_path: Path,
     tarfile_side_effect,
     securetar_side_effect,
-    expected_result,
-    expect_exception,
+    expected_exception,
 ):
     """Parameterized test for validate_password."""
     enc_tar = Path(copy(get_fixture_path("backup_example_enc.tar"), tmp_path))
@@ -120,9 +119,8 @@ async def test_validate_password(
             MagicMock(side_effect=securetar_side_effect),
         ),
     ):
-        if expect_exception:
-            with pytest.raises(BackupFileNotFoundError):
-                await enc_backup.validate_password(None)
+        if expected_exception:
+            with pytest.raises(expected_exception):
+                await enc_backup.validate_backup(None)
         else:
-            result = await enc_backup.validate_password(None)
-            assert result == expected_result
+            await enc_backup.validate_backup(None)

--- a/tests/backups/test_backup.py
+++ b/tests/backups/test_backup.py
@@ -93,7 +93,7 @@ async def test_validate_backup(
     securetar_side_effect,
     expected_exception,
 ):
-    """Parameterized test for validate_password."""
+    """Parameterized test for validate_backup."""
     enc_tar = Path(copy(get_fixture_path("backup_example_enc.tar"), tmp_path))
     enc_backup = Backup(coresys, enc_tar, "test", None)
     await enc_backup.load()

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -344,7 +344,7 @@ async def test_fail_invalid_full_backup(
 
     backup_instance = full_backup_mock.return_value
     backup_instance.all_locations[None]["protected"] = True
-    backup_instance.validate_password = AsyncMock(return_value=False)
+    backup_instance.validate_backup.side_effect = BackupInvalidError()
 
     with pytest.raises(BackupInvalidError):
         await manager.do_restore_full(backup_instance)
@@ -373,7 +373,7 @@ async def test_fail_invalid_partial_backup(
 
     backup_instance = partial_backup_mock.return_value
     backup_instance.all_locations[None]["protected"] = True
-    backup_instance.validate_password = AsyncMock(return_value=False)
+    backup_instance.validate_backup.side_effect = BackupInvalidError()
 
     with pytest.raises(BackupInvalidError):
         await manager.do_restore_partial(backup_instance)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Since #5519 we check the encryption password early in restore case. This has the side effect that we check the file existance early too. However, in the non-encryption case, the file is not checked early.

This PR changes the behavior to always validate the backup file before restoring, ensuring both encryption and non-encryption cases are handled consistently.

In particular, the last case of test_restore_immediate_errors actually validates that behavior. That test should actually have failed so far. But it seems that because we validate the backup shortly after freeze anyways, the exception still got raised early enough.

A simply `await asyncio.sleep(10)` right after the freeze makes the test case fail. With this change, the test works consistently.


<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the backup validation process to perform comprehensive checks for backup integrity and file accessibility.

- **Bug Fixes**
  - Improved error handling during backup restoration to provide clearer, more informative notifications for issues such as missing or corrupted backups.

- **New Features**
  - Introduced a new exception, `BackupInvalidError`, for more specific error reporting during backup validation.
  - Added a mock method `validate_backup` to simulate backup validation in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->