### PR TITLE
Fix DockerLogOutOfOrder precision errors in pull progress tracking

### DIFF
--- a/supervisor/jobs/__init__.py
+++ b/supervisor/jobs/__init__.py
@@ -7,6 +7,7 @@ from contextvars import Context, ContextVar, Token
 from dataclasses import dataclass
 from datetime import datetime
 import logging
+import math
 from typing import Any, Self
 from uuid import uuid4
 
@@ -97,7 +98,7 @@ class SupervisorJob:
         default=0,
         validator=[ge(0), le(100), _invalid_if_done],
         on_setattr=_on_change,
-        converter=lambda val: round(val, 1),
+        converter=lambda val: math.floor(val * 10) / 10,
     )
     stage: str | None = field(
         default=None, validator=[_invalid_if_done], on_setattr=_on_change


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This PR fixes DockerLogOutOfOrder errors that were being incorrectly triggered due to floating-point precision issues during Docker image pull progress tracking. The errors occurred when calculated progress values had small precision differences compared to stored values, causing false positives for "backward progress" detection.

The fix implements consistent floor-based rounding (instead of round-to-nearest) for both job progress storage and comparison logic. This ensures that calculated and stored progress values use the same precision, eliminating false DockerLogOutOfOrder exceptions.

**Root Cause:**
- Job progress was rounded to 1 decimal place using `round(val, 1)` 
- Progress comparison used raw floating-point values
- Small precision differences (e.g., 91.28472850448557 vs stored 91.3) triggered false "backward progress" errors

**Solution:**
- Changed SupervisorJob progress converter to use `math.floor(val * 10) / 10` (floor rounding)
- Updated progress comparison in DockerInterface to use the same floor rounding before comparison
- Added comprehensive unit test to verify the fix works correctly

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: N/A
- Link to cli pull request: N/A
- Link to client library pull request: N/A

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/