### PR TITLE
Fix Docker Hub manifest fetching by using correct registry API endpoint

### DIFF
--- a/supervisor/docker/const.py
+++ b/supervisor/docker/const.py
@@ -16,6 +16,10 @@ RE_RETRYING_DOWNLOAD_STATUS = re.compile(r"Retrying in \d+ seconds?")
 # Docker's default registry is docker.io
 DOCKER_HUB = "docker.io"
 
+# Docker Hub API endpoint (used for direct registry API calls)
+# While docker.io is the registry identifier, registry-1.docker.io is the actual API endpoint
+DOCKER_HUB_API = "registry-1.docker.io"
+
 # Legacy Docker Hub identifier for backward compatibility
 DOCKER_HUB_LEGACY = "hub.docker.com"
 

--- a/tests/docker/test_manifest.py
+++ b/tests/docker/test_manifest.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from supervisor.coresys import CoreSys
 from supervisor.docker.manifest import (
     DOCKER_HUB,
+    DOCKER_HUB_API,
     ImageManifest,
     RegistryManifestFetcher,
     parse_image_reference,
@@ -141,3 +142,21 @@ def test_get_credentials_not_found(coresys: CoreSys, websession: MagicMock):
     creds = fetcher._get_credentials("unknown.io")  # pylint: disable=protected-access
 
     assert creds is None
+
+
+def test_get_api_endpoint_docker_hub(coresys: CoreSys, websession: MagicMock):
+    """Test Docker Hub registry translates to API endpoint."""
+    fetcher = RegistryManifestFetcher(coresys)
+
+    endpoint = fetcher._get_api_endpoint(DOCKER_HUB)  # pylint: disable=protected-access
+
+    assert endpoint == DOCKER_HUB_API
+
+
+def test_get_api_endpoint_other_registry(coresys: CoreSys, websession: MagicMock):
+    """Test other registries pass through unchanged."""
+    fetcher = RegistryManifestFetcher(coresys)
+
+    endpoint = fetcher._get_api_endpoint("ghcr.io")  # pylint: disable=protected-access
+
+    assert endpoint == "ghcr.io"


### PR DESCRIPTION
## Proposed change

This PR fixes Docker Hub manifest fetching by using the correct registry API endpoint. The manifest fetcher was using `docker.io` as the registry API endpoint, but Docker Hub's actual registry API is at `registry-1.docker.io`. When trying to access `https://docker.io/v2/...`, requests were being redirected to `https://www.docker.com/` (the marketing site), which returned HTML instead of JSON, causing manifest fetching to fail with errors like:

```
WARNING (MainThread) [supervisor.docker.manifest] Failed to fetch manifest: 200, message='Attempt to decode JSON with unexpected mimetype: text/html; charset=utf-8', url='https://www.docker.com/'
```

This affected add-ons hosted on Docker Hub (e.g., `homeassistant/amd64-addon-piper:2.2.1`), preventing accurate progress tracking during image pulls.

**Technical details:**

This matches exactly what Docker itself does internally - see `daemon/pkg/registry/config.go:49` where Docker hardcodes `DefaultRegistryHost = "registry-1.docker.io"` for registry operations.

**Changes:**
- Add `DOCKER_HUB_API` constant for the actual Docker Hub API endpoint (`registry-1.docker.io`)
- Add `_get_api_endpoint()` helper method to translate `docker.io` to `registry-1.docker.io` for HTTP API calls
- Update `_get_auth_token()` and `_fetch_manifest()` to use the API endpoint
- Keep `docker.io` as the registry identifier for naming and credentials (no breaking changes)
- Add tests to verify the API endpoint translation works correctly

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
