### PR TITLE
Use requets http library for connectivity check

### DIFF
--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -10,8 +10,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import aiohttp
-from aiohttp.client_exceptions import ClientError
 from awesomeversion import AwesomeVersion, AwesomeVersionException
+import requests
 
 from .const import (
     ATTR_SUPERVISOR_INTERNET,
@@ -286,12 +286,13 @@ class Supervisor(CoreSysAttributes):
     )
     async def check_connectivity(self):
         """Check the connection."""
-        timeout = aiohttp.ClientTimeout(total=10)
         try:
-            await self.sys_websession.head(
-                "https://checkonline.home-assistant.io/online.txt", timeout=timeout
+            await self.sys_run_in_executor(
+                requests.head,
+                "https://checkonline.home-assistant.io/online.txt",
+                timeout=10,
             )
-        except (ClientError, TimeoutError):
+        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
             self.connectivity = False
         else:
             self.connectivity = True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The global aiohttp session might cache DNS lookups or pool connections. This can lead to inaccurate connectivity checks, especially when the DNS server gets changed after a network setup change.

Instead of using the global aiohttp session for the connectivity checks this uses the synchronous requests library to perform the connectivity check. This ensures that the DNS resolution is done fresh for each check and that the connection is not pooled.

This is another attempt to fix #5332, which got revert in #5851.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
