### PR TITLE
Return 401 for non-Basic Authorization headers on /auth endpoint

### DIFF
--- a/supervisor/api/auth.py
+++ b/supervisor/api/auth.py
@@ -49,7 +49,10 @@ class APIAuth(CoreSysAttributes):
 
         Return a coroutine.
         """
-        auth = BasicAuth.decode(request.headers[AUTHORIZATION])
+        try:
+            auth = BasicAuth.decode(request.headers[AUTHORIZATION])
+        except ValueError as err:
+            raise HTTPUnauthorized(headers=REALM_HEADER) from err
         return self.sys_auth.check_login(addon, auth.login, auth.password)
 
     def _process_dict(

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -330,6 +330,18 @@ async def test_auth_basic_auth_failure(
     assert resp.status == 401
 
 
+@pytest.mark.parametrize("api_client", [TEST_ADDON_SLUG], indirect=True)
+async def test_auth_bearer_token_returns_401(
+    api_client: TestClient, install_addon_ssh: Addon
+):
+    """Test that a Bearer token in Authorization header returns 401, not 500."""
+    resp = await api_client.post(
+        "/auth", headers={"Authorization": "Bearer sometoken123"}
+    )
+    assert "Basic realm" in resp.headers[WWW_AUTHENTICATE]
+    assert resp.status == 401
+
+
 @pytest.mark.parametrize("api_client", ["local_example"], indirect=True)
 async def test_auth_addon_no_auth_access(
     api_client: TestClient, install_addon_example: Addon


### PR DESCRIPTION
## Proposed change

The `/auth` endpoint calls `aiohttp.BasicAuth.decode()` whenever an `Authorization` header is present, but that method raises `ValueError` for any non-Basic auth scheme (e.g. `Bearer <token>`). This unhandled exception bubbled up as a 500 Internal Server Error instead of the expected 401 Unauthorized response.

The fix catches the `ValueError` in `_process_basic()` and raises `HTTPUnauthorized` with the `WWW-Authenticate: Basic realm=...` header, so callers receive a proper 401.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
