### PR TITLE
Disable Home Assistant watchdog during system shutdown

### DIFF
--- a/tests/homeassistant/test_home_assistant_watchdog.py
+++ b/tests/homeassistant/test_home_assistant_watchdog.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, PropertyMock, patch
 from aiodocker.containers import DockerContainer
 from awesomeversion import AwesomeVersion
 
-from supervisor.const import BusEvent
+from supervisor.const import BusEvent, CoreState
 from supervisor.coresys import CoreSys
 from supervisor.docker.const import ContainerState
 from supervisor.docker.monitor import DockerContainerStateEvent
@@ -175,3 +175,73 @@ async def test_home_assistant_watchdog_skip_on_load(
         events.assert_not_called()
         restart.assert_not_called()
         start.assert_not_called()
+
+
+async def test_home_assistant_watchdog_unregisters_on_shutdown(
+    coresys: CoreSys,
+) -> None:
+    """Test home assistant watchdog unregisters when entering shutdown states."""
+    coresys.homeassistant.version = AwesomeVersion("2022.7.3")
+    with (
+        patch(
+            "supervisor.docker.interface.DockerInterface.version",
+            new=PropertyMock(return_value=AwesomeVersion("2022.7.3")),
+        ),
+        patch.object(type(coresys.homeassistant.core.instance), "attach"),
+    ):
+        await coresys.homeassistant.core.load()
+
+    coresys.homeassistant.core.watchdog = True
+
+    # Verify watchdog listener is registered
+    assert coresys.homeassistant.core._watchdog_listener is not None
+    watchdog_listener = coresys.homeassistant.core._watchdog_listener
+
+    with (
+        patch.object(type(coresys.homeassistant.core), "restart") as restart,
+        patch.object(type(coresys.homeassistant.core), "start") as start,
+        patch.object(
+            type(coresys.homeassistant.core.instance),
+            "current_state",
+            return_value=ContainerState.FAILED,
+        ),
+    ):
+        # Watchdog should respond to events before shutdown
+        coresys.bus.fire_event(
+            BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
+            DockerContainerStateEvent(
+                name="homeassistant",
+                state=ContainerState.FAILED,
+                id="abc123",
+                time=1,
+            ),
+        )
+        await asyncio.sleep(0)
+        start.assert_called_once()
+        start.reset_mock()
+
+        # Test each shutdown state
+        for shutdown_state in (CoreState.SHUTDOWN, CoreState.STOPPING, CoreState.CLOSE):
+            # Reload to reset listener
+            coresys.homeassistant.core._watchdog_listener = watchdog_listener
+
+            # Fire shutdown state change
+            coresys.bus.fire_event(BusEvent.SUPERVISOR_STATE_CHANGE, shutdown_state)
+            await asyncio.sleep(0)
+
+            # Verify watchdog listener is unregistered
+            assert coresys.homeassistant.core._watchdog_listener is None
+
+            # Watchdog should not respond to events after shutdown
+            coresys.bus.fire_event(
+                BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
+                DockerContainerStateEvent(
+                    name="homeassistant",
+                    state=ContainerState.FAILED,
+                    id="abc123",
+                    time=1,
+                ),
+            )
+            await asyncio.sleep(0)
+            start.assert_not_called()
+            restart.assert_not_called()


### PR DESCRIPTION
## Proposed change

During system shutdown (reboot/poweroff), the Home Assistant watchdog was incorrectly detecting the Core container as failed and attempting to restart it. This occurred because Docker stops all containers in parallel with Supervisor's shutdown sequence, causing the watchdog to trigger while add-ons are still being stopped.

This led to Core being abruptly terminated before it could cleanly shut down its SQLite database, resulting in a warning on the next startup: "The system could not validate that the sqlite3 database was shutdown cleanly".

This PR fixes the issue by registering a supervisor state change listener that unregisters the watchdog when entering any shutdown state (SHUTDOWN, STOPPING, or CLOSE). This prevents restart attempts during both user-initiated reboots (via API) and external shutdown signals (Docker SIGTERM, console reboot commands).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #6511
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
