### PR TITLE
Avoid loading add-on store repositories too early

### DIFF
--- a/supervisor/store/__init__.py
+++ b/supervisor/store/__init__.py
@@ -75,8 +75,6 @@ class StoreManager(CoreSysAttributes, FileConfiguration):
 
     async def load(self) -> None:
         """Start up add-on management."""
-        await self.data.update()
-
         # Init custom repositories and load add-ons
         await self.update_repositories(
             self._data[ATTR_REPOSITORIES], add_with_errors=True

--- a/supervisor/store/git.py
+++ b/supervisor/store/git.py
@@ -97,7 +97,9 @@ class GitRepo(CoreSysAttributes):
             }
 
             try:
-                _LOGGER.info("Cloning add-on %s repository", self.url)
+                _LOGGER.info(
+                    "Cloning add-on %s repository from %s", self.path, self.url
+                )
                 self.repo = await self.sys_run_in_executor(
                     ft.partial(
                         git.Repo.clone_from, self.url, str(self.path), **git_args
@@ -128,7 +130,7 @@ class GitRepo(CoreSysAttributes):
             return
 
         async with self.lock:
-            _LOGGER.info("Update add-on %s repository", self.url)
+            _LOGGER.info("Update add-on %s repository from %s", self.path, self.url)
 
             try:
                 branch = self.repo.active_branch.name


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
When initially loading the store manager, update_repositories makes sure that all repositories are actually present. If they are for some reason corrupted or content is missing, we currently still trying to load them which leads to an unnecessary warning:

```
2025-03-03 11:55:54.324 WARNING (SyncWorker_1) [supervisor.store.data] No repository information exists at /data/addons/git/a0d7b954
...
2025-03-03 11:55:54.343 INFO (MainThread) [supervisor.store.git] Cloning add-on https://github.com/hassio-addons/repository repository
```

Since update_repositories always loads the data, simply remove the superfluous earlier loading attempt.

While at it, also improve the cloning/update log messages to make it clear what repository is cloned/updated.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - **Add-On & Repository Improvements:** Optimized the internal loading process for add-ons and repository updates by removing a redundant synchronization step, resulting in a more streamlined operation.
  - **Logging Enhancements:** Refined messages during repository cloning and updating to provide added context for troubleshooting.
  - **Overall Impact:** These behind-the-scenes improvements promote a more consistent and efficient experience when managing add-ons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->