### PR TITLE
Avoid early DNS plug-in start

### DIFF
--- a/supervisor/host/network.py
+++ b/supervisor/host/network.py
@@ -158,6 +158,7 @@ class NetworkManager(CoreSysAttributes):
             DBUS_ATTR_PRIMARY_CONNECTION in changed
             and changed[DBUS_ATTR_PRIMARY_CONNECTION]
             and changed[DBUS_ATTR_PRIMARY_CONNECTION] != DBUS_OBJECT_BASE
+            and await self.sys_plugins.dns.is_running()
         ):
             await self.sys_plugins.dns.restart()
 

--- a/supervisor/plugins/dns.py
+++ b/supervisor/plugins/dns.py
@@ -211,7 +211,7 @@ class PluginDns(PluginBase):
         try:
             await self.instance.restart()
         except DockerError as err:
-            raise CoreDNSError("Can't start CoreDNS plugin", _LOGGER.error) from err
+            raise CoreDNSError("Can't restart CoreDNS plugin", _LOGGER.error) from err
 
     async def start(self) -> None:
         """Run CoreDNS."""

--- a/tests/host/test_connectivity.py
+++ b/tests/host/test_connectivity.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=protected-access
 import asyncio
-from unittest.mock import PropertyMock, patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
 
@@ -92,7 +92,12 @@ async def test_dns_restart_on_connection_change(
 ):
     """Test dns plugin is restarted when primary connection changes."""
     await coresys.host.network.load()
-    with patch.object(PluginDns, "restart") as restart:
+    with (
+        patch.object(PluginDns, "restart") as restart,
+        patch.object(
+            PluginDns, "is_running", new_callable=AsyncMock, return_value=True
+        ),
+    ):
         network_manager_service.emit_properties_changed({"PrimaryConnection": "/"})
         await network_manager_service.ping()
         restart.assert_not_called()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
A connectivity check can potentially be triggered before the DNS plug-in is loaded. Avoid calling restart on the DNS plug-in before it got initially loaded. This prevents starting before attaching. The attaching makes sure that the DNS plug-in container is recreated before the DNS plug-in is initially started, which is e.g. needed by a potentially hassio network configuration change (e.g. the migration required to enable/disable IPv6 on the hassio network, see #5879).

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of DNS plugin restarts to ensure it only attempts to restart when the plugin is actively running, reducing unnecessary operations.
  - Updated error messaging to accurately reflect restart operations for clearer troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->