### PR TITLE
Avoid duplicate evaluate_system() calls during resolution manager setup

### DIFF
--- a/supervisor/resolution/module.py
+++ b/supervisor/resolution/module.py
@@ -215,8 +215,8 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
 
     async def load(self):
         """Load the resoulution manager."""
-        # Initial system check when the manager is loaded
-        await self.check.check_system()
+        # Initial healthcheck check
+        await self.healthcheck()
 
         # Schedule the healthcheck
         self.sys_scheduler.register_task(self.healthcheck, SCHEDULED_HEALTHCHECK)

--- a/supervisor/resolution/module.py
+++ b/supervisor/resolution/module.py
@@ -215,8 +215,8 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
 
     async def load(self):
         """Load the resoulution manager."""
-        # Initial healthcheck when the manager is loaded
-        await self.healthcheck()
+        # Initial system check when the manager is loaded
+        await self.check.check_system()
 
         # Schedule the healthcheck
         self.sys_scheduler.register_task(self.healthcheck, SCHEDULED_HEALTHCHECK)


### PR DESCRIPTION
## Proposed change

This PR optimizes the resolution manager initialization to avoid duplicate `evaluate_system()` calls during supervisor setup. 

Currently, when the resolution manager loads, it calls `healthcheck()` which internally calls `evaluate_system()`. However, during the setup stage, the supervisor's main setup process also calls `evaluate_system()`, creating redundant system evaluation work.

Remove the `evaluate_system()` in the setup stage. Also move the OS Agent diagnostics initialization into the start phase. This allows to leverage the broad exception handling. Finally check if OS Agent is connected at all, which prevents the common case of D-Bus not being available without causing exceptions. Supervisor already raises an error earlier if OS Agent is missing.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/