### PR TITLE
Return proper API errors for mqtt/mysql service conflicts

### DIFF
--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -85,6 +85,12 @@ class APIGone(APIError):
     status = 410
 
 
+class APIConflict(APIError):
+    """API conflict error."""
+
+    status = 409
+
+
 class APITooManyRequests(APIError):
     """API too many requests error."""
 
@@ -667,6 +673,41 @@ class DiscoveryError(HassioError):
 
 class ServicesError(HassioError):
     """Services Errors."""
+
+
+class ServiceAlreadyProvidedError(ServicesError, APIConflict):
+    """Raise when a service is already provided by another app."""
+
+    error_key = "service_already_provided_error"
+    message_template = "The {service} service is already provided by {app}"
+
+    def __init__(
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        service: str,
+        app: str,
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"service": service, "app": app}
+        super().__init__(None, logger)
+
+
+class ServiceNotProvidedError(ServicesError, APINotFound):
+    """Raise when a service is not currently provided by any app."""
+
+    error_key = "service_not_provided_error"
+    message_template = "The {service} service is not currently provided by any app"
+
+    def __init__(
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        service: str,
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"service": service}
+        super().__init__(None, logger)
 
 
 # utils/dbus

--- a/supervisor/services/modules/mqtt.py
+++ b/supervisor/services/modules/mqtt.py
@@ -69,7 +69,7 @@ class MQTTService(ServiceInterface):
         """Write the data into service object."""
         if self.enabled:
             raise ServiceAlreadyProvidedError(
-                _LOGGER.error,
+                _LOGGER.debug,
                 service=SERVICE_MQTT,
                 app=self._data[ATTR_APP],
             )
@@ -83,7 +83,7 @@ class MQTTService(ServiceInterface):
     async def del_service_data(self, app: App) -> None:
         """Remove the data from service object."""
         if not self.enabled:
-            raise ServiceNotProvidedError(_LOGGER.warning, service=SERVICE_MQTT)
+            raise ServiceNotProvidedError(_LOGGER.debug, service=SERVICE_MQTT)
 
         self._data.clear()
         await self.save()

--- a/supervisor/services/modules/mqtt.py
+++ b/supervisor/services/modules/mqtt.py
@@ -6,7 +6,7 @@ from typing import Any
 import voluptuous as vol
 
 from ...addons.addon import App
-from ...exceptions import ServicesError
+from ...exceptions import ServiceAlreadyProvidedError, ServiceNotProvidedError
 from ...validate import network_port
 from ..const import (
     ATTR_APP,
@@ -68,9 +68,10 @@ class MQTTService(ServiceInterface):
     async def set_service_data(self, app: App, data: dict[str, Any]) -> None:
         """Write the data into service object."""
         if self.enabled:
-            raise ServicesError(
-                f"There is already a MQTT service in use from {self._data[ATTR_APP]}",
+            raise ServiceAlreadyProvidedError(
                 _LOGGER.error,
+                service=SERVICE_MQTT,
+                app=self._data[ATTR_APP],
             )
 
         self._data.update(data)
@@ -82,9 +83,7 @@ class MQTTService(ServiceInterface):
     async def del_service_data(self, app: App) -> None:
         """Remove the data from service object."""
         if not self.enabled:
-            raise ServicesError(
-                "Can't remove nonexistent service data", _LOGGER.warning
-            )
+            raise ServiceNotProvidedError(_LOGGER.warning, service=SERVICE_MQTT)
 
         self._data.clear()
         await self.save()

--- a/supervisor/services/modules/mysql.py
+++ b/supervisor/services/modules/mysql.py
@@ -6,7 +6,7 @@ from typing import Any
 import voluptuous as vol
 
 from ...addons.addon import App
-from ...exceptions import ServicesError
+from ...exceptions import ServiceAlreadyProvidedError, ServiceNotProvidedError
 from ...validate import network_port
 from ..const import (
     ATTR_APP,
@@ -62,9 +62,10 @@ class MySQLService(ServiceInterface):
     async def set_service_data(self, app: App, data: dict[str, Any]) -> None:
         """Write the data into service object."""
         if self.enabled:
-            raise ServicesError(
-                f"There is already a MySQL service in use from {self._data[ATTR_APP]}",
+            raise ServiceAlreadyProvidedError(
                 _LOGGER.error,
+                service=SERVICE_MYSQL,
+                app=self._data[ATTR_APP],
             )
 
         self._data.update(data)
@@ -76,7 +77,7 @@ class MySQLService(ServiceInterface):
     async def del_service_data(self, app: App) -> None:
         """Remove the data from service object."""
         if not self.enabled:
-            raise ServicesError("Can't remove not exists services", _LOGGER.warning)
+            raise ServiceNotProvidedError(_LOGGER.warning, service=SERVICE_MYSQL)
 
         self._data.clear()
         await self.save()

--- a/supervisor/services/modules/mysql.py
+++ b/supervisor/services/modules/mysql.py
@@ -63,7 +63,7 @@ class MySQLService(ServiceInterface):
         """Write the data into service object."""
         if self.enabled:
             raise ServiceAlreadyProvidedError(
-                _LOGGER.error,
+                _LOGGER.debug,
                 service=SERVICE_MYSQL,
                 app=self._data[ATTR_APP],
             )
@@ -77,7 +77,7 @@ class MySQLService(ServiceInterface):
     async def del_service_data(self, app: App) -> None:
         """Remove the data from service object."""
         if not self.enabled:
-            raise ServiceNotProvidedError(_LOGGER.warning, service=SERVICE_MYSQL)
+            raise ServiceNotProvidedError(_LOGGER.debug, service=SERVICE_MYSQL)
 
         self._data.clear()
         await self.save()

--- a/tests/api/test_services.py
+++ b/tests/api/test_services.py
@@ -3,6 +3,12 @@
 from aiohttp.test_utils import TestClient
 import pytest
 
+from supervisor.addons.addon import App
+from supervisor.const import ATTR_SERVICES
+from supervisor.coresys import CoreSys
+
+from tests.const import TEST_ADDON_SLUG
+
 
 @pytest.mark.parametrize(
     ("method", "url"),
@@ -14,3 +20,59 @@ async def test_service_not_found(api_client: TestClient, method: str, url: str):
     assert resp.status == 404
     body = await resp.json()
     assert body["message"] == "Service does not exist"
+
+
+@pytest.mark.parametrize("service", ["mqtt", "mysql"])
+@pytest.mark.parametrize("api_client", [TEST_ADDON_SLUG], indirect=True)
+async def test_set_service_already_provided(
+    api_client: TestClient,
+    coresys: CoreSys,
+    install_app_ssh: App,
+    service: str,
+):
+    """Test setting service data when another app already provides it returns 409."""
+    install_app_ssh.data[ATTR_SERVICES] = [f"{service}:provide"]
+    await coresys.services.load()
+
+    coresys.services.data._data[service].update(  # pylint: disable=protected-access
+        {"host": "existing", "port": 1883, "addon": "core_mosquitto"}
+    )
+
+    resp = await api_client.post(
+        f"/services/{service}",
+        json={"host": "new.example.com", "port": 1883},
+    )
+    assert resp.status == 409
+    body = await resp.json()
+    assert body["result"] == "error"
+    assert body["error_key"] == "service_already_provided_error"
+    assert body["extra_fields"] == {"service": service, "app": "core_mosquitto"}
+    assert (
+        body["message"]
+        == f"The {service} service is already provided by core_mosquitto"
+    )
+
+
+@pytest.mark.parametrize("service", ["mqtt", "mysql"])
+@pytest.mark.parametrize("api_client", [TEST_ADDON_SLUG], indirect=True)
+async def test_del_service_not_provided(
+    api_client: TestClient,
+    coresys: CoreSys,
+    install_app_ssh: App,
+    service: str,
+):
+    """Test deleting service data when no app provides it returns 404."""
+    install_app_ssh.data[ATTR_SERVICES] = [f"{service}:provide"]
+    await coresys.services.load()
+
+    coresys.services.data._data[service].clear()  # pylint: disable=protected-access
+
+    resp = await api_client.delete(f"/services/{service}")
+    assert resp.status == 404
+    body = await resp.json()
+    assert body["result"] == "error"
+    assert body["error_key"] == "service_not_provided_error"
+    assert body["extra_fields"] == {"service": service}
+    assert (
+        body["message"] == f"The {service} service is not currently provided by any app"
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

After #6739 added unexpected-error logging and Sentry capture to the `api_process` wrappers, two user-triggered service conflicts started surfacing on Sentry (SUPERVISOR-1JTQ and SUPERVISOR-1JWM) as if they were unexpected errors:

- `POST /services/{mqtt,mysql}` when another app already provides the service.
- `DELETE /services/{mqtt,mysql}` when no app currently provides it.

Both paths raised a generic `ServicesError`, which the API layer translated into an opaque HTTP 400 without an `error_key` or `extra_fields`, and which #6739 now also logs and captures via Sentry — so every legitimate conflict or mis-ordered request showed up as a bug.

This PR introduces two new-style API exceptions with translation keys and structured `extra_fields`:

- `ServiceAlreadyProvidedError` → 409 Conflict, `error_key: service_already_provided_error`, fields `{service, app}`.
- `ServiceNotProvidedError` → 404 Not Found, `error_key: service_not_provided_error`, fields `{service}`.

A shared `APIConflict` base class (status 409) is also added for future 409 responses. The `mqtt` and `mysql` service modules now raise these specific errors instead of the generic `ServicesError`, so the API returns structured, translatable responses and these expected user conflicts stop being captured as bugs.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes SUPERVISOR-1JTQ, fixes SUPERVISOR-1JWM
- This PR is related to issue: #6739
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
