### PR TITLE
Make sure to close file stream after backup upload

### DIFF
--- a/supervisor/api/backups.py
+++ b/supervisor/api/backups.py
@@ -541,7 +541,7 @@ class APIBackups(CoreSysAttributes):
             tar_file = await self.sys_run_in_executor(open_backup_file)
             while chunk := await contents.read_chunk(size=2**16):
                 await self.sys_run_in_executor(backup_file_stream.write, chunk)
-            backup_file_stream.close()
+            await self.sys_run_in_executor(backup_file_stream.close)
 
             backup = await asyncio.shield(
                 self.sys_backups.import_backup(

--- a/supervisor/api/backups.py
+++ b/supervisor/api/backups.py
@@ -541,6 +541,7 @@ class APIBackups(CoreSysAttributes):
             tar_file = await self.sys_run_in_executor(open_backup_file)
             while chunk := await contents.read_chunk(size=2**16):
                 await self.sys_run_in_executor(backup_file_stream.write, chunk)
+            backup_file_stream.close()
 
             backup = await asyncio.shield(
                 self.sys_backups.import_backup(
@@ -563,8 +564,7 @@ class APIBackups(CoreSysAttributes):
             return False
 
         finally:
-            if temp_dir or backup:
-                await self.sys_run_in_executor(close_backup_file)
+            await self.sys_run_in_executor(close_backup_file)
 
         if backup:
             return {ATTR_SLUG: backup.slug}

--- a/supervisor/api/backups.py
+++ b/supervisor/api/backups.py
@@ -531,6 +531,8 @@ class APIBackups(CoreSysAttributes):
 
         def close_backup_file() -> None:
             if backup_file_stream:
+                # Make sure it got closed, in case of exception. It is safe to
+                # close the file stream twice.
                 backup_file_stream.close()
             if temp_dir:
                 temp_dir.cleanup()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Currently the file stream does not get closed before importing the file stream. It seems the test case didn't catch that, presumably because it is a race condition if the bytes get flushed to disk or not.

Properly close the stream before continue handling the file.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5724
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the reliability of backup operations by ensuring that file streams are properly closed in all scenarios. This improvement streamlines resource management and reduces potential errors during backup procedures, contributing to a more stable backup experience for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->