### PR TITLE
Intercept host logs Range header for Systemd v256+ compatibility

### DIFF
--- a/supervisor/api/host.py
+++ b/supervisor/api/host.py
@@ -37,6 +37,7 @@ from ..host.const import (
     LogFormat,
     LogFormatter,
 )
+from ..host.logs import SYSTEMD_JOURNAL_GATEWAYD_LINES_MAX
 from ..utils.systemd_journal import journal_logs_reader
 from .const import (
     ATTR_AGENT_VERSION,
@@ -238,13 +239,11 @@ class APIHost(CoreSysAttributes):
                 # return 2 lines at minimum.
                 lines = max(2, lines)
             # entries=cursor[[:num_skip]:num_entries]
-            range_header = f"entries=:-{lines - 1}:{'' if follow else lines}"
+            range_header = f"entries=:-{lines - 1}:{SYSTEMD_JOURNAL_GATEWAYD_LINES_MAX if follow else lines}"
         elif RANGE in request.headers:
             range_header = request.headers[RANGE]
         else:
-            range_header = (
-                f"entries=:-{DEFAULT_LINES - 1}:{'' if follow else DEFAULT_LINES}"
-            )
+            range_header = f"entries=:-{DEFAULT_LINES - 1}:{SYSTEMD_JOURNAL_GATEWAYD_LINES_MAX if follow else DEFAULT_LINES}"
 
         async with self.sys_host.logs.journald_logs(
             params=params, range_header=range_header, accept=LogFormat.JOURNAL

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -7,7 +7,7 @@ from aiohttp.test_utils import TestClient
 from supervisor.host.const import LogFormat
 
 DEFAULT_LOG_RANGE = "entries=:-99:100"
-DEFAULT_LOG_RANGE_FOLLOW = "entries=:-99:"
+DEFAULT_LOG_RANGE_FOLLOW = "entries=:-99:18446744073709551615"
 
 
 async def common_test_api_advanced_logs(

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -16,7 +16,7 @@ from tests.dbus_service_mocks.base import DBusServiceMock
 from tests.dbus_service_mocks.systemd import Systemd as SystemdService
 
 DEFAULT_RANGE = "entries=:-99:100"
-DEFAULT_RANGE_FOLLOW = "entries=:-99:"
+DEFAULT_RANGE_FOLLOW = "entries=:-99:18446744073709551615"
 # pylint: disable=protected-access
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Since Systemd v256 the Range header must not end with a trailing colon. We relied on this undocumented feature when following logs, and the frontend or CLI may still use it in requests. To fix the requests failing with new Systemd version, intercept the header and fill in the num_entries to maximum possible value, which avoids the journal-gatewayd returning the response prematurely and also works on older Systemd versions.

The journal-gatewayd would still return response if follow flag is used along with num_entries, but this behavior is unchanged and would be better fixed in the backend.

Link: https://github.com/systemd/systemd/issues/37172

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
