### PR TITLE
Use dbus-broker instead of dbus-daemon in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -364,7 +364,7 @@ jobs:
       - name: Install additional system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libpulse0 libudev1 dbus-daemon
+          sudo apt-get install -y --no-install-recommends libpulse0 libudev1 dbus-broker
       - name: Register Python problem matcher
         run: |
           echo "::add-matcher::.github/workflows/matchers/python.json"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,11 @@
 import asyncio
 from collections.abc import AsyncGenerator, Generator
 from datetime import datetime
+import os
 from pathlib import Path
+import socket
 import subprocess
+import time
 from unittest.mock import AsyncMock, MagicMock, Mock, PropertyMock, patch
 from uuid import uuid4
 
@@ -261,22 +264,90 @@ async def docker() -> DockerAPI:
 
 
 @pytest.fixture(scope="session")
-def dbus_session() -> Generator[str]:
-    """Start a dbus session.
+def dbus_session(tmp_path_factory: pytest.TempPathFactory) -> Generator[str]:
+    """Start a dbus-broker session bus.
 
     Returns session address.
+
+    Unlike dbus-daemon, dbus-broker-launch has no --print-address and expects
+    its listener socket via the sd_listen_fds protocol (fd 3, LISTEN_PID,
+    LISTEN_FDS). We create the unix socket ourselves, dup it to fd 3 in the
+    child via preexec_fn, and set LISTEN_PID to the post-fork pid. Readiness
+    is picked up via sd_notify(READY=1) on NOTIFY_SOCKET.
     """
-    with subprocess.Popen(
-        [
-            "dbus-daemon",
-            "--nofork",
-            "--print-address",
-            "--session",
-        ],
-        stdout=subprocess.PIPE,
-    ) as proc:
-        yield proc.stdout.readline().decode("utf-8").strip()
-        proc.terminate()
+    runtime_dir = tmp_path_factory.mktemp("dbus_session")
+    socket_path = runtime_dir / "bus"
+    notify_path = runtime_dir / "notify"
+    config_path = runtime_dir / "bus.conf"
+    stderr_path = runtime_dir / "broker.log"
+    config_path.write_text(
+        f"""<?xml version="1.0"?>
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <type>session</type>
+  <listen>unix:path={socket_path}</listen>
+  <policy context="default">
+    <allow user="*"/>
+    <allow send_destination="*"/>
+    <allow receive_sender="*"/>
+    <allow own="*"/>
+  </policy>
+</busconfig>
+"""
+    )
+
+    listen_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listen_sock.bind(str(socket_path))
+    listen_sock.listen(16)
+
+    notify_sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    notify_sock.bind(str(notify_path))
+
+    listen_fd = listen_sock.fileno()
+
+    def _preexec() -> None:
+        # Move the listener to fd 3 where sd_listen_fds expects it, and set
+        # the sd_listen_fds / sd_notify env vars. These are set here (not via
+        # env= on Popen) because LISTEN_PID must match the post-fork pid.
+        os.dup2(listen_fd, 3)
+        os.environ["LISTEN_PID"] = str(os.getpid())
+        os.environ["LISTEN_FDS"] = "1"
+        os.environ["NOTIFY_SOCKET"] = str(notify_path)
+
+    with (
+        stderr_path.open("wb") as stderr_file,
+        subprocess.Popen(
+            ["dbus-broker-launch", "--config-file", str(config_path)],
+            # Include fd 3 so Python's post-fork fd cleanup doesn't close the
+            # dup2'd copy before exec.
+            pass_fds=(listen_fd, 3),
+            preexec_fn=_preexec,  # noqa: PLW1509 — session-scoped, pre-threads
+            stderr=stderr_file,
+        ) as proc,
+    ):
+        listen_sock.close()
+        try:
+            # Block until the launcher reports READY=1.
+            notify_sock.settimeout(0.5)
+            deadline = time.monotonic() + 10
+            while True:
+                if proc.poll() is not None:
+                    raise RuntimeError(
+                        f"dbus-broker-launch exited with {proc.returncode} "
+                        f"before readiness: {stderr_path.read_text()}"
+                    )
+                if time.monotonic() > deadline:
+                    raise RuntimeError("dbus-broker-launch readiness timed out")
+                try:
+                    if b"READY=1" in notify_sock.recv(4096):
+                        break
+                except TimeoutError:
+                    continue
+            notify_sock.close()
+            yield f"unix:path={socket_path}"
+        finally:
+            proc.terminate()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -315,14 +315,15 @@ def dbus_session(tmp_path_factory: pytest.TempPathFactory) -> Generator[str]:
         os.environ["LISTEN_FDS"] = "1"
         os.environ["NOTIFY_SOCKET"] = str(notify_path)
 
+    # preexec_fn is safe: this session-scoped fixture runs before any threads.
     with (
         stderr_path.open("wb") as stderr_file,
-        subprocess.Popen(
+        subprocess.Popen(  # pylint: disable=subprocess-popen-preexec-fn
             ["dbus-broker-launch", "--config-file", str(config_path)],
             # Include fd 3 so Python's post-fork fd cleanup doesn't close the
             # dup2'd copy before exec.
             pass_fds=(listen_fd, 3),
-            preexec_fn=_preexec,  # noqa: PLW1509 — session-scoped, pre-threads
+            preexec_fn=_preexec,  # noqa: PLW1509
             stderr=stderr_file,
         ) as proc,
     ):


### PR DESCRIPTION
## Proposed change

Switch the test suite's session bus fixture from `dbus-daemon` to `dbus-broker`. `dbus-broker` is the modern D-Bus implementation used on Home Assistant OS, so tests now run against the same broker as production.

`dbus-broker-launch` has no `--print-address` equivalent, so the fixture creates the unix socket itself, passes it to the launcher via the `sd_listen_fds` protocol, and waits for `sd_notify(READY=1)` on `NOTIFY_SOCKET` before yielding the bus address.

Implementation notes:

- `LISTEN_PID` / `LISTEN_FDS` / `NOTIFY_SOCKET` are set inside `preexec_fn` rather than via `env=` on `Popen`, because `LISTEN_PID` must match the post-fork pid.
- Fd 3 is included in `pass_fds` so Python's post-fork fd cleanup preserves the `dup2`'d copy until `exec`.
- The bus config grants a permissive default policy (`send_destination="*"`, `receive_sender="*"`, `own="*"`) to match the behavior tests previously relied on with `dbus-daemon`.

The CI workflow still installs `dbus-daemon`; a follow-up will switch that to `dbus-broker`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
