### PR TITLE
Fix addon options reset to defaults

### DIFF
--- a/supervisor/api/addons.py
+++ b/supervisor/api/addons.py
@@ -307,13 +307,17 @@ class APIAddons(CoreSysAttributes):
         # Validate/Process Body
         body = await api_validate(SCHEMA_OPTIONS, request)
         if ATTR_OPTIONS in body:
-            try:
-                addon.options = addon.schema(body[ATTR_OPTIONS])
-            except vol.Invalid as ex:
-                raise AddonConfigurationInvalidError(
-                    addon=addon.slug,
-                    validation_error=humanize_error(body[ATTR_OPTIONS], ex),
-                ) from None
+            # None resets options to defaults, otherwise validate the options
+            if body[ATTR_OPTIONS] is None:
+                addon.options = None
+            else:
+                try:
+                    addon.options = addon.schema(body[ATTR_OPTIONS])
+                except vol.Invalid as ex:
+                    raise AddonConfigurationInvalidError(
+                        addon=addon.slug,
+                        validation_error=humanize_error(body[ATTR_OPTIONS], ex),
+                    ) from None
         if ATTR_BOOT in body:
             if addon.boot_config == AddonBootConfig.MANUAL_ONLY:
                 raise AddonBootConfigCannotChangeError(

--- a/tests/api/test_addons.py
+++ b/tests/api/test_addons.py
@@ -562,6 +562,27 @@ async def test_addon_set_options(api_client: TestClient, install_addon_example: 
     assert install_addon_example.options == {"message": "test"}
 
 
+async def test_addon_reset_options(
+    api_client: TestClient, install_addon_example: Addon
+):
+    """Test resetting options for an addon to defaults.
+
+    Fixes SUPERVISOR-171F.
+    """
+    # First set some custom options
+    install_addon_example.options = {"message": "custom"}
+    assert install_addon_example.persist["options"] == {"message": "custom"}
+
+    # Reset to defaults by sending null
+    resp = await api_client.post(
+        "/addons/local_example/options", json={"options": None}
+    )
+    assert resp.status == 200
+
+    # Persisted options should be empty (meaning defaults will be used)
+    assert install_addon_example.persist["options"] == {}
+
+
 async def test_addon_set_options_error(
     api_client: TestClient, install_addon_example: Addon
 ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix a regression introduced in #6303 where clicking "Reset defaults" in the addon configuration UI causes an `AttributeError`.

When users reset addon options to defaults, the frontend sends `{"options": null}`. After #6303, the API calls `addon.schema(body[ATTR_OPTIONS])` directly with `None`, which causes `AttributeError: 'NoneType' object has no attribute 'items'` in `AddonOptions.__call__()`.

Previously, `addon.schema` was used inside a voluptuous validation chain (`vol.All(dict, self)`), where the `dict` check would reject `None` before reaching `__call__`. The refactor changed this to call `addon.schema()` directly, bypassing that protection.

The fix explicitly checks for `None` before calling validation. When `options` is `None`, it sets `addon.options = None` directly, which properly resets options to defaults (the setter already handles this case).

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
