### PR TITLE
Fix typo in log message when running commands in a container

### DIFF
--- a/supervisor/docker/manager.py
+++ b/supervisor/docker/manager.py
@@ -632,7 +632,7 @@ class DockerAPI(CoreSysAttributes):
 
         image_with_tag = f"{image}:{version}"
 
-        _LOGGER.info("Runing command '%s' on %s", command, image_with_tag)
+        _LOGGER.info("Running command '%s' on %s", command, image_with_tag)
         container = None
         try:
             container = self.dockerpy.containers.run(


### PR DESCRIPTION
This is a typo, and I suspect the overhead of a full PR OP is not necessary, so I'm ignoring the template at my own peril.