### PR TITLE
Add explicit StrEnum conversions for D-Bus and Docker properties

### DIFF
--- a/supervisor/dbus/resolved.py
+++ b/supervisor/dbus/resolved.py
@@ -103,19 +103,25 @@ class Resolved(DBusInterfaceProxy):
     @dbus_property
     def dns_over_tls(self) -> DNSOverTLSEnabled | None:
         """Return DNS over TLS enabled."""
-        return self.properties[DBUS_ATTR_DNS_OVER_TLS]
+        if (value := self.properties.get(DBUS_ATTR_DNS_OVER_TLS)) is not None:
+            return DNSOverTLSEnabled(value)
+        return None
 
     @property
     @dbus_property
     def dns_stub_listener(self) -> DNSStubListenerEnabled | None:
         """Return DNS stub listener enabled on port 53."""
-        return self.properties[DBUS_ATTR_DNS_STUB_LISTENER]
+        if (value := self.properties.get(DBUS_ATTR_DNS_STUB_LISTENER)) is not None:
+            return DNSStubListenerEnabled(value)
+        return None
 
     @property
     @dbus_property
     def dnssec(self) -> DNSSECValidation | None:
         """Return DNSSEC validation enforced."""
-        return self.properties[DBUS_ATTR_DNSSEC]
+        if (value := self.properties.get(DBUS_ATTR_DNSSEC)) is not None:
+            return DNSSECValidation(value)
+        return None
 
     @property
     @dbus_property
@@ -159,7 +165,9 @@ class Resolved(DBusInterfaceProxy):
     @dbus_property
     def llmnr(self) -> MulticastProtocolEnabled | None:
         """Return LLMNR enabled."""
-        return self.properties[DBUS_ATTR_LLMNR]
+        if (value := self.properties.get(DBUS_ATTR_LLMNR)) is not None:
+            return MulticastProtocolEnabled(value)
+        return None
 
     @property
     @dbus_property
@@ -171,13 +179,17 @@ class Resolved(DBusInterfaceProxy):
     @dbus_property
     def multicast_dns(self) -> MulticastProtocolEnabled | None:
         """Return MDNS enabled."""
-        return self.properties[DBUS_ATTR_MULTICAST_DNS]
+        if (value := self.properties.get(DBUS_ATTR_MULTICAST_DNS)) is not None:
+            return MulticastProtocolEnabled(value)
+        return None
 
     @property
     @dbus_property
     def resolv_conf_mode(self) -> ResolvConfMode | None:
         """Return how /etc/resolv.conf managed on host."""
-        return self.properties[DBUS_ATTR_RESOLV_CONF_MODE]
+        if (value := self.properties.get(DBUS_ATTR_RESOLV_CONF_MODE)) is not None:
+            return ResolvConfMode(value)
+        return None
 
     @property
     @dbus_property

--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -161,7 +161,7 @@ class DockerInterface(JobGroup, ABC):
             return None
 
         policy = self.meta_host["RestartPolicy"].get("Name")
-        return policy if policy else RestartPolicy.NO
+        return RestartPolicy(policy) if policy else RestartPolicy.NO
 
     @property
     def security_opt(self) -> list[str]:


### PR DESCRIPTION
Convert string values from D-Bus and Docker API to their respective StrEnum types explicitly to satisfy typeguard runtime type checking.

The conversions will raise ValueError if an unknown enum value is encountered, this will be caught in Sentry. Since D-Bus and the particular property from Docker API are not mission critical for Supervisor update functionality, it will be possible to add new enum values in the future as they arise.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
