### PR TITLE
Add exponential backoff strategy to watchdog restart

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -1562,7 +1562,15 @@ class Addon(AddonModel):
                 )
                 break
 
-            await asyncio.sleep(WATCHDOG_RETRY_SECONDS)
+            # Exponential backoff to spread retries over the throttle window
+            delay = WATCHDOG_RETRY_SECONDS * (1 << max(attempts - 1, 0))
+            _LOGGER.debug(
+                "Watchdog will retry addon %s in %s seconds (attempt %s)",
+                self.name,
+                delay,
+                attempts + 1,
+            )
+            await asyncio.sleep(delay)
 
     async def container_state_changed(self, event: DockerContainerStateEvent) -> None:
         """Set addon state from container state."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The idea is to apply a bit more backoff (exponential strategy) on the retry attempts of Watchdog. Currently it will do a maximum of 5 attempts, of each 10 seconds delay. If I understand the throttle mechanism well enough implemented in HA Supervisor, this can mean that after ~50 seconds, it will wait for ~29 minutes (30 minutes is the throttle). Some containers can take some more time to start up and I can think we can utilize the time in between the throttle a bit better.

My suggestion would be to apply a simple exponential strategy to gradually increase the delay. This of course within the criteria it will not overextend too much.
I apply a left shift, which results in the following timeouts:

```
Attempt Time
1	10s
2	20s
3	40s
4	80s
5	160s
```

The total cumulative time is 360 seconds at max, well within the throttle cap.

```py
delay = WATCHDOG_RETRY_SECONDS * (1 << max(attempts - 1, 0))
```

For high-performance systems I would recommend the left shift. Every cycle counts and in this simple exponential backoff the power op is considered slower. :)

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
