### PR TITLE
Do not log expected missing plugin containers as error during network creation

### DIFF
--- a/supervisor/docker/network.py
+++ b/supervisor/docker/network.py
@@ -24,7 +24,7 @@ from ..const import (
     OBSERVER_DOCKER_NAME,
     SUPERVISOR_DOCKER_NAME,
 )
-from ..exceptions import DockerError
+from ..exceptions import DockerError, DockerNotFound
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -290,6 +290,8 @@ class DockerNetwork:
         try:
             container = await self.docker.containers.get(name)
         except aiodocker.DockerError as err:
+            if err.status == HTTPStatus.NOT_FOUND:
+                raise DockerNotFound(f"Can't find {name}") from err
             raise DockerError(f"Can't find {name}: {err}", _LOGGER.error) from err
 
         if container.id not in self.containers:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

On fresh startup, when the Supervisor Docker network does not yet exist, `_create_supervisor_network()` creates the network and then re-attaches the known plugin containers (Supervisor, Observer, CLI, DNS, Audio) to it. At that point those plugin containers legitimately do not exist yet, so `docker.containers.get()` returns 404. The callers already wrap these calls in `with suppress(DockerError)`, but `attach_container_by_name()` passed `_LOGGER.error` into the `DockerError` constructor, which logged the message at ERROR level before the exception was suppressed. This produced noisy, misleading ERROR lines during normal fresh startup:

```
ERROR [supervisor.docker.network] Can't find hassio_observer: 404 Client Error ... No such container: hassio_observer
ERROR [supervisor.docker.network] Can't find hassio_cli: 404 Client Error ... No such container: hassio_cli
ERROR [supervisor.docker.network] Can't find hassio_dns: 404 Client Error ... No such container: hassio_dns
ERROR [supervisor.docker.network] Can't find hassio_audio: 404 Client Error ... No such container: hassio_audio
```

Convert 404 responses from `docker.containers.get()` into a `DockerNotFound` exception raised without logging. Other Docker API failures still raise `DockerError` and log at ERROR level as before. Since `DockerNotFound` is a subclass of `DockerError`, existing `suppress(DockerError)` call sites continue to swallow both.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
