### PR TITLE
Fix RAUC D-Bus type annotations for runtime type checking

### DIFF
--- a/supervisor/dbus/rauc.py
+++ b/supervisor/dbus/rauc.py
@@ -1,6 +1,5 @@
 """D-Bus interface for rauc."""
 
-from ctypes import c_uint32, c_uint64
 import logging
 from typing import Any, NotRequired, TypedDict
 
@@ -33,13 +32,15 @@ SlotStatusDataType = TypedDict(
         "state": str,
         "device": str,
         "bundle.compatible": NotRequired[str],
+        "bundle.hash": NotRequired[str],
         "sha256": NotRequired[str],
-        "size": NotRequired[c_uint64],
-        "installed.count": NotRequired[c_uint32],
+        "size": NotRequired[int],
+        "installed.count": NotRequired[int],
+        "installed.transaction": NotRequired[str],
         "bundle.version": NotRequired[str],
         "installed.timestamp": NotRequired[str],
         "status": NotRequired[str],
-        "activated.count": NotRequired[c_uint32],
+        "activated.count": NotRequired[int],
         "activated.timestamp": NotRequired[str],
         "boot-status": NotRequired[str],
         "bootname": NotRequired[str],
@@ -117,7 +118,7 @@ class Rauc(DBusInterfaceProxy):
         return self.connected_dbus.signal(DBUS_SIGNAL_RAUC_INSTALLER_COMPLETED)
 
     @dbus_connected
-    async def mark(self, state: RaucState, slot_identifier: str) -> tuple[str, str]:
+    async def mark(self, state: RaucState, slot_identifier: str) -> list[str]:
         """Get slot status."""
         return await self.connected_dbus.Installer.call("mark", state, slot_identifier)
 


### PR DESCRIPTION
## Proposed change

This PR fixes type annotations in the RAUC D-Bus interface module to satisfy typeguard runtime type checking. The changes address type mismatches where D-Bus returns standard Python types but the annotations incorrectly specified ctypes.

**Changes:**

- Replaced `c_uint32` and `c_uint64` with standard Python `int` in `SlotStatusDataType`, as D-Bus returns Python integers, not ctypes objects
- Fixed `mark()` method return type from `tuple[str, str]` to `list[str]` to match actual D-Bus return value
- Added missing optional fields `bundle.hash` and `installed.transaction` to `SlotStatusDataType`

These changes ensure that typeguard runtime checks pass for RAUC D-Bus interactions.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
