### PR TITLE
Drop ensure_builtin_repositories()

### DIFF
--- a/supervisor/backups/backup.py
+++ b/supervisor/backups/backup.py
@@ -931,5 +931,5 @@ class Backup(JobGroup):
         Return a coroutine.
         """
         return self.sys_store.update_repositories(
-            self.repositories, issue_on_error=True, replace=replace
+            set(self.repositories), issue_on_error=True, replace=replace
         )

--- a/supervisor/store/__init__.py
+++ b/supervisor/store/__init__.py
@@ -21,7 +21,7 @@ from .addon import AddonStore
 from .const import FILE_HASSIO_STORE, BuiltinRepository
 from .data import StoreData
 from .repository import Repository
-from .validate import SCHEMA_STORE_FILE
+from .validate import DEFAULT_REPOSITORIES, SCHEMA_STORE_FILE
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -67,9 +67,9 @@ class StoreManager(CoreSysAttributes, FileConfiguration):
         # Make sure the built-in repositories are all present
         # This is especially important when adding new built-in repositories
         # to make sure existing installations have them.
-        all_repositories: set[str] = set(self._data.get(ATTR_REPOSITORIES, [])) | {
-            repo.value for repo in BuiltinRepository
-        }
+        all_repositories: set[str] = (
+            set(self._data.get(ATTR_REPOSITORIES, [])) | DEFAULT_REPOSITORIES
+        )
         await self.update_repositories(all_repositories, issue_on_error=True)
 
     @Job(

--- a/supervisor/store/__init__.py
+++ b/supervisor/store/__init__.py
@@ -21,7 +21,7 @@ from .addon import AddonStore
 from .const import FILE_HASSIO_STORE, BuiltinRepository
 from .data import StoreData
 from .repository import Repository
-from .validate import SCHEMA_STORE_FILE, ensure_builtin_repositories
+from .validate import SCHEMA_STORE_FILE
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -231,14 +231,8 @@ class StoreManager(CoreSysAttributes, FileConfiguration):
         """Update repositories by adding new ones and removing stale ones."""
         current_repositories = {repository.source for repository in self.all}
 
-        # Determine changes needed
-        if replace:
-            target_repositories = set(ensure_builtin_repositories(list_repositories))
-            repositories_to_add = target_repositories - current_repositories
-        else:
-            # When not replacing, just add the new repositories
-            repositories_to_add = set(list_repositories) - current_repositories
-            target_repositories = current_repositories | repositories_to_add
+        # Determine repositories to add
+        repositories_to_add = set(list_repositories) - current_repositories
 
         # Add new repositories
         add_errors = await asyncio.gather(
@@ -259,7 +253,7 @@ class StoreManager(CoreSysAttributes, FileConfiguration):
             repositories_to_remove: list[Repository] = [
                 repository
                 for repository in self.all
-                if repository.source not in target_repositories
+                if repository.source not in list_repositories
                 and not repository.is_builtin
             ]
 

--- a/supervisor/store/const.py
+++ b/supervisor/store/const.py
@@ -35,7 +35,3 @@ class BuiltinRepository(StrEnum):
             return URL_HASSIO_ADDONS
         else:
             return self.value  # For URL-based repos, value is the URL
-
-
-# All repositories that are considered "built-in" and protected from removal
-ALL_BUILTIN_REPOSITORIES = {repo.value for repo in BuiltinRepository}

--- a/supervisor/store/validate.py
+++ b/supervisor/store/validate.py
@@ -4,7 +4,7 @@ import voluptuous as vol
 
 from ..const import ATTR_MAINTAINER, ATTR_NAME, ATTR_REPOSITORIES, ATTR_URL
 from ..validate import RE_REPOSITORY
-from .const import ALL_BUILTIN_REPOSITORIES, BuiltinRepository
+from .const import BuiltinRepository
 
 # pylint: disable=no-value-for-parameter
 SCHEMA_REPOSITORY_CONFIG = vol.Schema(
@@ -15,15 +15,6 @@ SCHEMA_REPOSITORY_CONFIG = vol.Schema(
     },
     extra=vol.REMOVE_EXTRA,
 )
-
-
-def ensure_builtin_repositories(addon_repositories: list[str]) -> list[str]:
-    """Ensure builtin repositories are in list.
-
-    Note: This should not be used in validation as the resulting list is not
-    stable. This can have side effects when comparing data later on.
-    """
-    return list(set(addon_repositories) | ALL_BUILTIN_REPOSITORIES)
 
 
 def validate_repository(repository: str) -> str:
@@ -44,11 +35,11 @@ def validate_repository(repository: str) -> str:
 
 repositories = vol.All([validate_repository], vol.Unique())
 
+DEFAULT_REPOSITORIES = [repo.value for repo in BuiltinRepository]
+
 SCHEMA_STORE_FILE = vol.Schema(
     {
-        vol.Optional(
-            ATTR_REPOSITORIES, default=list(ALL_BUILTIN_REPOSITORIES)
-        ): repositories,
+        vol.Optional(ATTR_REPOSITORIES, default=DEFAULT_REPOSITORIES): repositories,
     },
     extra=vol.REMOVE_EXTRA,
 )

--- a/supervisor/store/validate.py
+++ b/supervisor/store/validate.py
@@ -35,11 +35,13 @@ def validate_repository(repository: str) -> str:
 
 repositories = vol.All([validate_repository], vol.Unique())
 
-DEFAULT_REPOSITORIES = [repo.value for repo in BuiltinRepository]
+DEFAULT_REPOSITORIES = {repo.value for repo in BuiltinRepository}
 
 SCHEMA_STORE_FILE = vol.Schema(
     {
-        vol.Optional(ATTR_REPOSITORIES, default=DEFAULT_REPOSITORIES): repositories,
+        vol.Optional(
+            ATTR_REPOSITORIES, default=lambda: list(DEFAULT_REPOSITORIES)
+        ): repositories,
     },
     extra=vol.REMOVE_EXTRA,
 )

--- a/tests/store/test_custom_repository.py
+++ b/tests/store/test_custom_repository.py
@@ -17,7 +17,7 @@ from supervisor.exceptions import (
 from supervisor.resolution.const import SuggestionType
 from supervisor.store import StoreManager
 from supervisor.store.addon import AddonStore
-from supervisor.store.const import ALL_BUILTIN_REPOSITORIES
+from supervisor.store.const import BuiltinRepository
 from supervisor.store.repository import Repository
 
 
@@ -189,7 +189,9 @@ async def test_preinstall_valid_repository(
 ):
     """Test add core repository valid."""
     with patch("supervisor.store.git.GitRepo.load", return_value=None):
-        await store_manager.update_repositories(list(ALL_BUILTIN_REPOSITORIES))
+        await store_manager.update_repositories(
+            [repo.value for repo in BuiltinRepository]
+        )
 
         def validate():
             assert store_manager.get("core").validate()

--- a/tests/store/test_custom_repository.py
+++ b/tests/store/test_custom_repository.py
@@ -50,7 +50,9 @@ async def test_add_valid_repository(
         patch("pathlib.Path.exists", return_value=True),
     ):
         if use_update:
-            await store_manager.update_repositories(current + ["http://example.com"])
+            await store_manager.update_repositories(
+                set(current) | {"http://example.com"}
+            )
         else:
             await store_manager.add_repository("http://example.com")
 
@@ -70,7 +72,7 @@ async def test_add_invalid_repository(coresys: CoreSys, store_manager: StoreMana
         ),
     ):
         await store_manager.update_repositories(
-            current + ["http://example.com"], issue_on_error=True
+            set(current) | {"http://example.com"}, issue_on_error=True
         )
 
         assert not await get_repository_by_url(
@@ -96,7 +98,9 @@ async def test_error_on_invalid_repository(
         pytest.raises(StoreError),
     ):
         if use_update:
-            await store_manager.update_repositories(current + ["http://example.com"])
+            await store_manager.update_repositories(
+                set(current) | {"http://example.com"}
+            )
         else:
             await store_manager.add_repository("http://example.com")
 
@@ -118,7 +122,7 @@ async def test_add_invalid_repository_file(
         patch("pathlib.Path.exists", return_value=False),
     ):
         await store_manager.update_repositories(
-            current + ["http://example.com"], issue_on_error=True
+            set(current) | {"http://example.com"}, issue_on_error=True
         )
 
         assert not await get_repository_by_url(
@@ -146,7 +150,7 @@ async def test_add_repository_with_git_error(
     current = coresys.store.repository_urls
     with patch("supervisor.store.git.GitRepo.load", side_effect=git_error):
         await store_manager.update_repositories(
-            current + ["http://example.com"], issue_on_error=True
+            set(current) | {"http://example.com"}, issue_on_error=True
         )
 
     assert "http://example.com" in coresys.store.repository_urls
@@ -175,7 +179,9 @@ async def test_error_on_repository_with_git_error(
         pytest.raises(StoreError),
     ):
         if use_update:
-            await store_manager.update_repositories(current + ["http://example.com"])
+            await store_manager.update_repositories(
+                set(current) | {"http://example.com"}
+            )
         else:
             await store_manager.add_repository("http://example.com")
 
@@ -190,7 +196,7 @@ async def test_preinstall_valid_repository(
     """Test add core repository valid."""
     with patch("supervisor.store.git.GitRepo.load", return_value=None):
         await store_manager.update_repositories(
-            [repo.value for repo in BuiltinRepository]
+            {repo.value for repo in BuiltinRepository}
         )
 
         def validate():
@@ -215,7 +221,7 @@ async def test_remove_repository(
     assert test_repository.slug in coresys.store.repositories
 
     if use_update:
-        await store_manager.update_repositories([])
+        await store_manager.update_repositories(set())
     else:
         await store_manager.remove_repository(test_repository)
 
@@ -243,7 +249,7 @@ async def test_remove_used_repository(
         match="Can't remove 'https://github.com/awesome-developer/awesome-repo'. It's used by installed add-ons",
     ):
         if use_update:
-            await store_manager.update_repositories([])
+            await store_manager.update_repositories(set())
         else:
             await store_manager.remove_repository(
                 coresys.store.repositories[store_addon.repository]
@@ -254,7 +260,7 @@ async def test_update_partial_error(coresys: CoreSys, store_manager: StoreManage
     """Test partial error on update does partial save and errors."""
     with patch("supervisor.store.repository.RepositoryGit.validate", return_value=True):
         with patch("supervisor.store.git.GitRepo.load", return_value=None):
-            await store_manager.update_repositories([])
+            await store_manager.update_repositories(set())
 
         store_manager.data.update.assert_called_once()
         store_manager.data.update.reset_mock()
@@ -270,7 +276,7 @@ async def test_update_partial_error(coresys: CoreSys, store_manager: StoreManage
             pytest.raises(StoreError),
         ):
             await store_manager.update_repositories(
-                current + ["http://example.com", "http://example2.com"]
+                set(current) | {"http://example.com", "http://example2.com"}
             )
 
     assert len(coresys.store.repository_urls) == initial + 1
@@ -305,7 +311,7 @@ async def test_add_with_update_repositories(
         ),
         patch("pathlib.Path.exists", return_value=True),
     ):
-        await store_manager.update_repositories(["http://example.com"], replace=False)
+        await store_manager.update_repositories({"http://example.com"}, replace=False)
 
     assert test_repository.source in coresys.store.repository_urls
     assert "http://example.com" in coresys.store.repository_urls
@@ -324,7 +330,7 @@ async def test_add_repository_fails_if_out_of_date(
     ):
         if use_update:
             await store_manager.update_repositories(
-                coresys.store.repository_urls + ["http://example.com"],
+                set(coresys.store.repository_urls) | {"http://example.com"}
             )
         else:
             await store_manager.add_repository("http://example.com")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
With the new Repository classes we have the is_builtin property, so we can easily make sure that built-ins are not removed. The `ensure_builtin_repositories()` is really redundant logic at this point. This allows us to further cleanup the code by removing the `ensure_builtin_repositories()` function and the ALL_BUILTIN_REPOSITORIES constant.

This came up in discussions of PR https://github.com/home-assistant/supervisor/pull/5990#discussion_r2195466349.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined repository update logic for improved efficiency and maintainability.
  * Replaced static repository lists with dynamic enumeration-based lists for built-in repositories.
  * Ensured built-in repositories are always included during startup.
  * Changed repository collections from lists to sets for uniqueness and simplified handling.

* **Tests**
  * Updated tests to use the new enumeration-based approach for built-in repositories and set-based collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->