### PR TITLE
Revert "Do not backup add-on being uninstalled (#5917)"

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -1335,13 +1335,6 @@ class Addon(AddonModel):
 
         wait_for_start: asyncio.Task | None = None
 
-        # Refuse to backup if add-on is unknown (e.g. has been uninstalled by the user
-        # since the backup got started).
-        if self.state == AddonState.UNKNOWN:
-            raise AddonsError(
-                f"Add-on {self.slug} is not installed, cannot backup!", _LOGGER.error
-            )
-
         data = {
             ATTR_USER: self.persist,
             ATTR_SYSTEM: self.data,

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -102,7 +102,7 @@ async def test_addon_state_listener(coresys: CoreSys, install_addon_ssh: Addon) 
     with patch.object(DockerAddon, "attach"):
         await install_addon_ssh.load()
 
-    assert install_addon_ssh.state == AddonState.STOPPED
+    assert install_addon_ssh.state == AddonState.UNKNOWN
 
     with patch.object(Addon, "watchdog_container"):
         _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.RUNNING)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,6 @@ from supervisor.const import (
     ATTR_TYPE,
     ATTR_VERSION,
     REQUEST_FROM,
-    AddonState,
     CoreState,
 )
 from supervisor.coresys import CoreSys
@@ -632,7 +631,6 @@ async def install_addon_ssh(coresys: CoreSys, repository):
     coresys.addons.data._data = coresys.addons.data._schema(coresys.addons.data._data)
 
     addon = Addon(coresys, store.slug)
-    addon.state = AddonState.STOPPED
     coresys.addons.local[addon.slug] = addon
     yield addon
 
@@ -645,7 +643,6 @@ async def install_addon_example(coresys: CoreSys, repository):
     coresys.addons.data._data = coresys.addons.data._schema(coresys.addons.data._data)
 
     addon = Addon(coresys, store.slug)
-    addon.state = AddonState.STOPPED
     coresys.addons.local[addon.slug] = addon
     yield addon
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This reverts commit 63fde3b4109310e95ebdcc8e3c23a04ff96ba592.

This change introduced another more severe regression, causing all add-ons that haven't been started since Supervisor startup to cause errors during their backup. More sophisticated check would have to be implemented to address edge cases during backups for non-existing add-ons (or their config actually).

Fixes #5924

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5924
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved backup process for add-ons by allowing backups to proceed even if the add-on state is unknown.
- **Tests**
	- Updated tests to reflect the new behavior for add-on states and backup handling.
- **Chores**
	- Cleaned up test fixtures and imports for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->