### PR TITLE
Improve CpuArch type safety across codebase

### DIFF
--- a/supervisor/addons/build.py
+++ b/supervisor/addons/build.py
@@ -20,6 +20,7 @@ from ..const import (
     FILE_SUFFIX_CONFIGURATION,
     META_ADDON,
     SOCKET_DOCKER,
+    CpuArch,
 )
 from ..coresys import CoreSys, CoreSysAttributes
 from ..docker.const import DOCKER_HUB
@@ -67,7 +68,7 @@ class AddonBuild(FileConfiguration, CoreSysAttributes):
         raise RuntimeError()
 
     @cached_property
-    def arch(self) -> str:
+    def arch(self) -> CpuArch:
         """Return arch of the add-on."""
         return self.sys_arch.match([self.addon.arch])
 

--- a/supervisor/addons/model.py
+++ b/supervisor/addons/model.py
@@ -87,6 +87,7 @@ from ..const import (
     AddonBootConfig,
     AddonStage,
     AddonStartup,
+    CpuArch,
 )
 from ..coresys import CoreSys
 from ..docker.const import Capabilities
@@ -548,7 +549,7 @@ class AddonModel(JobGroup, ABC):
         return self.data.get(ATTR_MACHINE, [])
 
     @property
-    def arch(self) -> str:
+    def arch(self) -> CpuArch:
         """Return architecture to use for the addon's image."""
         if ATTR_IMAGE in self.data:
             return self.sys_arch.match(self.data[ATTR_ARCH])

--- a/supervisor/bootstrap.py
+++ b/supervisor/bootstrap.py
@@ -13,7 +13,7 @@ from colorlog import ColoredFormatter
 
 from .addons.manager import AddonManager
 from .api import RestAPI
-from .arch import CpuArch
+from .arch import CpuArchManager
 from .auth import Auth
 from .backups.manager import BackupManager
 from .bus import Bus
@@ -71,7 +71,7 @@ async def initialize_coresys() -> CoreSys:
     coresys.jobs = await JobManager(coresys).load_config()
     coresys.core = await Core(coresys).post_init()
     coresys.plugins = await PluginManager(coresys).load_config()
-    coresys.arch = CpuArch(coresys)
+    coresys.arch = CpuArchManager(coresys)
     coresys.auth = await Auth(coresys).load_config()
     coresys.updater = await Updater(coresys).load_config()
     coresys.api = RestAPI(coresys)

--- a/supervisor/coresys.py
+++ b/supervisor/coresys.py
@@ -29,7 +29,7 @@ from .const import (
 if TYPE_CHECKING:
     from .addons.manager import AddonManager
     from .api import RestAPI
-    from .arch import CpuArch
+    from .arch import CpuArchManager
     from .auth import Auth
     from .backups.manager import BackupManager
     from .bus import Bus
@@ -78,7 +78,7 @@ class CoreSys:
         # Internal objects pointers
         self._docker: DockerAPI | None = None
         self._core: Core | None = None
-        self._arch: CpuArch | None = None
+        self._arch: CpuArchManager | None = None
         self._auth: Auth | None = None
         self._homeassistant: HomeAssistant | None = None
         self._supervisor: Supervisor | None = None
@@ -266,17 +266,17 @@ class CoreSys:
         self._plugins = value
 
     @property
-    def arch(self) -> CpuArch:
-        """Return CpuArch object."""
+    def arch(self) -> CpuArchManager:
+        """Return CpuArchManager object."""
         if self._arch is None:
-            raise RuntimeError("CpuArch not set!")
+            raise RuntimeError("CpuArchManager not set!")
         return self._arch
 
     @arch.setter
-    def arch(self, value: CpuArch) -> None:
-        """Set a CpuArch object."""
+    def arch(self, value: CpuArchManager) -> None:
+        """Set a CpuArchManager object."""
         if self._arch:
-            raise RuntimeError("CpuArch already set!")
+            raise RuntimeError("CpuArchManager already set!")
         self._arch = value
 
     @property
@@ -733,8 +733,8 @@ class CoreSysAttributes:
         return self.coresys.plugins
 
     @property
-    def sys_arch(self) -> CpuArch:
-        """Return CpuArch object."""
+    def sys_arch(self) -> CpuArchManager:
+        """Return CpuArchManager object."""
         return self.coresys.arch
 
     @property

--- a/tests/addons/test_manager.py
+++ b/tests/addons/test_manager.py
@@ -10,7 +10,7 @@ from awesomeversion import AwesomeVersion
 import pytest
 
 from supervisor.addons.addon import Addon
-from supervisor.arch import CpuArch
+from supervisor.arch import CpuArchManager
 from supervisor.config import CoreConfig
 from supervisor.const import AddonBoot, AddonStartup, AddonState, BusEvent
 from supervisor.coresys import CoreSys
@@ -54,7 +54,9 @@ async def fixture_mock_arch_disk() -> AsyncGenerator[None]:
     """Mock supported arch and disk space."""
     with (
         patch("shutil.disk_usage", return_value=(42, 42, 2 * (1024.0**3))),
-        patch.object(CpuArch, "supported", new=PropertyMock(return_value=["amd64"])),
+        patch.object(
+            CpuArchManager, "supported", new=PropertyMock(return_value=["amd64"])
+        ),
     ):
         yield
 

--- a/tests/api/test_addons.py
+++ b/tests/api/test_addons.py
@@ -9,7 +9,7 @@ import pytest
 
 from supervisor.addons.addon import Addon
 from supervisor.addons.build import AddonBuild
-from supervisor.arch import CpuArch
+from supervisor.arch import CpuArchManager
 from supervisor.const import AddonState
 from supervisor.coresys import CoreSys
 from supervisor.docker.addon import DockerAddon
@@ -236,7 +236,9 @@ async def test_api_addon_rebuild_healthcheck(
         patch.object(AddonBuild, "is_valid", return_value=True),
         patch.object(DockerAddon, "is_running", return_value=False),
         patch.object(Addon, "need_build", new=PropertyMock(return_value=True)),
-        patch.object(CpuArch, "supported", new=PropertyMock(return_value=["amd64"])),
+        patch.object(
+            CpuArchManager, "supported", new=PropertyMock(return_value=["amd64"])
+        ),
         patch.object(DockerAddon, "run", new=container_events_task),
         patch.object(
             coresys.docker,
@@ -308,7 +310,9 @@ async def test_api_addon_rebuild_force(
         patch.object(
             Addon, "need_build", new=PropertyMock(return_value=False)
         ),  # Image-based
-        patch.object(CpuArch, "supported", new=PropertyMock(return_value=["amd64"])),
+        patch.object(
+            CpuArchManager, "supported", new=PropertyMock(return_value=["amd64"])
+        ),
     ):
         resp = await api_client.post("/addons/local_ssh/rebuild")
 
@@ -326,7 +330,9 @@ async def test_api_addon_rebuild_force(
         patch.object(
             Addon, "need_build", new=PropertyMock(return_value=False)
         ),  # Image-based
-        patch.object(CpuArch, "supported", new=PropertyMock(return_value=["amd64"])),
+        patch.object(
+            CpuArchManager, "supported", new=PropertyMock(return_value=["amd64"])
+        ),
         patch.object(DockerAddon, "run", new=container_events_task),
         patch.object(
             coresys.docker,

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -10,7 +10,7 @@ from awesomeversion import AwesomeVersion
 import pytest
 
 from supervisor.addons.addon import Addon
-from supervisor.arch import CpuArch
+from supervisor.arch import CpuArchManager
 from supervisor.backups.manager import BackupManager
 from supervisor.config import CoreConfig
 from supervisor.const import AddonState, CoreState
@@ -191,7 +191,9 @@ async def test_api_store_update_healthcheck(
         patch.object(DockerAddon, "run", new=container_events_task),
         patch.object(DockerInterface, "install"),
         patch.object(DockerAddon, "is_running", return_value=False),
-        patch.object(CpuArch, "supported", new=PropertyMock(return_value=["amd64"])),
+        patch.object(
+            CpuArchManager, "supported", new=PropertyMock(return_value=["amd64"])
+        ),
     ):
         resp = await api_client.post(f"/store/addons/{TEST_ADDON_SLUG}/update")
 
@@ -548,7 +550,9 @@ async def test_api_store_addons_addon_availability_arch_not_supported(
         coresys.addons.data.user[addon_obj.slug] = {"version": AwesomeVersion("0.0.1")}
 
     # Mock the system architecture to be different
-    with patch.object(CpuArch, "supported", new=PropertyMock(return_value=["amd64"])):
+    with patch.object(
+        CpuArchManager, "supported", new=PropertyMock(return_value=["amd64"])
+    ):
         resp = await api_client.request(
             api_method, f"/store/addons/{addon_obj.slug}/{api_action}"
         )

--- a/tests/store/test_store_manager.py
+++ b/tests/store/test_store_manager.py
@@ -9,7 +9,7 @@ from awesomeversion import AwesomeVersion
 import pytest
 
 from supervisor.addons.addon import Addon
-from supervisor.arch import CpuArch
+from supervisor.arch import CpuArchManager
 from supervisor.backups.manager import BackupManager
 from supervisor.coresys import CoreSys
 from supervisor.exceptions import AddonNotSupportedError, StoreJobError
@@ -163,7 +163,9 @@ async def test_update_unavailable_addon(
     with (
         patch.object(BackupManager, "do_backup_partial") as backup,
         patch.object(AddonStore, "data", new=PropertyMock(return_value=addon_config)),
-        patch.object(CpuArch, "supported", new=PropertyMock(return_value=["amd64"])),
+        patch.object(
+            CpuArchManager, "supported", new=PropertyMock(return_value=["amd64"])
+        ),
         patch.object(CoreSys, "machine", new=PropertyMock(return_value="qemux86-64")),
         patch.object(
             HomeAssistant,
@@ -219,7 +221,9 @@ async def test_install_unavailable_addon(
 
     with (
         patch.object(AddonStore, "data", new=PropertyMock(return_value=addon_config)),
-        patch.object(CpuArch, "supported", new=PropertyMock(return_value=["amd64"])),
+        patch.object(
+            CpuArchManager, "supported", new=PropertyMock(return_value=["amd64"])
+        ),
         patch.object(CoreSys, "machine", new=PropertyMock(return_value="qemux86-64")),
         patch.object(
             HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improve type safety for CPU architecture handling by ensuring `CpuArch` enum values are used consistently instead of plain strings.

The codebase had two confusingly named things:
- `supervisor.const.CpuArch` - A `StrEnum` defining valid CPU architecture values
- `supervisor.arch.CpuArch` - A manager class for architecture detection and matching

The manager class was returning plain strings, but type annotations expected the `CpuArch` enum. This caused typeguard runtime errors when running with type checking enabled.

No issues have been reported in production since this only affects type checking, but this change improves code clarity and correctness.

**Changes:**
- Rename `supervisor.arch.CpuArch` class to `CpuArchManager` to avoid confusion
- Update `CpuArchManager` methods (`default`, `supervisor`, `supported`, `match()`, `detect_cpu()`) to return `CpuArch` enum values
- Update `addon.arch` property to return `CpuArch` enum
- Simplify `MAP_ARCH` dict type from `dict[CpuArch | str, str]` to `dict[CpuArch, str]`
- Remove unnecessary `str()` conversions in `check_image()` and `install()`

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] CLI updated (if necessary)
- [ ] Client library updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
