### PR TITLE
Fix type annotations for sentinel values in job manager

### DIFF
--- a/supervisor/jobs/__init__.py
+++ b/supervisor/jobs/__init__.py
@@ -9,7 +9,7 @@ from contextvars import Context, ContextVar, Token
 from dataclasses import dataclass
 from datetime import datetime
 import logging
-from typing import Any, Self
+from typing import Any, Self, cast
 from uuid import uuid4
 
 from attr.validators import gt, lt
@@ -196,7 +196,7 @@ class SupervisorJob:
         self,
         progress: float | None = None,
         stage: str | None = None,
-        extra: dict[str, Any] | None = DEFAULT,  # type: ignore
+        extra: dict[str, Any] | None | type[DEFAULT] = DEFAULT,
         done: bool | None = None,
     ) -> None:
         """Update multiple fields with one on change event."""
@@ -207,8 +207,8 @@ class SupervisorJob:
             self.progress = progress
         if stage is not None:
             self.stage = stage
-        if extra != DEFAULT:
-            self.extra = extra
+        if extra is not DEFAULT:
+            self.extra = cast(dict[str, Any] | None, extra)
 
         # Done has special event. use that to trigger on change if included
         # If not then just use any other field to trigger
@@ -306,19 +306,21 @@ class JobManager(FileConfiguration, CoreSysAttributes):
         reference: str | None = None,
         initial_stage: str | None = None,
         internal: bool = False,
-        parent_id: str | None = DEFAULT,  # type: ignore
+        parent_id: str | None | type[DEFAULT] = DEFAULT,
         child_job_syncs: list[ChildJobSyncFilter] | None = None,
     ) -> SupervisorJob:
         """Create a new job."""
-        job = SupervisorJob(
-            name,
-            reference=reference,
-            stage=initial_stage,
-            on_change=self._on_job_change,
-            internal=internal,
-            child_job_syncs=child_job_syncs,
-            **({} if parent_id == DEFAULT else {"parent_id": parent_id}),  # type: ignore
-        )
+        kwargs: dict[str, Any] = {
+            "reference": reference,
+            "stage": initial_stage,
+            "on_change": self._on_job_change,
+            "internal": internal,
+            "child_job_syncs": child_job_syncs,
+        }
+        if parent_id is not DEFAULT:
+            kwargs["parent_id"] = parent_id
+
+        job = SupervisorJob(name, **kwargs)
 
         # Shouldn't happen but inability to find a parent for progress reporting
         # shouldn't raise and break the active job


### PR DESCRIPTION
## Proposed change

This PR fixes type annotation issues in the job manager that were causing runtime type checking failures with `typeguard`. The issue occurred when using sentinel values to distinguish between "parameter not provided" and "parameter explicitly set to None".

The changes add proper type annotations for sentinel values (`type[DEFAULT]`) and refactor parameter handling to satisfy both runtime type checkers (typeguard) and static type checkers (mypy).

**Key changes:**
- Added `type[DEFAULT]` to type annotations for `parent_id` and `extra` parameters
- Refactored `new_job()` to build kwargs dictionary conditionally for cleaner type handling
- Added explicit type cast in `update()` method for type narrowing
- Changed sentinel comparisons from `==` to `is` for proper identity checking
- Removed `# type: ignore` comments that were masking the type issues

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
