### PR TITLE
Handle malformed addon map entries gracefully

### DIFF
--- a/supervisor/addons/validate.py
+++ b/supervisor/addons/validate.py
@@ -266,6 +266,14 @@ def _migrate_addon_config(protocol=False):
         volumes = []
         for entry in config.get(ATTR_MAP, []):
             if isinstance(entry, dict):
+                # Validate that dict entries have required 'type' field
+                if ATTR_TYPE not in entry:
+                    _LOGGER.warning(
+                        "Add-on config has invalid map entry missing 'type' field: %s. Skipping invalid entry for %s",
+                        entry,
+                        name,
+                    )
+                    continue
                 volumes.append(entry)
             if isinstance(entry, str):
                 result = RE_VOLUME.match(entry)

--- a/supervisor/addons/validate.py
+++ b/supervisor/addons/validate.py
@@ -278,6 +278,11 @@ def _migrate_addon_config(protocol=False):
             if isinstance(entry, str):
                 result = RE_VOLUME.match(entry)
                 if not result:
+                    _LOGGER.warning(
+                        "Add-on config has invalid map entry: %s. Skipping invalid entry for %s",
+                        entry,
+                        name,
+                    )
                     continue
                 volumes.append(
                     {
@@ -286,8 +291,8 @@ def _migrate_addon_config(protocol=False):
                     }
                 )
 
-        if volumes:
-            config[ATTR_MAP] = volumes
+        # Always update config to clear potentially malformed ones
+        config[ATTR_MAP] = volumes
 
         # 2023-10 "config" became "homeassistant" so /config can be used for addon's public config
         if any(volume[ATTR_TYPE] == MappingType.CONFIG for volume in volumes):

--- a/tests/addons/test_config.py
+++ b/tests/addons/test_config.py
@@ -154,9 +154,15 @@ def test_malformed_map_entries():
     valid_config = vd.SCHEMA_ADDON_CONFIG(config)
     assert valid_config["map"] == []
 
-    # Test case 3: Mix of valid and invalid entries (invalid should be filtered out)
+    # Test case 3: Invalid string format that doesn't match regex
+    config["map"] = ["invalid_format", "not:a:valid:mapping", "share:invalid_mode"]
+    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    assert valid_config["map"] == []
+
+    # Test case 4: Mix of valid and invalid entries (invalid should be filtered out)
     config["map"] = [
         "share:rw",  # Valid string format
+        "invalid_string",  # Invalid string format
         {},  # Invalid empty dict
         {"type": "config", "read_only": True},  # Valid dict format
         {"read_only": False},  # Invalid - missing type
@@ -167,7 +173,7 @@ def test_malformed_map_entries():
     assert any(entry["type"] == "share" for entry in valid_config["map"])
     assert any(entry["type"] == "config" for entry in valid_config["map"])
 
-    # Test case 4: The specific case from the UplandJacob repo (malformed YAML format)
+    # Test case 5: The specific case from the UplandJacob repo (malformed YAML format)
     # This simulates what YAML "- addon_config: rw" creates
     config["map"] = [{"addon_config": "rw"}]  # Wrong structure, missing 'type' key
     valid_config = vd.SCHEMA_ADDON_CONFIG(config)


### PR DESCRIPTION
## Proposed change

Fix crash when addon configurations contain malformed map entries missing the required `type` field. This issue was introduced by commit 1fb15772d which added `addon.map_volumes` access in docker config checks, exposing a validation bug in the addon config migration code.

The problem occurred when addon configurations contained YAML entries like:
```yaml
map:
  - addon_config: rw
```

This creates `{"addon_config": "rw"}` which lacks the required `"type"` field, causing a `KeyError: 'type'` during migration before schema validation could run.

The fix:
1. **Validates dict entries** during migration and skips invalid ones with helpful warnings
2. **Always updates config** with filtered results to replace malformed entries 
3. **Provides clear diagnostics** to help addon developers fix their configs
4. **Gracefully degrades** by filtering out invalid entries rather than crashing

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #6124
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/