### PR TITLE
Ensure dt_utc in /os/info always returns current time

### DIFF
--- a/supervisor/dbus/timedate.py
+++ b/supervisor/dbus/timedate.py
@@ -8,12 +8,11 @@ from typing import Any
 from dbus_fast.aio.message_bus import MessageBus
 
 from ..exceptions import DBusError, DBusInterfaceError, DBusServiceUnkownError
-from ..utils.dt import get_time_zone, utc_from_timestamp
+from ..utils.dt import get_time_zone
 from .const import (
     DBUS_ATTR_LOCAL_RTC,
     DBUS_ATTR_NTP,
     DBUS_ATTR_NTPSYNCHRONIZED,
-    DBUS_ATTR_TIMEUSEC,
     DBUS_ATTR_TIMEZONE,
     DBUS_IFACE_TIMEDATE,
     DBUS_NAME_TIMEDATE,
@@ -64,12 +63,6 @@ class TimeDate(DBusInterfaceProxy):
     def ntp_synchronized(self) -> bool:
         """Return if NTP is synchronized."""
         return self.properties[DBUS_ATTR_NTPSYNCHRONIZED]
-
-    @property
-    @dbus_property
-    def dt_utc(self) -> datetime:
-        """Return the system UTC time."""
-        return utc_from_timestamp(self.properties[DBUS_ATTR_TIMEUSEC] / 1000000)
 
     @property
     def timezone_tzinfo(self) -> tzinfo | None:

--- a/supervisor/host/info.py
+++ b/supervisor/host/info.py
@@ -1,7 +1,7 @@
 """Info control for host."""
 
 import asyncio
-from datetime import datetime, tzinfo
+from datetime import UTC, datetime, tzinfo
 import logging
 
 from ..coresys import CoreSysAttributes
@@ -78,9 +78,9 @@ class InfoCenter(CoreSysAttributes):
         return self.sys_dbus.timedate.timezone_tzinfo
 
     @property
-    def dt_utc(self) -> datetime | None:
+    def dt_utc(self) -> datetime:
         """Return host UTC time."""
-        return self.sys_dbus.timedate.dt_utc
+        return datetime.now(UTC)
 
     @property
     def use_rtc(self) -> bool | None:

--- a/tests/dbus/test_timedate.py
+++ b/tests/dbus/test_timedate.py
@@ -25,15 +25,11 @@ async def test_timedate_info(
     """Test timedate properties."""
     timedate = TimeDate()
 
-    assert timedate.dt_utc is None
     assert timedate.ntp is None
 
     await timedate.connect(dbus_session_bus)
 
-    assert timedate.dt_utc == datetime(2021, 5, 19, 8, 36, 54, 405718, tzinfo=UTC)
     assert timedate.ntp is True
-
-    assert timedate.dt_utc.isoformat() == "2021-05-19T08:36:54.405718+00:00"
 
     timedate_service.emit_properties_changed({"NTP": False})
     await timedate_service.ping()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The /os/info API endpoint has been using D-Bus property TimeUSec which got cached between requests, so the time returned was not always the same as current time on the host system at the time of the request. Since there's no reason to use D-Bus API for the time, as Supervisor runs on the same machine and time is global, simply format current datetime object with Python and return it in the response.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #6581
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
