### PR TITLE
Remove unused Docker config from backup metadata

### DIFF
--- a/supervisor/backups/backup.py
+++ b/supervisor/backups/backup.py
@@ -199,16 +199,6 @@ class Backup(JobGroup):
         return self._data[ATTR_EXTRA]
 
     @property
-    def docker(self) -> dict[str, Any]:
-        """Return backup Docker config data."""
-        return self._data.get(ATTR_DOCKER, {})
-
-    @docker.setter
-    def docker(self, value: dict[str, Any]) -> None:
-        """Set the Docker config data."""
-        self._data[ATTR_DOCKER] = value
-
-    @property
     def location(self) -> str | None:
         """Return the location of the backup."""
         return self.locations[0]

--- a/supervisor/backups/validate.py
+++ b/supervisor/backups/validate.py
@@ -14,7 +14,6 @@ from ..const import (
     ATTR_CRYPTO,
     ATTR_DATE,
     ATTR_DAYS_UNTIL_STALE,
-    ATTR_DOCKER,
     ATTR_EXCLUDE_DATABASE,
     ATTR_EXTRA,
     ATTR_FOLDERS,
@@ -35,7 +34,7 @@ from ..const import (
     FOLDER_SSL,
 )
 from ..store.validate import repositories
-from ..validate import SCHEMA_DOCKER_CONFIG, version_tag
+from ..validate import version_tag
 
 ALL_FOLDERS = [
     FOLDER_SHARE,
@@ -114,7 +113,6 @@ SCHEMA_BACKUP = vol.Schema(
                 )
             ),
         ),
-        vol.Optional(ATTR_DOCKER, default=dict): SCHEMA_DOCKER_CONFIG,
         vol.Optional(ATTR_FOLDERS, default=list): vol.All(
             v1_folderlist, [vol.In(ALL_FOLDERS)], vol.Unique()
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Complete the cleanup started in #5605 by removing the leftover `docker` property and schema entry from backup metadata.

#5605 dropped the Docker config (registry credentials, IPv6 setting) from the backup/restore operations, but the `Backup.docker` property and the `SCHEMA_BACKUP` validation entry remained. This caused every new backup to include an empty `"docker": {"registries": {}, "enable_ipv6": null}` in `backup.json` for no reason.

This PR removes:
- The `docker` getter/setter on `Backup`
- The `ATTR_DOCKER` schema entry from `SCHEMA_BACKUP`

Old backups containing the `docker` key still load correctly because the schema uses `extra=vol.ALLOW_EXTRA`. The `docker` key is also kept in `IGNORED_COMPARISON_FIELDS` to ensure consolidation of old encrypted/unencrypted backup copies continues to work.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
