### PR TITLE
Handle add-on filesystem errors gracefully and reduce Sentry noise

### DIFF
--- a/supervisor/addons/addon.py
+++ b/supervisor/addons/addon.py
@@ -1682,8 +1682,9 @@ class App(AppModel):
         ]:
             await self._restart_after_problem(event.state)
 
-    def refresh_path_cache(self) -> Awaitable[None]:
+    async def refresh_path_cache(self) -> None:
         """Refresh cache of existing paths."""
         if self.is_detached or not self.app_store:
-            return super().refresh_path_cache()
-        return self.app_store.refresh_path_cache()
+            await super().refresh_path_cache()
+        else:
+            await self.app_store.refresh_path_cache()

--- a/supervisor/addons/model.py
+++ b/supervisor/addons/model.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from contextlib import suppress
 from datetime import datetime
 import logging
@@ -91,6 +91,7 @@ from ..const import (
 from ..coresys import CoreSys
 from ..docker.const import Capabilities
 from ..exceptions import (
+    AppFileReadError,
     AppNotSupportedArchitectureError,
     AppNotSupportedError,
     AppNotSupportedHomeAssistantVersionError,
@@ -682,9 +683,15 @@ class AppModel(JobGroup, ABC):
             # Return data
             return readme.read_text(encoding="utf-8", errors="replace")
 
-        return await self.sys_run_in_executor(read_readme)
+        try:
+            return await self.sys_run_in_executor(read_readme)
+        except OSError as err:
+            self.sys_resolution.check_oserror(err)
+            raise AppFileReadError(
+                _LOGGER.error, app=self.slug, error=str(err)
+            ) from err
 
-    def refresh_path_cache(self) -> Awaitable[None]:
+    async def refresh_path_cache(self) -> None:
         """Refresh cache of existing paths."""
 
         def check_paths():
@@ -693,7 +700,13 @@ class AppModel(JobGroup, ABC):
             self._path_changelog_exists = self.path_changelog.exists()
             self._path_documentation_exists = self.path_documentation.exists()
 
-        return self.sys_run_in_executor(check_paths)
+        try:
+            await self.sys_run_in_executor(check_paths)
+        except OSError as err:
+            self.sys_resolution.check_oserror(err)
+            raise AppFileReadError(
+                _LOGGER.error, app=self.slug, error=str(err)
+            ) from err
 
     def validate_availability(self) -> None:
         """Validate if app is available for current system."""

--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -185,17 +185,32 @@ class Core(CoreSysAttributes):
 
         # Execute each load task in secure context
         for setup_task in setup_loads:
+            unhealthy_before = self.sys_resolution.unhealthy.copy()
             try:
                 await setup_task
             except Exception as err:  # pylint: disable=broad-except
-                _LOGGER.critical(
-                    "Fatal error happening on load Task %s: %s",
-                    setup_task,
-                    err,
-                    exc_info=True,
-                )
+                # If the error already caused a new unhealthy reason to
+                # be set (e.g. via check_oserror), it was handled by the
+                # resolution system and the user has been notified. Skip
+                # capturing to Sentry in that case.
+                capture_exception = self.sys_resolution.unhealthy == unhealthy_before
+
                 self.sys_resolution.add_unhealthy_reason(UnhealthyReason.SETUP)
-                await async_capture_exception(err)
+
+                if capture_exception:
+                    _LOGGER.critical(
+                        "Fatal error happening on load Task %s: %s",
+                        setup_task,
+                        err,
+                        exc_info=True,
+                    )
+                    await async_capture_exception(err)
+                else:
+                    _LOGGER.error(
+                        "Error on load Task %s: %s",
+                        setup_task,
+                        err,
+                    )
 
     async def start(self) -> None:
         """Start Supervisor orchestration."""

--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -18,6 +18,7 @@ from .const import (
 from .coresys import CoreSys, CoreSysAttributes
 from .dbus.const import StopUnitMode, UnitActiveState
 from .exceptions import (
+    AppFileReadError,
     HassioError,
     HomeAssistantCrashError,
     HomeAssistantError,
@@ -185,32 +186,27 @@ class Core(CoreSysAttributes):
 
         # Execute each load task in secure context
         for setup_task in setup_loads:
-            unhealthy_before = self.sys_resolution.unhealthy.copy()
             try:
                 await setup_task
-            except Exception as err:  # pylint: disable=broad-except
-                # If the error already caused a new unhealthy reason to
-                # be set (e.g. via check_oserror), it was handled by the
-                # resolution system and the user has been notified. Skip
-                # capturing to Sentry in that case.
-                capture_exception = self.sys_resolution.unhealthy == unhealthy_before
-
+            except AppFileReadError as err:
+                # Already reported to the user via the resolution system
+                # (unhealthy reason set by check_oserror). Log without
+                # stack trace and skip Sentry capture to avoid noise.
+                _LOGGER.error(
+                    "Error on load Task %s: %s",
+                    setup_task,
+                    err,
+                )
                 self.sys_resolution.add_unhealthy_reason(UnhealthyReason.SETUP)
-
-                if capture_exception:
-                    _LOGGER.critical(
-                        "Fatal error happening on load Task %s: %s",
-                        setup_task,
-                        err,
-                        exc_info=True,
-                    )
-                    await async_capture_exception(err)
-                else:
-                    _LOGGER.error(
-                        "Error on load Task %s: %s",
-                        setup_task,
-                        err,
-                    )
+            except Exception as err:  # pylint: disable=broad-except
+                _LOGGER.critical(
+                    "Fatal error happening on load Task %s: %s",
+                    setup_task,
+                    err,
+                    exc_info=True,
+                )
+                self.sys_resolution.add_unhealthy_reason(UnhealthyReason.SETUP)
+                await async_capture_exception(err)
 
     async def start(self) -> None:
         """Start Supervisor orchestration."""

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -551,6 +551,26 @@ class AppBuildFailedUnknownError(AppsError, APIUnknownSupervisorError):
         super().__init__(logger)
 
 
+class AppFileReadError(AppsError, APIError):
+    """Raise when an app metadata file cannot be read due to a filesystem error."""
+
+    error_key = "addon_file_read_error"
+    message_template = (
+        "Could not read metadata for app {addon} due to a filesystem error: {error}"
+    )
+
+    def __init__(
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        app: str,
+        error: str,
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"addon": app, "error": error}
+        super().__init__(None, logger)
+
+
 class AppsJobError(AppsError, JobException):
     """Raise on job errors."""
 

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -25,6 +25,7 @@ from supervisor.docker.const import ContainerState
 from supervisor.docker.manager import CommandReturn, DockerAPI
 from supervisor.docker.monitor import DockerContainerStateEvent
 from supervisor.exceptions import (
+    AppFileReadError,
     AppPortConflict,
     AppPrePostBackupCommandReturnedError,
     AppsJobError,
@@ -35,7 +36,12 @@ from supervisor.exceptions import (
 )
 from supervisor.hardware.helper import HwHelper
 from supervisor.ingress import Ingress
-from supervisor.resolution.const import ContextType, IssueType, SuggestionType
+from supervisor.resolution.const import (
+    ContextType,
+    IssueType,
+    SuggestionType,
+    UnhealthyReason,
+)
 from supervisor.resolution.data import Issue
 from supervisor.utils.dt import utcnow
 
@@ -859,6 +865,54 @@ async def test_app_pulse_error(
 
         assert "can't write pulse/client.config" in caplog.text
         assert coresys.core.healthy is False
+
+
+@pytest.mark.usefixtures("tmp_supervisor_data")
+async def test_long_description_bad_message(coresys: CoreSys, install_app_example: App):
+    """Test long_description raises AppFileReadError and marks unhealthy on EBADMSG."""
+    err = OSError()
+    err.errno = errno.EBADMSG
+    with (
+        patch("supervisor.addons.model.Path.exists", side_effect=err),
+        pytest.raises(AppFileReadError),
+    ):
+        await install_app_example.long_description()
+
+    assert coresys.core.healthy is False
+    assert UnhealthyReason.OSERROR_BAD_MESSAGE in coresys.resolution.unhealthy
+
+
+@pytest.mark.usefixtures("tmp_supervisor_data")
+async def test_long_description_other_oserror(
+    coresys: CoreSys, install_app_example: App
+):
+    """Test long_description raises AppFileReadError without unhealthy on other OSError."""
+    err = OSError()
+    err.errno = errno.EIO
+    with (
+        patch("supervisor.addons.model.Path.exists", side_effect=err),
+        pytest.raises(AppFileReadError),
+    ):
+        await install_app_example.long_description()
+
+    assert coresys.core.healthy is True
+
+
+@pytest.mark.usefixtures("tmp_supervisor_data")
+async def test_refresh_path_cache_bad_message(
+    coresys: CoreSys, install_app_example: App
+):
+    """Test refresh_path_cache raises AppFileReadError and marks unhealthy on EBADMSG."""
+    err = OSError()
+    err.errno = errno.EBADMSG
+    with (
+        patch("supervisor.addons.model.Path.exists", side_effect=err),
+        pytest.raises(AppFileReadError),
+    ):
+        await install_app_example.refresh_path_cache()
+
+    assert coresys.core.healthy is False
+    assert UnhealthyReason.OSERROR_BAD_MESSAGE in coresys.resolution.unhealthy
 
 
 @pytest.mark.usefixtures("coresys")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,10 +10,10 @@ import pytest
 
 from supervisor.const import CoreState
 from supervisor.coresys import CoreSys
-from supervisor.exceptions import WhoamiSSLError
+from supervisor.exceptions import AppFileReadError, HassioError, WhoamiSSLError
 from supervisor.host.control import SystemControl
 from supervisor.host.info import InfoCenter
-from supervisor.resolution.const import IssueType, SuggestionType
+from supervisor.resolution.const import IssueType, SuggestionType, UnhealthyReason
 from supervisor.supervisor import Supervisor
 from supervisor.utils.whoami import WhoamiData
 
@@ -156,3 +156,78 @@ async def test_write_state_failure(
 
     assert "Can't update the Supervisor state" in caplog.text
     assert coresys.core.state == CoreState.RUNNING
+
+
+# Components whose load() method is awaited from Core.setup().
+_SETUP_LOAD_COMPONENTS = (
+    "api",
+    "hardware",
+    "dbus",
+    "host",
+    "os",
+    "mounts",
+    "docker",
+    "updater",
+    "plugins",
+    "homeassistant",
+    "arch",
+    "store",
+    "apps",
+    "backups",
+    "services",
+    "discovery",
+    "ingress",
+    "resolution",
+)
+
+
+@pytest.fixture
+def mocked_setup_loads(coresys: CoreSys):
+    """Replace all load() calls in Core.setup() with AsyncMock."""
+    with (
+        patch.object(coresys, "init_websession", new=AsyncMock()),
+        patch.object(Supervisor, "check_connectivity", new=AsyncMock()),
+        patch.object(coresys.core, "_adjust_system_datetime", new=AsyncMock()),
+    ):
+        patches = [
+            patch.object(getattr(coresys, attr), "load", new=AsyncMock())
+            for attr in _SETUP_LOAD_COMPONENTS
+        ]
+        for p in patches:
+            p.start()
+        try:
+            yield
+        finally:
+            for p in patches:
+                p.stop()
+
+
+@pytest.mark.usefixtures("mocked_setup_loads")
+async def test_setup_app_file_read_error_not_captured(
+    coresys: CoreSys, caplog: pytest.LogCaptureFixture
+):
+    """Test setup does not capture AppFileReadError to Sentry but marks unhealthy."""
+    coresys.apps.load.side_effect = AppFileReadError(
+        app="local_example", error="[Errno 74] Bad message"
+    )
+    with patch("supervisor.core.async_capture_exception") as capture_mock:
+        await coresys.core.setup()
+
+    capture_mock.assert_not_called()
+    assert "Fatal error happening on load Task" not in caplog.text
+    assert "Error on load Task" in caplog.text
+    assert UnhealthyReason.SETUP in coresys.resolution.unhealthy
+
+
+@pytest.mark.usefixtures("mocked_setup_loads")
+async def test_setup_unhandled_exception_captured(
+    coresys: CoreSys, caplog: pytest.LogCaptureFixture
+):
+    """Test setup captures unhandled exceptions to Sentry and marks unhealthy."""
+    coresys.apps.load.side_effect = HassioError("boom")
+    with patch("supervisor.core.async_capture_exception") as capture_mock:
+        await coresys.core.setup()
+
+    capture_mock.assert_called_once()
+    assert "Fatal error happening on load Task" in caplog.text
+    assert UnhealthyReason.SETUP in coresys.resolution.unhealthy


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Handle `OSError` (e.g. errno 74 / EBADMSG) in add-on metadata reads (`long_description`, `refresh_path_cache`) gracefully instead of letting them bubble up as unhandled exceptions. A new translatable `AddonFileReadError` is raised after calling `check_oserror()` to mark the system unhealthy, giving API consumers a proper error response.

Additionally, in `core.py` `setup()`, skip Sentry reporting when the resolution system has already handled the error (detected by checking if a new unhealthy reason was added during task execution). This avoids flooding Sentry with filesystem corruption errors that aren't actionable for developers -- the user is already notified via the resolution system. The log level is also lowered from `critical` (which triggers Sentry via `LoggingIntegration`) to `error` without stack trace in that case.

SUPERVISOR-BC6 alone accounts for 548K Sentry events from a single user with a corrupt filesystem.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes SUPERVISOR-BC6, SUPERVISOR-BZJ
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] CLI updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
