### PR TITLE
Improve JobGroup locking with external ownership tracking

### DIFF
--- a/supervisor/jobs/decorator.py
+++ b/supervisor/jobs/decorator.py
@@ -447,8 +447,7 @@ class Job(CoreSysAttributes):
         """Release concurrency control locks."""
         if self._is_group_concurrency():
             # Group-level concurrency: delegate to job group
-            assert job_group is not None  # Should be validated during _post_init
-            job_group.release(job)
+            cast(JobGroup, job_group).release(job)
         elif self.concurrency in (JobConcurrency.REJECT, JobConcurrency.QUEUE):
             # Job-level concurrency: use semaphore
             if self.lock.locked():
@@ -460,9 +459,8 @@ class Job(CoreSysAttributes):
         """Handle concurrency control limits."""
         if self._is_group_concurrency():
             # Group-level concurrency: delegate to job group
-            assert job_group is not None  # Validated during _post_init
             try:
-                await job_group.acquire(
+                await cast(JobGroup, job_group).acquire(
                     job, wait=self.concurrency == JobConcurrency.GROUP_QUEUE
                 )
             except JobGroupExecutionLimitExceeded as err:

--- a/supervisor/jobs/decorator.py
+++ b/supervisor/jobs/decorator.py
@@ -118,13 +118,6 @@ class Job(CoreSysAttributes):
                 )
             self._rate_limited_calls = {}
 
-        if self.throttle is not None and self._is_group_concurrency():
-            # We cannot release group locks when Job is not running (e.g. throttled)
-            # which makes these combinations impossible to use currently.
-            raise RuntimeError(
-                f"Job {self.name} is using throttling ({self.throttle}) with group concurrency ({self.concurrency}), which is not allowed!"
-            )
-
     @property
     def throttle_max_calls(self) -> int:
         """Return max calls for throttle."""

--- a/supervisor/jobs/decorator.py
+++ b/supervisor/jobs/decorator.py
@@ -71,7 +71,7 @@ class Job(CoreSysAttributes):
         self.on_condition = on_condition
         self._throttle_period = throttle_period
         self._throttle_max_calls = throttle_max_calls
-        self._lock: asyncio.Semaphore | None = None
+        self._lock: asyncio.Lock | None = None
         self._last_call: dict[str | None, datetime] = {}
         self._rate_limited_calls: dict[str | None, list[datetime]] | None = None
         self._internal = internal
@@ -126,9 +126,9 @@ class Job(CoreSysAttributes):
         return self._throttle_max_calls
 
     @property
-    def lock(self) -> asyncio.Semaphore:
+    def lock(self) -> asyncio.Lock:
         """Return lock for limits."""
-        # asyncio.Semaphore objects must be created in event loop
+        # asyncio.Lock objects must be created in event loop
         # Since this is sync code it is not safe to create if missing here
         if not self._lock:
             raise RuntimeError("Lock has not been created yet!")
@@ -200,7 +200,7 @@ class Job(CoreSysAttributes):
 
         # Setup lock for limits
         if self._lock is None:
-            self._lock = asyncio.Semaphore()
+            self._lock = asyncio.Lock()
 
         # Job groups
         job_group: JobGroup | None = None

--- a/supervisor/jobs/job_group.py
+++ b/supervisor/jobs/job_group.py
@@ -28,11 +28,6 @@ class JobGroup(CoreSysAttributes):
         self._job_reference: str | None = job_reference
 
     @property
-    def active_job_id(self) -> str | None:
-        """Get active job UUID."""
-        return self._lock_owner.uuid if self._lock_owner else None
-
-    @property
     def active_job(self) -> SupervisorJob | None:
         """Get active job ID."""
         return self._lock_owner

--- a/supervisor/jobs/job_group.py
+++ b/supervisor/jobs/job_group.py
@@ -1,9 +1,11 @@
 """Job group object."""
 
 from asyncio import Lock
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 from ..coresys import CoreSys, CoreSysAttributes
-from ..exceptions import JobGroupExecutionLimitExceeded
+from ..exceptions import JobException, JobGroupExecutionLimitExceeded
 from . import SupervisorJob
 
 
@@ -23,14 +25,24 @@ class JobGroup(CoreSysAttributes):
         self.coresys: CoreSys = coresys
         self._group_name: str = group_name
         self._lock: Lock = Lock()
-        self._active_job: SupervisorJob | None = None
-        self._parent_jobs: list[SupervisorJob] = []
+        self._lock_owner: str | None = None
+        self._parent_jobs: list[str] = []
         self._job_reference: str | None = job_reference
+
+    @property
+    def active_job_id(self) -> str | None:
+        """Get active job UUID."""
+        return self._lock_owner
 
     @property
     def active_job(self) -> SupervisorJob | None:
         """Get active job ID."""
-        return self._active_job
+        if self._lock_owner:
+            try:
+                return self.sys_jobs.get_job(self._lock_owner)
+            except Exception:
+                return None
+        return None
 
     @property
     def group_name(self) -> str:
@@ -40,39 +52,78 @@ class JobGroup(CoreSysAttributes):
     @property
     def has_lock(self) -> bool:
         """Return true if current task has the lock on this job group."""
-        return (
-            self.active_job is not None
-            and self.sys_jobs.is_job
-            and self.active_job == self.sys_jobs.current
-        )
+        if not self._lock_owner:
+            return False
+
+        if self.sys_jobs.is_job:
+            current_job = self.sys_jobs.current
+            return current_job.uuid == self._lock_owner
+
+        return False
 
     @property
     def job_reference(self) -> str | None:
         """Return value to use as reference for all jobs created for this job group."""
         return self._job_reference
 
+    def is_locked_by(self, job: SupervisorJob) -> bool:
+        """Check if this specific job owns the lock."""
+        return self._lock_owner == job.uuid
+
+    def can_acquire(self, job: SupervisorJob) -> bool:
+        """Check if the job can acquire the lock without waiting."""
+        return not self._lock_owner or self.is_locked_by(job)
+
     async def acquire(self, job: SupervisorJob, wait: bool = False) -> None:
         """Acquire the lock for the group for the specified job."""
+        # If we already own the lock (nested call), just update parent stack
+        if self.is_locked_by(job):
+            if self._lock_owner:
+                self._parent_jobs.append(self._lock_owner)
+            self._lock_owner = job.uuid
+            return
+
         # If there's another job running and we're not waiting, raise
-        if self.active_job and not self.has_lock and not wait:
+        if self._lock_owner and not wait:
             raise JobGroupExecutionLimitExceeded(
                 f"Another job is running for job group {self.group_name}"
             )
 
-        # Else if we don't have the lock, acquire it
-        if not self.has_lock:
-            await self._lock.acquire()
+        # Acquire the actual asyncio lock
+        await self._lock.acquire()
 
-        # Store the job ID we acquired the lock for
-        if self.active_job:
-            self._parent_jobs.append(self.active_job)
+        # Set ownership
+        self._lock_owner = job.uuid
 
-        self._active_job = job
-
-    def release(self) -> None:
+    def release(self, job: SupervisorJob | None = None) -> None:
         """Release the lock for the group or return it to parent."""
+        # Allow release by specific job UUID or current job
+        if job and not self.is_locked_by(job):
+            raise JobException(f"Job {job.uuid} does not own the lock")
+        elif not job and not self.has_lock:
+            raise JobException("Current context does not own the lock")
+
+        # Return to parent job if exists
         if self._parent_jobs:
-            self._active_job = self._parent_jobs.pop()
+            self._lock_owner = self._parent_jobs.pop()
         else:
-            self._active_job = None
+            self._lock_owner = None
             self._lock.release()
+
+    def force_release(self) -> None:
+        """Force release the lock (for cleanup/error scenarios)."""
+        if self._lock.locked():
+            self._lock_owner = None
+            self._parent_jobs.clear()
+            self._lock.release()
+
+    @asynccontextmanager
+    async def acquire_context(
+        self, job: SupervisorJob, wait: bool = False
+    ) -> AsyncIterator[None]:
+        """Context manager for acquiring and automatically releasing the lock."""
+        await self.acquire(job, wait=wait)
+        try:
+            yield
+        finally:
+            self.release(job)

--- a/supervisor/jobs/job_group.py
+++ b/supervisor/jobs/job_group.py
@@ -3,7 +3,7 @@
 from asyncio import Lock
 
 from ..coresys import CoreSys, CoreSysAttributes
-from ..exceptions import JobException, JobGroupExecutionLimitExceeded
+from ..exceptions import JobGroupExecutionLimitExceeded
 from . import SupervisorJob
 
 
@@ -71,9 +71,6 @@ class JobGroup(CoreSysAttributes):
 
     def release(self) -> None:
         """Release the lock for the group or return it to parent."""
-        if not self.has_lock:
-            raise JobException("Cannot release as caller does not own lock")
-
         if self._parent_jobs:
             self._active_job = self._parent_jobs.pop()
         else:

--- a/supervisor/jobs/job_group.py
+++ b/supervisor/jobs/job_group.py
@@ -59,10 +59,6 @@ class JobGroup(CoreSysAttributes):
         """Check if this specific job owns the lock."""
         return self._lock_owner == job
 
-    def can_acquire(self, job: SupervisorJob) -> bool:
-        """Check if the job can acquire the lock without waiting."""
-        return not self._lock_owner or self.is_locked_by(job)
-
     async def acquire(self, job: SupervisorJob, wait: bool = False) -> None:
         """Acquire the lock for the group for the specified job."""
         # If we already own the lock (nested call or same job chain), just update parent stack


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Refactors JobGroup concurrency system to enable external lock management. This allows to release Job group locks outside of a running Job context, which allows the use of context manager in the decorator and execution limits combined with group concurrency parameters.

**JobGroup** (supervisor/jobs/job_group.py):
  - Add `release(job)` parameter to enable external lock release with ownership verification
  - Add `is_locked_by(job)` helper methods

**Job Decorator** (supervisor/jobs/decorator.py):
  - Add helper methods `_is_group_concurrency()` and `_is_group_throttle()` for cleaner logic separation
  - Remove all `cast(JobGroup, job_group)` calls by using proper type checking
  - Change from `asyncio.Semaphore()` to `asyncio.Lock()` for consistency with `JobGroup`
  - Enable throttling with group concurrency - remove artificial restriction since external lock release now works

**Tests** (tests/jobs/test_job_decorator.py):
  - Add test_group_concurrency_with_group_throttling() to verify the combination works correctly

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
