### PR TITLE
Drop build for deprecated architectures and re-tag legacy build instead

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -34,6 +34,9 @@ on:
 
 env:
   DEFAULT_PYTHON: "3.13"
+  COSIGN_VERSION: "v2.5.3"
+  CRANE_VERSION: "v0.20.7"
+  CRANE_SHA256: "8ef3564d264e6b5ca93f7b7f5652704c4dd29d33935aff6947dd5adefd05953e"
   BUILD_NAME: supervisor
   BUILD_TYPE: supervisor
 
@@ -134,7 +137,7 @@ jobs:
         if: needs.init.outputs.publish == 'true'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
-          cosign-release: "v2.5.3"
+          cosign-release: ${{ env.COSIGN_VERSION }}
 
       - name: Install dirhash and calc hash
         if: needs.init.outputs.publish == 'true'
@@ -173,7 +176,7 @@ jobs:
 
   version:
     name: Update version
-    needs: ["init", "run_supervisor"]
+    needs: ["init", "run_supervisor", "retag_deprecated"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
@@ -352,3 +355,50 @@ jobs:
       - name: Get supervisor logs on failiure
         if: ${{ cancelled() || failure() }}
         run: docker logs hassio_supervisor
+
+  retag_deprecated:
+    needs: ["build", "init"]
+    name: Re-tag deprecated ${{ matrix.arch }} images
+    if: needs.init.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    strategy:
+      matrix:
+        arch: ["armhf", "armv7", "i386"]
+    env:
+      # Last available release for deprecated architectures
+      FROZEN_VERSION: "2025.11.5"
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        with:
+          cosign-release: ${{ env.COSIGN_VERSION }}
+
+      - name: Install crane
+        run: |
+          curl -sLO https://github.com/google/go-containerregistry/releases/download/${{ env.CRANE_VERSION }}/go-containerregistry_Linux_x86_64.tar.gz
+          echo "${{ env.CRANE_SHA256 }}  go-containerregistry_Linux_x86_64.tar.gz" | sha256sum -c -
+          tar xzf go-containerregistry_Linux_x86_64.tar.gz crane
+          sudo mv crane /usr/local/bin/
+
+      - name: Re-tag deprecated image with updated version label
+        run: |
+          crane auth login ghcr.io -u ${{ github.repository_owner }} -p ${{ secrets.GITHUB_TOKEN }}
+          crane mutate \
+            --label io.hass.version=${{ needs.init.outputs.version }} \
+            --tag ghcr.io/home-assistant/${{ matrix.arch }}-hassio-supervisor:${{ needs.init.outputs.version }} \
+            ghcr.io/home-assistant/${{ matrix.arch }}-hassio-supervisor:${{ env.FROZEN_VERSION }}
+
+      - name: Sign image with Cosign
+        run: |
+          cosign sign --yes ghcr.io/home-assistant/${{ matrix.arch }}-hassio-supervisor:${{ needs.init.outputs.version }}

--- a/build.yaml
+++ b/build.yaml
@@ -1,10 +1,7 @@
 image: ghcr.io/home-assistant/{arch}-hassio-supervisor
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-python:3.13-alpine3.22-2025.11.1
-  armhf: ghcr.io/home-assistant/armhf-base-python:3.13-alpine3.22-2025.11.1
-  armv7: ghcr.io/home-assistant/armv7-base-python:3.13-alpine3.22-2025.11.1
   amd64: ghcr.io/home-assistant/amd64-base-python:3.13-alpine3.22-2025.11.1
-  i386: ghcr.io/home-assistant/i386-base-python:3.13-alpine3.22-2025.11.1
 cosign:
   base_identity: https://github.com/home-assistant/docker-base/.*
   identity: https://github.com/home-assistant/supervisor/.*


### PR DESCRIPTION
## Proposed change

To ensure that e.g. airgapped devices running on deprecated archs can still update the Supervisor when they become online, the version of Supervisor in the version file must stay available for all architectures. Since the base images will no longer exist for those archs and to avoid the need for building it from current source, add job that pulls the last available image, changes the label in the metadata and publishes it under the new tag. That way we'll get a new image with a different SHA (compared to a plain re-tag), so the GHCR metrics should reflect how many devices still pull these old images.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
