### PR TITLE
Remove CLI command hint from unknown error messages

### DIFF
--- a/supervisor/api/utils.py
+++ b/supervisor/api/utils.py
@@ -148,7 +148,7 @@ def api_return_error(
         if check_exception_chain(error, DockerAPIError):
             message = format_message(message)
     if not message:
-        message = "Unknown error, see supervisor"
+        message = "Unknown error, see Supervisor logs"
 
     match error_type:
         case const.CONTENT_TYPE_TEXT:

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -120,7 +120,7 @@ class APIUnknownSupervisorError(APIError):
     ) -> None:
         """Initialize exception."""
         self.message_template = (
-            f"{self.message_template}. Check supervisor logs for details"
+            f"{self.message_template}. Check Supervisor logs for details"
         )
         super().__init__(None, logger, job_id=job_id)
 

--- a/supervisor/jobs/__init__.py
+++ b/supervisor/jobs/__init__.py
@@ -98,7 +98,7 @@ class SupervisorJobError:
     """Representation of an error occurring during a supervisor job."""
 
     type_: type[HassioError] = HassioError
-    message: str = "Unknown error, see supervisor logs"
+    message: str = "Unknown error, see Supervisor logs"
     stage: str | None = None
     error_key: str | None = None
     extra_fields: dict[str, Any] | None = None

--- a/tests/api/test_addons.py
+++ b/tests/api/test_addons.py
@@ -599,7 +599,7 @@ async def test_addon_start_options_error(
         body = await resp.json()
         assert (
             body["message"]
-            == "An unknown error occurred with addon local_example. Check supervisor logs for details"
+            == "An unknown error occurred with addon local_example. Check Supervisor logs for details"
         )
         assert body["error_key"] == "addon_unknown_error"
         assert body["extra_fields"] == {
@@ -681,7 +681,7 @@ async def test_addon_rebuild_fails_error(api_client: TestClient, coresys: CoreSy
     body = await resp.json()
     assert (
         body["message"]
-        == "An unknown error occurred while trying to build the image for addon local_ssh. Check supervisor logs for details"
+        == "An unknown error occurred while trying to build the image for addon local_ssh. Check Supervisor logs for details"
     )
     assert body["error_key"] == "addon_build_failed_unknown_error"
     assert body["extra_fields"] == {

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -182,7 +182,7 @@ async def test_list_users_ws_error(
     result = await resp.json()
     assert result == {
         "result": "error",
-        "message": "Can't request listing users on Home Assistant. Check supervisor logs for details",
+        "message": "Can't request listing users on Home Assistant. Check Supervisor logs for details",
         "error_key": "auth_list_users_error",
     }
     assert "Can't request listing users on Home Assistant: fail" in caplog.text
@@ -373,7 +373,7 @@ async def test_auth_backend_login_failure(api_client: TestClient):
     body = await resp.json()
     assert (
         body["message"]
-        == "Unable to validate authentication details with Home Assistant. Check supervisor logs for details"
+        == "Unable to validate authentication details with Home Assistant. Check Supervisor logs for details"
     )
     assert body["error_key"] == "auth_home_assistant_api_validation_error"
     assert "extra_fields" not in body

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -198,7 +198,7 @@ async def test_api_store_repair_repository_git_error(
     }
     assert (
         result["message"]
-        == f"An unknown error occurred with addon repository {test_repository.slug}. Check supervisor logs for details"
+        == f"An unknown error occurred with addon repository {test_repository.slug}. Check Supervisor logs for details"
     )
 
 

--- a/tests/api/test_supervisor.py
+++ b/tests/api/test_supervisor.py
@@ -443,7 +443,7 @@ async def test_supervisor_api_stats_failure(
     body = await resp.json()
     assert (
         body["message"]
-        == "An unknown error occurred with Supervisor. Check supervisor logs for details"
+        == "An unknown error occurred with Supervisor. Check Supervisor logs for details"
     )
     assert body["error_key"] == "supervisor_unknown_error"
     assert "extra_fields" not in body

--- a/tests/jobs/test_job_manager.py
+++ b/tests/jobs/test_job_manager.py
@@ -198,7 +198,7 @@ async def test_notify_on_change(coresys: CoreSys, ha_ws_client: AsyncMock):
                         "errors": [
                             {
                                 "type": "HassioError",
-                                "message": "Unknown error, see supervisor logs",
+                                "message": "Unknown error, see Supervisor logs",
                                 "stage": "test",
                                 "error_key": None,
                                 "extra_fields": None,
@@ -228,7 +228,7 @@ async def test_notify_on_change(coresys: CoreSys, ha_ws_client: AsyncMock):
                     "errors": [
                         {
                             "type": "HassioError",
-                            "message": "Unknown error, see supervisor logs",
+                            "message": "Unknown error, see Supervisor logs",
                             "stage": "test",
                             "error_key": None,
                             "extra_fields": None,


### PR DESCRIPTION
## Proposed change

Remove the `(check with 'ha supervisor logs')` CLI command hint from unknown error messages.

Since #6303 introduced specific error messages for many common cases (e.g. wrong username now tells you exactly what's wrong and suggests `ha auth list`), the generic CLI hint in unknown error messages is no
longer as useful. The "Check supervisor logs for details" rider is kept — only the parenthesized command hint is removed.

Closes #6250 rationale — the original pain point (users not knowing where to look after a vague error) is largely addressed by the specific error messages.

This effectively reverts #6250.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- Removes `MESSAGE_CHECK_SUPERVISOR_LOGS` and `EXTRA_FIELDS_LOGS_COMMAND`
  constants from `exceptions.py`
- Simplifies `APIUnknownSupervisorError.__init__` to just append the
  plain text rider without extra fields
- Updates fallback messages in `api/utils.py` and `jobs/__init__.py`

## Checklist

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.