### PR TITLE
Fix missing metadata of stopped add-ons after aiodocker migration

### DIFF
--- a/supervisor/docker/manager.py
+++ b/supervisor/docker/manager.py
@@ -530,18 +530,6 @@ class DockerAPI(CoreSysAttributes):
                 f"Dockerd connection issue for {name}: {err}", _LOGGER.error
             ) from err
 
-        # Get container metadata
-        try:
-            container_attrs = await container.show()
-        except aiodocker.DockerError as err:
-            raise DockerAPIError(
-                f"Can't inspect new container {name}: {err}", _LOGGER.error
-            ) from err
-        except requests.RequestException as err:
-            raise DockerRequestError(
-                f"Dockerd connection issue for {name}: {err}", _LOGGER.error
-            ) from err
-
         # Setup network and store container id in cidfile
         def setup_network_and_cidfile() -> None:
             # Write cidfile
@@ -584,7 +572,18 @@ class DockerAPI(CoreSysAttributes):
                 f"Dockerd connection issue for {name}: {err}", _LOGGER.error
             ) from err
 
-        # Return metadata
+        # Get container metadata after the container is started
+        try:
+            container_attrs = await container.show()
+        except aiodocker.DockerError as err:
+            raise DockerAPIError(
+                f"Can't inspect started container {name}: {err}", _LOGGER.error
+            ) from err
+        except requests.RequestException as err:
+            raise DockerRequestError(
+                f"Dockerd connection issue for {name}: {err}", _LOGGER.error
+            ) from err
+
         return container_attrs
 
     async def pull_image(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
After the aiodocker migration in #6415 some add-ons may have been missing IP addresses because the metadata was retrieved for the container before it was started and network initialized. This manifested as some containers being unreachable through ingress (e.g. 'Ingress error: Cannot connect to host 0.0.0.0:8099'), especially if they have been started manually after Supervisor startup.

To fix it, simply move retrieval of the container metadata (which is then persisted in DockerInterface._meta) to the end of the run method, where all attributes should have correct values. This is similar to the flow before the refactoring, where Container.reload() was called to update the metadata.


## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
