### PR TITLE
Force reload of /etc/resolv.conf on WebSession init

### DIFF
--- a/supervisor/coresys.py
+++ b/supervisor/coresys.py
@@ -124,7 +124,10 @@ class CoreSys:
 
         resolver: aiohttp.abc.AbstractResolver
         try:
-            resolver = aiohttp.AsyncResolver(loop=self.loop)
+            # Use "unused" kwargs to force dedicated resolver instance. Otherwise
+            # aiodns won't reload /etc/resolv.conf which we need to make our connection
+            # check work in all cases.
+            resolver = aiohttp.AsyncResolver(loop=self.loop, timeout=None)
             # pylint: disable=protected-access
             _LOGGER.debug(
                 "Initializing ClientSession with AsyncResolver. Using nameservers %s",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Since #5862 we recreate the aiohttp WebSession to force reload /etc/resolv.conf. However, since aiohttp 3.12.0 (first shipped with Supervisor 2025.05.4) aiohttp no longer initializes a separate DNSResolver instance (https://github.com/aio-libs/aiohttp/pull/10897) for each WebSession. This rendered #5862 essentially useless.

Force a separate DNSResolver instance to force /etc/resolv.conf reread.

Note: The automatic reload of /etc/resolv.conf of aiodns doesn't work in Supervisor's case since /etc is stored on a overlayfs and we overwrite the file at runtime. Inotify isn't working in this case (see also https://github.com/home-assistant/supervisor/pull/5862#issuecomment-2851258794).

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5995
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of network connection checks by ensuring the DNS resolver reloads system configuration as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->