### PR TITLE
Fix UnboundLocalError when Core API fails post-update

### DIFF
--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -332,22 +332,22 @@ class HomeAssistantCore(JobGroup):
             except HomeAssistantError:
                 # The API stopped responding between the update and now
                 self._error_state = True
-
-            # Verify that the frontend is loaded
-            if "frontend" not in data.get("components", []):
-                _LOGGER.error("API responds but frontend is not loaded")
-                self._error_state = True
-            # Check that the frontend is actually accessible
-            elif not await self.sys_homeassistant.api.check_frontend_available():
-                _LOGGER.error(
-                    "Frontend component loaded but frontend is not accessible"
-                )
-                self._error_state = True
             else:
-                # Health checks passed, clean up old image
-                with suppress(DockerError):
-                    await self.instance.cleanup(old_image=old_image)
-                return
+                # Verify that the frontend is loaded
+                if "frontend" not in data.get("components", []):
+                    _LOGGER.error("API responds but frontend is not loaded")
+                    self._error_state = True
+                # Check that the frontend is actually accessible
+                elif not await self.sys_homeassistant.api.check_frontend_available():
+                    _LOGGER.error(
+                        "Frontend component loaded but frontend is not accessible"
+                    )
+                    self._error_state = True
+                else:
+                    # Health checks passed, clean up old image
+                    with suppress(DockerError):
+                        await self.instance.cleanup(old_image=old_image)
+                    return
 
         # Update going wrong, revert it
         if self.error_state and rollback:

--- a/tests/api/test_homeassistant.py
+++ b/tests/api/test_homeassistant.py
@@ -14,6 +14,7 @@ from supervisor.const import DNS_SUFFIX, CoreState
 from supervisor.coresys import CoreSys
 from supervisor.docker.homeassistant import DockerHomeAssistant
 from supervisor.docker.interface import DockerInterface
+from supervisor.exceptions import HomeAssistantError
 from supervisor.homeassistant.api import APIState, HomeAssistantAPI
 from supervisor.homeassistant.const import WSEvent
 from supervisor.homeassistant.core import HomeAssistantCore
@@ -515,4 +516,49 @@ async def test_update_frontend_check_fails_triggers_rollback(
         Issue(IssueType.UPDATE_ROLLBACK, ContextType.CORE) in coresys.resolution.issues
     )
     # Old image should not be cleaned up so rollback doesn't need to re-download
+    mock_cleanup.assert_not_called()
+
+
+async def test_update_get_config_error_triggers_rollback(
+    api_client: TestClient,
+    coresys: CoreSys,
+    caplog: pytest.LogCaptureFixture,
+    tmp_supervisor_data: Path,
+):
+    """Test that update triggers rollback when get_config raises HomeAssistantError."""
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    coresys.homeassistant.version = AwesomeVersion("2025.8.0")
+
+    update_call_count = 0
+
+    async def mock_update(*args, **kwargs):
+        nonlocal update_call_count
+        update_call_count += 1
+        if update_call_count == 1:
+            coresys.homeassistant.version = AwesomeVersion("2025.8.3")
+        elif update_call_count == 2:
+            coresys.homeassistant.version = AwesomeVersion("2025.8.0")
+
+    with (
+        patch.object(DockerInterface, "update", new=mock_update),
+        patch.object(
+            DockerHomeAssistant,
+            "version",
+            new=PropertyMock(return_value=AwesomeVersion("2025.8.0")),
+        ),
+        patch.object(HomeAssistantAPI, "get_config", side_effect=HomeAssistantError),
+        patch.object(
+            HomeAssistantAPI, "check_frontend_available", return_value=True
+        ) as mock_check_frontend,
+        patch.object(DockerInterface, "cleanup") as mock_cleanup,
+    ):
+        resp = await api_client.post("/core/update", json={"version": "2025.8.3"})
+
+    assert resp.status == 200
+    assert "HomeAssistant update failed -> rollback!" in caplog.text
+    assert update_call_count == 2
+    mock_check_frontend.assert_not_called()
+    assert (
+        Issue(IssueType.UPDATE_ROLLBACK, ContextType.CORE) in coresys.resolution.issues
+    )
     mock_cleanup.assert_not_called()


### PR DESCRIPTION
## Proposed change

When the Home Assistant Core API stopped responding between a Core update finishing and the post-update health check, `HomeAssistantCore.update` raised `UnboundLocalError: cannot access local variable 'data' where it is not associated with a value` instead of rolling back. That aborted the whole update with a `JobException` and skipped the rollback path entirely.

PR #6726 intentionally removed the `return` from the `except HomeAssistantError` block so execution would fall through to the rollback logic below, but it didn't guard the subsequent `data.get("components", ...)` access — so when the API call failed, `data` was never bound.

This PR moves the frontend-loaded / frontend-reachable checks into an `else` clause of the `try`/`except`. When `get_config()` succeeds, the health checks run as before. When it fails, `error_state` is set and control falls through to the existing rollback block, which is the behavior #6726 intended.

A regression test (`test_update_get_config_error_triggers_rollback`) verifies that a `HomeAssistantError` from `get_config()` now triggers the rollback: `DockerInterface.update` is called a second time, an `UPDATE_ROLLBACK` issue is created, `check_frontend_available` is not called, and the old image is not cleaned up.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes SUPERVISOR-1JVX
- This PR is related to issue: #6726
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
