### PR TITLE
Add remaining NetworkManager device type enums

### DIFF
--- a/supervisor/dbus/const.py
+++ b/supervisor/dbus/const.py
@@ -304,21 +304,38 @@ class DeviceType(DBusIntEnum):
     UNKNOWN = 0
     ETHERNET = 1
     WIRELESS = 2
+    UNUSED1 = 3
+    UNUSED2 = 4
     BLUETOOTH = 5
+    OLPC_MESH = 6
+    WIMAX = 7
     MODEM = 8
+    INFINIBAND = 9
+    BOND = 10
     VLAN = 11
+    ADSL = 12
     BRIDGE = 13
     GENERIC = 14
+    TEAM = 15
     TUN = 16
     IP_TUNNEL = 17
     MAC_VLAN = 18
     VXLAN = 19
     VETH = 20
+    MACSEC = 21
     DUMMY = 22
     PPP = 23
+    OVS_INTERFACE = 24
+    OVS_PORT = 25
+    OVS_BRIDGE = 26
+    WPAN = 27
+    LOWPAN6 = 28
     WIREGUARD = 29
     WIFI_P2P = 30
+    VRF = 31
     LOOPBACK = 32
+    HSR = 33
+    IPVLAN = 34
 
 
 class WirelessMethodType(DBusIntEnum):


### PR DESCRIPTION
## Proposed change

Add the remaining NetworkManager `NMDeviceType` values to `DeviceType` in `supervisor/dbus/const.py`.

This prevents valid D-Bus device types from being treated as unknown values, which reduces unnecessary warning/Sentry noise and keeps Supervisor's enum mapping aligned with upstream NetworkManager.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6574
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
