### PR TITLE
Fix port conflict tests for aiodocker 0.25.0 compatibility

### DIFF
--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -1017,9 +1017,7 @@ async def test_addon_start_port_conflict_error(
     install_addon_ssh.data["image"] = "test/amd64-addon-ssh"
     coresys.docker.containers.create.return_value.start.side_effect = aiodocker.DockerError(
         HTTPStatus.INTERNAL_SERVER_ERROR,
-        {
-            "message": "failed to set up container networking: driver failed programming external connectivity on endpoint addon_local_ssh (ea4d0fdaa72cf86f2c9199a04208e3eaf0c5a0d6fd34b3c7f4fab2daadb1f3a9): failed to bind host port for 0.0.0.0:2222:172.30.33.4:22/tcp: address already in use"
-        },
+        "failed to set up container networking: driver failed programming external connectivity on endpoint addon_local_ssh (ea4d0fdaa72cf86f2c9199a04208e3eaf0c5a0d6fd34b3c7f4fab2daadb1f3a9): failed to bind host port for 0.0.0.0:2222:172.30.33.4:22/tcp: address already in use",
     )
     await install_addon_ssh.load()
 

--- a/tests/plugins/test_observer.py
+++ b/tests/plugins/test_observer.py
@@ -16,9 +16,7 @@ async def test_observer_start_port_conflict(
     """Test port conflict error when trying to start observer."""
     coresys.docker.containers.create.return_value.start.side_effect = aiodocker.DockerError(
         HTTPStatus.INTERNAL_SERVER_ERROR,
-        {
-            "message": "failed to set up container networking: driver failed programming external connectivity on endpoint hassio_observer (ea4d0fdaa72cf86f2c9199a04208e3eaf0c5a0d6fd34b3c7f4fab2daadb1f3a9): failed to bind host port for 0.0.0.0:4357:172.30.33.4:80/tcp: address already in use"
-        },
+        "failed to set up container networking: driver failed programming external connectivity on endpoint hassio_observer (ea4d0fdaa72cf86f2c9199a04208e3eaf0c5a0d6fd34b3c7f4fab2daadb1f3a9): failed to bind host port for 0.0.0.0:4357:172.30.33.4:80/tcp: address already in use",
     )
     await coresys.plugins.observer.load()
 


### PR DESCRIPTION
## Proposed change

This PR fixes two broken tests that were failing after the aiodocker 0.25.0 upgrade (#6448). The tests `test_addon_start_port_conflict_error` and `test_observer_start_port_conflict` were incorrectly passing dict objects to `aiodocker.DockerError` instead of string messages.

The aiodocker 0.25.0 release included [PR #854](https://github.com/aio-libs/aiodocker/pull/854) which refactored the exception hierarchy. The library now extracts the message string from Docker API JSON responses before creating `DockerError` instances, rather than passing the entire dict. The port conflict detection code added in #6445 correctly expected `err.message` to be a string for regex matching, which caused TypeErrors when the tests passed dicts.

This fix updates both tests to pass message strings directly, matching the real aiodocker 0.25.0 behavior and allowing the port conflict detection to work as intended.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6445 (port conflict detection), #6448 (aiodocker 0.25.0 upgrade)
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
