### PR TITLE
Add dedicated version update refresh for main components

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -345,6 +345,9 @@ class RestAPI(CoreSysAttributes):
         api_root.coresys = self.coresys
 
         self.webapp.add_routes([web.get("/info", api_root.info)])
+        self.webapp.add_routes([web.post("/reload_updates", api_root.reload_updates)])
+
+        # Deprecated
         self.webapp.add_routes([web.post("/refresh_updates", api_root.refresh_updates)])
         self.webapp.add_routes(
             [web.get("/available_updates", api_root.available_updates)]

--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -347,7 +347,7 @@ class RestAPI(CoreSysAttributes):
         self.webapp.add_routes([web.get("/info", api_root.info)])
         self.webapp.add_routes([web.post("/reload_updates", api_root.reload_updates)])
 
-        # Deprecated
+        # Discouraged
         self.webapp.add_routes([web.post("/refresh_updates", api_root.refresh_updates)])
         self.webapp.add_routes(
             [web.get("/available_updates", api_root.available_updates)]

--- a/supervisor/api/root.py
+++ b/supervisor/api/root.py
@@ -113,3 +113,8 @@ class APIRoot(CoreSysAttributes):
         await asyncio.shield(
             asyncio.gather(self.sys_updater.reload(), self.sys_store.reload())
         )
+
+    @api_process
+    async def reload_updates(self, request: web.Request) -> None:
+        """Refresh updater update information."""
+        await self.sys_updater.reload()

--- a/tests/api/test_root.py
+++ b/tests/api/test_root.py
@@ -1,7 +1,9 @@
 """Test Supervisor API."""
 
 # pylint: disable=protected-access
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
+
+from aiohttp.test_utils import TestClient
 
 from supervisor.api.const import ATTR_AVAILABLE_UPDATES
 from supervisor.coresys import CoreSys
@@ -78,3 +80,18 @@ async def test_api_refresh_updates(api_client, coresys: CoreSys):
 
     assert coresys.updater.reload.called
     assert coresys.store.reload.called
+
+
+async def test_api_reload_updates(
+    coresys: CoreSys,
+    api_client: TestClient,
+):
+    """Test reload updates."""
+    with (
+        patch("supervisor.updater.Updater.fetch_data") as fetch_data,
+    ):
+        resp = await api_client.post("/reload_updates")
+
+        fetch_data.assert_called_once_with()
+
+    assert resp.status == 200


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Currently we have the /refresh_updates endpoint which updates the main component versions (Core, OS, Supervisor, Plug-ins) and the add-on store at the same time. This leads to much more updates then necessary.

To allow more fine grained update refresh control introduce a new endpoint /refresh_update which only refreshes the main component versions.

The /store/reload endpoint already allows to update the add-on store only.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2651
- Link to cli pull request:
- Link to client library pull request: https://github.com/home-assistant-libs/python-supervisor-client/pull/90

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint to refresh updater information independently from other components.  
- **Tests**
  - Added tests to verify the new updater refresh endpoint functions correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->