### PR TITLE
Fix return type hints for middleware methods

### DIFF
--- a/supervisor/api/middleware/security.py
+++ b/supervisor/api/middleware/security.py
@@ -1,6 +1,6 @@
 """Handle security part of this API."""
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 import logging
 import re
 from typing import Final
@@ -89,7 +89,7 @@ CORE_ONLY_PATHS: Final = re.compile(
 )
 
 # Policy role add-on API access
-ADDONS_ROLE_ACCESS: dict[str, re.Pattern] = {
+ADDONS_ROLE_ACCESS: dict[str, re.Pattern[str]] = {
     ROLE_DEFAULT: re.compile(
         r"^(?:"
         r"|/.+/info"
@@ -181,7 +181,7 @@ class SecurityMiddleware(CoreSysAttributes):
 
     @middleware
     async def block_bad_requests(
-        self, request: Request, handler: Callable
+        self, request: Request, handler: Callable[[Request], Awaitable[StreamResponse]]
     ) -> StreamResponse:
         """Process request and tblock commonly known exploit attempts."""
         if FILTERS.search(self._recursive_unquote(request.path)):
@@ -201,7 +201,7 @@ class SecurityMiddleware(CoreSysAttributes):
 
     @middleware
     async def system_validation(
-        self, request: Request, handler: Callable
+        self, request: Request, handler: Callable[[Request], Awaitable[StreamResponse]]
     ) -> StreamResponse:
         """Check if core is ready to response."""
         if self.sys_core.state not in VALID_API_STATES:
@@ -213,7 +213,7 @@ class SecurityMiddleware(CoreSysAttributes):
 
     @middleware
     async def token_validation(
-        self, request: Request, handler: Callable
+        self, request: Request, handler: Callable[[Request], Awaitable[StreamResponse]]
     ) -> StreamResponse:
         """Check security access of this layer."""
         request_from: CoreSysAttributes | None = None
@@ -285,7 +285,9 @@ class SecurityMiddleware(CoreSysAttributes):
         raise HTTPForbidden()
 
     @middleware
-    async def core_proxy(self, request: Request, handler: Callable) -> StreamResponse:
+    async def core_proxy(
+        self, request: Request, handler: Callable[[Request], Awaitable[StreamResponse]]
+    ) -> StreamResponse:
         """Validate user from Core API proxy."""
         if (
             request[REQUEST_FROM] != self.sys_homeassistant


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix return type hints in `SecurityMiddleware` methods to use `StreamResponse` instead of `Response`. This is the correct type since middleware handlers can return any `StreamResponse` subclass, including `FileResponse` and other streaming responses. The change was identified while enabling typeguard for runtime type checking.

While at it, also improve rather loose type hints with more specific hints.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] CLI updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
