### PR TITLE
Fix RestartPolicy type annotation for runtime type checking

### DIFF
--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -58,9 +58,6 @@ MAP_ARCH: dict[CpuArch, str] = {
 }
 
 
-_RESTART_POLICY_MAP: dict[str, RestartPolicy] = {p.value: p for p in RestartPolicy}
-
-
 def _restart_policy_from_model(meta_host: dict[str, Any]) -> RestartPolicy | None:
     """Get restart policy from host config model."""
     if "RestartPolicy" not in meta_host:
@@ -70,8 +67,8 @@ def _restart_policy_from_model(meta_host: dict[str, Any]) -> RestartPolicy | Non
     if not name:
         return RestartPolicy.NO
 
-    if name in _RESTART_POLICY_MAP:
-        return _RESTART_POLICY_MAP[name]
+    if name in RestartPolicy:
+        return RestartPolicy(name)
 
     _LOGGER.warning("Unknown Docker restart policy '%s', treating as no", name)
     return RestartPolicy.NO


### PR DESCRIPTION
## Proposed change

The `restart_policy` property returned a plain `str` from the Docker API instead of a `RestartPolicy` enum instance, causing a `TypeCheckError` with runtime type checking:

```
TypeCheckError: the return value (str) did not match any element in the union:
  supervisor.docker.const.RestartPolicy: is not an instance of supervisor.docker.const.RestartPolicy
  NoneType: is not an instance of NoneType
```

This introduces `_restart_policy_from_model()` which uses explicit mapping to always return a proper `RestartPolicy` enum member, consistent with the existing `_container_state_from_model()` pattern. Unknown values from Docker are logged and default to `RestartPolicy.NO`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
