### PR TITLE
Fix WebSocket transport None race condition in proxy

### DIFF
--- a/supervisor/api/proxy.py
+++ b/supervisor/api/proxy.py
@@ -224,6 +224,11 @@ class APIProxy(CoreSysAttributes):
             raise HTTPBadGateway
         _LOGGER.info("Home Assistant WebSocket API request initialize")
 
+        # Check if transport is still valid before WebSocket upgrade
+        if request.transport is None:
+            _LOGGER.warning("WebSocket connection lost before upgrade")
+            raise web.HTTPBadRequest(reason="Connection closed")
+
         # init server
         server = web.WebSocketResponse(heartbeat=30)
         await server.prepare(request)

--- a/tests/api/test_proxy.py
+++ b/tests/api/test_proxy.py
@@ -9,7 +9,7 @@ import logging
 from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
-from aiohttp import ClientPayloadError, ClientWebSocketResponse, WSCloseCode
+from aiohttp import ClientPayloadError, ClientWebSocketResponse, WSCloseCode, web
 from aiohttp.http_websocket import WSMessage, WSMsgType
 from aiohttp.test_utils import TestClient
 import pytest
@@ -221,6 +221,32 @@ async def test_proxy_auth_abort_log(
         assert (
             "Unexpected message during authentication for WebSocket API" in caplog.text
         )
+
+
+async def test_websocket_transport_none(
+    coresys,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test WebSocket connection with transport None is handled gracefully."""
+    # Get the API proxy instance from coresys
+    api_proxy = APIProxy.__new__(APIProxy)
+    api_proxy.coresys = coresys
+
+    # Create a mock request with transport set to None to simulate connection loss
+    mock_request = AsyncMock(spec=web.Request)
+    mock_request.transport = None
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        # This should raise HTTPBadRequest, not AssertionError
+        with pytest.raises(web.HTTPBadRequest) as exc_info:
+            await api_proxy.websocket(mock_request)
+
+        # Verify the error reason
+        assert exc_info.value.reason == "Connection closed"
+
+        # Verify the warning was logged
+        assert "WebSocket connection lost before upgrade" in caplog.text
 
 
 @pytest.mark.parametrize("path", ["", "mock_path"])


### PR DESCRIPTION
## Proposed change

This PR fixes a race condition in the WebSocket proxy that occurs when clients disconnect during the WebSocket handshake.

The connection can be lost in the window between the Home Assistant API state check and the `server.prepare(request)` call. When that happens, `request.transport` becomes `None`, and aiohttp's WebSocket upgrade code (`web_ws.py` `_pre_start`) fails. Prior to aiohttp 3.14.0 it hit `assert transport is not None` (`AssertionError`); as of 3.14.0 (#6902) it raises `ConnectionResetError("Connection lost")` instead. In both cases the exception propagates out of the handler unhandled, producing a 500 response and a Sentry report for what is really just a client disconnect.

On Sentry we saw ~7k events daily, limited to ~90 users. Something on those systems seems to constantly poke the WebSocket API unsuccessfully.

The fix adds a transport validity check before attempting the WebSocket upgrade. If the connection is already closed (`request.transport is None`), we log a warning and raise `HTTPBadRequest` with a clear reason. aiohttp treats the resulting 4xx as a normal response, so the race no longer surfaces as an unhandled exception or a Sentry event.

**Behavior after fix:**
- Graceful `HTTPBadRequest` response with reason "Connection closed"
- Warning logged: "WebSocket connection lost before upgrade"
- No more 500s or Sentry noise from this path

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
