### PR TITLE
Add optional no_colors query parameter to advanced logs endpoints

### DIFF
--- a/supervisor/api/host.py
+++ b/supervisor/api/host.py
@@ -252,6 +252,9 @@ class APIHost(CoreSysAttributes):
         if "verbose" in request.query or request.headers[ACCEPT] == CONTENT_TYPE_X_LOG:
             log_formatter = LogFormatter.VERBOSE
 
+        if "no_colors" in request.query:
+            no_colors = True
+
         if "lines" in request.query:
             lines = request.query.get("lines", DEFAULT_LINES)
             try:

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -32,8 +32,24 @@ async def _common_test_api_advanced_logs(
         range_header=DEFAULT_LOG_RANGE,
         accept=LogFormat.JOURNAL,
     )
+    journal_logs_reader.assert_called_with(ANY, LogFormatter.PLAIN, False)
 
     journald_logs.reset_mock()
+    journal_logs_reader.reset_mock()
+
+    resp = await api_client.get(f"{path_prefix}/logs?no_colors")
+    assert resp.status == 200
+    assert resp.content_type == "text/plain"
+
+    journald_logs.assert_called_once_with(
+        params={"SYSLOG_IDENTIFIER": syslog_identifier},
+        range_header=DEFAULT_LOG_RANGE,
+        accept=LogFormat.JOURNAL,
+    )
+    journal_logs_reader.assert_called_with(ANY, LogFormatter.PLAIN, True)
+
+    journald_logs.reset_mock()
+    journal_logs_reader.reset_mock()
 
     resp = await api_client.get(f"{path_prefix}/logs/follow")
     assert resp.status == 200

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -292,6 +292,18 @@ async def test_advaced_logs_query_parameters(
     )
     journal_logs_reader.assert_called_with(ANY, LogFormatter.VERBOSE, False)
 
+    journal_logs_reader.reset_mock()
+    journald_logs.reset_mock()
+
+    # Check no_colors query parameter
+    await api_client.get("/host/logs?no_colors")
+    journald_logs.assert_called_once_with(
+        params={"SYSLOG_IDENTIFIER": coresys.host.logs.default_identifiers},
+        range_header=DEFAULT_RANGE,
+        accept=LogFormat.JOURNAL,
+    )
+    journal_logs_reader.assert_called_with(ANY, LogFormatter.VERBOSE, True)
+
 
 async def test_advanced_logs_boot_id_offset(
     api_client: TestClient, coresys: CoreSys, journald_logs: MagicMock


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for `no_colors` query parameter on all advanced logs API endpoints, allowing users to optionally strip ANSI color sequences from log output. This complements the existing color stripping on /latest endpoints added in #6319.

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/supervisor/pull/6326
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [x] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
