### PR TITLE
Add missing BRIDGE device type to NetworkManager enum

### DIFF
--- a/supervisor/dbus/const.py
+++ b/supervisor/dbus/const.py
@@ -306,6 +306,7 @@ class DeviceType(DBusIntEnum):
     WIRELESS = 2
     BLUETOOTH = 5
     VLAN = 11
+    BRIDGE = 13
     TUN = 16
     VETH = 20
     WIREGUARD = 29


### PR DESCRIPTION
## Proposed change

Add the missing `BRIDGE` (13) entry to the `DeviceType` NetworkManager enum. Without it, any system with a bridge interface logs a warning:

```
Unknown DeviceType value received from D-Bus: 13
```

This showed up on my dev system. It is unlikely to be seen in practice on HAOS since bridge interfaces are usually not present there, but the value should be recognized regardless.

Reference: https://networkmanager.dev/docs/api/latest/nm-dbus-types.html#NMDeviceType

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
