### PR TITLE
Drop wheel from build-system.requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=82.0.0", "wheel~=0.46.1"]
+requires = ["setuptools~=82.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Proposed change

Drop `wheel` from `[build-system].requires` in `pyproject.toml`.

Since setuptools 70.1 the `bdist_wheel` command is implemented inside setuptools itself (`wheel.bdist_wheel` is just a deprecated alias). With `setuptools~=82.0.0` pinned, the standalone `wheel` package is no longer required to build Supervisor — including the editable install used inside the container (`uv pip install -e ./supervisor`). Supervisor is also not published as a wheel anywhere, so `wheel` really has no job to do here.

Dropping it also avoids unnecessary churn: the `home-assistant/wheels` musllinux index is only refreshed on merges to `main`, so a dependabot bump against `wheel` (e.g. #6729) fails to build PRs because the requested version isn't available on that index yet, and `uv` refuses to fall through to PyPI for a package already found on the primary index.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: supersedes #6729
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
