### PR TITLE
Load resolution evaluation, check and fixups early

### DIFF
--- a/supervisor/bootstrap.py
+++ b/supervisor/bootstrap.py
@@ -55,6 +55,7 @@ async def initialize_coresys() -> CoreSys:
     # Initialize core objects
     coresys.docker = await DockerAPI(coresys).load_config()
     coresys.resolution = await ResolutionManager(coresys).load_config()
+    await coresys.resolution.load_modules()
     coresys.jobs = await JobManager(coresys).load_config()
     coresys.core = Core(coresys)
     coresys.plugins = await PluginManager(coresys).load_config()

--- a/supervisor/resolution/check.py
+++ b/supervisor/resolution/check.py
@@ -32,20 +32,18 @@ class ResolutionCheck(CoreSysAttributes):
         """Return all list of all checks."""
         return list(self._checks.values())
 
-    async def load_modules(self) -> None:
-        """Load all checks."""
+    def load_modules(self) -> None:
+        """Load and setup all checks.
 
-        def _load_modules() -> dict[str, CheckBase]:
-            """Load and setup checks in executor."""
-            package = f"{__package__}.checks"
-            checks: dict[str, CheckBase] = {}
-            for module in get_valid_modules("checks"):
-                check_module = import_module(f"{package}.{module}")
-                check = check_module.setup(self.coresys)
-                checks[check.slug] = check
-            return checks
-
-        self._checks = await self.sys_run_in_executor(_load_modules)
+        Must be run in executor.
+        """
+        package = f"{__package__}.checks"
+        checks: dict[str, CheckBase] = {}
+        for module in get_valid_modules("checks"):
+            check_module = import_module(f"{package}.{module}")
+            check = check_module.setup(self.coresys)
+            checks[check.slug] = check
+        self._checks = checks
 
     def get(self, slug: str) -> CheckBase:
         """Return check based on slug."""

--- a/supervisor/resolution/check.py
+++ b/supervisor/resolution/check.py
@@ -32,10 +32,10 @@ class ResolutionCheck(CoreSysAttributes):
         """Return all list of all checks."""
         return list(self._checks.values())
 
-    async def load(self) -> None:
+    async def load_modules(self) -> None:
         """Load all checks."""
 
-        def _load() -> dict[str, CheckBase]:
+        def _load_modules() -> dict[str, CheckBase]:
             """Load and setup checks in executor."""
             package = f"{__package__}.checks"
             checks: dict[str, CheckBase] = {}
@@ -45,7 +45,7 @@ class ResolutionCheck(CoreSysAttributes):
                 checks[check.slug] = check
             return checks
 
-        self._checks = await self.sys_run_in_executor(_load)
+        self._checks = await self.sys_run_in_executor(_load_modules)
 
     def get(self, slug: str) -> CheckBase:
         """Return check based on slug."""

--- a/supervisor/resolution/evaluate.py
+++ b/supervisor/resolution/evaluate.py
@@ -33,10 +33,10 @@ class ResolutionEvaluation(CoreSysAttributes):
         """Return all list of all checks."""
         return list(self._evalutions.values())
 
-    async def load(self) -> None:
+    async def load_modules(self) -> None:
         """Load all evaluations."""
 
-        def _load() -> dict[str, EvaluateBase]:
+        def _load_modules() -> dict[str, EvaluateBase]:
             """Load and setup evaluations in executor."""
             package = f"{__package__}.evaluations"
             evaluations: dict[str, EvaluateBase] = {}
@@ -46,7 +46,7 @@ class ResolutionEvaluation(CoreSysAttributes):
                 evaluations[evaluation.slug] = evaluation
             return evaluations
 
-        self._evalutions = await self.sys_run_in_executor(_load)
+        self._evalutions = await self.sys_run_in_executor(_load_modules)
 
     def get(self, slug: str) -> EvaluateBase:
         """Return check based on slug."""

--- a/supervisor/resolution/evaluate.py
+++ b/supervisor/resolution/evaluate.py
@@ -33,20 +33,18 @@ class ResolutionEvaluation(CoreSysAttributes):
         """Return all list of all checks."""
         return list(self._evalutions.values())
 
-    async def load_modules(self) -> None:
-        """Load all evaluations."""
+    def load_modules(self) -> None:
+        """Load and setup all evaluations.
 
-        def _load_modules() -> dict[str, EvaluateBase]:
-            """Load and setup evaluations in executor."""
-            package = f"{__package__}.evaluations"
-            evaluations: dict[str, EvaluateBase] = {}
-            for module in get_valid_modules("evaluations"):
-                evaluate_module = import_module(f"{package}.{module}")
-                evaluation = evaluate_module.setup(self.coresys)
-                evaluations[evaluation.slug] = evaluation
-            return evaluations
-
-        self._evalutions = await self.sys_run_in_executor(_load_modules)
+        Must be run in executor.
+        """
+        package = f"{__package__}.evaluations"
+        evaluations: dict[str, EvaluateBase] = {}
+        for module in get_valid_modules("evaluations"):
+            evaluate_module = import_module(f"{package}.{module}")
+            evaluation = evaluate_module.setup(self.coresys)
+            evaluations[evaluation.slug] = evaluation
+        self._evalutions = evaluations
 
     def get(self, slug: str) -> EvaluateBase:
         """Return check based on slug."""

--- a/supervisor/resolution/fixup.py
+++ b/supervisor/resolution/fixup.py
@@ -22,10 +22,10 @@ class ResolutionFixup(CoreSysAttributes):
         self.coresys = coresys
         self._fixups: dict[str, FixupBase] = {}
 
-    async def load(self) -> None:
+    async def load_modules(self) -> None:
         """Load all fixups."""
 
-        def _load() -> dict[str, FixupBase]:
+        def _load_modules() -> dict[str, FixupBase]:
             """Load and setup fixups in executor."""
             package = f"{__package__}.fixups"
             fixups: dict[str, FixupBase] = {}
@@ -35,7 +35,7 @@ class ResolutionFixup(CoreSysAttributes):
                 fixups[fixup.slug] = fixup
             return fixups
 
-        self._fixups = await self.sys_run_in_executor(_load)
+        self._fixups = await self.sys_run_in_executor(_load_modules)
 
     @property
     def all_fixes(self) -> list[FixupBase]:

--- a/supervisor/resolution/fixup.py
+++ b/supervisor/resolution/fixup.py
@@ -22,20 +22,18 @@ class ResolutionFixup(CoreSysAttributes):
         self.coresys = coresys
         self._fixups: dict[str, FixupBase] = {}
 
-    async def load_modules(self) -> None:
-        """Load all fixups."""
+    def load_modules(self) -> None:
+        """Load and setup all fixups.
 
-        def _load_modules() -> dict[str, FixupBase]:
-            """Load and setup fixups in executor."""
-            package = f"{__package__}.fixups"
-            fixups: dict[str, FixupBase] = {}
-            for module in get_valid_modules("fixups"):
-                fixup_module = import_module(f"{package}.{module}")
-                fixup = fixup_module.setup(self.coresys)
-                fixups[fixup.slug] = fixup
-            return fixups
-
-        self._fixups = await self.sys_run_in_executor(_load_modules)
+        Must be run in executor.
+        """
+        package = f"{__package__}.fixups"
+        fixups: dict[str, FixupBase] = {}
+        for module in get_valid_modules("fixups"):
+            fixup_module = import_module(f"{package}.{module}")
+            fixup = fixup_module.setup(self.coresys)
+            fixups[fixup.slug] = fixup
+        self._fixups = fixups
 
     @property
     def all_fixes(self) -> list[FixupBase]:

--- a/supervisor/resolution/module.py
+++ b/supervisor/resolution/module.py
@@ -46,6 +46,12 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
         self._unsupported: list[UnsupportedReason] = []
         self._unhealthy: list[UnhealthyReason] = []
 
+    async def load_modules(self):
+        """Load resolution evaluation, check and fixup modules."""
+        await self._evaluate.load_modules()
+        await self._check.load_modules()
+        await self._fixup.load_modules()
+
     @property
     def data(self) -> dict[str, Any]:
         """Return data."""
@@ -195,10 +201,6 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
 
     async def load(self):
         """Load the resoulution manager."""
-        await self.check.load()
-        await self.fixup.load()
-        await self.evaluate.load()
-
         # Initial healthcheck when the manager is loaded
         await self.healthcheck()
 

--- a/supervisor/resolution/module.py
+++ b/supervisor/resolution/module.py
@@ -48,9 +48,14 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
 
     async def load_modules(self):
         """Load resolution evaluation, check and fixup modules."""
-        await self._evaluate.load_modules()
-        await self._check.load_modules()
-        await self._fixup.load_modules()
+
+        def _load_modules():
+            """Load and setup all resolution modules."""
+            self._evaluate.load_modules()
+            self._check.load_modules()
+            self._fixup.load_modules()
+
+        await self.sys_run_in_executor(_load_modules)
 
     @property
     def data(self) -> dict[str, Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -328,9 +328,6 @@ async def coresys(
     coresys_obj._store.save_data = AsyncMock()
     coresys_obj._mounts.save_data = AsyncMock()
 
-    # Load resolution center
-    await coresys_obj.resolution.load()
-
     # Mock test client
     coresys_obj._supervisor.instance._meta = {
         "Config": {"Labels": {"io.hass.arch": "amd64"}}

--- a/tests/resolution/check/test_check.py
+++ b/tests/resolution/check/test_check.py
@@ -113,6 +113,6 @@ async def test_get_checks(coresys: CoreSys):
 
 async def test_dynamic_check_loader(coresys: CoreSys):
     """Test dynamic check loader, this ensures that all checks have defined a setup function."""
-    await coresys.resolution.check.load_modules()
+    coresys.resolution.check.load_modules()
     for check in get_valid_modules("checks"):
         assert check in coresys.resolution.check._checks

--- a/tests/resolution/check/test_check.py
+++ b/tests/resolution/check/test_check.py
@@ -113,6 +113,6 @@ async def test_get_checks(coresys: CoreSys):
 
 async def test_dynamic_check_loader(coresys: CoreSys):
     """Test dynamic check loader, this ensures that all checks have defined a setup function."""
-    await coresys.resolution.check.load()
+    await coresys.resolution.check.load_modules()
     for check in get_valid_modules("checks"):
         assert check in coresys.resolution.check._checks


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Before #5652, these modules were loaded in the constructor, hence early in `initialize_coresys()`. Moving them late actually exposed an issue where NetworkManager connectivity setter couldn't get the `connectivity_check` evaluation, leading to an exception early in bootstrap.

Technically, it might be safe to load the resolution modules only in `Core.connect()`, however then we'd have to load them separately for pytest. Let's go conservative and load them the same place where they got loaded before #5652.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the system’s startup process to ensure all resolution-related modules are consistently loaded before subsequent operations, improving overall efficiency and maintainability.
- **Tests**
  - Adjusted test cases to align with the revamped module-loading process, ensuring reliable and consistent behavior during system startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->