### PR TITLE
Guard _migrate validator against non-dict add-on configs

### DIFF
--- a/supervisor/addons/validate.py
+++ b/supervisor/addons/validate.py
@@ -244,6 +244,8 @@ def _migrate_addon_config(protocol=False):
     """Migrate addon config."""
 
     def _migrate(config: dict[str, Any]):
+        if not isinstance(config, dict):
+            raise vol.Invalid("Add-on config must be a dictionary!")
         name = config.get(ATTR_NAME)
         if not name:
             raise vol.Invalid("Invalid Add-on config!")

--- a/tests/addons/test_config.py
+++ b/tests/addons/test_config.py
@@ -532,3 +532,12 @@ def test_ulimits_invalid_values():
     config["ulimits"] = {"nofile": {}}
     with pytest.raises(vol.Invalid):
         vd.SCHEMA_ADDON_CONFIG(config)
+
+
+def test_non_dict_config_raises_invalid():
+    """Test that a non-dict config raises vol.Invalid, not AttributeError."""
+    with pytest.raises(vol.Invalid):
+        vd.SCHEMA_ADDON_CONFIG("not a dict")
+
+    with pytest.raises(vol.Invalid):
+        vd.SCHEMA_ADDON_CONFIG(["list", "not", "dict"])


### PR DESCRIPTION
## Proposed change

The `_migrate` function in `supervisor/addons/validate.py` is the first validator in the `SCHEMA_ADDON_CONFIG` voluptuous `All()` chain, meaning it receives raw config data directly. If a malformed add-on config file contains a non-dict value (e.g. a string or list), the call to `config.get(ATTR_NAME)` raises an `AttributeError` instead of a proper `vol.Invalid` error, causing an unhandled exception that surfaces to users.

This PR adds an `isinstance(config, dict)` guard at the top of `_migrate` so that non-dict inputs are rejected with a clean `vol.Invalid` error rather than crashing with `AttributeError: 'str' object has no attribute 'get'`.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
