### PR TITLE
Improve D-Bus timeout error handling

### DIFF
--- a/supervisor/dbus/udisks2/__init__.py
+++ b/supervisor/dbus/udisks2/__init__.py
@@ -66,8 +66,8 @@ class UDisks2Manager(DBusInterfaceProxy):
         try:
             await super().connect(bus)
             await self.udisks2_object_manager.connect(bus)
-        except DBusError:
-            _LOGGER.warning("Can't connect to udisks2")
+        except DBusError as err:
+            _LOGGER.critical("Can't connect to udisks2: %s", err)
         except (DBusServiceUnkownError, DBusInterfaceError):
             _LOGGER.warning(
                 "No udisks2 support on the host. Host control has been disabled."

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -403,7 +403,11 @@ class DBusParseError(DBusError):
 
 
 class DBusTimeoutError(DBusError):
-    """D-Bus call timed out."""
+    """D-Bus call timeout."""
+
+
+class DBusTimedOutError(DBusError):
+    """D-Bus call timed out (typically when systemd D-Bus service activation fail)."""
 
 
 class DBusNoReplyError(DBusError):

--- a/supervisor/os/data_disk.py
+++ b/supervisor/os/data_disk.py
@@ -189,12 +189,13 @@ class DataDisk(CoreSysAttributes):
             await self.sys_dbus.agent.datadisk.reload_device()
 
         # Register for signals on devices added/removed
-        self.sys_dbus.udisks2.udisks2_object_manager.dbus.object_manager.on_interfaces_added(
-            self._udisks2_interface_added
-        )
-        self.sys_dbus.udisks2.udisks2_object_manager.dbus.object_manager.on_interfaces_removed(
-            self._udisks2_interface_removed
-        )
+        if self.sys_dbus.udisks2.is_connected:
+            self.sys_dbus.udisks2.udisks2_object_manager.dbus.object_manager.on_interfaces_added(
+                self._udisks2_interface_added
+            )
+            self.sys_dbus.udisks2.udisks2_object_manager.dbus.object_manager.on_interfaces_removed(
+                self._udisks2_interface_removed
+            )
 
     @Job(
         name="data_disk_migrate",

--- a/supervisor/utils/dbus.py
+++ b/supervisor/utils/dbus.py
@@ -31,6 +31,7 @@ from ..exceptions import (
     DBusObjectError,
     DBusParseError,
     DBusServiceUnkownError,
+    DBusTimedOutError,
     DBusTimeoutError,
     HassioNotSupportedError,
 )
@@ -87,6 +88,8 @@ class DBus:
             return DBusNotConnectedError(err.text)
         if err.type == ErrorType.TIMEOUT:
             return DBusTimeoutError(err.text)
+        if err.type == ErrorType.TIMED_OUT:
+            return DBusTimedOutError(err.text)
         if err.type == ErrorType.NO_REPLY:
             return DBusNoReplyError(err.text)
         return DBusFatalError(err.text, type_=err.type)


### PR DESCRIPTION
Typically D-Bus timeouts are related to systemd activation timing out after 25s. The current dbus-fast timeout of 10s is well below that so we never get the actual D-Bus error. This increases the dbus-fast timeout to 30s, which will make sure we wait long enought to get the actual D-Bus error from the broker.

Note that this should not slow down a system experiencing this error, since we tried three times each waiting for 10s. With the new error handling typically we'll end up waiting 25s and then receive the actual D-Bus error. There is no point in waiting for multiple D-Bus/systemd caused timeouts.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5663
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error reporting for failed service connections to provide more actionable information.
	- Introduced checks to ensure system notifications are set up only when the service is properly connected, improving reliability.
	- Increased inspection timeout thresholds to enhance stability during periods of high system load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->