### PR TITLE
Propagate timezone setting to host in OS 16.2 and newer

### DIFF
--- a/supervisor/api/supervisor.py
+++ b/supervisor/api/supervisor.py
@@ -142,6 +142,7 @@ class APISupervisor(CoreSysAttributes):
         ):
             await self.sys_run_in_executor(validate_timezone, timezone)
             await self.sys_config.set_timezone(timezone)
+            await self.sys_host.control.set_timezone(timezone)
 
         if ATTR_CHANNEL in body:
             self.sys_updater.channel = body[ATTR_CHANNEL]

--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -392,6 +392,19 @@ class Core(CoreSysAttributes):
 
     async def _adjust_system_datetime(self) -> None:
         """Adjust system time/date on startup."""
+        # Ensure host system timezone matches supervisor timezone configuration
+        if (
+            self.sys_config.timezone
+            and self.sys_host.info.timezone != self.sys_config.timezone
+            and self.sys_dbus.timedate.is_connected
+        ):
+            _LOGGER.info(
+                "Timezone in Supervisor config '%s' differs from host '%s'",
+                self.sys_config.timezone,
+                self.sys_host.info.timezone,
+            )
+            await self.sys_host.control.set_timezone(self.sys_config.timezone)
+
         # If no timezone is detect or set
         # If we are not connected or time sync
         if (

--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -426,7 +426,9 @@ class Core(CoreSysAttributes):
             _LOGGER.warning("Can't adjust Time/Date settings: %s", err)
             return
 
-        await self.sys_config.set_timezone(self.sys_config.timezone or data.timezone)
+        timezone = self.sys_config.timezone or data.timezone
+        await self.sys_config.set_timezone(timezone)
+        await self.sys_host.control.set_timezone(timezone)
 
         # Calculate if system time is out of sync
         delta = data.dt_utc - utcnow()

--- a/supervisor/dbus/timedate.py
+++ b/supervisor/dbus/timedate.py
@@ -112,3 +112,8 @@ class TimeDate(DBusInterfaceProxy):
     async def set_ntp(self, use_ntp: bool) -> None:
         """Turn NTP on or off."""
         await self.connected_dbus.call("set_ntp", use_ntp, False)
+
+    @dbus_connected
+    async def set_timezone(self, timezone: str) -> None:
+        """Set timezone on host."""
+        await self.connected_dbus.call("set_timezone", timezone, False)

--- a/supervisor/host/control.py
+++ b/supervisor/host/control.py
@@ -97,6 +97,7 @@ class SystemControl(CoreSysAttributes):
             await self.sys_dbus.timedate.set_timezone(timezone)
             await self.sys_dbus.timedate.update()
         else:
+            # pylint: disable=fixme
             # TODO: we can change this to a warning once 16.2 is out
             _LOGGER.info(
                 "Skipping persistent timezone setting, OS %s < 16.2",

--- a/supervisor/host/control.py
+++ b/supervisor/host/control.py
@@ -3,6 +3,8 @@
 from datetime import datetime
 import logging
 
+from awesomeversion import AwesomeVersion
+
 from ..const import HostFeature
 from ..coresys import CoreSysAttributes
 from ..exceptions import HostNotSupportedError
@@ -80,3 +82,23 @@ class SystemControl(CoreSysAttributes):
         _LOGGER.info("Setting new host datetime: %s", new_time.isoformat())
         await self.sys_dbus.timedate.set_time(new_time)
         await self.sys_dbus.timedate.update()
+
+    async def set_timezone(self, timezone: str) -> None:
+        """Set timezone on host."""
+        self._check_dbus(HostFeature.TIMEDATE)
+
+        # /etc/localtime is not writable on OS older than 16.2
+        if (
+            self.coresys.os.available
+            and self.coresys.os.version is not None
+            and self.sys_os.version >= AwesomeVersion("16.2.dev0")
+        ):
+            _LOGGER.info("Setting host timezone: %s", timezone)
+            await self.sys_dbus.timedate.set_timezone(timezone)
+            await self.sys_dbus.timedate.update()
+        else:
+            # TODO: we can change this to a warning once 16.2 is out
+            _LOGGER.info(
+                "Skipping persistent timezone setting, OS %s < 16.2",
+                self.sys_os.version,
+            )

--- a/tests/dbus/test_timedate.py
+++ b/tests/dbus/test_timedate.py
@@ -82,6 +82,24 @@ async def test_dbus_setntp(
     assert timedate.ntp is False
 
 
+async def test_dbus_set_timezone(
+    timedate_service: TimeDateService, dbus_session_bus: MessageBus
+):
+    """Test setting of host timezone."""
+    timedate_service.SetTimezone.calls.clear()
+    timedate = TimeDate()
+
+    with pytest.raises(DBusNotConnectedError):
+        await timedate.set_timezone("Europe/Prague")
+
+    await timedate.connect(dbus_session_bus)
+
+    assert await timedate.set_timezone("Europe/Prague") is None
+    assert timedate_service.SetTimezone.calls == [("Europe/Prague", False)]
+    await timedate_service.ping()
+    assert timedate.timezone == "Europe/Prague"
+
+
 async def test_dbus_timedate_connect_error(
     dbus_session_bus: MessageBus, caplog: pytest.LogCaptureFixture
 ):

--- a/tests/host/test_control.py
+++ b/tests/host/test_control.py
@@ -1,9 +1,12 @@
 """Test host control."""
 
+import pytest
+
 from supervisor.coresys import CoreSys
 
 from tests.dbus_service_mocks.base import DBusServiceMock
 from tests.dbus_service_mocks.hostname import Hostname as HostnameService
+from tests.dbus_service_mocks.timedate import TimeDate as TimeDateService
 
 
 async def test_set_hostname(
@@ -20,3 +23,33 @@ async def test_set_hostname(
     assert hostname_service.SetStaticHostname.calls == [("test", False)]
     await hostname_service.ping()
     assert coresys.dbus.hostname.hostname == "test"
+
+
+@pytest.mark.parametrize("os_available", ["16.2"], indirect=True)
+async def test_set_timezone(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+    os_available: str,
+):
+    """Test set timezone."""
+    timedate_service: TimeDateService = all_dbus_services["timedate"]
+    timedate_service.SetTimezone.calls.clear()
+
+    assert coresys.dbus.timedate.timezone == "Etc/UTC"
+
+    await coresys.host.control.set_timezone("Europe/Prague")
+    assert timedate_service.SetTimezone.calls == [("Europe/Prague", False)]
+
+
+@pytest.mark.parametrize("os_available", ["16.1"], indirect=True)
+async def test_set_timezone_unsupported(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+    os_available: str,
+):
+    """Test DBus call is not made when OS doesn't support it."""
+    timedate_service: TimeDateService = all_dbus_services["timedate"]
+    timedate_service.SetTimezone.calls.clear()
+
+    await coresys.host.control.set_timezone("Europe/Prague")
+    assert timedate_service.SetTimezone.calls == []


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

With home-assistant/operating-system#4224, timezone setting in OS can be peristently set in HAOS as well. Propagate the timezone configured in Supervisor config (which can be changed through general system settings in HA Core) through the DBus API for setting the timezone.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
