### PR TITLE
Include Docker storage driver in Sentry reports

### DIFF
--- a/supervisor/misc/filter.py
+++ b/supervisor/misc/filter.py
@@ -72,6 +72,9 @@ def filter_data(coresys: CoreSys, event: Event, hint: Hint) -> Event | None:
                         "docker": coresys.docker.info.version,
                         "supervisor": coresys.supervisor.version,
                     },
+                    "docker": {
+                        "storage_driver": coresys.docker.info.storage,
+                    },
                     "host": {
                         "machine": coresys.machine,
                     },
@@ -110,6 +113,9 @@ def filter_data(coresys: CoreSys, event: Event, hint: Hint) -> Event | None:
                 "agent": coresys.dbus.agent.version,
                 "docker": coresys.docker.info.version,
                 "supervisor": coresys.supervisor.version,
+            },
+            "docker": {
+                "storage_driver": coresys.docker.info.storage,
             },
             "resolution": {
                 "issues": [attr.asdict(issue) for issue in coresys.resolution.issues],

--- a/tests/misc/test_filter_data.py
+++ b/tests/misc/test_filter_data.py
@@ -121,10 +121,15 @@ async def test_not_started(coresys):
     assert "versions" in filtered["contexts"]
     assert "docker" in filtered["contexts"]["versions"]
     assert "supervisor" in filtered["contexts"]["versions"]
+    assert "docker" in filtered["contexts"]
+    assert "storage_driver" in filtered["contexts"]["docker"]
     assert "host" in filtered["contexts"]
     assert "machine" in filtered["contexts"]["host"]
     assert filtered["contexts"]["versions"]["docker"] == coresys.docker.info.version
     assert filtered["contexts"]["versions"]["supervisor"] == coresys.supervisor.version
+    assert (
+        filtered["contexts"]["docker"]["storage_driver"] == coresys.docker.info.storage
+    )
     assert filtered["contexts"]["host"]["machine"] == coresys.machine
 
 
@@ -141,6 +146,9 @@ async def test_defaults(coresys):
     assert filtered["contexts"]["host"]["machine"] == "qemux86-64"
     assert filtered["contexts"]["versions"]["supervisor"] == AwesomeVersion(
         SUPERVISOR_VERSION
+    )
+    assert (
+        filtered["contexts"]["docker"]["storage_driver"] == coresys.docker.info.storage
     )
     assert filtered["user"]["id"] == coresys.machine_id
 


### PR DESCRIPTION
## Proposed change

This PR adds Docker storage driver information (e.g., `overlay2`, `vfs`, `btrfs`) to Sentry error reports. The storage driver is now included in the context data sent with every error report, allowing us to correlate issues with specific Docker storage backends.

The information is captured from `coresys.docker.info.storage` and included under `contexts.docker.storage_driver` in both SETUP and RUNNING state error reports.

This enhancement improves debugging capabilities by making it easier to identify storage-backend-specific issues, particularly useful for diagnosing problems related to different Docker configurations across various installations.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
