### PR TITLE
Prevent Sentry event feedback loop from warning handler

### DIFF
--- a/supervisor/bootstrap.py
+++ b/supervisor/bootstrap.py
@@ -7,6 +7,7 @@ from importlib import import_module
 import logging
 import os
 import signal
+import threading
 import warnings
 
 from colorlog import ColoredFormatter
@@ -235,6 +236,11 @@ def warning_handler(message, category, filename, lineno, file=None, line=None):
     """Warning handler which logs warnings using the logging module."""
     _LOGGER.warning("%s:%s: %s: %s", filename, lineno, category.__name__, message)
     if isinstance(message, Exception):
+        # Don't capture warnings originating from Sentry SDK threads to
+        # avoid a feedback loop: sending an event can trigger urllib3
+        # warnings which would be captured and sent as new events.
+        if threading.current_thread().name.startswith("sentry-sdk."):
+            return
         capture_exception(message)
 
 

--- a/tests/utils/test_sentry.py
+++ b/tests/utils/test_sentry.py
@@ -1,10 +1,12 @@
 """Unit tests for Sentry."""
 
+import threading
 from unittest.mock import patch
 
 import pytest
+from sentry_sdk.worker import BackgroundWorker
 
-from supervisor.bootstrap import initialize_coresys
+from supervisor.bootstrap import initialize_coresys, warning_handler
 
 
 @pytest.mark.usefixtures("supervisor_name", "docker")
@@ -16,3 +18,40 @@ async def test_sentry_disabled_by_default():
     ):
         await initialize_coresys()
         sentry_init.assert_not_called()
+
+
+def test_sentry_sdk_background_worker_thread_name():
+    """Test that the Sentry SDK background worker thread name starts with 'sentry-sdk.'.
+
+    The warning_handler in bootstrap.py skips capture_exception for warnings
+    originating from threads named 'sentry-sdk.*' to prevent a feedback loop.
+    This test ensures the SDK still uses the expected naming convention.
+    """
+    worker = BackgroundWorker()
+    worker.submit(lambda: None)
+    try:
+        assert worker._thread is not None
+        assert worker._thread.name.startswith("sentry-sdk.")
+    finally:
+        worker.kill()
+
+
+def test_warning_handler_suppresses_on_sentry_thread():
+    """Test that warning_handler does not call capture_exception on Sentry threads."""
+    with patch("supervisor.bootstrap.capture_exception") as mock_capture:
+        # Simulate being called from a Sentry SDK background thread
+        original_name = threading.current_thread().name
+        try:
+            threading.current_thread().name = "sentry-sdk.BackgroundWorker"
+            warning_handler(UserWarning("test"), UserWarning, "test.py", 1, None, None)
+            mock_capture.assert_not_called()
+        finally:
+            threading.current_thread().name = original_name
+
+
+def test_warning_handler_captures_on_main_thread():
+    """Test that warning_handler calls capture_exception on non-Sentry threads."""
+    with patch("supervisor.bootstrap.capture_exception") as mock_capture:
+        warning = UserWarning("test")
+        warning_handler(warning, UserWarning, "test.py", 1, None, None)
+        mock_capture.assert_called_once_with(warning)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The custom warning_handler sends warnings to Sentry via capture_exception. When the Sentry SDK's own HTTP transport triggers a warning (e.g. urllib3 InsecureRequestWarning due to broken CA certs), this creates a self-inducing feedback loop: the warning is captured, sent to Sentry, which triggers another warning, and so on.

Skip capture_exception for warnings originating from Sentry SDK background threads (identified by the "sentry-sdk." thread name prefix). Warnings are still logged normally via _LOGGER.warning.

A dedicated test validates that the SDK's BackgroundWorker thread uses the expected naming convention, so any future SDK change will be caught.


## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
