### PR TITLE
Always pass BUILD_FROM build arg for app builds

### DIFF
--- a/supervisor/addons/build.py
+++ b/supervisor/addons/build.py
@@ -121,11 +121,11 @@ class AppBuild(CoreSysAttributes):
         return self.sys_arch.match([self.app.arch])
 
     @property
-    def base_image(self) -> str | None:
-        """Return base image for this app, or None to use Dockerfile default."""
-        # No build config (otherwise default is coerced when reading the config)
+    def base_image(self) -> str:
+        """Return base image for this app."""
+        # No build config - use default base image for the architecture
         if not self._build_config.get(ATTR_BUILD_FROM):
-            return None
+            return f"ghcr.io/home-assistant/{self.arch!s}-base:latest"
 
         # Single base image in build config
         if isinstance(self._build_config[ATTR_BUILD_FROM], str):
@@ -249,13 +249,11 @@ class AppBuild(CoreSysAttributes):
             build_cmd.extend(["--label", f"{key}={value}"])
 
         build_args = {
+            "BUILD_FROM": self.base_image,
             "BUILD_VERSION": version,
             "BUILD_ARCH": self.arch,
             **self.additional_args,
         }
-
-        if self.base_image is not None:
-            build_args["BUILD_FROM"] = self.base_image
 
         for key, value in build_args.items():
             build_cmd.extend(["--build-arg", f"{key}={value}"])

--- a/tests/addons/test_build.py
+++ b/tests/addons/test_build.py
@@ -23,6 +23,16 @@ def _is_build_arg_in_command(command: list[str], arg_name: str) -> bool:
     return f"--build-arg {arg_name}=" in " ".join(command)
 
 
+def _get_build_arg_value(command: list[str], arg_name: str) -> str | None:
+    """Get the value of a build arg from docker command."""
+    prefix = f"{arg_name}="
+    for i, part in enumerate(command):
+        if part == "--build-arg" and i + 1 < len(command):
+            if command[i + 1].startswith(prefix):
+                return command[i + 1][len(prefix) :]
+    return None
+
+
 def _is_label_in_command(
     command: list[str], label_name: str, label_value: str = ""
 ) -> bool:
@@ -284,12 +294,12 @@ async def test_no_build_file_no_deprecation_warning(
     assert "uses build.yaml which is deprecated" not in caplog.text
 
 
-async def test_no_build_yaml_base_image_none(
+async def test_no_build_yaml_base_image_default(
     coresys: CoreSys, install_app_ssh: App, tmp_path: Path
 ):
-    """Test base_image is None when no build file exists."""
+    """Test base_image returns default when no build file exists."""
     dockerfile = tmp_path / "Dockerfile"
-    dockerfile.write_text("ARG BUILD_FROM=ghcr.io/home-assistant/base:latest\n")
+    dockerfile.write_text("ARG BUILD_FROM\nFROM ${BUILD_FROM}\n")
 
     with patch.object(
         type(install_app_ssh),
@@ -297,15 +307,15 @@ async def test_no_build_yaml_base_image_none(
         new=PropertyMock(return_value=tmp_path),
     ):
         build = await AppBuild.create(coresys, install_app_ssh)
-        assert build.base_image is None
+        assert build.base_image == "ghcr.io/home-assistant/amd64-base:latest"
 
 
-async def test_no_build_yaml_no_build_from_arg(
+async def test_no_build_yaml_default_build_from_arg(
     coresys: CoreSys, install_app_ssh: App, tmp_path: Path
 ):
-    """Test BUILD_FROM is not in docker args when no build file exists."""
+    """Test BUILD_FROM uses default base image when no build file exists."""
     dockerfile = tmp_path / "Dockerfile"
-    dockerfile.write_text("ARG BUILD_FROM=ghcr.io/home-assistant/base:latest\n")
+    dockerfile.write_text("ARG BUILD_FROM\nFROM ${BUILD_FROM}\n")
 
     with (
         patch.object(
@@ -330,7 +340,10 @@ async def test_no_build_yaml_no_build_from_arg(
             build.get_docker_args, AwesomeVersion("1.0.0"), "test-image:1.0.0", None
         )
 
-    assert not _is_build_arg_in_command(args["command"], "BUILD_FROM")
+    assert _is_build_arg_in_command(args["command"], "BUILD_FROM")
+    assert _get_build_arg_value(args["command"], "BUILD_FROM") == (
+        "ghcr.io/home-assistant/amd64-base:latest"
+    )
     assert _is_build_arg_in_command(args["command"], "BUILD_VERSION")
     assert _is_build_arg_in_command(args["command"], "BUILD_ARCH")
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

#6694 made `build.yaml` optional for local app builds, but stopped passing the `BUILD_FROM` build arg when no build config file exists. This broke apps whose Dockerfiles use `ARG BUILD_FROM` without a default value (e.g. `FROM ${BUILD_FROM}`), as the variable resolves to empty and Docker rejects the build.

This PR restores the previous behavior: `BUILD_FROM` is always passed as a build arg, defaulting to the architecture-specific base image (`ghcr.io/home-assistant/{arch}-base:latest`) when no `build.yaml`/`build.json` is present.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
