### PR TITLE
Use securetar v3 for backups when Core >= 2026.3.0

### DIFF
--- a/supervisor/backups/backup.py
+++ b/supervisor/backups/backup.py
@@ -58,14 +58,22 @@ from ..exceptions import (
     BackupInvalidError,
     BackupPermissionError,
 )
+from ..homeassistant.const import LANDINGPAGE
 from ..jobs.const import JOB_GROUP_BACKUP
 from ..jobs.decorator import Job
 from ..jobs.job_group import JobGroup
-from ..utils import remove_folder
+from ..utils import remove_folder, version_is_new_enough
 from ..utils.dt import parse_datetime, utcnow
 from ..utils.json import json_bytes
 from ..utils.sentinel import DEFAULT
-from .const import BUF_SIZE, LOCATION_CLOUD_BACKUP, SECURETAR_CREATE_VERSION, BackupType
+from .const import (
+    BUF_SIZE,
+    CORE_SECURETAR_V3_MIN_VERSION,
+    LOCATION_CLOUD_BACKUP,
+    SECURETAR_CREATE_VERSION,
+    SECURETAR_V3_CREATE_VERSION,
+    BackupType,
+)
 from .validate import SCHEMA_BACKUP
 
 IGNORED_COMPARISON_FIELDS = {ATTR_PROTECTED, ATTR_CRYPTO, ATTR_DOCKER}
@@ -444,6 +452,15 @@ class Backup(JobGroup):
     @asynccontextmanager
     async def create(self) -> AsyncGenerator[None]:
         """Create new backup file."""
+        core_version = self.sys_homeassistant.version
+        if (
+            core_version is not None
+            and core_version != LANDINGPAGE
+            and version_is_new_enough(core_version, CORE_SECURETAR_V3_MIN_VERSION)
+        ):
+            securetar_version = SECURETAR_V3_CREATE_VERSION
+        else:
+            securetar_version = SECURETAR_CREATE_VERSION
 
         def _open_outer_tarfile() -> SecureTarArchive:
             """Create and open outer tarfile."""
@@ -457,7 +474,7 @@ class Backup(JobGroup):
                 self.tarfile,
                 "w",
                 bufsize=BUF_SIZE,
-                create_version=SECURETAR_CREATE_VERSION,
+                create_version=securetar_version,
                 password=self._password,
             )
             try:

--- a/supervisor/backups/const.py
+++ b/supervisor/backups/const.py
@@ -3,10 +3,14 @@
 from enum import StrEnum
 from typing import Literal
 
+from awesomeversion import AwesomeVersion
+
 from ..mounts.mount import Mount
 
 BUF_SIZE = 2**20 * 4  # 4MB
 SECURETAR_CREATE_VERSION = 2
+SECURETAR_V3_CREATE_VERSION = 3
+CORE_SECURETAR_V3_MIN_VERSION: AwesomeVersion = AwesomeVersion("2026.3.0")
 DEFAULT_FREEZE_TIMEOUT = 600
 LOCATION_CLOUD_BACKUP = ".cloud_backup"
 


### PR DESCRIPTION
## Proposed change

Use securetar v3 for creating backups when Home Assistant Core is 2026.3.0
or newer. Falls back to v2 for older Core versions.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] CLI updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
