### PR TITLE
Trigger auto-update through Core WebSocket call

### DIFF
--- a/supervisor/homeassistant/const.py
+++ b/supervisor/homeassistant/const.py
@@ -32,6 +32,7 @@ class WSType(StrEnum):
     SUPERVISOR_EVENT = "supervisor/event"
     BACKUP_START = "backup/start"
     BACKUP_END = "backup/end"
+    HASSIO_UPDATE_ADDON = "hassio/update/addon"
 
 
 class WSEvent(StrEnum):

--- a/tests/misc/test_tasks.py
+++ b/tests/misc/test_tasks.py
@@ -1,6 +1,5 @@
 """Test scheduled tasks."""
 
-import asyncio
 from collections.abc import AsyncGenerator
 from pathlib import Path
 from shutil import copy
@@ -253,15 +252,16 @@ async def test_update_addons_auto_update_success(
         assert install_addon_example.need_update is True
         assert install_addon_example.auto_update_available is True
 
-        await asyncio.sleep(0.01)
+        # Make sure all job events from installing the add-on are cleared
         ha_ws_client.async_send_command.reset_mock()
 
         # pylint: disable-next=protected-access
         await tasks._update_addons()
-        await asyncio.sleep(0.01)
 
-        assert ha_ws_client.async_send_command.call_args_list[0][0][0] == {
-            "type": "hassio/update/addon",
-            "addon": install_addon_example.slug,
-            "backup": True,
-        }
+        ha_ws_client.async_send_command.assert_any_call(
+            {
+                "type": "hassio/update/addon",
+                "addon": install_addon_example.slug,
+                "backup": True,
+            }
+        )

--- a/tests/misc/test_tasks.py
+++ b/tests/misc/test_tasks.py
@@ -258,6 +258,7 @@ async def test_update_addons_auto_update_success(
 
         # pylint: disable-next=protected-access
         await tasks._update_addons()
+        await asyncio.sleep(0)
 
         assert ha_ws_client.async_send_command.call_args_list[0][0][0] == {
             "type": "hassio/update/addon",

--- a/tests/misc/test_tasks.py
+++ b/tests/misc/test_tasks.py
@@ -253,12 +253,12 @@ async def test_update_addons_auto_update_success(
         assert install_addon_example.need_update is True
         assert install_addon_example.auto_update_available is True
 
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
         ha_ws_client.async_send_command.reset_mock()
 
         # pylint: disable-next=protected-access
         await tasks._update_addons()
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
 
         assert ha_ws_client.async_send_command.call_args_list[0][0][0] == {
             "type": "hassio/update/addon",

--- a/tests/misc/test_tasks.py
+++ b/tests/misc/test_tasks.py
@@ -9,7 +9,7 @@ from awesomeversion import AwesomeVersion
 import pytest
 
 from supervisor.addons.addon import Addon
-from supervisor.const import CoreState
+from supervisor.const import ATTR_VERSION_TIMESTAMP, CoreState
 from supervisor.coresys import CoreSys
 from supervisor.exceptions import HomeAssistantError
 from supervisor.homeassistant.api import HomeAssistantAPI
@@ -244,8 +244,8 @@ async def test_update_addons_auto_update_success(
     await coresys.core.set_state(CoreState.RUNNING)
 
     # Set up the add-on as eligible for auto-update
-
     install_addon_example.auto_update = True
+    install_addon_example.data_store[ATTR_VERSION_TIMESTAMP] = 0
     with patch.object(
         Addon, "version", new=PropertyMock(return_value=AwesomeVersion("1.0"))
     ):

--- a/tests/misc/test_tasks.py
+++ b/tests/misc/test_tasks.py
@@ -253,11 +253,12 @@ async def test_update_addons_auto_update_success(
         assert install_addon_example.need_update is True
         assert install_addon_example.auto_update_available is True
 
-        # pylint: disable-next=protected-access
+        await asyncio.sleep(0)
         ha_ws_client.async_send_command.reset_mock()
+
+        # pylint: disable-next=protected-access
         await tasks._update_addons()
 
-        await asyncio.sleep(0)
         assert ha_ws_client.async_send_command.call_args_list[0][0][0] == {
             "type": "hassio/update/addon",
             "addon": install_addon_example.slug,

--- a/tests/misc/test_tasks.py
+++ b/tests/misc/test_tasks.py
@@ -1,5 +1,6 @@
 """Test scheduled tasks."""
 
+import asyncio
 from collections.abc import AsyncGenerator
 from pathlib import Path
 from shutil import copy
@@ -256,6 +257,7 @@ async def test_update_addons_auto_update_success(
         ha_ws_client.async_send_command.reset_mock()
         await tasks._update_addons()
 
+        await asyncio.sleep(0)
         assert ha_ws_client.async_send_command.call_args_list[0][0][0] == {
             "type": "hassio/update/addon",
             "addon": install_addon_example.slug,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Instead of auto-updating add-ons on Supervisor side trigger an update through Core via a WebSocket command. This makes sure that the backup is categorized correctly and all backup features like retention are applied.


<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Add-on updates now trigger a WebSocket command to Home Assistant Core, enabling automatic updates with backup creation.
- **Tests**
  - Introduced a new test to verify that add-ons marked for auto-update correctly send the update command via WebSocket.
- **Chores**
  - Added a new constant for the add-on update WebSocket event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->