### PR TITLE
Fix `docker.run_command()` needing `detach` but not enforcing it

### DIFF
--- a/supervisor/docker/homeassistant.py
+++ b/supervisor/docker/homeassistant.py
@@ -213,9 +213,6 @@ class DockerHomeAssistant(DockerInterface):
             privileged=True,
             init=True,
             entrypoint=[],
-            detach=True,
-            stdout=True,
-            stderr=True,
             mounts=[
                 Mount(
                     type=MountType.BIND.value,

--- a/supervisor/docker/manager.py
+++ b/supervisor/docker/manager.py
@@ -311,6 +311,7 @@ class DockerAPI:
             container = self.docker.containers.run(
                 f"{image}:{tag}",
                 command=command,
+                detach=True,
                 network=self.network.name,
                 use_config_proxy=False,
                 **kwargs,
@@ -329,7 +330,7 @@ class DockerAPI:
                 with suppress(docker_errors.DockerException, requests.RequestException):
                     container.remove(force=True, v=True)
 
-        return CommandReturn(result.get("StatusCode"), output)
+        return CommandReturn(result["StatusCode"], output)
 
     def repair(self) -> None:
         """Repair local docker overlayfs2 issues."""

--- a/tests/docker/test_manager.py
+++ b/tests/docker/test_manager.py
@@ -34,6 +34,7 @@ async def test_run_command_success(docker: DockerAPI):
     docker.docker.containers.run.assert_called_once_with(
         "alpine:3.18",
         command="echo hello",
+        detach=True,
         network=docker.network.name,
         use_config_proxy=False,
         stdout=True,
@@ -66,6 +67,7 @@ async def test_run_command_with_defaults(docker: DockerAPI):
     docker.docker.containers.run.assert_called_once_with(
         "ubuntu:latest",  # default tag
         command=None,  # default command
+        detach=True,
         network=docker.network.name,
         use_config_proxy=False,
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`docker.run_command` only works with `Detach=True`, but was not including it in the default `container.run` args (i.e. was broken by default).

This fixes it, and also remove the redundant arguments from `docker.run_command` callers.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Extracted from https://github.com/home-assistant/supervisor/pull/5974.

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of container command execution to ensure consistent detachment and output stream behavior.
  * Adjusted retrieval of command exit codes for more reliable status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->