### PR TITLE
Fix flaky test_group_throttle_rate_limit race condition

### DIFF
--- a/tests/jobs/test_job_decorator.py
+++ b/tests/jobs/test_job_decorator.py
@@ -941,7 +941,7 @@ async def test_group_throttle_rate_limit(coresys: CoreSys, error: JobException |
 
     start = utcnow()
 
-    with time_machine.travel(start):
+    with time_machine.travel(start, tick=False):
         await asyncio.gather(
             *[test1.execute(), test1.execute(), test2.execute(), test2.execute()]
         )


### PR DESCRIPTION
## Proposed change

This PR fixes a flaky test that was failing intermittently in CI, [specifically this run](https://github.com/home-assistant/supervisor/actions/runs/21467527110/attempts/1):

<details>

```
2026-01-29T06:12:24.2448084Z ________________ test_group_throttle_rate_limit[PluginJobError] ________________
2026-01-29T06:12:24.2448757Z 
2026-01-29T06:12:24.2449142Z coresys = <supervisor.coresys.CoreSys object at 0x7fca81aa7b10>
2026-01-29T06:12:24.2450091Z error = <class 'supervisor.exceptions.PluginJobError'>
2026-01-29T06:12:24.2450614Z 
2026-01-29T06:12:24.2450951Z     @pytest.mark.parametrize("error", [None, PluginJobError])
2026-01-29T06:12:24.2451978Z     async def test_group_throttle_rate_limit(coresys: CoreSys, error: JobException | None):
2026-01-29T06:12:24.2452940Z         """Test the group throttle rate limit."""
2026-01-29T06:12:24.2453599Z     
2026-01-29T06:12:24.2453896Z         class TestClass(JobGroup):
2026-01-29T06:12:24.2454196Z             """Test class."""
2026-01-29T06:12:24.2454412Z     
2026-01-29T06:12:24.2454631Z             def __init__(self, coresys: CoreSys, reference: str):
2026-01-29T06:12:24.2454965Z                 """Initialize the test class."""
2026-01-29T06:12:24.2455318Z                 super().__init__(coresys, f"test_class_{reference}", reference)
2026-01-29T06:12:24.2455664Z                 self.run = asyncio.Lock()
2026-01-29T06:12:24.2455905Z                 self.call = 0
2026-01-29T06:12:24.2456108Z     
2026-01-29T06:12:24.2456258Z             @Job(
2026-01-29T06:12:24.2456515Z                 name=f"test_group_throttle_rate_limit_execute_{uuid4().hex}",
2026-01-29T06:12:24.2456879Z                 throttle=JobThrottle.GROUP_RATE_LIMIT,
2026-01-29T06:12:24.2457176Z                 throttle_period=timedelta(hours=1),
2026-01-29T06:12:24.2457446Z                 throttle_max_calls=2,
2026-01-29T06:12:24.2457685Z                 on_condition=error,
2026-01-29T06:12:24.2457906Z             )
2026-01-29T06:12:24.2458081Z             async def execute(self):
2026-01-29T06:12:24.2458331Z                 """Execute the class method."""
2026-01-29T06:12:24.2458588Z                 self.call += 1
2026-01-29T06:12:24.2458789Z     
2026-01-29T06:12:24.2458958Z         test1 = TestClass(coresys, "test1")
2026-01-29T06:12:24.2459214Z         test2 = TestClass(coresys, "test2")
2026-01-29T06:12:24.2459440Z     
2026-01-29T06:12:24.2459648Z         start = utcnow()
2026-01-29T06:12:24.2459841Z     
2026-01-29T06:12:24.2460009Z         with time_machine.travel(start):
2026-01-29T06:12:24.2460254Z             await asyncio.gather(
2026-01-29T06:12:24.2460590Z                 *[test1.execute(), test1.execute(), test2.execute(), test2.execute()]
2026-01-29T06:12:24.2460930Z             )
2026-01-29T06:12:24.2461100Z         assert test1.call == 2
2026-01-29T06:12:24.2461320Z         assert test2.call == 2
2026-01-29T06:12:24.2461516Z     
2026-01-29T06:12:24.2461752Z         with time_machine.travel(start + timedelta(milliseconds=1)):
2026-01-29T06:12:24.2462432Z             with pytest.raises(JobException if error is None else error):
2026-01-29T06:12:24.2462775Z                 await test1.execute()
2026-01-29T06:12:24.2463096Z             with pytest.raises(JobException if error is None else error):
2026-01-29T06:12:24.2463633Z                 await test2.execute()
2026-01-29T06:12:24.2463864Z     
2026-01-29T06:12:24.2464031Z         assert test1.call == 2
2026-01-29T06:12:24.2464249Z         assert test2.call == 2
2026-01-29T06:12:24.2464447Z     
2026-01-29T06:12:24.2464712Z         with time_machine.travel(start + timedelta(hours=1, milliseconds=1)):
2026-01-29T06:12:24.2465074Z             await test1.execute()
2026-01-29T06:12:24.2465298Z >           await test2.execute()
2026-01-29T06:12:24.2465447Z 
2026-01-29T06:12:24.2465541Z tests/jobs/test_job_decorator.py:962: 
2026-01-29T06:12:24.2466026Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2026-01-29T06:12:24.2466372Z supervisor/jobs/decorator.py:287: in wrapper
2026-01-29T06:12:24.2466681Z     if not await self._handle_throttling(group_name):
2026-01-29T06:12:24.2466974Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-01-29T06:12:24.2467266Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2026-01-29T06:12:24.2467502Z 
2026-01-29T06:12:24.2467671Z self = <supervisor.jobs.decorator.Job object at 0x7fca80e7e210>
2026-01-29T06:12:24.2468012Z group_name = 'test_class_test2'
2026-01-29T06:12:24.2468157Z 
2026-01-29T06:12:24.2468356Z     async def _handle_throttling(self, group_name: str | None) -> bool:
2026-01-29T06:12:24.2468849Z         """Handle throttling limits. Returns True if job should continue, False if throttled."""
2026-01-29T06:12:24.2469374Z         if self.throttle in (JobThrottle.THROTTLE, JobThrottle.GROUP_THROTTLE):
2026-01-29T06:12:24.2469841Z             time_since_last_call = datetime.now() - self.last_call(group_name)
2026-01-29T06:12:24.2470248Z             throttle_period = self.throttle_period(group_name)
2026-01-29T06:12:24.2470567Z             if time_since_last_call < throttle_period:
2026-01-29T06:12:24.2470896Z                 # Always return False when throttled (skip execution)
2026-01-29T06:12:24.2471197Z                 return False
2026-01-29T06:12:24.2471421Z         elif self._is_rate_limit_throttle():
2026-01-29T06:12:24.2471712Z             # Only reprocess array when necessary (at limit)
2026-01-29T06:12:24.2472099Z             if len(self.rate_limited_calls(group_name)) >= self.throttle_max_calls:
2026-01-29T06:12:24.2472464Z                 self.set_rate_limited_calls(
2026-01-29T06:12:24.2472698Z                     [
2026-01-29T06:12:24.2472891Z                         call
2026-01-29T06:12:24.2473146Z                         for call in self.rate_limited_calls(group_name)
2026-01-29T06:12:24.2473718Z                         if call > datetime.now() - self.throttle_period(group_name)
2026-01-29T06:12:24.2474042Z                     ],
2026-01-29T06:12:24.2474235Z                     group_name,
2026-01-29T06:12:24.2474429Z                 )
2026-01-29T06:12:24.2474597Z     
2026-01-29T06:12:24.2474862Z             if len(self.rate_limited_calls(group_name)) >= self.throttle_max_calls:
2026-01-29T06:12:24.2475210Z                 on_condition = (
2026-01-29T06:12:24.2475527Z                     JobException if self.on_condition is None else self.on_condition
2026-01-29T06:12:24.2475866Z                 )
2026-01-29T06:12:24.2476049Z >               raise on_condition(
2026-01-29T06:12:24.2476501Z                     f"Rate limit exceeded, more than {self.throttle_max_calls} calls in {self.throttle_period(group_name)}",
2026-01-29T06:12:24.2476962Z                 )
2026-01-29T06:12:24.2477336Z E               supervisor.exceptions.PluginJobError: Rate limit exceeded, more than 2 calls in 1:00:00
2026-01-29T06:12:24.2477709Z 
2026-01-29T06:12:24.2477836Z supervisor/jobs/decorator.py:552: PluginJobError
```

</details>

The `test_group_throttle_rate_limit` test had an async timing race condition where concurrent operations executed in `asyncio.gather()` were getting slightly different timestamps (microseconds apart), even though they were inside a `time_machine.travel()` context.

The issue occurred because `time_machine` by default allows time to advance during execution (`tick=True`). When test2's execute calls were timestamped rather late, say `start + 2ms` due to async scheduling delays, causing a false "Rate limit exceeded" error.

The fix uses `tick=False` to completely freeze time during the concurrent operations, ensuring all 4 calls get the exact same timestamp and eliminating the race condition.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
