### PR TITLE
Handle non-zero subprocess exits

### DIFF
--- a/supervisor/utils/__init__.py
+++ b/supervisor/utils/__init__.py
@@ -95,7 +95,7 @@ def remove_folder(
     if content_only:
         find_args.extend(["-mindepth", "1"])
     try:
-        proc = subprocess.run(
+        subprocess.run(
             ["/usr/bin/find", str(folder), "-xdev", *find_args, "-delete"],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
@@ -103,10 +103,11 @@ def remove_folder(
             text=True,
             check=True,
         )
-        if proc.returncode != 0:
-            _LOGGER.error("Can't remove folder %s: %s", folder, proc.stderr.strip())
     except OSError as err:
         _LOGGER.exception("Can't remove folder %s: %s", folder, err)
+    except subprocess.CalledProcessError as procerr:
+        _LOGGER.error("Can't remove folder %s: %s", folder, procerr.stderr.strip())
+        raise procerr
 
 
 def remove_folder_with_excludes(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
With PR #5634 (which had the goal to remove I/O in event loop for backup operations) the semantics of `remove_folder` changed slightly: Non-zero exits of subprocesses were no longer handled, but lead to a CalledProcessError.

Now to restore the semantics of `remove_folder` we should simply log an error. However, this semantic change actually uncovered a potential problem in deployed systems: There are 34 users on beta channel which regularly seem to run `FixupStoreExecuteReset`, and with the semantic change we see those errors in Sentry.

An obvious problem could be no space. But in a quick test that would not execute the repair in first place since the fixup has the job condition `FREE_SPACE` set. So the problem is likely elsewhere.

With this change, we log the stderr of find, while still raising the exception. With that we should get more context in Sentry to see what could be the underlying error.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
