### PR TITLE
Handle unexpected WebSocket messages during auth

### DIFF
--- a/supervisor/api/proxy.py
+++ b/supervisor/api/proxy.py
@@ -6,7 +6,7 @@ from contextlib import asynccontextmanager
 import logging
 
 import aiohttp
-from aiohttp import web
+from aiohttp import WSMessageTypeError, web
 from aiohttp.client_exceptions import ClientConnectorError
 from aiohttp.client_ws import ClientWebSocketResponse
 from aiohttp.hdrs import AUTHORIZATION, CONTENT_TYPE
@@ -237,6 +237,11 @@ class APIProxy(CoreSysAttributes):
                 {"type": "auth_ok", "ha_version": self.sys_homeassistant.version},
                 dumps=json_dumps,
             )
+        except WSMessageTypeError as err:
+            _LOGGER.error(
+                "Unexpected message during authentication for WebSocket API: %s", err
+            )
+            return server
         except (RuntimeError, ValueError) as err:
             _LOGGER.error("Can't initialize handshake: %s", err)
             return server

--- a/supervisor/api/proxy.py
+++ b/supervisor/api/proxy.py
@@ -215,8 +215,8 @@ class APIProxy(CoreSysAttributes):
                 dumps=json_dumps,
             )
 
-            # Check API access
-            response = await server.receive_json()
+            # Check API access, wait up to 10s just like _async_handle_auth_phase in Core
+            response = await server.receive_json(timeout=10)
             supervisor_token = response.get("api_password") or response.get(
                 "access_token"
             )
@@ -237,6 +237,9 @@ class APIProxy(CoreSysAttributes):
                 {"type": "auth_ok", "ha_version": self.sys_homeassistant.version},
                 dumps=json_dumps,
             )
+        except TimeoutError:
+            _LOGGER.error("Timeout during authentication for WebSocket API")
+            return server
         except WSMessageTypeError as err:
             _LOGGER.error(
                 "Unexpected message during authentication for WebSocket API: %s", err


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
When an add-on does not respond or closes the WebSocket connection during the authentication phase Supervisor does not handle errors gracefully. Simply log such unexpected authentication to avoid unnecessary stack traces in the log and make such cases no longer appear on Sentry.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling during real-time connection authentication for smoother and more reliable interactions.
	- Improved logging for timeout errors and unexpected messages during WebSocket authentication failures.

- **Tests**
	- Added a new test to verify logging behavior when a WebSocket connection is closed during the authentication process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->