### PR TITLE
Avoid initializing Blockbuster on Supervisor info call

### DIFF
--- a/supervisor/__main__.py
+++ b/supervisor/__main__.py
@@ -13,7 +13,7 @@ zlib_fast.enable()
 
 # pylint: disable=wrong-import-position
 from supervisor import bootstrap  # noqa: E402
-from supervisor.utils.blockbuster import activate_blockbuster  # noqa: E402
+from supervisor.utils.blockbuster import BlockBusterManager  # noqa: E402
 from supervisor.utils.logging import activate_log_queue_handler  # noqa: E402
 
 # pylint: enable=wrong-import-position
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     coresys = loop.run_until_complete(bootstrap.initialize_coresys())
     loop.set_debug(coresys.config.debug)
     if coresys.config.detect_blocking_io:
-        activate_blockbuster()
+        BlockBusterManager.activate()
     loop.run_until_complete(coresys.core.connect())
 
     loop.run_until_complete(bootstrap.supervisor_debugger(coresys))

--- a/supervisor/api/supervisor.py
+++ b/supervisor/api/supervisor.py
@@ -49,11 +49,7 @@ from ..const import (
 from ..coresys import CoreSysAttributes
 from ..exceptions import APIError
 from ..store.validate import repositories
-from ..utils.blockbuster import (
-    activate_blockbuster,
-    blockbuster_enabled,
-    deactivate_blockbuster,
-)
+from ..utils.blockbuster import BlockBusterManager
 from ..utils.sentry import close_sentry, init_sentry
 from ..utils.validate import validate_timezone
 from ..validate import version_tag, wait_boot
@@ -110,7 +106,7 @@ class APISupervisor(CoreSysAttributes):
             ATTR_DEBUG_BLOCK: self.sys_config.debug_block,
             ATTR_DIAGNOSTICS: self.sys_config.diagnostics,
             ATTR_AUTO_UPDATE: self.sys_updater.auto_update,
-            ATTR_DETECT_BLOCKING_IO: blockbuster_enabled(),
+            ATTR_DETECT_BLOCKING_IO: BlockBusterManager.is_enabled(),
             ATTR_COUNTRY: self.sys_config.country,
             # Depricated
             ATTR_WAIT_BOOT: self.sys_config.wait_boot,
@@ -180,10 +176,10 @@ class APISupervisor(CoreSysAttributes):
                 detect_blocking_io = DetectBlockingIO.ON
 
             if detect_blocking_io == DetectBlockingIO.ON:
-                activate_blockbuster()
+                BlockBusterManager.activate()
             elif detect_blocking_io == DetectBlockingIO.OFF:
                 self.sys_config.detect_blocking_io = False
-                deactivate_blockbuster()
+                BlockBusterManager.deactivate()
 
         # Deprecated
         if ATTR_WAIT_BOOT in body:

--- a/supervisor/utils/blockbuster.py
+++ b/supervisor/utils/blockbuster.py
@@ -2,6 +2,40 @@
 
 import logging
 
+from blockbuster import BlockBuster as _BlockBuster
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+class BlockBuster:
+    _instance: _BlockBuster | None = None
+
+    @classmethod
+    def is_enabled(cls):
+        """Return true if blockbuster detection is enabled."""
+        if cls._instance is None:
+            return False
+        for _, fn in cls._instance.functions.items():
+            return fn.activated
+        return False
+
+    @classmethod
+    def activate(cls):
+        """Activate blockbuster detection."""
+        _LOGGER.info("Activating BlockBuster blocking I/O detection")
+        if cls._instance is None:
+            cls._instance = _BlockBuster()
+        cls._instance.activate()
+
+    @classmethod
+    def deactivate(cls):
+        """Deactivate blockbuster detection."""
+        _LOGGER.info("Deactivating BlockBuster blocking I/O detection")
+        if cls._instance:
+            cls._instance.deactivate()
+
+import logging
+
 from blockbuster import BlockBuster
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)

--- a/supervisor/utils/blockbuster.py
+++ b/supervisor/utils/blockbuster.py
@@ -2,13 +2,15 @@
 
 import logging
 
-from blockbuster import BlockBuster as _BlockBuster
+from blockbuster import BlockBuster
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
-class BlockBuster:
-    _instance: _BlockBuster | None = None
+class BlockBusterManager:
+    """Manage BlockBuster instance."""
+
+    _instance: BlockBuster | None = None
 
     @classmethod
     def is_enabled(cls):
@@ -24,7 +26,7 @@ class BlockBuster:
         """Activate blockbuster detection."""
         _LOGGER.info("Activating BlockBuster blocking I/O detection")
         if cls._instance is None:
-            cls._instance = _BlockBuster()
+            cls._instance = BlockBuster()
         cls._instance.activate()
 
     @classmethod
@@ -33,41 +35,3 @@ class BlockBuster:
         _LOGGER.info("Deactivating BlockBuster blocking I/O detection")
         if cls._instance:
             cls._instance.deactivate()
-
-import logging
-
-from blockbuster import BlockBuster
-
-_LOGGER: logging.Logger = logging.getLogger(__name__)
-_blockbuster: BlockBuster | None = None
-
-
-def _get_blockbuster() -> BlockBuster:
-    # pylint: disable=global-statement
-    global _blockbuster  # noqa: PLW0603
-    if _blockbuster is None:
-        _blockbuster = BlockBuster()
-    return _blockbuster
-
-
-def blockbuster_enabled() -> bool:
-    """Return true if blockbuster detection is enabled."""
-    if _blockbuster is None:
-        return False
-
-    # We activate all or none so just check the first one
-    for _, fn in _blockbuster.functions.items():
-        return fn.activated
-    return False
-
-
-def activate_blockbuster() -> None:
-    """Activate blockbuster detection."""
-    _LOGGER.info("Activating BlockBuster blocking I/O detection")
-    _get_blockbuster().activate()
-
-
-def deactivate_blockbuster() -> None:
-    """Deactivate blockbuster detection."""
-    _LOGGER.info("Deactivating BlockBuster blocking I/O detection")
-    _get_blockbuster().deactivate()

--- a/supervisor/utils/blockbuster.py
+++ b/supervisor/utils/blockbuster.py
@@ -1,24 +1,28 @@
 """Activate and deactivate blockbuster for finding blocking I/O."""
 
-from functools import cache
 import logging
 
 from blockbuster import BlockBuster
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+_blockbuster: BlockBuster | None = None
 
 
-@cache
 def _get_blockbuster() -> BlockBuster:
-    """Get blockbuster instance."""
-    return BlockBuster()
+    # pylint: disable=global-statement
+    global _blockbuster  # noqa: PLW0603
+    if _blockbuster is None:
+        _blockbuster = BlockBuster()
+    return _blockbuster
 
 
 def blockbuster_enabled() -> bool:
     """Return true if blockbuster detection is enabled."""
-    blockbuster = _get_blockbuster()
+    if _blockbuster is None:
+        return False
+
     # We activate all or none so just check the first one
-    for _, fn in blockbuster.functions.items():
+    for _, fn in _blockbuster.functions.items():
         return fn.activated
     return False
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Instead of creating an instance of Blockbuster to simply check if Bluckbuster is enabled, use a global variable to store the instance of Blockbuster and only initialize it when needed. This avoids unnecessary initialization of Blockbuster when it is not required.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal management of the BlockBuster feature with a new streamlined activation system. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->