### PR TITLE
Improve backup upload location determination

### DIFF
--- a/supervisor/api/backups.py
+++ b/supervisor/api/backups.py
@@ -53,7 +53,6 @@ from ..coresys import CoreSysAttributes
 from ..exceptions import APIError, APIForbidden, APINotFound
 from ..jobs import JobSchedulerOptions, SupervisorJob
 from ..mounts.const import MountUsage
-from ..mounts.mount import Mount
 from ..resolution.const import UnhealthyReason
 from .const import (
     ATTR_ADDITIONAL_LOCATIONS,
@@ -495,7 +494,7 @@ class APIBackups(CoreSysAttributes):
         """Upload a backup file."""
         location: LOCATION_TYPE = None
         locations: list[LOCATION_TYPE] | None = None
-        tmp_path = self.sys_config.path_tmp
+
         if ATTR_LOCATION in request.query:
             location_names: list[str] = request.query.getall(ATTR_LOCATION, [])
             self._validate_cloud_backup_location(
@@ -510,9 +509,6 @@ class APIBackups(CoreSysAttributes):
             ]
             location = locations.pop(0)
 
-            if location and location != LOCATION_CLOUD_BACKUP:
-                tmp_path = cast(Mount, location).local_where
-
         filename: str | None = None
         if ATTR_FILENAME in request.query:
             filename = request.query.get(ATTR_FILENAME)
@@ -521,13 +517,14 @@ class APIBackups(CoreSysAttributes):
             except vol.Invalid as ex:
                 raise APIError(humanize_error(filename, ex)) from None
 
+        tmp_path = await self.sys_backups.get_upload_path_for_location(location)
         temp_dir: TemporaryDirectory | None = None
         backup_file_stream: IOBase | None = None
 
         def open_backup_file() -> Path:
             nonlocal temp_dir, backup_file_stream
             temp_dir = TemporaryDirectory(dir=tmp_path.as_posix())
-            tar_file = Path(temp_dir.name, "backup.tar")
+            tar_file = Path(temp_dir.name, "upload.tar")
             backup_file_stream = tar_file.open("wb")
             return tar_file
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
For local backup upload locations, check if the location is on the same file system an thuse allows to move the backup file after upload. This allows custom backup mounts. Currently there is no documented, persistent way to create such mounts in with Home Assistant OS installations, but since we might add local mounts in the future this seems a worthwhile addition.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5837
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
