### PR TITLE
Simplify API validation by removing confusing origin parameter

### DIFF
--- a/supervisor/addons/options.py
+++ b/supervisor/addons/options.py
@@ -187,7 +187,7 @@ class AddonOptions(CoreSysAttributes):
 
             # Device valid
             self.devices.add(device)
-            return str(device.path)
+            return str(value)
 
         raise vol.Invalid(
             f"Fatal error for option '{key}' with type '{typ}' in {self._name} ({self._slug})"

--- a/supervisor/api/addons.py
+++ b/supervisor/api/addons.py
@@ -306,7 +306,7 @@ class APIAddons(CoreSysAttributes):
         )
 
         # Validate/Process Body
-        body = await api_validate(addon_schema, request, origin=[ATTR_OPTIONS])
+        body = await api_validate(addon_schema, request)
         if ATTR_OPTIONS in body:
             addon.options = body[ATTR_OPTIONS]
         if ATTR_BOOT in body:

--- a/supervisor/api/utils.py
+++ b/supervisor/api/utils.py
@@ -193,7 +193,6 @@ def api_return_ok(data: dict[str, Any] | list[Any] | None = None) -> web.Respons
 async def api_validate(
     schema: vol.Schema | vol.All,
     request: web.Request,
-    origin: list[str] | None = None,
 ) -> dict[str, Any]:
     """Validate request data with schema."""
     data: dict[str, Any] = await request.json(loads=json_loads)
@@ -201,14 +200,6 @@ async def api_validate(
         data_validated = schema(data)
     except vol.Invalid as ex:
         raise APIError(humanize_error(data, ex)) from None
-
-    if not origin:
-        return data_validated
-
-    for origin_value in origin:
-        if origin_value not in data_validated:
-            continue
-        data_validated[origin_value] = data[origin_value]
 
     return data_validated
 

--- a/tests/addons/test_options.py
+++ b/tests/addons/test_options.py
@@ -233,12 +233,13 @@ def test_simple_device_schema(coresys):
     ):
         coresys.hardware.update_device(device)
 
-    assert AddonOptions(
+    data_device_path = AddonOptions(
         coresys,
         {"name": "str", "password": "password", "input": "device"},
         MOCK_ADDON_NAME,
         MOCK_ADDON_SLUG,
     )({"name": "Pascal", "password": "1234", "input": "/dev/ttyUSB0"})
+    assert data_device_path["input"] == "/dev/ttyUSB0"
 
     data = AddonOptions(
         coresys,
@@ -246,7 +247,7 @@ def test_simple_device_schema(coresys):
         MOCK_ADDON_NAME,
         MOCK_ADDON_SLUG,
     )({"name": "Pascal", "password": "1234", "input": "/dev/serial/by-id/xyx"})
-    assert data["input"] == "/dev/ttyUSB0"
+    assert data["input"] == "/dev/serial/by-id/xyx"
 
     assert AddonOptions(
         coresys,


### PR DESCRIPTION
## Proposed change

This PR simplifies the API validation system by removing a confusing single-use parameter that was causing validation functions to behave unpredictably.

The `api_validate()` function had an `origin` parameter that was only used in one place (addon options API) and caused validation to preserve raw user input instead of using validated values. This violated the principle of least surprise and made the validation system inconsistent across the codebase.

**Key improvements:**
- Removes the confusing `origin` parameter from `api_validate()` that was only used in one location
- Makes device validation non-transformative (preserves user input)
- Simplifies validation logic to be consistent across all API endpoints
- Maintains backward compatibility for existing addon configurations

**Technical details:**
- Device validation still preserves whatever path the user provides (device path or by-id path)
- UI continues to guide users toward stable by-id paths, but validation doesn't force transformation
- All other API endpoints already used standard validation without the `origin` parameter

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: Discovered during code analysis of device path handling
- Link to documentation pull request: N/A
- Link to cli pull request: N/A
- Link to client library pull request: N/A

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/