### PR TITLE
Reuse `check_exception_chain` in Sentry filter, tighten its types

### DIFF
--- a/supervisor/misc/filter.py
+++ b/supervisor/misc/filter.py
@@ -13,6 +13,7 @@ from sentry_sdk.types import Event, Hint
 from ..const import DOCKER_IPV4_NETWORK_MASK, HEADER_TOKEN, HEADER_TOKEN_OLD, CoreState
 from ..coresys import CoreSys
 from ..exceptions import APITooManyRequests, AppConfigurationError
+from ..utils import check_exception_chain
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -46,21 +47,16 @@ def sanitize_url(url: str) -> str:
 
 def filter_data(coresys: CoreSys, event: Event, hint: Hint) -> Event | None:
     """Filter event data before sending to sentry."""
-    # Ignore some exceptions. Walk the __cause__ chain because rate-limit
-    # errors are often wrapped (e.g. DockerHubRateLimitExceeded wrapped in
-    # SupervisorUpdateError by supervisor.update()).
+    # Ignore some exceptions. check_exception_chain walks __cause__ so
+    # wrapped rate limits (e.g. DockerHubRateLimitExceeded wrapped in
+    # SupervisorUpdateError via `raise X from err`) are also dropped.
     if "exc_info" in hint:
         _, exc_value, _ = hint["exc_info"]
-        err: BaseException | None = exc_value
-        while err is not None:
-            if isinstance(err, (AppConfigurationError, APITooManyRequests)):
-                _LOGGER.debug(
-                    "Skipping Sentry event for %s: %s",
-                    type(err).__name__,
-                    exc_value,
-                )
-                return None
-            err = err.__cause__
+        if exc_value is not None and check_exception_chain(
+            exc_value, (AppConfigurationError, APITooManyRequests)
+        ):
+            _LOGGER.debug("Skipping Sentry event for %s", type(exc_value).__name__)
+            return None
 
     # Ignore issue if system is not supported or diagnostics is disabled
     if not coresys.config.diagnostics or not coresys.core.supported or coresys.dev:

--- a/supervisor/utils/__init__.py
+++ b/supervisor/utils/__init__.py
@@ -11,7 +11,6 @@ import re
 import socket
 import subprocess
 from tempfile import TemporaryDirectory
-from typing import Any
 
 from awesomeversion import AwesomeVersion
 
@@ -57,18 +56,27 @@ async def check_port(address: IPv4Address, port: int) -> bool:
     return True
 
 
-def check_exception_chain(err: BaseException, object_type: Any) -> bool:
-    """Check if exception chain include sub exception.
+def check_exception_chain(
+    err: BaseException,
+    object_type: type[BaseException] | tuple[type[BaseException], ...],
+) -> bool:
+    """Check if exception chain contains the target type.
 
-    It's not full recursive because we need mostly only access to the latest.
+    Walks the __cause__ chain, which Python sets when code explicitly chains
+    exceptions via `raise B() from a`. Our codebase consistently uses that
+    pattern for re-raises, so __cause__ reliably reflects the "caused by"
+    relationship we want to match. __context__ is not used because it can
+    include unrelated in-flight exceptions from surrounding except blocks.
+
+    Not fully recursive because we mostly only need access to the latest.
     """
-    if issubclass(type(err), object_type):
+    if isinstance(err, object_type):
         return True
 
-    if not err.__context__:
+    if err.__cause__ is None:
         return False
 
-    return check_exception_chain(err.__context__, object_type)
+    return check_exception_chain(err.__cause__, object_type)
 
 
 def get_message_from_exception_chain(err: BaseException) -> str:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Switch the Sentry noise filter in filter_data to call the existing check_exception_chain helper instead of an inline loop. One shared utility for "does the chain contain this type" matches what the reviewer suggested and removes a bit of duplication.

While touching check_exception_chain:

- Walk __cause__ instead of __context__. __cause__ is what Python sets when code uses `raise B() from a`, which is the explicit "caused by" signal we actually want to match. __context__ can also include unrelated in-flight exceptions from surrounding except blocks. Every existing call site in Supervisor uses `raise X from err`, which sets both attributes, so switching is behaviour-preserving for all current callers.
- Replace the `Any` type of object_type with `type[BaseException] | tuple[type[BaseException], ...]`, which is what isinstance/issubclass actually accept and lets mypy catch misuse at the call site.
- Replace `issubclass(type(err), object_type)` with `isinstance`, which is the idiomatic form and honours virtual subclasses.

Review feedback from #6732.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
