### PR TITLE
Remove unused requests dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ orjson==3.11.7
 pulsectl==24.12.0
 pyudev==0.24.4
 PyYAML==6.0.3
-requests==2.33.0
 securetar==2026.2.0
 sentry-sdk==2.56.0
 setuptools==82.0.1

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -11,5 +11,4 @@ pytest==9.0.2
 ruff==0.15.7
 time-machine==3.2.0
 types-pyyaml==6.0.12.20250915
-types-requests==2.32.4.20260324
 urllib3==2.6.3

--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -16,7 +16,6 @@ import aiodocker
 import aiohttp
 from awesomeversion import AwesomeVersion
 from awesomeversion.strategy import AwesomeVersionStrategy
-import requests
 
 from ..const import (
     ATTR_PASSWORD,
@@ -34,7 +33,6 @@ from ..exceptions import (
     DockerHubRateLimitExceeded,
     DockerJobError,
     DockerNotFound,
-    DockerRequestError,
 )
 from ..jobs.const import JOB_GROUP_DOCKER_INTERFACE, JobConcurrency
 from ..jobs.decorator import Job
@@ -328,7 +326,7 @@ class DockerInterface(JobGroup, ABC):
 
     async def exists(self) -> bool:
         """Return True if Docker image exists in local repository."""
-        with suppress(aiodocker.DockerError, requests.RequestException):
+        with suppress(aiodocker.DockerError):
             await self.sys_docker.images.inspect(f"{self.image}:{self.version!s}")
             return True
         return False
@@ -343,10 +341,6 @@ class DockerInterface(JobGroup, ABC):
                 return None
             raise DockerAPIError(
                 f"Docker API error occurred while getting container information: {err!s}"
-            ) from err
-        except requests.RequestException as err:
-            raise DockerRequestError(
-                f"Error communicating with Docker to get container information: {err!s}"
             ) from err
 
     async def is_running(self) -> bool:
@@ -368,7 +362,7 @@ class DockerInterface(JobGroup, ABC):
         self, version: AwesomeVersion, *, skip_state_event_if_down: bool = False
     ) -> None:
         """Attach to running Docker container."""
-        with suppress(aiodocker.DockerError, requests.RequestException):
+        with suppress(aiodocker.DockerError):
             docker_container = await self.sys_docker.containers.get(self.name)
             self._meta = await docker_container.show()
             self.sys_docker.monitor.watch_container(self._meta)
@@ -386,7 +380,7 @@ class DockerInterface(JobGroup, ABC):
                     ),
                 )
 
-        with suppress(aiodocker.DockerError, requests.RequestException):
+        with suppress(aiodocker.DockerError):
             if not self._meta and self.image:
                 self._meta = await self.sys_docker.images.inspect(
                     f"{self.image}:{version!s}"
@@ -489,7 +483,7 @@ class DockerInterface(JobGroup, ABC):
         if self.image == expected_image:
             try:
                 image = await self.sys_docker.images.inspect(image_name)
-            except (aiodocker.DockerError, requests.RequestException) as err:
+            except aiodocker.DockerError as err:
                 raise DockerError(
                     f"Could not get {image_name} for check due to: {err!s}",
                     _LOGGER.error,
@@ -611,10 +605,6 @@ class DockerInterface(JobGroup, ABC):
         except (aiodocker.DockerError, ValueError) as err:
             raise DockerNotFound(
                 f"No version found for {self.image}", _LOGGER.info
-            ) from err
-        except requests.RequestException as err:
-            raise DockerRequestError(
-                f"Communication issues with dockerd on Host: {err}", _LOGGER.warning
             ) from err
 
         _LOGGER.info("Found %s versions: %s", self.image, available_version)

--- a/supervisor/docker/manager.py
+++ b/supervisor/docker/manager.py
@@ -23,7 +23,6 @@ from aiodocker.stream import Stream
 from aiodocker.types import JSONObject
 from aiohttp import ClientTimeout, UnixConnector
 from awesomeversion import AwesomeVersion, AwesomeVersionCompareException
-import requests
 
 from ..const import (
     ATTR_ENABLE_IPV6,
@@ -44,7 +43,6 @@ from ..exceptions import (
     DockerError,
     DockerNoSpaceOnDevice,
     DockerNotFound,
-    DockerRequestError,
 )
 from ..utils.common import FileConfiguration
 from ..validate import SCHEMA_DOCKER_CONFIG
@@ -589,12 +587,6 @@ class DockerAPI(CoreSysAttributes):
             raise DockerAPIError(
                 f"Can't start {name or container.id}: {err}", _LOGGER.error
             ) from err
-        except requests.RequestException as err:
-            raise DockerRequestError(
-                f"Dockerd connection issue for {name or container.id}: {err}",
-                _LOGGER.error,
-            ) from err
-
         return container
 
     async def run(
@@ -609,10 +601,6 @@ class DockerAPI(CoreSysAttributes):
         except aiodocker.DockerError as err:
             raise DockerAPIError(
                 f"Can't inspect started container {name}: {err}", _LOGGER.error
-            ) from err
-        except requests.RequestException as err:
-            raise DockerRequestError(
-                f"Dockerd connection issue for {name}: {err}", _LOGGER.error
             ) from err
 
         return container_attrs
@@ -992,7 +980,7 @@ class DockerAPI(CoreSysAttributes):
                 if err.status != HTTPStatus.NOT_FOUND:
                     raise
 
-        except (aiodocker.DockerError, requests.RequestException) as err:
+        except aiodocker.DockerError as err:
             raise DockerError(
                 f"Can't remove image {image}: {err}", _LOGGER.warning
             ) from err
@@ -1041,7 +1029,7 @@ class DockerAPI(CoreSysAttributes):
 
         try:
             return await self.images.inspect(docker_image_list[0])
-        except (aiodocker.DockerError, requests.RequestException) as err:
+        except aiodocker.DockerError as err:
             raise DockerError(
                 f"Could not inspect imported image due to: {err!s}", _LOGGER.error
             ) from err
@@ -1095,7 +1083,7 @@ class DockerAPI(CoreSysAttributes):
                         f"{current_image} not found for cleanup", _LOGGER.warning
                     ) from None
                 raise
-        except (aiodocker.DockerError, requests.RequestException) as err:
+        except aiodocker.DockerError as err:
             raise DockerError(
                 f"Can't get {current_image} for cleanup", _LOGGER.warning
             ) from err
@@ -1129,7 +1117,7 @@ class DockerAPI(CoreSysAttributes):
             images_list = await self.images.list(
                 filters=json.dumps({"reference": image_names})
             )
-        except (aiodocker.DockerError, requests.RequestException) as err:
+        except aiodocker.DockerError as err:
             raise DockerError(
                 f"Corrupt docker overlayfs found: {err}", _LOGGER.warning
             ) from err
@@ -1138,6 +1126,6 @@ class DockerAPI(CoreSysAttributes):
             if docker_image["Id"] in keep:
                 continue
 
-            with suppress(aiodocker.DockerError, requests.RequestException):
+            with suppress(aiodocker.DockerError):
                 _LOGGER.info("Cleanup images: %s", docker_image["RepoTags"])
                 await self.images.delete(docker_image["Id"], force=True)

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -859,10 +859,6 @@ class DockerAPIError(DockerError):
     """Docker API error."""
 
 
-class DockerRequestError(DockerError):
-    """Dockerd OS issues."""
-
-
 class DockerTrustError(DockerError):
     """Raise if images are not trusted."""
 


### PR DESCRIPTION
## Proposed change

Remove the `requests` dependency from Supervisor. This is a leftover from the docker-py era — aiodocker uses aiohttp as its HTTP transport and wraps connection errors into `aiodocker.DockerError`, so `requests.RequestException` was never raised. All related dead exception handling code and the unused `DockerRequestError` exception class have been removed.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
