### PR TITLE
Return 401 Unauthorized when using json/url encoded auth fails

### DIFF
--- a/supervisor/api/auth.py
+++ b/supervisor/api/auth.py
@@ -79,13 +79,18 @@ class APIAuth(CoreSysAttributes):
         # Json
         if request.headers.get(CONTENT_TYPE) == CONTENT_TYPE_JSON:
             data = await request.json(loads=json_loads)
-            return await self._process_dict(request, addon, data)
+            if not await self._process_dict(request, addon, data):
+                raise HTTPUnauthorized()
+            return True
 
         # URL encoded
         if request.headers.get(CONTENT_TYPE) == CONTENT_TYPE_URL:
             data = await request.post()
-            return await self._process_dict(request, addon, data)
+            if not await self._process_dict(request, addon, data):
+                raise HTTPUnauthorized()
+            return True
 
+        # Advertise Basic authentication by default
         raise HTTPUnauthorized(headers=REALM_HEADER)
 
     @api_process

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
+from aiohttp.hdrs import WWW_AUTHENTICATE
 from aiohttp.test_utils import TestClient
 import pytest
 
@@ -137,8 +138,8 @@ async def test_auth_json_invalid_credentials(
     resp = await api_client.post(
         "/auth", json={"username": "test", "password": "wrong"}
     )
-    # Do we really want the API to return 400 here?
-    assert resp.status == 400
+    assert WWW_AUTHENTICATE not in resp.headers
+    assert resp.status == 401
 
 
 @pytest.mark.parametrize("api_client", [TEST_ADDON_SLUG], indirect=True)
@@ -184,8 +185,8 @@ async def test_auth_urlencoded_failure(
         data="username=test&password=fail",
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
-    # Do we really want the API to return 400 here?
-    assert resp.status == 400
+    assert WWW_AUTHENTICATE not in resp.headers
+    assert resp.status == 401
 
 
 @pytest.mark.parametrize("api_client", [TEST_ADDON_SLUG], indirect=True)
@@ -196,7 +197,7 @@ async def test_auth_unsupported_content_type(
     resp = await api_client.post(
         "/auth", data="something", headers={"Content-Type": "text/plain"}
     )
-    # This probably should be 400 here for better consistency
+    assert "Basic realm" in resp.headers[WWW_AUTHENTICATE]
     assert resp.status == 401
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
When authentication using JSON payload or URL encoded payload fails, use the generic HTTP response code 401 Unauthorized instead of 400 Bad Request.

This is a more appropriate response code for authentication errors and is consistent with the behavior of other authentication methods.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication error handling to return 401 Unauthorized for failed JSON and URL-encoded authentication attempts.
  - Adjusted response headers to ensure the `WWW_AUTHENTICATE` header is only present when appropriate.
- **Tests**
  - Updated authentication tests to reflect new status codes and header behaviors for failed login scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->