### PR TITLE
Fix fetching host info on setups where UDisks is not fully functional

### DIFF
--- a/supervisor/hardware/disk.py
+++ b/supervisor/hardware/disk.py
@@ -9,7 +9,12 @@ from typing import Any
 from supervisor.resolution.const import UnhealthyReason
 
 from ..coresys import CoreSys, CoreSysAttributes
-from ..exceptions import DBusError, DBusObjectError, HardwareNotFound
+from ..exceptions import (
+    DBusError,
+    DBusNotConnectedError,
+    DBusObjectError,
+    HardwareNotFound,
+)
 from .const import UdevSubsystem
 from .data import Device
 
@@ -207,6 +212,8 @@ class HwDisk(CoreSysAttributes):
         try:
             block_device = self.sys_dbus.udisks2.get_block_device_by_path(device_path)
             drive = self.sys_dbus.udisks2.get_drive(block_device.drive)
+        except DBusNotConnectedError:
+            return None
         except DBusObjectError:
             _LOGGER.warning(
                 "Unable to find UDisks2 drive for device at %s", device_path.as_posix()

--- a/tests/hardware/test_disk.py
+++ b/tests/hardware/test_disk.py
@@ -376,3 +376,14 @@ async def test_try_get_nvme_life_time_missing_percent_used(
         coresys.config.path_supervisor
     )
     assert lifetime is None
+
+
+async def test_try_get_nvme_life_time_dbus_not_connected(coresys: CoreSys):
+    """Test getting lifetime info from an NVMe when DBUS is not connected."""
+    # Set the dbus for udisks2 bus to be None, to make it forcibly disconnected.
+    coresys.dbus.udisks2.dbus = None
+
+    lifetime = await coresys.hardware.disk.get_disk_life_time(
+        coresys.config.path_supervisor
+    )
+    assert lifetime is None


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes a bug on my NAS, where DBUS is limited. Whenever a host info request is done from the GUI (for example when listing addons), it would return a HTTP 500, because it got an exception on the disk part and prevents the GUI from proceeding to the addons page.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
