### PR TITLE
Allow deeply nested dicts and lists in addon config schemas

### DIFF
--- a/supervisor/addons/options.py
+++ b/supervisor/addons/options.py
@@ -93,15 +93,7 @@ class AddonOptions(CoreSysAttributes):
 
             typ = self.raw_schema[key]
             try:
-                if isinstance(typ, list):
-                    # nested value list
-                    options[key] = self._nested_validate_list(typ[0], value, key)
-                elif isinstance(typ, dict):
-                    # nested value dict
-                    options[key] = self._nested_validate_dict(typ, value, key)
-                else:
-                    # normal value
-                    options[key] = self._single_validate(typ, value, key)
+                options[key] = self._validate_element(typ, value, key)
             except (IndexError, KeyError):
                 raise vol.Invalid(
                     f"Type error for option '{key}' in {self._name} ({self._slug})"
@@ -111,7 +103,20 @@ class AddonOptions(CoreSysAttributes):
         return options
 
     # pylint: disable=no-value-for-parameter
-    def _single_validate(self, typ: str, value: Any, key: str):
+    def _validate_element(self, typ: Any, value: Any, key: str) -> Any:
+        """Validate a value against a type specification."""
+        if isinstance(typ, list):
+            # nested value list
+            return self._nested_validate_list(typ[0], value, key)
+        elif isinstance(typ, dict):
+            # nested value dict
+            return self._nested_validate_dict(typ, value, key)
+        else:
+            # normal value
+            return self._single_validate(typ, value, key)
+
+    # pylint: disable=no-value-for-parameter
+    def _single_validate(self, typ: str, value: Any, key: str) -> Any:
         """Validate a single element."""
         # if required argument
         if value is None:
@@ -188,7 +193,9 @@ class AddonOptions(CoreSysAttributes):
             f"Fatal error for option '{key}' with type '{typ}' in {self._name} ({self._slug})"
         ) from None
 
-    def _nested_validate_list(self, typ: Any, data_list: list[Any], key: str):
+    def _nested_validate_list(
+        self, typ: Any, data_list: list[Any], key: str
+    ) -> list[Any]:
         """Validate nested items."""
         options = []
 
@@ -201,17 +208,13 @@ class AddonOptions(CoreSysAttributes):
         # Process list
         for element in data_list:
             # Nested?
-            if isinstance(typ, dict):
-                c_options = self._nested_validate_dict(typ, element, key)
-                options.append(c_options)
-            else:
-                options.append(self._single_validate(typ, element, key))
+            options.append(self._validate_element(typ, element, key))
 
         return options
 
     def _nested_validate_dict(
         self, typ: dict[Any, Any], data_dict: dict[Any, Any], key: str
-    ):
+    ) -> dict[Any, Any]:
         """Validate nested items."""
         options = {}
 
@@ -231,12 +234,7 @@ class AddonOptions(CoreSysAttributes):
                 continue
 
             # Nested?
-            if isinstance(typ[c_key], list):
-                options[c_key] = self._nested_validate_list(
-                    typ[c_key][0], c_value, c_key
-                )
-            else:
-                options[c_key] = self._single_validate(typ[c_key], c_value, c_key)
+            options[c_key] = self._validate_element(typ[c_key], c_value, c_key)
 
         self._check_missing_options(typ, options, key)
         return options

--- a/supervisor/addons/options.py
+++ b/supervisor/addons/options.py
@@ -274,17 +274,27 @@ class UiOptions(CoreSysAttributes):
 
         # read options
         for key, value in raw_schema.items():
-            if isinstance(value, list):
-                # nested value list
-                self._nested_ui_list(ui_schema, value, key)
-            elif isinstance(value, dict):
-                # nested value dict
-                self._nested_ui_dict(ui_schema, value, key)
-            else:
-                # normal value
-                self._single_ui_option(ui_schema, value, key)
+            self._ui_schema_element(ui_schema, value, key)
 
         return ui_schema
+
+    def _ui_schema_element(
+        self,
+        ui_schema: list[dict[str, Any]],
+        value: str,
+        key: str,
+        multiple: bool = False,
+    ):
+        if isinstance(value, list):
+            # nested value list
+            assert not multiple
+            self._nested_ui_list(ui_schema, value, key)
+        elif isinstance(value, dict):
+            # nested value dict
+            self._nested_ui_dict(ui_schema, value, key, multiple)
+        else:
+            # normal value
+            self._single_ui_option(ui_schema, value, key, multiple)
 
     def _single_ui_option(
         self,
@@ -377,10 +387,7 @@ class UiOptions(CoreSysAttributes):
             _LOGGER.error("Invalid schema %s", key)
             return
 
-        if isinstance(element, dict):
-            self._nested_ui_dict(ui_schema, element, key, multiple=True)
-        else:
-            self._single_ui_option(ui_schema, element, key, multiple=True)
+        self._ui_schema_element(ui_schema, element, key, multiple=True)
 
     def _nested_ui_dict(
         self,
@@ -399,11 +406,7 @@ class UiOptions(CoreSysAttributes):
 
         nested_schema: list[dict[str, Any]] = []
         for c_key, c_value in option_dict.items():
-            # Nested?
-            if isinstance(c_value, list):
-                self._nested_ui_list(nested_schema, c_value, c_key)
-            else:
-                self._single_ui_option(nested_schema, c_value, c_key)
+            self._ui_schema_element(nested_schema, c_value, c_key)
 
         ui_node["schema"] = nested_schema
         ui_schema.append(ui_node)

--- a/supervisor/addons/validate.py
+++ b/supervisor/addons/validate.py
@@ -137,7 +137,13 @@ RE_DOCKER_IMAGE_BUILD = re.compile(
     r"^([a-zA-Z\-\.:\d{}]+/)*?([\-\w{}]+)/([\-\w{}]+)(:[\.\-\w{}]+)?$"
 )
 
-SCHEMA_ELEMENT = vol.Match(RE_SCHEMA_ELEMENT)
+SCHEMA_ELEMENT = vol.Schema(
+    vol.Any(
+        vol.Match(RE_SCHEMA_ELEMENT),
+        [vol.Self],
+        {str: vol.Self},
+    )
+)
 
 RE_MACHINE = re.compile(
     r"^!?(?:"
@@ -406,20 +412,7 @@ _SCHEMA_ADDON_CONFIG = vol.Schema(
         vol.Optional(ATTR_CODENOTARY): vol.Email(),
         vol.Optional(ATTR_OPTIONS, default={}): dict,
         vol.Optional(ATTR_SCHEMA, default={}): vol.Any(
-            vol.Schema(
-                {
-                    str: vol.Any(
-                        SCHEMA_ELEMENT,
-                        [
-                            vol.Any(
-                                SCHEMA_ELEMENT,
-                                {str: vol.Any(SCHEMA_ELEMENT, [SCHEMA_ELEMENT])},
-                            )
-                        ],
-                        vol.Schema({str: vol.Any(SCHEMA_ELEMENT, [SCHEMA_ELEMENT])}),
-                    )
-                }
-            ),
+            vol.Schema({str: SCHEMA_ELEMENT}),
             False,
         ),
         vol.Optional(ATTR_IMAGE): docker_image,

--- a/supervisor/addons/validate.py
+++ b/supervisor/addons/validate.py
@@ -140,7 +140,13 @@ RE_DOCKER_IMAGE_BUILD = re.compile(
 SCHEMA_ELEMENT = vol.Schema(
     vol.Any(
         vol.Match(RE_SCHEMA_ELEMENT),
-        [vol.Self],
+        [
+            # A list may not directly contain another list
+            vol.Any(
+                vol.Match(RE_SCHEMA_ELEMENT),
+                {str: vol.Self},
+            )
+        ],
         {str: vol.Self},
     )
 )

--- a/tests/addons/test_config.py
+++ b/tests/addons/test_config.py
@@ -325,3 +325,97 @@ def test_valid_slug():
     config["slug"] = "complemento telefónico"
     with pytest.raises(vol.Invalid):
         assert vd.SCHEMA_ADDON_CONFIG(config)
+
+
+def test_valid_schema():
+    """Test valid and invalid addon slugs."""
+    config = load_json_fixture("basic-addon-config.json")
+
+    # Basic types
+    config["schema"] = {
+        "bool_basic": "bool",
+        "mail_basic": "email",
+        "url_basic": "url",
+        "port_basic": "port",
+        "match_basic": "match(.*@.*)",
+        "list_basic": "list(option1|option2|option3)",
+        # device
+        "device_basic": "device",
+        "device_filter": "device(subsystem=tty)",
+        # str
+        "str_basic": "str",
+        "str_basic2": "str(,)",
+        "str_min": "str(5,)",
+        "str_max": "str(,10)",
+        "str_minmax": "str(5,10)",
+        # password
+        "password_basic": "password",
+        "password_basic2": "password(,)",
+        "password_min": "password(5,)",
+        "password_max": "password(,10)",
+        "password_minmax": "password(5,10)",
+        # int
+        "int_basic": "int",
+        "int_basic2": "int(,)",
+        "int_min": "int(5,)",
+        "int_max": "int(,10)",
+        "int_minmax": "int(5,10)",
+        # float
+        "float_basic": "float",
+        "float_basic2": "float(,)",
+        "float_min": "float(5,)",
+        "float_max": "float(,10)",
+        "float_minmax": "float(5,10)",
+    }
+    assert vd.SCHEMA_ADDON_CONFIG(config)
+
+    # Different valid ways of nesting dicts and lists
+    config["schema"] = {
+        "str_list": ["str"],
+        "dict_in_list": [
+            {
+                "required": "str",
+                "optional": "str?",
+            }
+        ],
+        "dict": {
+            "required": "str",
+            "optional": "str?",
+            "str_list_in_dict": ["str"],
+            "dict_in_list_in_dict": [
+                {
+                    "required": "str",
+                    "optional": "str?",
+                    "str_list_in_dict_in_list_in_dict": ["str"],
+                }
+            ],
+            "dict_in_dict": {
+                "str_list_in_dict_in_dict": ["str"],
+                "dict_in_list_in_dict_in_dict": [
+                    {
+                        "required": "str",
+                        "optional": "str?",
+                    }
+                ],
+                "dict_in_dict_in_dict": {
+                    "required": "str",
+                    "optional": "str",
+                },
+            },
+        },
+    }
+    assert vd.SCHEMA_ADDON_CONFIG(config)
+
+    # List nested within dict within list
+    config["schema"] = {"field": [{"subfield": ["str"]}]}
+    assert vd.SCHEMA_ADDON_CONFIG(config)
+
+    # No lists directly nested within each other
+    config["schema"] = {"field": [["str"]]}
+    with pytest.raises(vol.Invalid):
+        assert vd.SCHEMA_ADDON_CONFIG(config)
+
+    # Field types must be valid
+    config["schema"] = {"field": "invalid"}
+    with pytest.raises(vol.Invalid):
+        assert vd.SCHEMA_ADDON_CONFIG(config)

--- a/tests/addons/test_options.py
+++ b/tests/addons/test_options.py
@@ -129,6 +129,64 @@ def test_complex_schema_dict(coresys):
         )({"name": "Pascal", "password": "1234", "extend": "test"})
 
 
+def test_complex_schema_dict_and_list(coresys):
+    """Test with complex dict/list nested schema."""
+    assert AddonOptions(
+        coresys,
+        {
+            "name": "str",
+            "packages": [
+                {
+                    "name": "str",
+                    "options": {"optional": "bool"},
+                    "dependencies": [{"name": "str"}],
+                }
+            ],
+        },
+        MOCK_ADDON_NAME,
+        MOCK_ADDON_SLUG,
+    )(
+        {
+            "name": "Pascal",
+            "packages": [
+                {
+                    "name": "core",
+                    "options": {"optional": False},
+                    "dependencies": [{"name": "supervisor"}, {"name": "audio"}],
+                }
+            ],
+        }
+    )
+
+    with pytest.raises(vol.error.Invalid):
+        assert AddonOptions(
+            coresys,
+            {
+                "name": "str",
+                "packages": [
+                    {
+                        "name": "str",
+                        "options": {"optional": "bool"},
+                        "dependencies": [{"name": "str"}],
+                    }
+                ],
+            },
+            MOCK_ADDON_NAME,
+            MOCK_ADDON_SLUG,
+        )(
+            {
+                "name": "Pascal",
+                "packages": [
+                    {
+                        "name": "core",
+                        "options": {"optional": False},
+                        "dependencies": [{"name": "supervisor"}, "wrong"],
+                    }
+                ],
+            }
+        )
+
+
 def test_simple_device_schema(coresys):
     """Test with simple schema."""
     for device in (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove the arbitrary (and undocumented) restrictions on how lists and dicts can be nested within themselves and each other in addon config schemas, so e.g. the following is now allowed:

```yaml
schema:
  filters:
    - conditions:
        - property: str
          condition: list(equal|not_equal)
          value: str
      actions:
        accept: bool?
        latency: int?
```

The only remaining restriction is that list-of-lists (`field: [[str]]`) are disallowed, because there's no way to represent them in the current encoding for `UiOptions` (and they can already be represented in a more self-documenting way: `field: [{subfield: [str]}]`).

The current documentation at https://developers.home-assistant.io/docs/add-ons/configuration#options--schema does not mention the restrictions, and as such does not require an update per-se.

A documentation PR has been created at home-assistant/developers.home-assistant#2778, but can also be applied independently of the current PR.

## Related issues

There is discussion at #2640 about changing the way addon configuration schemas are defined, but that discussion is already 4 years old. Given that the configuration UI already bails out to raw YAML syntax for some more complex schemas like the one down below, it does not worsen the current situation to simply loosen the current restrictions:

```yaml
schema:
  filters:
    - conditions:
        - str?
      accept: bool?
      latency: int?
```

The only other currently available option for addons requiring more complex schemas is to forego Supervisor-side validation entirely.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is also related to issue: #2640
- Link to documentation pull request: home-assistant/developers.home-assistant#2778
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [x] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] ~~[CLI][cli-repository] updated (if necessary)~~ Not necessary, the JSON for the addon options that is exposed by the CLI is not changed.
- [ ] ~~[Client library][client-library-repository] updated (if necessary)~~ Not necessary, the JSON for the addon options that is exposed by the client library is not changed.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
