### PR TITLE
Validate device option type before path conversion in add-on options

### DIFF
--- a/supervisor/addons/options.py
+++ b/supervisor/addons/options.py
@@ -169,6 +169,10 @@ class AddonOptions(CoreSysAttributes):
         elif typ.startswith(_LIST):
             return vol.In(match.group("list").split("|"))(str(value))
         elif typ.startswith(_DEVICE):
+            if not isinstance(value, str):
+                raise vol.Invalid(
+                    f"Expected a string for option '{key}' in {self._name} ({self._slug})"
+                )
             try:
                 device = self.sys_hardware.get_by_path(Path(value))
             except HardwareNotFound:

--- a/tests/addons/test_options.py
+++ b/tests/addons/test_options.py
@@ -273,6 +273,25 @@ def test_simple_device_schema(coresys):
         )({"name": "Pascal", "password": "1234", "input": "/dev/video1"})
 
 
+def test_device_schema_wrong_type(coresys):
+    """Test device option rejects non-string values."""
+    with pytest.raises(vol.error.Invalid):
+        AddonOptions(
+            coresys,
+            {"name": "str", "input": "device(subsystem=tty)"},
+            MOCK_ADDON_NAME,
+            MOCK_ADDON_SLUG,
+        )({"name": "Pascal", "input": {"baudrate": 115200, "flow_control": True}})
+
+    with pytest.raises(vol.error.Invalid):
+        AddonOptions(
+            coresys,
+            {"name": "str", "input": "device"},
+            MOCK_ADDON_NAME,
+            MOCK_ADDON_SLUG,
+        )({"name": "Pascal", "input": 12345})
+
+
 def test_simple_schema_password(coresys):
     """Test with simple schema password pwned."""
     validate = AddonOptions(


### PR DESCRIPTION
## Proposed change

When an add-on schema defines a `device` or `device(subsystem=...)` option, the validation code in `AddonOptions._single_validate` passes the value directly to `Path()`. If the value is not a string (e.g. a dict or int sent by the frontend), this raises an unhandled `TypeError` instead of a clean validation error.

This adds a type check before the `Path()` call so that non-string values are rejected with a proper `vol.Invalid` error.

Tracked as [SUPERVISOR-175H](https://home-assistant-io.sentry.io/issues/SUPERVISOR-175H) in Sentry (11 users affected, triggered by the OpenThread Border Router add-on options page).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes SUPERVISOR-175H
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
