### PR TITLE
Refactor Supervisor network reattach path

### DIFF
--- a/supervisor/const.py
+++ b/supervisor/const.py
@@ -14,6 +14,9 @@ SUPERVISOR_VERSION = "9999.09.9.dev9999"
 SERVER_SOFTWARE = f"HomeAssistantSupervisor/{SUPERVISOR_VERSION} aiohttp/{aiohttpversion} Python/{systemversion[0]}.{systemversion[1]}"
 
 DOCKER_PREFIX: str = "hassio"
+AUDIO_DOCKER_NAME: str = f"{DOCKER_PREFIX}_audio"
+CLI_DOCKER_NAME: str = f"{DOCKER_PREFIX}_cli"
+DNS_DOCKER_NAME: str = f"{DOCKER_PREFIX}_dns"
 OBSERVER_DOCKER_NAME: str = f"{DOCKER_PREFIX}_observer"
 SUPERVISOR_DOCKER_NAME: str = f"{DOCKER_PREFIX}_supervisor"
 

--- a/supervisor/docker/audio.py
+++ b/supervisor/docker/audio.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from ..const import DOCKER_CPU_RUNTIME_ALLOCATION
+from ..const import AUDIO_DOCKER_NAME, DOCKER_CPU_RUNTIME_ALLOCATION
 from ..coresys import CoreSysAttributes
 from ..exceptions import DockerJobError
 from ..hardware.const import PolicyGroup
@@ -23,8 +23,6 @@ from .const import (
 from .interface import DockerInterface
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
-
-AUDIO_DOCKER_NAME: str = "hassio_audio"
 
 
 class DockerAudio(DockerInterface, CoreSysAttributes):

--- a/supervisor/docker/cli.py
+++ b/supervisor/docker/cli.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from ..const import CLI_DOCKER_NAME
 from ..coresys import CoreSysAttributes
 from ..exceptions import DockerJobError
 from ..jobs.const import JobConcurrency
@@ -10,8 +11,6 @@ from .const import ENV_TIME, ENV_TOKEN
 from .interface import DockerInterface
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
-
-CLI_DOCKER_NAME: str = "hassio_cli"
 
 
 class DockerCli(DockerInterface, CoreSysAttributes):

--- a/supervisor/docker/dns.py
+++ b/supervisor/docker/dns.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from ..const import DNS_DOCKER_NAME
 from ..coresys import CoreSysAttributes
 from ..exceptions import DockerJobError
 from ..jobs.const import JobConcurrency
@@ -10,8 +11,6 @@ from .const import ENV_TIME, MOUNT_DBUS, DockerMount, MountType
 from .interface import DockerInterface
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
-
-DNS_DOCKER_NAME: str = "hassio_dns"
 
 
 class DockerDNS(DockerInterface, CoreSysAttributes):

--- a/supervisor/docker/network.py
+++ b/supervisor/docker/network.py
@@ -10,21 +10,18 @@ import aiodocker
 from aiodocker.networks import DockerNetwork as AiodockerNetwork
 
 from ..const import (
-    ATTR_AUDIO,
-    ATTR_CLI,
-    ATTR_DNS,
-    ATTR_OBSERVER,
-    ATTR_SUPERVISOR,
+    AUDIO_DOCKER_NAME,
+    CLI_DOCKER_NAME,
+    DNS_DOCKER_NAME,
     DOCKER_IPV4_NETWORK_MASK,
     DOCKER_IPV4_NETWORK_RANGE,
     DOCKER_IPV6_NETWORK_MASK,
     DOCKER_NETWORK,
     DOCKER_NETWORK_DRIVER,
-    DOCKER_PREFIX,
     OBSERVER_DOCKER_NAME,
     SUPERVISOR_DOCKER_NAME,
 )
-from ..exceptions import DockerError
+from ..exceptions import DockerError, DockerNotFound
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -218,24 +215,26 @@ class DockerNetwork:
 
         await self.reload()
 
-        with suppress(DockerError):
-            await self.attach_container_by_name(
-                SUPERVISOR_DOCKER_NAME, [ATTR_SUPERVISOR], self.supervisor
-            )
-
-        with suppress(DockerError):
-            await self.attach_container_by_name(
-                OBSERVER_DOCKER_NAME, [ATTR_OBSERVER], self.observer
-            )
-
-        for name, ip in (
-            (ATTR_CLI, self.cli),
-            (ATTR_DNS, self.dns),
-            (ATTR_AUDIO, self.audio),
+        # Reattach Supervisor-managed containers; missing ones are expected on fresh install.
+        for container_name, ipv4 in (
+            (SUPERVISOR_DOCKER_NAME, self.supervisor),
+            (OBSERVER_DOCKER_NAME, self.observer),
+            (CLI_DOCKER_NAME, self.cli),
+            (DNS_DOCKER_NAME, self.dns),
+            (AUDIO_DOCKER_NAME, self.audio),
         ):
-            with suppress(DockerError):
-                await self.attach_container_by_name(
-                    f"{DOCKER_PREFIX}_{name}", [name], ip
+            try:
+                await self.attach_container_by_name(container_name, ipv4=ipv4)
+            except DockerNotFound:
+                _LOGGER.debug(
+                    "No %s container to attach to Supervisor network",
+                    container_name,
+                )
+            except DockerError as err:
+                _LOGGER.error(
+                    "Can't attach %s to Supervisor network: %s",
+                    container_name,
+                    err,
                 )
 
     async def reload(self) -> None:
@@ -284,16 +283,18 @@ class DockerNetwork:
             ) from err
 
     async def attach_container_by_name(
-        self, name: str, alias: list[str] | None = None, ipv4: IPv4Address | None = None
+        self, name: str, ipv4: IPv4Address | None = None
     ) -> None:
         """Attach container to Supervisor network."""
         try:
             container = await self.docker.containers.get(name)
         except aiodocker.DockerError as err:
-            raise DockerError(f"Can't find {name}: {err}", _LOGGER.error) from err
+            if err.status == HTTPStatus.NOT_FOUND:
+                raise DockerNotFound(f"Can't find {name}") from err
+            raise DockerError(f"Can't find {name}: {err}") from err
 
         if container.id not in self.containers:
-            await self.attach_container(container.id, name, alias, ipv4)
+            await self.attach_container(container.id, name, ipv4=ipv4)
 
     async def detach_default_bridge(
         self, container_id: str, name: str | None = None

--- a/supervisor/docker/network.py
+++ b/supervisor/docker/network.py
@@ -215,9 +215,20 @@ class DockerNetwork:
 
         await self.reload()
 
-        # Reattach Supervisor-managed containers; missing ones are expected on fresh install.
+        # Supervisor is running this code, so its container must exist.
+        try:
+            await self.attach_container_by_name(
+                SUPERVISOR_DOCKER_NAME, ipv4=self.supervisor
+            )
+        except DockerError as err:
+            _LOGGER.critical(
+                "Can't attach Supervisor to Supervisor network: %s",
+                err,
+                exc_info=True,
+            )
+
+        # Plugin containers don't exist yet on fresh install; that's expected.
         for container_name, ipv4 in (
-            (SUPERVISOR_DOCKER_NAME, self.supervisor),
             (OBSERVER_DOCKER_NAME, self.observer),
             (CLI_DOCKER_NAME, self.cli),
             (DNS_DOCKER_NAME, self.dns),
@@ -231,10 +242,11 @@ class DockerNetwork:
                     container_name,
                 )
             except DockerError as err:
-                _LOGGER.error(
+                _LOGGER.critical(
                     "Can't attach %s to Supervisor network: %s",
                     container_name,
                     err,
+                    exc_info=True,
                 )
 
     async def reload(self) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Clean up the reattach path in `DockerNetwork._create_supervisor_network()` that runs after the Supervisor network is (re)created.

On fresh startup, the Supervisor Docker network does not yet exist, so `_create_supervisor_network()` creates it and then re-attaches the known Supervisor-managed containers (Supervisor, Observer, CLI, DNS, Audio) to it. At that point the plugin containers legitimately do not exist yet, so `docker.containers.get()` returns 404. The callers wrapped these calls in `with suppress(DockerError):`, but `attach_container_by_name()` passed `_LOGGER.error` into the `DockerError` constructor, which logged the message at ERROR level before the exception was suppressed. This produced noisy, misleading ERROR lines during normal fresh startup:

```
ERROR [supervisor.docker.network] Can't find hassio_observer: 404 Client Error ... No such container: hassio_observer
ERROR [supervisor.docker.network] Can't find hassio_cli:      404 Client Error ... No such container: hassio_cli
ERROR [supervisor.docker.network] Can't find hassio_dns:      404 Client Error ... No such container: hassio_dns
ERROR [supervisor.docker.network] Can't find hassio_audio:    404 Client Error ... No such container: hassio_audio
```

Changes:

- `attach_container_by_name()` now raises `DockerNotFound` silently on 404 and `DockerError` without implicit logging on other Docker API errors.
- `_create_supervisor_network()` iterates all managed containers in a single loop using explicit `try/except`, replacing the three separate `suppress(DockerError)` blocks. Missing containers are logged at DEBUG; unexpected Docker errors at ERROR.
- Drop the `alias` argument on the reattach path. Docker adds the container name as an implicit network alias, and inter-container lookups go through `ExtraHosts` (`/etc/hosts`), not Docker DNS, so the explicit alias list was cosmetic and actually inconsistent with the first-create path in `DockerAPI._run()` (which uses the dashed hostname, e.g. `hassio-dns`, whereas the reattach path used the short slug `dns`).
- Consolidate `AUDIO_DOCKER_NAME`, `CLI_DOCKER_NAME`, `DNS_DOCKER_NAME` in `supervisor/const.py` alongside the existing `OBSERVER_DOCKER_NAME` and `SUPERVISOR_DOCKER_NAME` constants, and import them from there in the respective Docker wrapper modules.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
