### PR TITLE
Reload ingress tokens on addon update and rebuild

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -926,6 +926,10 @@ class Addon(AddonModel):
             await self.sys_addons.data.update(store)
             await self._check_ingress_port()
 
+            # Reload ingress tokens in case addon gained ingress support
+            if self.with_ingress:
+                await self.sys_ingress.reload()
+
             # Cleanup
             with suppress(DockerError):
                 await self.instance.cleanup(
@@ -979,6 +983,11 @@ class Addon(AddonModel):
                 await self.sys_addons.data.update(self.addon_store)
 
             await self._check_ingress_port()
+
+            # Reload ingress tokens in case addon gained ingress support
+            if self.with_ingress:
+                await self.sys_ingress.reload()
+
             _LOGGER.info("Add-on '%s' successfully rebuilt", self.slug)
 
         finally:


### PR DESCRIPTION
## Proposed change

When an add-on updates from having no ingress to having ingress support, accessing the ingress URL returns a 503 error instead of working.

The root cause is that `update()` and `rebuild()` both call `_check_ingress_port()` to assign a dynamic port, but neither calls `sys_ingress.reload()` to rebuild the ingress token map. The `install()` method does this correctly, but the update/rebuild paths were missing it. As a result, `Ingress.get(token)` returns `None` and the proxy raises `HTTPServiceUnavailable`.

This PR adds `sys_ingress.reload()` after `_check_ingress_port()` in both `update()` and `rebuild()`, guarded by `if self.with_ingress`. The call is idempotent — for add-ons that already had ingress, it simply rebuilds the same token map.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] CLI updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
