### PR TITLE
Cancel Supervisor startup task on early shutdown signal

### DIFF
--- a/supervisor/bootstrap.py
+++ b/supervisor/bootstrap.py
@@ -2,6 +2,7 @@
 
 # ruff: noqa: T100
 import asyncio
+from collections.abc import Callable
 from importlib import import_module
 import logging
 import os
@@ -289,26 +290,22 @@ def check_environment() -> None:
         _LOGGER.critical("Can't find Docker socket!")
 
 
-def register_signal_handlers(loop: asyncio.AbstractEventLoop, coresys: CoreSys) -> None:
+def register_signal_handlers(
+    loop: asyncio.AbstractEventLoop, shutdown_handler: Callable[[], None]
+) -> None:
     """Register SIGTERM, SIGHUP and SIGKILL to stop the Supervisor."""
     try:
-        loop.add_signal_handler(
-            signal.SIGTERM, lambda: loop.create_task(coresys.core.stop())
-        )
+        loop.add_signal_handler(signal.SIGTERM, shutdown_handler)
     except (ValueError, RuntimeError):
         _LOGGER.warning("Could not bind to SIGTERM")
 
     try:
-        loop.add_signal_handler(
-            signal.SIGHUP, lambda: loop.create_task(coresys.core.stop())
-        )
+        loop.add_signal_handler(signal.SIGHUP, shutdown_handler)
     except (ValueError, RuntimeError):
         _LOGGER.warning("Could not bind to SIGHUP")
 
     try:
-        loop.add_signal_handler(
-            signal.SIGINT, lambda: loop.create_task(coresys.core.stop())
-        )
+        loop.add_signal_handler(signal.SIGINT, shutdown_handler)
     except (ValueError, RuntimeError):
         _LOGGER.warning("Could not bind to SIGINT")
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When receiving a shutdown signal during startup, the Supervisor should cancel its startup task to ensure a graceful shutdown. This prevents Supervisor accidentally accessing the Event loop after it has been closed by the stop procedure:

```
Traceback (most recent call last):
  File "__main__.py", line 72, in <module>
    loop.run_until_complete(coresys.core.start())
  File "asyncio/base_events.py", line 723, in run_until_complete
    raise RuntimeError('Event loop stopped before Future completed.')
RuntimeError: Event loop stopped before Future completed.
```


## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
