### PR TITLE
Add more context to Sentry reports early during startup

### DIFF
--- a/tests/misc/test_filter_data.py
+++ b/tests/misc/test_filter_data.py
@@ -72,7 +72,7 @@ def test_defaults(coresys):
     with patch("shutil.disk_usage", return_value=(42, 42, 2 * (1024.0**3))):
         filtered = filter_data(coresys, SAMPLE_EVENT, {})
 
-    assert ["installation_type", "supervised"] in filtered["tags"]
+    assert filtered["tags"]["installation_type"] == "supervised"
     assert filtered["contexts"]["host"]["arch"] == "amd64"
     assert filtered["contexts"]["host"]["machine"] == "qemux86-64"
     assert filtered["contexts"]["versions"]["supervisor"] == AwesomeVersion(
@@ -84,7 +84,6 @@ def test_defaults(coresys):
 def test_sanitize(coresys):
     """Test event sanitation."""
     event = {
-        "tags": [["url", "https://mydomain.com"]],
         "request": {
             "url": "https://mydomain.com",
             "headers": [
@@ -100,8 +99,6 @@ def test_sanitize(coresys):
     coresys.core.state = CoreState.RUNNING
     with patch("shutil.disk_usage", return_value=(42, 42, 2 * (1024.0**3))):
         filtered = filter_data(coresys, event, {})
-
-    assert ["url", "https://example.com"] in filtered["tags"]
 
     assert filtered["request"]["url"] == "https://example.com"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Initialize machine information before Sentry. With this we can set the user and machine for all reports, even during early Supervisor startup.

Also use the new tag format which is a dictionary.

Note that it seems that with the current Sentry SDK version the `AioHttpIntegration` no longer sets the URL as a tag. So sanitation is no longer reuqired.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the system startup process by consolidating machine ID initialization for smoother performance.
  - Optimized event data processing by reorganizing user identification and tag assignment for improved consistency.

- **New Features**
  - Introduced a new asynchronous method for initializing machine-specific information.

- **Bug Fixes**
  - Adjusted assertions in tests to reflect changes in event data structure and expected values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->