### PR TITLE
Revert "Recreate aiohttp session on connectivity check (#5332)"

### DIFF
--- a/supervisor/coresys.py
+++ b/supervisor/coresys.py
@@ -68,7 +68,7 @@ class CoreSys:
 
         # External objects
         self._loop: asyncio.BaseEventLoop = asyncio.get_running_loop()
-        self._websession = None
+        self._websession: aiohttp.ClientSession = aiohttp.ClientSession()
 
         # Global objects
         self._config: CoreConfig = CoreConfig()
@@ -101,8 +101,10 @@ class CoreSys:
         self._bus: Bus | None = None
         self._mounts: MountManager | None = None
 
-        # Setup aiohttp session
-        self.create_websession()
+        # Set default header for aiohttp
+        self._websession._default_headers = MappingProxyType(
+            {aiohttp.hdrs.USER_AGENT: SERVER_SOFTWARE}
+        )
 
         # Task factory attributes
         self._set_task_context: list[Callable[[Context], Context]] = []
@@ -581,16 +583,6 @@ class CoreSys:
             funct = partial(funct, **kwargs)
 
         return self.loop.run_in_executor(None, funct, *args)
-
-    def create_websession(self) -> None:
-        """Create a new aiohttp session."""
-        if self._websession:
-            self.create_task(self._websession.close())
-
-        # Create session and set default header for aiohttp
-        self._websession: aiohttp.ClientSession = aiohttp.ClientSession(
-            headers=MappingProxyType({aiohttp.hdrs.USER_AGENT: SERVER_SOFTWARE})
-        )
 
     def _create_context(self) -> Context:
         """Create a new context for a task."""

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -292,8 +292,6 @@ class Supervisor(CoreSysAttributes):
                 "https://checkonline.home-assistant.io/online.txt", timeout=timeout
             )
         except (ClientError, TimeoutError):
-            # Need to recreate the websession to avoid stale connection checks
-            self.coresys.create_websession()
             self.connectivity = False
         else:
             self.connectivity = True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This reverts commit 1504278223a8d852d3b11de25f676fa8d6501a70 (#5332).

It turns out that recreating the session can cause race conditions, e.g. with API checks triggered by proxied requests running alongside. These manifest in the following error:

```
AttributeError: 'NoneType' object has no attribute 'connect' ...
  File "supervisor/homeassistant/api.py", line 187, in check_api_state
    if state := await self.get_api_state():
  File "supervisor/homeassistant/api.py", line 171, in get_api_state
    data = await self.get_core_state()
  File "supervisor/homeassistant/api.py", line 145, in get_core_state
    return await self._get_json("api/core/state")
  File "supervisor/homeassistant/api.py", line 132, in _get_json
    async with self.make_request("get", path) as resp:
  File "contextlib.py", line 214, in __aenter__
    return await anext(self.gen)
  File "supervisor/homeassistant/api.py", line 106, in make_request
    async with getattr(self.sys_websession, method)(
  File "aiohttp/client.py", line 1425, in __aenter__
    self._resp: _RetType = await self._coro
  File "aiohttp/client.py", line 703, in _request
    conn = await self._connector.connect(
```

The only reason for the _connection in the aiohttp client to be None is when close() gets called on the session. The only place this is being done is the connectivity check.

So it seems that between fetching the session from the `sys_websession` property) and actually using the connector, a connectivity check has been run which then causes the above stack trace.

Let's not mess with the lifetime of the ClientSession object and simply revert the change. Another solution for the original problem needs to be found.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of network sessions for more efficient connectivity checks.
- **Chores**
  - Streamlined session management to reduce redundant operations during error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->