### PR TITLE
Apply store reload suggestion automatically on connectivity change

### DIFF
--- a/supervisor/resolution/fixups/base.py
+++ b/supervisor/resolution/fixups/base.py
@@ -3,6 +3,7 @@
 from abc import ABC, abstractmethod
 import logging
 
+from ...const import BusEvent
 from ...coresys import CoreSys, CoreSysAttributes
 from ...exceptions import ResolutionFixupError
 from ..const import ContextType, IssueType, SuggestionType
@@ -65,6 +66,11 @@ class FixupBase(ABC, CoreSysAttributes):
     def auto(self) -> bool:
         """Return if a fixup can be apply as auto fix."""
         return False
+
+    @property
+    def bus_event(self) -> BusEvent | None:
+        """Return the BusEvent that triggers this fixup, or None if not event-based."""
+        return None
 
     @property
     def all_suggestions(self) -> list[Suggestion]:

--- a/supervisor/resolution/fixups/store_execute_reload.py
+++ b/supervisor/resolution/fixups/store_execute_reload.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from ...const import BusEvent
 from ...coresys import CoreSys
 from ...exceptions import (
     ResolutionFixupError,
@@ -68,3 +69,8 @@ class FixupStoreExecuteReload(FixupBase):
     def auto(self) -> bool:
         """Return if a fixup can be apply as auto fix."""
         return True
+
+    @property
+    def bus_event(self) -> BusEvent | None:
+        """Return the BusEvent that triggers this fixup, or None if not event-based."""
+        return BusEvent.SUPERVISOR_CONNECTIVITY_CHANGE

--- a/tests/resolution/fixup/test_store_execute_reload.py
+++ b/tests/resolution/fixup/test_store_execute_reload.py
@@ -1,9 +1,14 @@
 """Test evaluation base."""
 
 # pylint: disable=import-error,protected-access
+import asyncio
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
+from supervisor.const import BusEvent
 from supervisor.coresys import CoreSys
+from supervisor.exceptions import ResolutionFixupError
 from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.data import Issue, Suggestion
 from supervisor.resolution.fixups.store_execute_reload import FixupStoreExecuteReload
@@ -32,3 +37,94 @@ async def test_fixup(coresys: CoreSys, supervisor_internet):
     assert mock_repositorie.update.called
     assert len(coresys.resolution.suggestions) == 0
     assert len(coresys.resolution.issues) == 0
+
+
+@pytest.mark.usefixtures("supervisor_internet")
+async def test_store_execute_reload_runs_on_connectivity_true(coresys: CoreSys):
+    """Test fixup runs when connectivity goes from false to true."""
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    coresys.supervisor.connectivity = False
+    await asyncio.sleep(0)
+
+    mock_repository = AsyncMock()
+    coresys.store.repositories["test_store"] = mock_repository
+    coresys.resolution.add_issue(
+        Issue(
+            IssueType.FATAL_ERROR,
+            ContextType.STORE,
+            reference="test_store",
+        ),
+        suggestions=[SuggestionType.EXECUTE_RELOAD],
+    )
+
+    with patch.object(coresys.store, "reload") as mock_reload:
+        # Fire event with connectivity True
+        coresys.supervisor.connectivity = True
+        await asyncio.sleep(0.1)
+
+        mock_repository.load.assert_called_once()
+        mock_reload.assert_awaited_once_with(mock_repository)
+
+
+@pytest.mark.usefixtures("supervisor_internet")
+async def test_store_execute_reload_does_not_run_on_connectivity_false(
+    coresys: CoreSys,
+):
+    """Test fixup does not run when connectivity goes from true to false."""
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    coresys.supervisor.connectivity = True
+    await asyncio.sleep(0)
+
+    mock_repository = AsyncMock()
+    coresys.store.repositories["test_store"] = mock_repository
+    coresys.resolution.add_issue(
+        Issue(
+            IssueType.FATAL_ERROR,
+            ContextType.STORE,
+            reference="test_store",
+        ),
+        suggestions=[SuggestionType.EXECUTE_RELOAD],
+    )
+
+    # Fire event with connectivity True
+    coresys.supervisor.connectivity = False
+    await asyncio.sleep(0.1)
+
+    mock_repository.load.assert_not_called()
+
+
+@pytest.mark.usefixtures("supervisor_internet")
+async def test_store_execute_reload_dismiss_suggestion_removes_listener(
+    coresys: CoreSys,
+):
+    """Test fixup does not run on event if suggestion has been dismissed."""
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    coresys.supervisor.connectivity = True
+    await asyncio.sleep(0)
+
+    mock_repository = AsyncMock()
+    coresys.store.repositories["test_store"] = mock_repository
+    coresys.resolution.add_issue(
+        issue := Issue(
+            IssueType.FATAL_ERROR,
+            ContextType.STORE,
+            reference="test_store",
+        ),
+        suggestions=[SuggestionType.EXECUTE_RELOAD],
+    )
+
+    with patch.object(
+        FixupStoreExecuteReload, "process_fixup", side_effect=ResolutionFixupError
+    ) as mock_fixup:
+        # Fire event with issue there to trigger fixup
+        coresys.bus.fire_event(BusEvent.SUPERVISOR_CONNECTIVITY_CHANGE, True)
+        await asyncio.sleep(0.1)
+        mock_fixup.assert_called_once()
+
+        # Remove issue and suggestion and re-fire to see listener is gone
+        mock_fixup.reset_mock()
+        coresys.resolution.dismiss_issue(issue)
+
+        coresys.bus.fire_event(BusEvent.SUPERVISOR_CONNECTIVITY_CHANGE, True)
+        await asyncio.sleep(0.1)
+        mock_fixup.assert_not_called()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Currently a network error at startup causes load of addon stores to be significantly delayed. We create an automated suggestion to reload each store but it has to wait for the task to get to it, which can take up to an hour:
https://github.com/home-assistant/supervisor/blob/381e719a0e5e874330caf6fca449aae8af147dbd/supervisor/resolution/module.py#L205

This adds the capability for fixups which are auto to define an event they listen for. They are automatically run if that event fires outside of the normal healthcheck cycle. And then the store execute reload suggestion we make when network is down at startup is set to listen for the `SUPERVISOR_CONNECTIVITY_CHANGE` event

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
