### PR TITLE
Avoid reading add-ons twice unnecessarily

### DIFF
--- a/supervisor/store/__init__.py
+++ b/supervisor/store/__init__.py
@@ -116,7 +116,7 @@ class StoreManager(CoreSysAttributes, FileConfiguration):
             )
 
             # read data from repositories
-            await self.load()
+            await self.data.update()
             await self._read_addons()
 
     @Job(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
So far a store reload lead to a reload of all add-ons twice, usually causing two messages in quick succession:
```
2025-04-25 17:01:05.058 INFO (MainThread) [supervisor.store] Loading add-ons from store: 91 all - 0 new - 0 remove
2025-04-25 17:01:05.058 INFO (MainThread) [supervisor.store] Loading add-ons from store: 91 all - 0 new - 0 remove
```

This is because when repository changes are detected, `reload()` calls `load()` which then calls `update_repositories()` which ends up calling `_read_addons()`, while `reload()` itself calls `_read_addons()` after `load()` as well.

One way to fix this would be to simply remove the `_read_addons()` call in `reload()`.

However, it seems the `update_repositories()` call (via `load()`) is not necessary at all, as we don't add new store repositories in `reload()`, and we already made sure the built-ins are present on startup.

So simply call `data.update()` to update the store data cache, as it was the case before #2225. There is no apparent reason documented why `data.update()` was changed to a `load()` call. It might be to regularly ensure that built-in repositories are still in the list of store repositories. But this type of regular invariant check is often harmful as it might hide bugs in other places.

Supervisor will still call `update_repositories()` in `load()` to ensure all built-in repositories are present, just in case the local configuration file got modified or corrupted.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the reliability of add-on and repository updates during the reload process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->