### PR TITLE
Fix parent job sync when parent reaches 100% progress

### DIFF
--- a/supervisor/jobs/__init__.py
+++ b/supervisor/jobs/__init__.py
@@ -327,8 +327,15 @@ class JobManager(FileConfiguration, CoreSysAttributes):
                 if not curr_parent.child_job_syncs:
                     continue
 
-                # No value in child job sync if the parent is done
+                # HACK: If parent trigger the same child job, we just skip this second
+                # sync. Maybe it would be better to have this reflected in the job stage
+                # and reset progress to 0 instead? There is no support for such stage
+                # information on Core update entities today though.
                 if curr_parent.done is True or curr_parent.progress >= 100:
+                    _LOGGER.debug(
+                        "Skipping parent job sync for done parent job %s",
+                        curr_parent.name,
+                    )
                     continue
 
                 # Break after first match at each parent as it doesn't make sense


### PR DESCRIPTION
## Proposed change

This PR fixes a bug where creating a second child job for the same parent job could fail with a `ValueError` when the parent job had already reached 100% progress from the first child job.

The issue occurs because the parent job sync validator requires `starting_progress < 100.0`, but when a parent reaches 100% from one child and then another child job is created, it tries to create a sync with a starting progress of 100%, violating this constraint.

The bug was introduced in #6207 (shipped in 2025.10.0) but only became visible in 2025.10.1 with #6195, which started using progress syncs. It manifests during Core update rollbacks when a second `docker_interface_install` job is created after the parent already reached 100% from the first install.

The fix skips parent job sync setup when the parent is already done or at 100% progress, as there's no value in syncing progress to a completed parent.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #6281
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
