### PR TITLE
Add DELETE method support to /core/api proxy

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -522,6 +522,7 @@ class RestAPI(CoreSysAttributes):
                 web.get("/core/api/stream", api_proxy.stream),
                 web.post("/core/api/{path:.+}", api_proxy.api),
                 web.get("/core/api/{path:.+}", api_proxy.api),
+                web.delete("/core/api/{path:.+}", api_proxy.api),
                 web.get("/core/api/", api_proxy.api),
             ]
         )


### PR DESCRIPTION
## Proposed change

This PR adds support for the DELETE HTTP method to the `/core/api` proxy endpoint.

Previously, the Supervisor's `/core/api` proxy only supported GET and POST methods, returning 405 Method Not Allowed for DELETE requests. This prevented addons from calling Home Assistant Core REST API endpoints that require DELETE methods, such as:
- `/api/config/automation/config/{id}` - deleting automations
- `/api/config/script/config/{id}` - deleting scripts
- `/api/config/scene/config/{id}` - deleting scenes
- `/api/states/{entity_id}` - deleting entity states

The underlying proxy implementation in `supervisor/api/proxy.py` already supported passing through any HTTP method via `request.method.lower()`, so only the route registration was needed.

Note: DELETE support is only added to the modern `/core/api/` endpoint, not the legacy `/homeassistant/api/` routes.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #6509
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
