### PR TITLE
Fix ingress Content-Encoding breaking streaming responses

### DIFF
--- a/supervisor/api/ingress.py
+++ b/supervisor/api/ingress.py
@@ -372,8 +372,10 @@ def _response_header(response: aiohttp.ClientResponse) -> CIMultiDict[str]:
             hdrs.TRANSFER_ENCODING,
             hdrs.CONTENT_LENGTH,
             hdrs.CONTENT_TYPE,
-            hdrs.CONTENT_ENCODING,
         ):
+            continue
+        # Preserve Content-Encoding: identity to prevent auto-compression
+        if name == hdrs.CONTENT_ENCODING and value.lower() != "identity":
             continue
         headers.add(name, value)
 


### PR DESCRIPTION
Preserve Content-Encoding: identity from add-ons to prevent aiohttp from auto-compressing uncompressed content, which breaks SSE and streaming responses.

Fixes #6470

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes a bug in the Supervisor ingress proxy that breaks Server-Sent Events (SSE) and all streaming responses for add-ons.

**Problem**: The ingress proxy was stripping all `Content-Encoding` headers from add-on responses. When a browser sends `Accept-Encoding: gzip, deflate, br, zstd`, aiohttp's automatic compression middleware would see no `Content-Encoding` header and add `Content-Encoding: deflate` to the response, even though the content wasn't actually compressed. This caused browsers to buffer the entire response trying to decompress it, preventing real-time streaming.

**Solution**: Preserve `Content-Encoding: identity` from add-on responses. Per RFC 9110, `identity` explicitly signals "no transformation applied" and is the standard way to indicate content should not be compressed. This is how all major proxies (nginx, Apache, HAProxy) handle this scenario.

**Impact**: 
- Add-ons can now opt-in to preventing compression by setting `Content-Encoding: identity`
- Backward compatible - existing add-ons continue working unchanged
- Enables SSE, chunked streaming, and real-time data delivery through ingress
- Industry-standard, minimal solution

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #6470
- This PR is related to issue: N/A
- Link to documentation pull request: N/A (no API changes)
- Link to cli pull request: N/A
- Link to client library pull request: N/A

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

### For Add-On Developers

To enable streaming through ingress, add this header in responses:

**nginx configuration:**
```nginx
add_header Content-Encoding identity;
```

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
