### PR TITLE
Fix build workflow by hardcoding architectures matrix

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -38,6 +38,7 @@ env:
   CRANE_SHA256: "8ef3564d264e6b5ca93f7b7f5652704c4dd29d33935aff6947dd5adefd05953e"
   BUILD_NAME: supervisor
   BUILD_TYPE: supervisor
+  ARCHITECTURES: '["amd64", "aarch64"]'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -48,7 +49,7 @@ jobs:
     name: Initialize build
     runs-on: ubuntu-latest
     outputs:
-      architectures: ${{ steps.info.outputs.architectures }}
+      architectures: ${{ env.ARCHITECTURES }}
       version: ${{ steps.version.outputs.version }}
       channel: ${{ steps.version.outputs.channel }}
       publish: ${{ steps.version.outputs.publish }}
@@ -58,10 +59,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
-      - name: Get information
-        id: info
-        uses: home-assistant/actions/helpers/info@master
 
       - name: Get version
         id: version


### PR DESCRIPTION
## Proposed change

The migration to new builder actions in #6653 removed `build.yaml`, which was the source of the architectures matrix via the `home-assistant/actions/helpers/info` action. Without it, the `architectures` output is empty and the build job fails with:

> Error when evaluating 'strategy' for job 'build'. .github/workflows/builder.yml (Line: 102, Col: 15): Matrix vector 'arch' does not contain any values

This PR removes the `info` action step and hardcodes the architecture matrix to `["amd64", "aarch64"]`. The new builder actions don't resolve architectures either (they expect them as input), so there is no dynamic source to replace `build.yaml` with.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6653
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
