### PR TITLE
Fix Core update rollback: delay image cleanup and fix missing rollback path

### DIFF
--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -321,8 +321,6 @@ class HomeAssistantCore(JobGroup):
 
             # Successfull - last step
             await self.sys_homeassistant.save_data()
-            with suppress(DockerError):
-                await self.instance.cleanup(old_image=old_image)
 
         # Update Home Assistant
         with suppress(HomeAssistantError):
@@ -347,6 +345,9 @@ class HomeAssistantCore(JobGroup):
                 )
                 self._error_state = True
             else:
+                # Health checks passed, clean up old image
+                with suppress(DockerError):
+                    await self.instance.cleanup(old_image=old_image)
                 return
 
         # Update going wrong, revert it

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -330,9 +330,8 @@ class HomeAssistantCore(JobGroup):
             try:
                 data = await self.sys_homeassistant.api.get_config()
             except HomeAssistantError:
-                # The API stoped responding between the up checks an now
+                # The API stopped responding between the update and now
                 self._error_state = True
-                return
 
             # Verify that the frontend is loaded
             if "frontend" not in data.get("components", []):

--- a/tests/api/test_homeassistant.py
+++ b/tests/api/test_homeassistant.py
@@ -458,10 +458,12 @@ async def test_update_frontend_check_success(api_client: TestClient, coresys: Co
             HomeAssistantAPI, "get_config", return_value={"components": ["frontend"]}
         ),
         patch.object(HomeAssistantAPI, "check_frontend_available", return_value=True),
+        patch.object(DockerInterface, "cleanup") as mock_cleanup,
     ):
         resp = await api_client.post("/core/update", json={"version": "2025.8.3"})
 
     assert resp.status == 200
+    mock_cleanup.assert_called_once()
 
 
 async def test_update_frontend_check_fails_triggers_rollback(
@@ -498,6 +500,7 @@ async def test_update_frontend_check_fails_triggers_rollback(
             HomeAssistantAPI, "get_config", return_value={"components": ["frontend"]}
         ),
         patch.object(HomeAssistantAPI, "check_frontend_available", return_value=False),
+        patch.object(DockerInterface, "cleanup") as mock_cleanup,
     ):
         resp = await api_client.post("/core/update", json={"version": "2025.8.3"})
 
@@ -511,3 +514,5 @@ async def test_update_frontend_check_fails_triggers_rollback(
     assert (
         Issue(IssueType.UPDATE_ROLLBACK, ContextType.CORE) in coresys.resolution.issues
     )
+    # Old image should not be cleaned up so rollback doesn't need to re-download
+    mock_cleanup.assert_not_called()


### PR DESCRIPTION
## Proposed change

Fix two issues with the Core update rollback flow:

1. **Old image cleaned up too early:** The previous version's Docker
   image was removed inside `_update()` before the post-update health
   checks (frontend loaded and accessible). If the health checks failed
   and a rollback was triggered, the old image had to be re-downloaded.
   Moved the cleanup to after health checks pass.

2. **Missing rollback when `get_config` fails:** When `get_config()`
   raised `HomeAssistantError` after the update, the code set
   `error_state = True` but immediately returned, skipping the rollback
   block. The other health check failure paths correctly fall through to
   the rollback logic; this was the only one that didn't.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] CLI updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
