### PR TITLE
Call Subscribe on systemd D-Bus connect to enable signals

### DIFF
--- a/supervisor/dbus/systemd.py
+++ b/supervisor/dbus/systemd.py
@@ -112,6 +112,12 @@ class Systemd(DBusInterfaceProxy):
                 "No systemd support on the host. Host control has been disabled."
             )
 
+        if self.is_connected:
+            try:
+                await self.connected_dbus.Manager.call("subscribe")
+            except DBusError:
+                _LOGGER.warning("Could not subscribe to systemd signals")
+
     @property
     @dbus_property
     def startup_time(self) -> float:

--- a/tests/dbus/test_systemd.py
+++ b/tests/dbus/test_systemd.py
@@ -32,6 +32,18 @@ async def test_dbus_systemd_info(dbus_session_bus: MessageBus):
     assert systemd.startup_time == 45.304696
 
 
+async def test_subscribe_on_connect(
+    systemd_service: SystemdService, dbus_session_bus: MessageBus
+):
+    """Test that Subscribe is called on connect to enable signal emission."""
+    systemd_service.Subscribe.calls.clear()
+    systemd = Systemd()
+
+    await systemd.connect(dbus_session_bus)
+
+    assert systemd_service.Subscribe.calls == [()]
+
+
 async def test_reboot(systemd_service: SystemdService, dbus_session_bus: MessageBus):
     """Test reboot."""
     systemd_service.Reboot.calls.clear()

--- a/tests/dbus_service_mocks/systemd.py
+++ b/tests/dbus_service_mocks/systemd.py
@@ -657,6 +657,10 @@ class Systemd(DBusServiceMock):
         """Power off host computer."""
 
     @dbus_method()
+    def Subscribe(self) -> None:
+        """Subscribe to systemd signals."""
+
+    @dbus_method()
     def StartUnit(self, name: "s", mode: "s") -> "o":
         """Start a service unit."""
         if self.mock_systemd_unit:


### PR DESCRIPTION
## Proposed change

Call `Subscribe()` on the systemd Manager D-Bus interface after connecting. systemd only emits bus signals (including `PropertiesChanged`) when at least one client has called `Subscribe()`. On regular HAOS systems, `systemd-logind` already does this, enabling signals for all bus clients. In environments without `systemd-logind` (such as the Supervisor devcontainer running systemd), no signals are emitted, causing e.g. the firewall gateway unit wait to time out.

Explicitly subscribing has no downsides and makes it clear that the Supervisor relies on these signals. There is no need to call `Unsubscribe()` as systemd automatically tracks clients and stops emitting signals when all subscribers disconnect from the bus.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
