### PR TITLE
Allow multiple set-cookie headers with addons ingress

### DIFF
--- a/supervisor/api/ingress.py
+++ b/supervisor/api/ingress.py
@@ -309,9 +309,9 @@ class APIIngress(CoreSysAttributes):
 
 def _init_header(
     request: web.Request, addon: Addon, session_data: IngressSessionData | None
-) -> CIMultiDict | dict[str, str]:
+) -> CIMultiDict[str]:
     """Create initial header."""
-    headers = {}
+    headers = CIMultiDict[str]()
 
     if session_data is not None:
         headers[HEADER_REMOTE_USER_ID] = session_data.user.id
@@ -337,7 +337,7 @@ def _init_header(
             istr(HEADER_REMOTE_USER_DISPLAY_NAME),
         ):
             continue
-        headers[name] = value
+        headers.add(name, value)
 
     # Update X-Forwarded-For
     if request.transport:
@@ -348,9 +348,9 @@ def _init_header(
     return headers
 
 
-def _response_header(response: aiohttp.ClientResponse) -> dict[str, str]:
+def _response_header(response: aiohttp.ClientResponse) -> CIMultiDict[str]:
     """Create response header."""
-    headers = {}
+    headers = CIMultiDict[str]()
 
     for name, value in response.headers.items():
         if name in (
@@ -360,7 +360,7 @@ def _response_header(response: aiohttp.ClientResponse) -> dict[str, str]:
             hdrs.CONTENT_ENCODING,
         ):
             continue
-        headers[name] = value
+        headers.add(name, value)
 
     return headers
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The HTTP specification allows multiple headers with the same name in both requests and responses, but the Supervisor's ingress proxy was only preserving the last header when multiple existed.  
This primarily affected Set-Cookie response headers where applications frequently set multiple cookies in a single response for session management, user preferences, and other functionality.

This change updates the ingress proxy to use CIMultiDict with the .add() method to preserve all header values.

(this same change is also required in the core, which has a separate PR: https://github.com/home-assistant/core/pull/148148)


## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4290
- This PR is related to issue: https://github.com/home-assistant/core/pull/148148
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of HTTP headers for more robust and consistent processing when accessing add-ons through ingress. No visible changes to user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->