### PR TITLE
Fix add-on store repository getting removed without internet

### DIFF
--- a/supervisor/store/git.py
+++ b/supervisor/store/git.py
@@ -134,7 +134,7 @@ class GitRepo(CoreSysAttributes):
 
             try:
                 git_cmd = git.Git()
-                git_cmd.ls_remote("--heads", self.url)
+                await self.sys_run_in_executor(git_cmd.ls_remote, "--heads", self.url)
             except git.CommandError as err:
                 _LOGGER.warning("Wasn't able to update %s repo: %s.", self.url, err)
                 raise StoreGitError() from err

--- a/supervisor/store/git.py
+++ b/supervisor/store/git.py
@@ -133,6 +133,13 @@ class GitRepo(CoreSysAttributes):
             _LOGGER.info("Update add-on %s repository from %s", self.path, self.url)
 
             try:
+                git_cmd = git.Git()
+                git_cmd.ls_remote("--heads", self.url)
+            except git.CommandError as err:
+                _LOGGER.warning("Wasn't able to update %s repo: %s.", self.url, err)
+                raise StoreGitError() from err
+
+            try:
                 branch = self.repo.active_branch.name
 
                 # Download data


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Currently, when a git command error happens in `pull()`, we declare the repository as corrupt. Subsequent system autofix runs then execute the reset resolution, which essentially removes the git repository from the system.

In situations where the Internet fails right between the last Supervisor connectivity check and the add-on store repository update (the connectivity checks are throttled to once every 10 minutes while connectivity is considered good), or if the outage is only partial (e.g. reaching connectivity check works but the store repository is not reachable), this leads to a git command error which declares the repository as corrupt just as well, and ultimately leads to the removal of the add-on store repository from the local system.

Run a git ls-remote first, which is used as an extra connectivity check. This will also avoid removing the repository if Internet connectivity works but the git provider is temporary down or not reachable.

Fixes: #5668

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the update process by refining error handling and messaging, ensuring a more stable synchronization experience when issues occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->