### PR TITLE
Fix WebSocket handshake error handling and unnecessary token refresh

### DIFF
--- a/supervisor/homeassistant/api.py
+++ b/supervisor/homeassistant/api.py
@@ -219,7 +219,7 @@ class HomeAssistantAPI(CoreSysAttributes):
                     self._access_token,
                     max_msg_size=max_msg_size,
                 )
-            except HomeAssistantAPIError:
+            except HomeAssistantAuthError:
                 self._access_token = None
                 if attempt == 2:
                     raise

--- a/supervisor/homeassistant/api.py
+++ b/supervisor/homeassistant/api.py
@@ -213,7 +213,7 @@ class HomeAssistantAPI(CoreSysAttributes):
                 return await WSClient.connect_with_auth(
                     self.session, self.ws_url, self._access_token
                 )
-            except HomeAssistantAPIError:
+            except HomeAssistantAuthError:
                 self._access_token = None
                 if attempt == 2:
                     raise

--- a/supervisor/homeassistant/websocket.py
+++ b/supervisor/homeassistant/websocket.py
@@ -185,7 +185,7 @@ class WSClient:
             TimeoutError,
         ) as err:
             await client.close()
-            raise HomeAssistantAPIError(
+            raise HomeAssistantWSConnectionError(
                 f"Unexpected error during WebSocket handshake: {err}"
             ) from err
 
@@ -234,7 +234,7 @@ class WSClient:
             TimeoutError,
         ) as err:
             await client.close()
-            raise HomeAssistantAPIError(
+            raise HomeAssistantWSConnectionError(
                 f"Unexpected error during WebSocket handshake: {err}"
             ) from err
 
@@ -309,7 +309,7 @@ class HomeAssistantWebSocket(CoreSysAttributes):
         try:
             await self._ensure_connected()
         except HomeAssistantWSError as err:
-            _LOGGER.debug("Can't send WebSocket command: %s", err)
+            _LOGGER.warning("Can't send WebSocket command: %s", err)
             return
 
         # _ensure_connected guarantees self.client is set

--- a/supervisor/homeassistant/websocket.py
+++ b/supervisor/homeassistant/websocket.py
@@ -188,7 +188,7 @@ class WSClient:
             TimeoutError,
         ) as err:
             await client.close()
-            raise HomeAssistantAPIError(
+            raise HomeAssistantWSConnectionError(
                 f"Unexpected error during WebSocket handshake: {err}"
             ) from err
 
@@ -235,7 +235,7 @@ class WSClient:
             TimeoutError,
         ) as err:
             await client.close()
-            raise HomeAssistantAPIError(
+            raise HomeAssistantWSConnectionError(
                 f"Unexpected error during WebSocket handshake: {err}"
             ) from err
 
@@ -310,7 +310,7 @@ class HomeAssistantWebSocket(CoreSysAttributes):
         try:
             await self._ensure_connected()
         except HomeAssistantWSError as err:
-            _LOGGER.debug("Can't send WebSocket command: %s", err)
+            _LOGGER.warning("Can't send WebSocket command: %s", err)
             return
 
         # _ensure_connected guarantees self.client is set


### PR DESCRIPTION
## Proposed change

Fix two issues with WebSocket error handling when Core's WebSocket
endpoint isn't ready (e.g. when the `http` integration fails to load):

1. **Unhandled exception:** `connect_with_auth`/`connect` raised
   `HomeAssistantAPIError` for handshake failures, but fire-and-forget
   callers only catch `HomeAssistantWSError` (a subclass, not a parent).
   This caused "Task exception was never retrieved" errors. Fixed by
   raising `HomeAssistantWSConnectionError` instead, which is the
   correct exception for connection-phase failures.

2. **Unnecessary token refresh spam:** The retry loop in
   `connect_websocket` caught the broad `HomeAssistantAPIError`, so
   connection errors (not just auth failures) triggered token
   invalidation and refresh. This caused "Updated Home Assistant API
   token" to be logged on every failed WebSocket message. Fixed by
   narrowing the catch to `HomeAssistantAuthError`.

Also raised the log level for failed fire-and-forget WebSocket commands
from debug to warning for better visibility.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] CLI updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
