### PR TITLE
Load DNS plug-in early

### DIFF
--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -124,6 +124,14 @@ class Core(CoreSysAttributes):
         """Start setting up supervisor orchestration."""
         await self.set_state(CoreState.SETUP)
 
+        # Start DNS plug-in early to make sure we can resolve hostnames using
+        # the DNS plug-in during the rest of the setup.
+        await self.sys_plugins.dns.load()
+
+        # Initializing aiohttp.ClientSession after DNS setup makes sure that
+        # aiodns is using the right DNS servers from the getgo (see #5857).
+        await self.coresys.init_websession()
+
         # Check internet on startup
         await self.sys_supervisor.check_connectivity()
 

--- a/supervisor/coresys.py
+++ b/supervisor/coresys.py
@@ -68,7 +68,6 @@ class CoreSys:
 
         # External objects
         self._loop: asyncio.BaseEventLoop = asyncio.get_running_loop()
-        self._websession: aiohttp.ClientSession = aiohttp.ClientSession()
 
         # Global objects
         self._config: CoreConfig = CoreConfig()
@@ -100,11 +99,7 @@ class CoreSys:
         self._security: Security | None = None
         self._bus: Bus | None = None
         self._mounts: MountManager | None = None
-
-        # Set default header for aiohttp
-        self._websession._default_headers = MappingProxyType(
-            {aiohttp.hdrs.USER_AGENT: SERVER_SOFTWARE}
-        )
+        self._websession: aiohttp.ClientSession | None = None
 
         # Task factory attributes
         self._set_task_context: list[Callable[[Context], Context]] = []
@@ -113,6 +108,14 @@ class CoreSys:
         """Load config in executor."""
         await self.config.read_data()
         return self
+
+    async def init_websession(self) -> None:
+        """Initialize global aiohttp ClientSession."""
+        session = aiohttp.ClientSession(
+            headers=MappingProxyType({aiohttp.hdrs.USER_AGENT: SERVER_SOFTWARE})
+        )
+
+        self._websession = session
 
     async def init_machine(self):
         """Initialize machine information."""
@@ -165,6 +168,8 @@ class CoreSys:
     @property
     def websession(self) -> aiohttp.ClientSession:
         """Return websession object."""
+        if self._websession is None:
+            raise RuntimeError("WebSession not setup yet")
         return self._websession
 
     @property

--- a/supervisor/plugins/dns.py
+++ b/supervisor/plugins/dns.py
@@ -177,7 +177,6 @@ class PluginDns(PluginBase):
 
         # Update supervisor
         await self._write_resolv(HOST_RESOLV)
-        await self.sys_supervisor.check_connectivity()
 
     async def install(self) -> None:
         """Install CoreDNS."""

--- a/supervisor/plugins/manager.py
+++ b/supervisor/plugins/manager.py
@@ -70,6 +70,9 @@ class PluginManager(CoreSysAttributes):
         """Load Supervisor plugins."""
         # Sequential to avoid issue on slow IO
         for plugin in self.all_plugins:
+            if plugin == self.dns:
+                # DNS pug-in is loaded separtely in setup().
+                continue
             try:
                 await plugin.load()
             except Exception as err:  # pylint: disable=broad-except

--- a/tests/addons/test_manager.py
+++ b/tests/addons/test_manager.py
@@ -190,7 +190,7 @@ async def test_addon_shutdown_error(
 
 
 async def test_addon_uninstall_removes_discovery(
-    coresys: CoreSys, install_addon_ssh: Addon
+    coresys: CoreSys, install_addon_ssh: Addon, websession: MagicMock
 ):
     """Test discovery messages removed when addon uninstalled."""
     assert coresys.discovery.list_messages == []
@@ -203,7 +203,6 @@ async def test_addon_uninstall_removes_discovery(
     assert coresys.discovery.list_messages == [message]
 
     coresys.homeassistant.api.ensure_access_token = AsyncMock()
-    coresys.websession.delete = MagicMock()
 
     await coresys.addons.uninstall(TEST_ADDON_SLUG)
     await asyncio.sleep(0)

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -276,6 +276,7 @@ async def test_api_backup_restore_background(
     backup_type: str,
     options: dict[str, Any],
     tmp_supervisor_data: Path,
+    supervisor_internet: AsyncMock,
 ):
     """Test background option on backup/restore APIs."""
     await coresys.core.set_state(CoreState.RUNNING)
@@ -472,6 +473,7 @@ async def test_restore_immediate_errors(
     api_client: TestClient,
     coresys: CoreSys,
     mock_partial_backup: Backup,
+    supervisor_internet: AsyncMock,
 ):
     """Test restore errors that return immediately even in background mode."""
     await coresys.core.set_state(CoreState.RUNNING)
@@ -1010,6 +1012,7 @@ async def test_restore_backup_from_location(
     coresys: CoreSys,
     tmp_supervisor_data: Path,
     local_location: str | None,
+    supervisor_internet: AsyncMock,
 ):
     """Test restoring a backup from a specific location."""
     await coresys.core.set_state(CoreState.RUNNING)
@@ -1059,6 +1062,7 @@ async def test_restore_backup_from_location(
 async def test_restore_backup_unencrypted_after_encrypted(
     api_client: TestClient,
     coresys: CoreSys,
+    supervisor_internet: AsyncMock,
 ):
     """Test restoring an unencrypted backup after an encrypted backup and vis-versa."""
     enc_tar = copy(get_fixture_path("test_consolidate.tar"), coresys.config.path_backup)
@@ -1131,6 +1135,7 @@ async def test_restore_homeassistant_adds_env(
     docker: DockerAPI,
     backup_type: str,
     postbody: dict[str, Any],
+    supervisor_internet: AsyncMock,
 ):
     """Test restoring home assistant from backup adds env to container."""
     event = asyncio.Event()
@@ -1328,6 +1333,7 @@ async def test_missing_file_removes_location_from_cache(
     url_path: str,
     body: dict[str, Any] | None,
     backup_file: str,
+    supervisor_internet: AsyncMock,
 ):
     """Test finding a missing file removes the location from cache."""
     await coresys.core.set_state(CoreState.RUNNING)
@@ -1387,6 +1393,7 @@ async def test_missing_file_removes_backup_from_cache(
     url_path: str,
     body: dict[str, Any] | None,
     backup_file: str,
+    supervisor_internet: AsyncMock,
 ):
     """Test finding a missing file removes the backup from cache if its the only one."""
     await coresys.core.set_state(CoreState.RUNNING)
@@ -1412,7 +1419,9 @@ async def test_missing_file_removes_backup_from_cache(
 
 @pytest.mark.usefixtures("tmp_supervisor_data")
 async def test_immediate_list_after_missing_file_restore(
-    api_client: TestClient, coresys: CoreSys
+    api_client: TestClient,
+    coresys: CoreSys,
+    supervisor_internet: AsyncMock,
 ):
     """Test race with reload for missing file on restore does not error."""
     await coresys.core.set_state(CoreState.RUNNING)

--- a/tests/api/test_discovery.py
+++ b/tests/api/test_discovery.py
@@ -84,12 +84,14 @@ async def test_api_list_discovery(
 
 @pytest.mark.parametrize("api_client", [TEST_ADDON_SLUG], indirect=True)
 async def test_api_send_del_discovery(
-    api_client: TestClient, coresys: CoreSys, install_addon_ssh: Addon
+    api_client: TestClient,
+    coresys: CoreSys,
+    install_addon_ssh: Addon,
+    websession: MagicMock,
 ):
     """Test adding and removing discovery."""
     install_addon_ssh.data["discovery"] = ["test"]
     coresys.homeassistant.api.ensure_access_token = AsyncMock()
-    coresys.websession.post = MagicMock()
 
     resp = await api_client.post("/discovery", json={"service": "test", "config": {}})
     assert resp.status == 200

--- a/tests/api/test_security.py
+++ b/tests/api/test_security.py
@@ -1,5 +1,7 @@
 """Test Supervisor API."""
 
+from unittest.mock import AsyncMock
+
 import pytest
 
 from supervisor.coresys import CoreSys
@@ -36,7 +38,9 @@ async def test_api_security_options_pwned(api_client, coresys: CoreSys):
 
 
 @pytest.mark.asyncio
-async def test_api_integrity_check(api_client, coresys: CoreSys):
+async def test_api_integrity_check(
+    api_client, coresys: CoreSys, supervisor_internet: AsyncMock
+):
     """Test security integrity check."""
     coresys.security.content_trust = False
 

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from pathlib import Path
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from aiohttp import ClientResponse
 from aiohttp.test_utils import TestClient
@@ -92,7 +92,9 @@ async def test_api_store_repositories_repository(
     assert result["data"]["slug"] == repository.slug
 
 
-async def test_api_store_add_repository(api_client: TestClient, coresys: CoreSys):
+async def test_api_store_add_repository(
+    api_client: TestClient, coresys: CoreSys, supervisor_internet: AsyncMock
+) -> None:
     """Test POST /store/repositories REST API."""
     with (
         patch("supervisor.store.repository.Repository.load", return_value=None),

--- a/tests/api/test_supervisor.py
+++ b/tests/api/test_supervisor.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=protected-access
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp.test_utils import TestClient
 from blockbuster import BlockingError
@@ -34,7 +34,7 @@ async def test_api_supervisor_options_debug(api_client: TestClient, coresys: Cor
 
 
 async def test_api_supervisor_options_add_repository(
-    api_client: TestClient, coresys: CoreSys
+    api_client: TestClient, coresys: CoreSys, supervisor_internet: AsyncMock
 ):
     """Test add a repository via POST /supervisor/options REST API."""
     assert REPO_URL not in coresys.store.repository_urls
@@ -231,7 +231,9 @@ async def test_api_supervisor_fallback_log_capture(
         capture_exception.assert_called_once()
 
 
-async def test_api_supervisor_reload(api_client: TestClient):
+async def test_api_supervisor_reload(
+    api_client: TestClient, supervisor_internet: AsyncMock, websession: MagicMock
+):
     """Test supervisor reload."""
     resp = await api_client.post("/supervisor/reload")
     assert resp.status == 200

--- a/tests/common.py
+++ b/tests/common.py
@@ -103,3 +103,31 @@ def get_job_decorator(func) -> Job:
 def reset_last_call(func, group: str | None = None) -> None:
     """Reset last call for a function using the Job decorator."""
     get_job_decorator(func).set_last_call(datetime.min, group)
+
+
+class MockResponse:
+    """Mock response for aiohttp requests."""
+
+    def __init__(self, *, status=200, text=""):
+        """Initialize mock response."""
+        self.status = status
+        self._text = text
+
+    def update_text(self, text: str):
+        """Update the text of the response."""
+        self._text = text
+
+    async def read(self):
+        """Read the response body."""
+        return self._text.encode("utf-8")
+
+    async def text(self) -> str:
+        """Return the response body as text."""
+        return self._text
+
+    async def __aenter__(self):
+        """Enter the context manager."""
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        """Exit the context manager."""

--- a/tests/os/test_manager.py
+++ b/tests/os/test_manager.py
@@ -1,6 +1,6 @@
 """Test Home Assistant OS functionality."""
 
-from unittest.mock import PropertyMock, patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 from awesomeversion import AwesomeVersion
 from dbus_fast import Variant
@@ -10,6 +10,7 @@ from supervisor.const import CoreState
 from supervisor.coresys import CoreSys
 from supervisor.exceptions import HassOSJobError
 
+from tests.common import MockResponse
 from tests.dbus_service_mocks.base import DBusServiceMock
 from tests.dbus_service_mocks.rauc import Rauc as RaucService
 
@@ -17,7 +18,9 @@ from tests.dbus_service_mocks.rauc import Rauc as RaucService
 
 
 @pytest.mark.usefixtures("no_job_throttle")
-async def test_ota_url_generic_x86_64_rename(coresys: CoreSys) -> None:
+async def test_ota_url_generic_x86_64_rename(
+    coresys: CoreSys, mock_update_data: MockResponse, supervisor_internet: AsyncMock
+) -> None:
     """Test download URL generated."""
     coresys.os._board = "intel-nuc"
     coresys.os._version = AwesomeVersion("5.13")
@@ -65,7 +68,9 @@ def test_ota_url_os_name_rel_5_downgrade(coresys: CoreSys) -> None:
     assert url == url_formatted
 
 
-async def test_update_fails_if_out_of_date(coresys: CoreSys) -> None:
+async def test_update_fails_if_out_of_date(
+    coresys: CoreSys, supervisor_internet: AsyncMock
+) -> None:
     """Test update of OS fails if Supervisor is out of date."""
     await coresys.core.set_state(CoreState.RUNNING)
     with (

--- a/tests/plugins/test_plugin_manager.py
+++ b/tests/plugins/test_plugin_manager.py
@@ -58,12 +58,14 @@ async def test_load(
             new=PropertyMock(return_value=AwesomeVersion("1970-01-01")),
         ),
     ):
+        await coresys.plugins.dns.load()
         await coresys.plugins.load()
 
         assert attach.call_count == 5
         update.assert_not_called()
 
         need_update.return_value = False
+        await coresys.plugins.dns.load()
         await coresys.plugins.load()
 
         assert attach.call_count == 10

--- a/tests/plugins/test_plugin_manager.py
+++ b/tests/plugins/test_plugin_manager.py
@@ -1,6 +1,6 @@
 """Test plugin manager."""
 
-from unittest.mock import PropertyMock, patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 from awesomeversion import AwesomeVersion
 import pytest
@@ -9,6 +9,8 @@ from supervisor.coresys import CoreSys
 from supervisor.docker.interface import DockerInterface
 from supervisor.plugins.base import PluginBase
 from supervisor.supervisor import Supervisor
+
+from tests.common import MockResponse
 
 
 def mock_awaitable_bool(value: bool):
@@ -37,7 +39,9 @@ async def test_repair(coresys: CoreSys):
 
 
 @pytest.mark.usefixtures("no_job_throttle")
-async def test_load(coresys: CoreSys):
+async def test_load(
+    coresys: CoreSys, mock_update_data: MockResponse, supervisor_internet: AsyncMock
+):
     """Test plugin manager load."""
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     await coresys.updater.load()

--- a/tests/resolution/check/test_check_docker_config.py
+++ b/tests/resolution/check/test_check_docker_config.py
@@ -53,6 +53,7 @@ async def test_check(
         ["homeassistant", "hassio_audio", "addon_local_ssh"], folder
     )
     with patch.object(DockerInterface, "is_running", return_value=True):
+        await coresys.plugins.dns.load()
         await coresys.plugins.load()
         await coresys.homeassistant.load()
         await coresys.addons.load()
@@ -106,6 +107,7 @@ async def test_check(
     # IF config issue is resolved, all issues are removed except the main one. Which will be removed if check isn't approved
     docker.containers.get = _make_mock_container_get([])
     with patch.object(DockerInterface, "is_running", return_value=True):
+        await coresys.plugins.dns.load()
         await coresys.plugins.load()
         await coresys.homeassistant.load()
         await coresys.addons.load()

--- a/tests/resolution/fixup/test_system_execute_integrity.py
+++ b/tests/resolution/fixup/test_system_execute_integrity.py
@@ -16,7 +16,7 @@ from supervisor.security.const import ContentTrustResult, IntegrityResult
 from supervisor.utils.dt import utcnow
 
 
-async def test_fixup(coresys: CoreSys):
+async def test_fixup(coresys: CoreSys, supervisor_internet: AsyncMock):
     """Test fixup."""
     system_execute_integrity = FixupSystemExecuteIntegrity(coresys)
 
@@ -42,7 +42,7 @@ async def test_fixup(coresys: CoreSys):
     assert len(coresys.resolution.issues) == 0
 
 
-async def test_fixup_error(coresys: CoreSys):
+async def test_fixup_error(coresys: CoreSys, supervisor_internet: AsyncMock):
     """Test fixup."""
     system_execute_integrity = FixupSystemExecuteIntegrity(coresys)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -34,7 +34,7 @@ async def test_write_state(run_supervisor_state: MagicMock, coresys: CoreSys):
     )
 
 
-async def test_adjust_system_datetime(coresys: CoreSys):
+async def test_adjust_system_datetime(coresys: CoreSys, websession: MagicMock):
     """Test _adjust_system_datetime method with successful retrieve_whoami."""
     utc_ts = datetime.datetime.now().replace(tzinfo=datetime.UTC)
     with patch(
@@ -52,7 +52,9 @@ async def test_adjust_system_datetime(coresys: CoreSys):
         mock_retrieve_whoami.assert_not_called()
 
 
-async def test_adjust_system_datetime_without_ssl(coresys: CoreSys):
+async def test_adjust_system_datetime_without_ssl(
+    coresys: CoreSys, websession: MagicMock
+):
     """Test _adjust_system_datetime method when retrieve_whoami raises WhoamiSSLError."""
     utc_ts = datetime.datetime.now().replace(tzinfo=datetime.UTC)
     with patch(
@@ -67,7 +69,9 @@ async def test_adjust_system_datetime_without_ssl(coresys: CoreSys):
         assert coresys.core.sys_config.timezone == "Europe/Zurich"
 
 
-async def test_adjust_system_datetime_if_time_behind(coresys: CoreSys):
+async def test_adjust_system_datetime_if_time_behind(
+    coresys: CoreSys, websession: MagicMock
+):
     """Test _adjust_system_datetime method when current time is ahead more than 3 days."""
     utc_ts = datetime.datetime.now().replace(tzinfo=datetime.UTC) + datetime.timedelta(
         days=4

--- a/tests/test_coresys.py
+++ b/tests/test_coresys.py
@@ -1,6 +1,7 @@
 """Testing handling with CoreState."""
 
 from datetime import timedelta
+from unittest.mock import MagicMock, patch
 
 from aiohttp.hdrs import USER_AGENT
 
@@ -36,9 +37,13 @@ async def test_now(coresys: CoreSys):
     assert zurich - utc <= timedelta(hours=2)
 
 
-def test_custom_user_agent(coresys: CoreSys):
+async def test_custom_user_agent(coresys: CoreSys):
     """Test custom useragent."""
-    assert (
-        "HomeAssistantSupervisor/9999.09.9.dev9999"
-        in coresys.websession._default_headers[USER_AGENT]  # pylint: disable=protected-access
-    )
+    with patch(
+        "supervisor.coresys.aiohttp.ClientSession", return_value=MagicMock()
+    ) as mock_session:
+        await coresys.init_websession()
+        assert (
+            "HomeAssistantSupervisor/9999.09.9.dev9999"
+            in mock_session.call_args_list[0][1]["headers"][USER_AGENT]
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Load the DNS plug-in early, and create the ClientSession after the plug-in got loaded and our `/etc/resolv.conf` got written. This makes sure that Supervisor only reaches out to the internet once we have DNS setup.
    
It also side steps an issue with aiodns, which today doesn't reload `resolv.conf` automatically when it changes. This lead to Supervisor using the initial `resolv.conf` as created by Docker. It meant that we did not use the DNS plug-in (and its fallback capabilities) in Supervisor. Also it meant that changes to the DNS setup at runtime did not propagate to the aiohttp ClientSession (as observed in #5332).
    
We could recreate the ClientSession or reload the DNS resolver. But that seems more complicated. This solution has the added benefit that requests to internet services as well as our Supervisor connectivity check is much more deterministic.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5857
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the order of DNS and web session initialization during system setup for more reliable DNS resolution.
  - Adjusted internal plugin loading to better handle dependencies between DNS and other components.

- **Tests**
  - Enhanced test reliability by introducing new fixtures to mock internet connectivity and HTTP sessions.
  - Updated numerous test signatures to use injected mocks for web sessions and connectivity, improving test isolation and maintainability.
  - Added a mock response class to streamline HTTP response simulation in tests.

No user-facing features or documentation changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->