### PR TITLE
Remove RuntimeError from APIError inheritance

### DIFF
--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -46,7 +46,7 @@ class HassioNotSupportedError(HassioError):
 # API
 
 
-class APIError(HassioError, RuntimeError):
+class APIError(HassioError):
     """API errors."""
 
     status = 400


### PR DESCRIPTION
## Proposed change

Remove `RuntimeError` from `APIError`'s inheritance chain. `APIError` previously inherited from both `HassioError` and `RuntimeError`, which meant all API errors (and their many subclasses) were also catchable as `RuntimeError`. This is a historical artifact — no code in the codebase relies on this relationship. Removing it prevents broad `except RuntimeError` clauses from unintentionally catching structured API errors.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
