### PR TITLE
Fix typeguard error in API decorator wrapper functions

### DIFF
--- a/supervisor/api/utils.py
+++ b/supervisor/api/utils.py
@@ -63,12 +63,10 @@ def json_loads(data: Any) -> dict[str, Any]:
 def api_process(method):
     """Wrap function with true/false calls to rest api."""
 
-    async def wrap_api(
-        api: CoreSysAttributes, *args, **kwargs
-    ) -> web.Response | web.StreamResponse:
+    async def wrap_api(*args, **kwargs) -> web.Response | web.StreamResponse:
         """Return API information."""
         try:
-            answer = await method(api, *args, **kwargs)
+            answer = await method(*args, **kwargs)
         except BackupFileNotFoundError as err:
             return api_return_error(err, status=404)
         except APIError as err:
@@ -109,12 +107,10 @@ def api_process_raw(content, *, error_type=None):
     def wrap_method(method):
         """Wrap function with raw output to rest api."""
 
-        async def wrap_api(
-            api: CoreSysAttributes, *args, **kwargs
-        ) -> web.Response | web.StreamResponse:
+        async def wrap_api(*args, **kwargs) -> web.Response | web.StreamResponse:
             """Return api information."""
             try:
-                msg_data = await method(api, *args, **kwargs)
+                msg_data = await method(*args, **kwargs)
             except APIError as err:
                 return api_return_error(
                     err,


### PR DESCRIPTION
## Proposed change

This PR fixes a typeguard runtime type checking error in the `@api_process` and `@api_process_raw` decorators by removing explicit type annotations from their wrapper functions.

**The Issue:**
When typeguard runtime type checking is enabled (via `install_import_hook('supervisor')`), it validates function parameters at runtime. The decorators had `api: CoreSysAttributes` as the first parameter, but they're used in two contexts:
- Instance methods (200+ uses): `def info(self, request)` where `self` is `CoreSysAttributes` ✅
- Standalone functions (2 uses in `api/__init__.py`): `def get_addon_logs(request, ...)` where first param is `web.Request` ❌

This caused typeguard to raise: `TypeCheckError: argument "api" (aiohttp.web_request.Request) is not an instance of supervisor.coresys.CoreSysAttributes`

**The Solution:**
- Remove explicit type annotations from the decorator wrapper functions
- Use only `*args, **kwargs` to forward all parameters transparently
- Type checking still works at all actual usage sites (200+ methods)
- Both usage patterns now work correctly with typeguard

**Note:** The `require_home_assistant` decorator was left unchanged as it only decorates instance methods and actively uses the typed parameter to extract `coresys`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
