### PR TITLE
Refactor API registration to support v1/v2 via shared methods

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -108,6 +108,11 @@ class RestAPI(CoreSysAttributes):
         enabled_versions = list(AppVersion) if v2_enabled else [AppVersion.V1]
         static_resource_configs: list[tuple[web.Application, StaticResourceConfig]] = []
 
+        # Panel is V1-only: the frontend assets are served from the root webapp only.
+        static_resource_configs.extend(
+            (self.versions[AppVersion.V1], config) for config in self._register_panel()
+        )
+
         for version in enabled_versions:
             app = self.versions[version]
             self._register_apps(app)
@@ -128,9 +133,6 @@ class RestAPI(CoreSysAttributes):
             self._register_network(app)
             self._register_observer(app)
             self._register_os(app)
-            static_resource_configs.extend(
-                (app, config) for config in self._register_panel()
-            )
             self._register_proxy(app)
             self._register_resolution(app)
             self._register_root(app)

--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -18,7 +18,7 @@ from .audio import APIAudio
 from .auth import APIAuth
 from .backups import APIBackups
 from .cli import APICli
-from .const import CONTENT_TYPE_TEXT
+from .const import CONTENT_TYPE_TEXT, AppVersion
 from .discovery import APIDiscovery
 from .dns import APICoreDNS
 from .docker import APIDocker
@@ -77,9 +77,9 @@ class RestAPI(CoreSysAttributes):
                 "max_field_size": MAX_LINE_SIZE,
             },
         )
-        # v2 sub-app: no middleware of its own — parent webapp's middleware
+        # V2 sub-app: no middleware of its own — the parent webapp's middleware
         # stack runs first for all requests including sub-app routes.
-        self.v2_app: web.Application = web.Application()
+        self._v2_app: web.Application = web.Application()
 
         # service stuff
         self._runner: web.AppRunner = web.AppRunner(self.webapp, shutdown_timeout=5)
@@ -89,60 +89,71 @@ class RestAPI(CoreSysAttributes):
         self._api_host: APIHost = APIHost()
         self._api_host.coresys = coresys
 
-        # handler instances shared between v1 and v2 registrations
-        self._api_apps: APIApps | None = None
-        self._api_backups: APIBackups | None = None
-        self._api_store: APIStore | None = None
+    @property
+    def versions(self) -> dict[AppVersion, web.Application]:
+        """Map of API version to its aiohttp application.
+
+        V1 is the root webapp (carries all middleware); V2 is a sub-app
+        mounted at /v2 — the parent middleware stack runs first for both.
+        Computed as a property so that reassigning self.webapp (e.g. in tests)
+        is automatically reflected.
+        """
+        return {AppVersion.V1: self.webapp, AppVersion.V2: self._v2_app}
 
     async def load(self) -> None:
         """Register REST API Calls."""
-        static_resource_configs: list[StaticResourceConfig] = []
+        v2_enabled = self.sys_config.feature_flags.get(
+            FeatureFlag.SUPERVISOR_V2_API, False
+        )
+        enabled_versions = list(AppVersion) if v2_enabled else [AppVersion.V1]
+        static_resource_configs: list[tuple[web.Application, StaticResourceConfig]] = []
 
-        self._register_apps()
-        self._register_audio()
-        self._register_auth()
-        self._register_backups()
-        self._register_cli()
-        self._register_discovery()
-        self._register_dns()
-        self._register_docker()
-        self._register_hardware()
-        self._register_homeassistant()
-        self._register_host()
-        self._register_jobs()
-        self._register_ingress()
-        self._register_mounts()
-        self._register_multicast()
-        self._register_network()
-        self._register_observer()
-        self._register_os()
-        static_resource_configs.extend(self._register_panel())
-        self._register_proxy()
-        self._register_resolution()
-        self._register_root()
-        self._register_security()
-        self._register_services()
-        self._register_store()
-        self._register_supervisor()
-
-        # Register v2 routes before mounting the sub-app
-        # (add_subapp freezes the sub-app's router)
-        if self.sys_config.feature_flags.get(FeatureFlag.SUPERVISOR_V2_API, False):
-            self._register_v2_apps()
-            self._register_v2_backups()
-            self._register_v2_store()
-            self.webapp.add_subapp("/v2", self.v2_app)
+        for version in enabled_versions:
+            app = self.versions[version]
+            self._register_apps(app)
+            self._register_audio(app)
+            self._register_auth(app)
+            self._register_backups(app)
+            self._register_cli(app)
+            self._register_discovery(app)
+            self._register_dns(app)
+            self._register_docker(app)
+            self._register_hardware(app)
+            self._register_homeassistant(app)
+            self._register_host(app)
+            self._register_ingress(app)
+            self._register_jobs(app)
+            self._register_mounts(app)
+            self._register_multicast(app)
+            self._register_network(app)
+            self._register_observer(app)
+            self._register_os(app)
+            static_resource_configs.extend(
+                (app, config) for config in self._register_panel()
+            )
+            self._register_proxy(app)
+            self._register_resolution(app)
+            self._register_root(app)
+            self._register_security(app)
+            self._register_services(app)
+            self._register_store(app)
+            self._register_supervisor(app)
 
         if static_resource_configs:
 
-            def process_configs() -> list[web.StaticResource]:
+            def process_configs() -> list[tuple[web.Application, web.StaticResource]]:
                 return [
-                    web.StaticResource(config.prefix, config.path)
-                    for config in static_resource_configs
+                    (app, web.StaticResource(config.prefix, config.path))
+                    for app, config in static_resource_configs
                 ]
 
-            for resource in await self.sys_run_in_executor(process_configs):
-                self.webapp.router.register_resource(resource)
+            for app, resource in await self.sys_run_in_executor(process_configs):
+                app.router.register_resource(resource)
+
+        # Must mount the V2 sub-app only after all its routes and resources are
+        # registered — add_subapp freezes the sub-app's router.
+        if v2_enabled:
+            self.webapp.add_subapp("/v2", self.versions[AppVersion.V2])
 
         await self.start()
 
@@ -150,11 +161,11 @@ class RestAPI(CoreSysAttributes):
         self,
         path: str,
         syslog_identifier: str,
+        app: web.Application,
         default_verbose: bool = False,
-    ):
+    ) -> None:
         """Register logs endpoint for a given path, returning logs for single syslog identifier."""
-
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get(
                     f"{path}/logs",
@@ -203,11 +214,11 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-    def _register_host(self) -> None:
+    def _register_host(self, app: web.Application) -> None:
         """Register hostcontrol functions."""
         api_host = self._api_host
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/host/info", api_host.info),
                 web.get(
@@ -250,12 +261,12 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-    def _register_network(self) -> None:
+    def _register_network(self, app: web.Application) -> None:
         """Register network functions."""
         api_network = APINetwork()
         api_network.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/network/info", api_network.info),
                 web.post("/network/reload", api_network.reload),
@@ -277,12 +288,12 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-    def _register_os(self) -> None:
+    def _register_os(self, app: web.Application) -> None:
         """Register OS functions."""
         api_os = APIOS()
         api_os.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/os/info", api_os.info),
                 web.post("/os/update", api_os.update),
@@ -297,7 +308,7 @@ class RestAPI(CoreSysAttributes):
         )
 
         # Boards endpoints
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/os/boards/green", api_os.boards_green_info),
                 web.post("/os/boards/green", api_os.boards_green_options),
@@ -307,12 +318,12 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-    def _register_security(self) -> None:
+    def _register_security(self, app: web.Application) -> None:
         """Register Security functions."""
         api_security = APISecurity()
         api_security.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/security/info", api_security.info),
                 web.post("/security/options", api_security.options),
@@ -320,12 +331,12 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-    def _register_jobs(self) -> None:
+    def _register_jobs(self, app: web.Application) -> None:
         """Register Jobs functions."""
         api_jobs = APIJobs()
         api_jobs.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/jobs/info", api_jobs.info),
                 web.post("/jobs/options", api_jobs.options),
@@ -335,12 +346,12 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-    def _register_cli(self) -> None:
+    def _register_cli(self, app: web.Application) -> None:
         """Register HA cli functions."""
         api_cli = APICli()
         api_cli.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/cli/info", api_cli.info),
                 web.get("/cli/stats", api_cli.stats),
@@ -348,12 +359,12 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-    def _register_observer(self) -> None:
+    def _register_observer(self, app: web.Application) -> None:
         """Register Observer functions."""
         api_observer = APIObserver()
         api_observer.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/observer/info", api_observer.info),
                 web.get("/observer/stats", api_observer.stats),
@@ -361,12 +372,12 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-    def _register_multicast(self) -> None:
+    def _register_multicast(self, app: web.Application) -> None:
         """Register Multicast functions."""
         api_multicast = APIMulticast()
         api_multicast.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/multicast/info", api_multicast.info),
                 web.get("/multicast/stats", api_multicast.stats),
@@ -375,46 +386,45 @@ class RestAPI(CoreSysAttributes):
             ]
         )
         self._register_advanced_logs(
-            "/multicast", "hassio_multicast", default_verbose=True
+            "/multicast", "hassio_multicast", default_verbose=True, app=app
         )
 
-    def _register_hardware(self) -> None:
+    def _register_hardware(self, app: web.Application) -> None:
         """Register hardware functions."""
         api_hardware = APIHardware()
         api_hardware.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/hardware/info", api_hardware.info),
                 web.get("/hardware/audio", api_hardware.audio),
             ]
         )
 
-    def _register_root(self) -> None:
+    def _register_root(self, app: web.Application) -> None:
         """Register root functions."""
         api_root = APIRoot()
         api_root.coresys = self.coresys
 
-        self.webapp.add_routes([web.get("/info", api_root.info)])
-        self.webapp.add_routes([web.post("/reload_updates", api_root.reload_updates)])
+        app.add_routes([web.get("/info", api_root.info)])
+        app.add_routes([web.post("/reload_updates", api_root.reload_updates)])
 
-        # Discouraged
-        self.webapp.add_routes([web.post("/refresh_updates", api_root.refresh_updates)])
-        self.webapp.add_routes(
-            [web.get("/available_updates", api_root.available_updates)]
-        )
+        if app is self.versions[AppVersion.V1]:
+            # Discouraged
+            app.add_routes([web.post("/refresh_updates", api_root.refresh_updates)])
+            app.add_routes([web.get("/available_updates", api_root.available_updates)])
 
-        # Remove: 2023
-        self.webapp.add_routes(
-            [web.get("/supervisor/available_updates", api_root.available_updates)]
-        )
+            # Remove: 2023
+            app.add_routes(
+                [web.get("/supervisor/available_updates", api_root.available_updates)]
+            )
 
-    def _register_resolution(self) -> None:
+    def _register_resolution(self, app: web.Application) -> None:
         """Register info functions."""
         api_resolution = APIResoulution()
         api_resolution.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/resolution/info", api_resolution.info),
                 web.post(
@@ -441,12 +451,12 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-    def _register_auth(self) -> None:
+    def _register_auth(self, app: web.Application) -> None:
         """Register auth functions."""
         api_auth = APIAuth()
         api_auth.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/auth", api_auth.auth),
                 web.post("/auth", api_auth.auth),
@@ -456,12 +466,12 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-    def _register_supervisor(self) -> None:
+    def _register_supervisor(self, app: web.Application) -> None:
         """Register Supervisor functions."""
         api_supervisor = APISupervisor()
         api_supervisor.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/supervisor/ping", api_supervisor.ping),
                 web.get("/supervisor/info", api_supervisor.info),
@@ -494,7 +504,7 @@ class RestAPI(CoreSysAttributes):
                 kwargs.pop("no_colors", None)  # no_colors not supported for Docker logs
                 return await api_supervisor.logs(*args, **kwargs)
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/supervisor/logs", get_supervisor_logs),
                 web.get(
@@ -513,12 +523,12 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-    def _register_homeassistant(self) -> None:
+    def _register_homeassistant(self, app: web.Application) -> None:
         """Register Home Assistant functions."""
         api_hass = APIHomeAssistant()
         api_hass.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/core/info", api_hass.info),
                 web.get("/core/stats", api_hass.stats),
@@ -532,31 +542,34 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-        self._register_advanced_logs("/core", "homeassistant")
+        self._register_advanced_logs("/core", "homeassistant", app=app)
 
-        # Reroute from legacy
-        self.webapp.add_routes(
-            [
-                web.get("/homeassistant/info", api_hass.info),
-                web.get("/homeassistant/stats", api_hass.stats),
-                web.post("/homeassistant/options", api_hass.options),
-                web.post("/homeassistant/restart", api_hass.restart),
-                web.post("/homeassistant/stop", api_hass.stop),
-                web.post("/homeassistant/start", api_hass.start),
-                web.post("/homeassistant/update", api_hass.update),
-                web.post("/homeassistant/rebuild", api_hass.rebuild),
-                web.post("/homeassistant/check", api_hass.check),
-            ]
-        )
+        if app is self.versions[AppVersion.V1]:
+            # Reroute from legacy
+            self.versions[AppVersion.V1].add_routes(
+                [
+                    web.get("/homeassistant/info", api_hass.info),
+                    web.get("/homeassistant/stats", api_hass.stats),
+                    web.post("/homeassistant/options", api_hass.options),
+                    web.post("/homeassistant/restart", api_hass.restart),
+                    web.post("/homeassistant/stop", api_hass.stop),
+                    web.post("/homeassistant/start", api_hass.start),
+                    web.post("/homeassistant/update", api_hass.update),
+                    web.post("/homeassistant/rebuild", api_hass.rebuild),
+                    web.post("/homeassistant/check", api_hass.check),
+                ]
+            )
 
-        self._register_advanced_logs("/homeassistant", "homeassistant")
+            self._register_advanced_logs(
+                "/homeassistant", "homeassistant", app=self.versions[AppVersion.V1]
+            )
 
-    def _register_proxy(self) -> None:
+    def _register_proxy(self, app: web.Application) -> None:
         """Register Home Assistant API Proxy."""
         api_proxy = APIProxy()
         api_proxy.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/core/api/websocket", api_proxy.websocket),
                 web.get("/core/websocket", api_proxy.websocket),
@@ -568,137 +581,132 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-        # Reroute from legacy
-        self.webapp.add_routes(
-            [
-                web.get("/homeassistant/api/websocket", api_proxy.websocket),
-                web.get("/homeassistant/websocket", api_proxy.websocket),
-                web.get("/homeassistant/api/stream", api_proxy.stream),
-                web.post("/homeassistant/api/{path:.+}", api_proxy.api),
-                web.get("/homeassistant/api/{path:.+}", api_proxy.api),
-                web.get("/homeassistant/api/", api_proxy.api),
-            ]
-        )
+        if app is self.versions[AppVersion.V1]:
+            # Reroute from legacy
+            app.add_routes(
+                [
+                    web.get("/homeassistant/api/websocket", api_proxy.websocket),
+                    web.get("/homeassistant/websocket", api_proxy.websocket),
+                    web.get("/homeassistant/api/stream", api_proxy.stream),
+                    web.post("/homeassistant/api/{path:.+}", api_proxy.api),
+                    web.get("/homeassistant/api/{path:.+}", api_proxy.api),
+                    web.get("/homeassistant/api/", api_proxy.api),
+                ]
+            )
 
-    def _register_apps(self) -> None:
+    def _register_apps(self, app: web.Application) -> None:
         """Register App functions."""
         api_apps = APIApps()
         api_apps.coresys = self.coresys
-        self._api_apps = api_apps
 
-        self.webapp.add_routes(
-            [
-                web.get("/addons", api_apps.list_apps_v1),
-                web.post("/addons/{app}/uninstall", api_apps.uninstall),
-                web.post("/addons/{app}/start", api_apps.start),
-                web.post("/addons/{app}/stop", api_apps.stop),
-                web.post("/addons/{app}/restart", api_apps.restart),
-                web.post("/addons/{app}/options", api_apps.options),
-                web.post("/addons/{app}/sys_options", api_apps.sys_options),
-                web.post("/addons/{app}/options/validate", api_apps.options_validate),
-                web.get("/addons/{app}/options/config", api_apps.options_config),
-                web.post("/addons/{app}/rebuild", api_apps.rebuild),
-                web.post("/addons/{app}/stdin", api_apps.stdin),
-                web.post("/addons/{app}/security", api_apps.security),
-                web.get("/addons/{app}/stats", api_apps.stats),
-            ]
-        )
+        if app is self.versions[AppVersion.V1]:
 
-        @api_process_raw(CONTENT_TYPE_TEXT, error_type=CONTENT_TYPE_TEXT)
-        async def get_app_logs(request, *args, **kwargs):
-            app = api_apps.get_app_for_request(request)
-            kwargs["identifier"] = f"addon_{app.slug}"
-            return await self._api_host.advanced_logs(request, *args, **kwargs)
+            @api_process_raw(CONTENT_TYPE_TEXT, error_type=CONTENT_TYPE_TEXT)
+            async def get_app_logs(request, *args, **kwargs):
+                addon = api_apps.get_app_for_request(request)
+                kwargs["identifier"] = f"addon_{addon.slug}"
+                return await self._api_host.advanced_logs(request, *args, **kwargs)
 
-        self.webapp.add_routes(
-            [
-                web.get("/addons/{app}/logs", get_app_logs),
-                web.get(
-                    "/addons/{app}/logs/follow",
-                    partial(get_app_logs, follow=True),
-                ),
-                web.get(
-                    "/addons/{app}/logs/latest",
-                    partial(get_app_logs, latest=True, no_colors=True),
-                ),
-                web.get("/addons/{app}/logs/boots/{bootid}", get_app_logs),
-                web.get(
-                    "/addons/{app}/logs/boots/{bootid}/follow",
-                    partial(get_app_logs, follow=True),
-                ),
-            ]
-        )
+            # Legacy routing to support requests for not installed apps
+            api_store = APIStore()
+            api_store.coresys = self.coresys
 
-        # Legacy routing to support requests for not installed apps
-        api_store = APIStore()
-        api_store.coresys = self.coresys
+            @api_process
+            async def apps_app_info(request: web.Request) -> dict[str, Any]:
+                """Route to store if info requested for not installed app."""
+                try:
+                    addon: App = api_apps.get_app_for_request(request)
+                    return await api_apps.info_data(addon)
+                except APIAppNotInstalled:
+                    # Route to store/{app}/info but add missing fields
+                    return dict(
+                        await api_store.apps_app_info_wrapped(request),
+                        state=AppState.UNKNOWN,
+                        options=self.sys_apps.store[request.match_info["app"]].options,
+                    )
 
-        @api_process
-        async def apps_app_info(request: web.Request) -> dict[str, Any]:
-            """Route to store if info requested for not installed app."""
-            try:
-                app: App = api_apps.get_app_for_request(request)
-                return await api_apps.info_data(app)
-            except APIAppNotInstalled:
-                # Route to store/{app}/info but add missing fields
-                return dict(
-                    await api_store.apps_app_info_wrapped(request),
-                    state=AppState.UNKNOWN,
-                    options=self.sys_apps.store[request.match_info["app"]].options,
-                )
+            app.add_routes(
+                [
+                    web.get("/addons", api_apps.list_apps_v1),
+                    web.get("/addons/{app}/info", apps_app_info),
+                    web.post("/addons/{app}/uninstall", api_apps.uninstall),
+                    web.post("/addons/{app}/start", api_apps.start),
+                    web.post("/addons/{app}/stop", api_apps.stop),
+                    web.post("/addons/{app}/restart", api_apps.restart),
+                    web.post("/addons/{app}/options", api_apps.options),
+                    web.post("/addons/{app}/sys_options", api_apps.sys_options),
+                    web.post(
+                        "/addons/{app}/options/validate", api_apps.options_validate
+                    ),
+                    web.get("/addons/{app}/options/config", api_apps.options_config),
+                    web.post("/addons/{app}/rebuild", api_apps.rebuild),
+                    web.post("/addons/{app}/stdin", api_apps.stdin),
+                    web.post("/addons/{app}/security", api_apps.security),
+                    web.get("/addons/{app}/stats", api_apps.stats),
+                    web.get("/addons/{app}/logs", get_app_logs),
+                    web.get(
+                        "/addons/{app}/logs/follow",
+                        partial(get_app_logs, follow=True),
+                    ),
+                    web.get(
+                        "/addons/{app}/logs/latest",
+                        partial(get_app_logs, latest=True, no_colors=True),
+                    ),
+                    web.get("/addons/{app}/logs/boots/{bootid}", get_app_logs),
+                    web.get(
+                        "/addons/{app}/logs/boots/{bootid}/follow",
+                        partial(get_app_logs, follow=True),
+                    ),
+                ]
+            )
 
-        self.webapp.add_routes([web.get("/addons/{app}/info", apps_app_info)])
+        if app is self.versions[AppVersion.V2]:
 
-    def _register_v2_apps(self) -> None:
-        """Register v2 app routes on the v2 sub-app (accessible as /v2/apps/...)."""
-        assert self._api_apps is not None
-        api_apps = self._api_apps
+            @api_process_raw(CONTENT_TYPE_TEXT, error_type=CONTENT_TYPE_TEXT)
+            async def get_app_logs_v2(request, *args, **kwargs):
+                addon = api_apps.get_app_for_request(request)
+                kwargs["identifier"] = f"addon_{addon.slug}"
+                return await self._api_host.advanced_logs(request, *args, **kwargs)
 
-        @api_process_raw(CONTENT_TYPE_TEXT, error_type=CONTENT_TYPE_TEXT)
-        async def get_app_logs_v2(request, *args, **kwargs):
-            app = api_apps.get_app_for_request(request)
-            kwargs["identifier"] = f"addon_{app.slug}"
-            return await self._api_host.advanced_logs(request, *args, **kwargs)
+            app.add_routes(
+                [
+                    web.get("/apps", api_apps.list_apps),
+                    web.get("/apps/{app}/info", api_apps.info),
+                    web.post("/apps/{app}/uninstall", api_apps.uninstall),
+                    web.post("/apps/{app}/start", api_apps.start),
+                    web.post("/apps/{app}/stop", api_apps.stop),
+                    web.post("/apps/{app}/restart", api_apps.restart),
+                    web.post("/apps/{app}/options", api_apps.options),
+                    web.post("/apps/{app}/sys_options", api_apps.sys_options),
+                    web.post("/apps/{app}/options/validate", api_apps.options_validate),
+                    web.get("/apps/{app}/options/config", api_apps.options_config),
+                    web.post("/apps/{app}/rebuild", api_apps.rebuild),
+                    web.post("/apps/{app}/stdin", api_apps.stdin),
+                    web.post("/apps/{app}/security", api_apps.security),
+                    web.get("/apps/{app}/stats", api_apps.stats),
+                    web.get("/apps/{app}/logs", get_app_logs_v2),
+                    web.get(
+                        "/apps/{app}/logs/follow",
+                        partial(get_app_logs_v2, follow=True),
+                    ),
+                    web.get(
+                        "/apps/{app}/logs/latest",
+                        partial(get_app_logs_v2, latest=True, no_colors=True),
+                    ),
+                    web.get("/apps/{app}/logs/boots/{bootid}", get_app_logs_v2),
+                    web.get(
+                        "/apps/{app}/logs/boots/{bootid}/follow",
+                        partial(get_app_logs_v2, follow=True),
+                    ),
+                ]
+            )
 
-        self.v2_app.add_routes(
-            [
-                web.get("/apps", api_apps.list_apps),
-                web.post("/apps/{app}/uninstall", api_apps.uninstall),
-                web.post("/apps/{app}/start", api_apps.start),
-                web.post("/apps/{app}/stop", api_apps.stop),
-                web.post("/apps/{app}/restart", api_apps.restart),
-                web.post("/apps/{app}/options", api_apps.options),
-                web.post("/apps/{app}/sys_options", api_apps.sys_options),
-                web.post("/apps/{app}/options/validate", api_apps.options_validate),
-                web.get("/apps/{app}/options/config", api_apps.options_config),
-                web.post("/apps/{app}/rebuild", api_apps.rebuild),
-                web.post("/apps/{app}/stdin", api_apps.stdin),
-                web.post("/apps/{app}/security", api_apps.security),
-                web.get("/apps/{app}/stats", api_apps.stats),
-                web.get("/apps/{app}/info", api_apps.info),
-                web.get("/apps/{app}/logs", get_app_logs_v2),
-                web.get(
-                    "/apps/{app}/logs/follow",
-                    partial(get_app_logs_v2, follow=True),
-                ),
-                web.get(
-                    "/apps/{app}/logs/latest",
-                    partial(get_app_logs_v2, latest=True, no_colors=True),
-                ),
-                web.get("/apps/{app}/logs/boots/{bootid}", get_app_logs_v2),
-                web.get(
-                    "/apps/{app}/logs/boots/{bootid}/follow",
-                    partial(get_app_logs_v2, follow=True),
-                ),
-            ]
-        )
-
-    def _register_ingress(self) -> None:
+    def _register_ingress(self, app: web.Application) -> None:
         """Register Ingress functions."""
         api_ingress = APIIngress()
         api_ingress.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.post("/ingress/session", api_ingress.create_session),
                 web.post("/ingress/validate_session", api_ingress.validate_session),
@@ -709,67 +717,60 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-    def _register_backups(self) -> None:
+    def _register_backups(self, app: web.Application) -> None:
         """Register backups functions."""
         api_backups = APIBackups()
         api_backups.coresys = self.coresys
-        self._api_backups = api_backups
 
-        self.webapp.add_routes(
+        if app is self.versions[AppVersion.V1]:
+            app.add_routes(
+                [
+                    web.get("/backups", api_backups.list_backups_v1),
+                    web.get("/backups/info", api_backups.info_v1),
+                    web.post("/backups/new/partial", api_backups.backup_partial_v1),
+                    web.get("/backups/{slug}/info", api_backups.backup_info_v1),
+                    web.post(
+                        "/backups/{slug}/restore/partial",
+                        api_backups.restore_partial_v1,
+                    ),
+                ]
+            )
+
+        if app is self.versions[AppVersion.V2]:
+            app.add_routes(
+                [
+                    web.get("/backups", api_backups.list_backups),
+                    web.get("/backups/info", api_backups.info),
+                    web.post("/backups/new/partial", api_backups.backup_partial),
+                    web.get("/backups/{slug}/info", api_backups.backup_info),
+                    web.post(
+                        "/backups/{slug}/restore/partial",
+                        api_backups.restore_partial,
+                    ),
+                ]
+            )
+
+        # Routes shared across versions
+        app.add_routes(
             [
-                web.get("/backups", api_backups.list_backups_v1),
-                web.get("/backups/info", api_backups.info_v1),
                 web.post("/backups/options", api_backups.options),
                 web.post("/backups/reload", api_backups.reload),
                 web.post("/backups/freeze", api_backups.freeze),
                 web.post("/backups/thaw", api_backups.thaw),
                 web.post("/backups/new/full", api_backups.backup_full),
-                web.post("/backups/new/partial", api_backups.backup_partial_v1),
                 web.post("/backups/new/upload", api_backups.upload),
-                web.get("/backups/{slug}/info", api_backups.backup_info_v1),
                 web.delete("/backups/{slug}", api_backups.remove),
                 web.post("/backups/{slug}/restore/full", api_backups.restore_full),
-                web.post(
-                    "/backups/{slug}/restore/partial",
-                    api_backups.restore_partial_v1,
-                ),
                 web.get("/backups/{slug}/download", api_backups.download),
             ]
         )
 
-    def _register_v2_backups(self) -> None:
-        """Register v2 backup routes on the v2 sub-app (accessible as /v2/backups/...)."""
-        assert self._api_backups is not None
-        api_backups = self._api_backups
-
-        self.v2_app.add_routes(
-            [
-                web.get("/backups", api_backups.list_backups),
-                web.get("/backups/info", api_backups.info),
-                web.post("/backups/options", api_backups.options),
-                web.post("/backups/reload", api_backups.reload),
-                web.post("/backups/freeze", api_backups.freeze),
-                web.post("/backups/thaw", api_backups.thaw),
-                web.post("/backups/new/full", api_backups.backup_full),
-                web.post("/backups/new/partial", api_backups.backup_partial),
-                web.post("/backups/new/upload", api_backups.upload),
-                web.get("/backups/{slug}/info", api_backups.backup_info),
-                web.delete("/backups/{slug}", api_backups.remove),
-                web.post("/backups/{slug}/restore/full", api_backups.restore_full),
-                web.post(
-                    "/backups/{slug}/restore/partial",
-                    api_backups.restore_partial,
-                ),
-                web.get("/backups/{slug}/download", api_backups.download),
-            ]
-        )
-
-    def _register_services(self) -> None:
+    def _register_services(self, app: web.Application) -> None:
         """Register services functions."""
         api_services = APIServices()
         api_services.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/services", api_services.list_services),
                 web.get("/services/{service}", api_services.get_service),
@@ -778,12 +779,12 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-    def _register_discovery(self) -> None:
+    def _register_discovery(self, app: web.Application) -> None:
         """Register discovery functions."""
         api_discovery = APIDiscovery()
         api_discovery.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/discovery", api_discovery.list_discovery),
                 web.get("/discovery/{uuid}", api_discovery.get_discovery),
@@ -792,12 +793,12 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-    def _register_dns(self) -> None:
+    def _register_dns(self, app: web.Application) -> None:
         """Register DNS functions."""
         api_dns = APICoreDNS()
         api_dns.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/dns/info", api_dns.info),
                 web.get("/dns/stats", api_dns.stats),
@@ -808,14 +809,16 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-        self._register_advanced_logs("/dns", "hassio_dns", default_verbose=True)
+        self._register_advanced_logs(
+            "/dns", "hassio_dns", default_verbose=True, app=app
+        )
 
-    def _register_audio(self) -> None:
+    def _register_audio(self, app: web.Application) -> None:
         """Register Audio functions."""
         api_audio = APIAudio()
         api_audio.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/audio/info", api_audio.info),
                 web.get("/audio/stats", api_audio.stats),
@@ -831,14 +834,16 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-        self._register_advanced_logs("/audio", "hassio_audio", default_verbose=True)
+        self._register_advanced_logs(
+            "/audio", "hassio_audio", default_verbose=True, app=app
+        )
 
-    def _register_mounts(self) -> None:
+    def _register_mounts(self, app: web.Application) -> None:
         """Register mounts endpoints."""
         api_mounts = APIMounts()
         api_mounts.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/mounts", api_mounts.info),
                 web.post("/mounts/options", api_mounts.options),
@@ -849,106 +854,97 @@ class RestAPI(CoreSysAttributes):
             ]
         )
 
-    def _register_store(self) -> None:
+    def _register_store(self, app: web.Application) -> None:
         """Register store endpoints."""
         api_store = APIStore()
         api_store.coresys = self.coresys
-        self._api_store = api_store
 
-        self.webapp.add_routes(
+        if app is self.versions[AppVersion.V1]:
+            app.add_routes(
+                [
+                    web.get("/store", api_store.store_info_v1),
+                    web.get("/store/addons", api_store.apps_list_v1),
+                    web.get("/store/addons/{app}", api_store.apps_app_info),
+                    web.get("/store/addons/{app}/icon", api_store.apps_app_icon),
+                    web.get("/store/addons/{app}/logo", api_store.apps_app_logo),
+                    web.get(
+                        "/store/addons/{app}/changelog", api_store.apps_app_changelog
+                    ),
+                    web.get(
+                        "/store/addons/{app}/documentation",
+                        api_store.apps_app_documentation,
+                    ),
+                    web.get(
+                        "/store/addons/{app}/availability",
+                        api_store.apps_app_availability,
+                    ),
+                    web.post("/store/addons/{app}/install", api_store.apps_app_install),
+                    web.post(
+                        "/store/addons/{app}/install/{version}",
+                        api_store.apps_app_install,
+                    ),
+                    web.post("/store/addons/{app}/update", api_store.apps_app_update),
+                    web.post(
+                        "/store/addons/{app}/update/{version}",
+                        api_store.apps_app_update,
+                    ),
+                    # Must be below others since it has a wildcard in resource path
+                    web.get("/store/addons/{app}/{version}", api_store.apps_app_info),
+                ]
+            )
+            # Reroute from legacy
+            app.add_routes(
+                [
+                    web.post("/addons/reload", api_store.reload),
+                    web.post("/addons/{app}/install", api_store.apps_app_install),
+                    web.post("/addons/{app}/update", api_store.apps_app_update),
+                    web.get("/addons/{app}/icon", api_store.apps_app_icon),
+                    web.get("/addons/{app}/logo", api_store.apps_app_logo),
+                    web.get("/addons/{app}/changelog", api_store.apps_app_changelog),
+                    web.get(
+                        "/addons/{app}/documentation",
+                        api_store.apps_app_documentation,
+                    ),
+                ]
+            )
+
+        if app is self.versions[AppVersion.V2]:
+            app.add_routes(
+                [
+                    web.get("/store", api_store.store_info),
+                    web.get("/store/apps", api_store.apps_list),
+                    web.get("/store/apps/{app}", api_store.apps_app_info),
+                    web.get("/store/apps/{app}/icon", api_store.apps_app_icon),
+                    web.get("/store/apps/{app}/logo", api_store.apps_app_logo),
+                    web.get(
+                        "/store/apps/{app}/changelog", api_store.apps_app_changelog
+                    ),
+                    web.get(
+                        "/store/apps/{app}/documentation",
+                        api_store.apps_app_documentation,
+                    ),
+                    web.get(
+                        "/store/apps/{app}/availability",
+                        api_store.apps_app_availability,
+                    ),
+                    web.post("/store/apps/{app}/install", api_store.apps_app_install),
+                    web.post(
+                        "/store/apps/{app}/install/{version}",
+                        api_store.apps_app_install,
+                    ),
+                    web.post("/store/apps/{app}/update", api_store.apps_app_update),
+                    web.post(
+                        "/store/apps/{app}/update/{version}",
+                        api_store.apps_app_update,
+                    ),
+                    # Must be below others since it has a wildcard in resource path
+                    web.get("/store/apps/{app}/{version}", api_store.apps_app_info),
+                ]
+            )
+
+        # Routes shared across versions
+        app.add_routes(
             [
-                web.get("/store", api_store.store_info_v1),
-                web.get("/store/addons", api_store.apps_list_v1),
-                web.get("/store/addons/{app}", api_store.apps_app_info),
-                web.get("/store/addons/{app}/icon", api_store.apps_app_icon),
-                web.get("/store/addons/{app}/logo", api_store.apps_app_logo),
-                web.get("/store/addons/{app}/changelog", api_store.apps_app_changelog),
-                web.get(
-                    "/store/addons/{app}/documentation",
-                    api_store.apps_app_documentation,
-                ),
-                web.get(
-                    "/store/addons/{app}/availability",
-                    api_store.apps_app_availability,
-                ),
-                web.post("/store/addons/{app}/install", api_store.apps_app_install),
-                web.post(
-                    "/store/addons/{app}/install/{version}",
-                    api_store.apps_app_install,
-                ),
-                web.post("/store/addons/{app}/update", api_store.apps_app_update),
-                web.post(
-                    "/store/addons/{app}/update/{version}",
-                    api_store.apps_app_update,
-                ),
-                # Must be below others since it has a wildcard in resource path
-                web.get("/store/addons/{app}/{version}", api_store.apps_app_info),
-                web.post("/store/reload", api_store.reload),
-                web.get("/store/repositories", api_store.repositories_list),
-                web.get(
-                    "/store/repositories/{repository}",
-                    api_store.repositories_repository_info,
-                ),
-                web.post("/store/repositories", api_store.add_repository),
-                web.delete(
-                    "/store/repositories/{repository}", api_store.remove_repository
-                ),
-                web.post(
-                    "/store/repositories/{repository}/repair",
-                    api_store.repositories_repository_repair,
-                ),
-            ]
-        )
-
-        # Reroute from legacy
-        self.webapp.add_routes(
-            [
-                web.post("/addons/reload", api_store.reload),
-                web.post("/addons/{app}/install", api_store.apps_app_install),
-                web.post("/addons/{app}/update", api_store.apps_app_update),
-                web.get("/addons/{app}/icon", api_store.apps_app_icon),
-                web.get("/addons/{app}/logo", api_store.apps_app_logo),
-                web.get("/addons/{app}/changelog", api_store.apps_app_changelog),
-                web.get(
-                    "/addons/{app}/documentation",
-                    api_store.apps_app_documentation,
-                ),
-            ]
-        )
-
-    def _register_v2_store(self) -> None:
-        """Register v2 store routes on the v2 sub-app (accessible as /v2/store/...)."""
-        assert self._api_store is not None
-        api_store = self._api_store
-
-        self.v2_app.add_routes(
-            [
-                web.get("/store", api_store.store_info),
-                web.get("/store/apps", api_store.apps_list),
-                web.get("/store/apps/{app}", api_store.apps_app_info),
-                web.get("/store/apps/{app}/icon", api_store.apps_app_icon),
-                web.get("/store/apps/{app}/logo", api_store.apps_app_logo),
-                web.get("/store/apps/{app}/changelog", api_store.apps_app_changelog),
-                web.get(
-                    "/store/apps/{app}/documentation",
-                    api_store.apps_app_documentation,
-                ),
-                web.get(
-                    "/store/apps/{app}/availability",
-                    api_store.apps_app_availability,
-                ),
-                web.post("/store/apps/{app}/install", api_store.apps_app_install),
-                web.post(
-                    "/store/apps/{app}/install/{version}",
-                    api_store.apps_app_install,
-                ),
-                web.post("/store/apps/{app}/update", api_store.apps_app_update),
-                web.post(
-                    "/store/apps/{app}/update/{version}",
-                    api_store.apps_app_update,
-                ),
-                # Must be below others since it has a wildcard in resource path
-                web.get("/store/apps/{app}/{version}", api_store.apps_app_info),
                 web.post("/store/reload", api_store.reload),
                 web.get("/store/repositories", api_store.repositories_list),
                 web.get(
@@ -970,12 +966,12 @@ class RestAPI(CoreSysAttributes):
         """Register panel for Home Assistant."""
         return [StaticResourceConfig("/app", Path(__file__).parent.joinpath("panel"))]
 
-    def _register_docker(self) -> None:
+    def _register_docker(self, app: web.Application) -> None:
         """Register docker configuration functions."""
         api_docker = APIDocker()
         api_docker.coresys = self.coresys
 
-        self.webapp.add_routes(
+        app.add_routes(
             [
                 web.get("/docker/info", api_docker.info),
                 web.post(

--- a/supervisor/api/const.py
+++ b/supervisor/api/const.py
@@ -76,6 +76,13 @@ ATTR_VENDOR = "vendor"
 ATTR_VIRTUALIZATION = "virtualization"
 
 
+class AppVersion(StrEnum):
+    """API version identifiers."""
+
+    V1 = "v1"
+    V2 = "v2"
+
+
 class BootSlot(StrEnum):
     """Boot slots used by HAOS."""
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -203,6 +203,31 @@ async def fixture_api_client_with_prefix(
 
 
 @pytest.fixture(
+    name="core_api_client_with_root",
+    params=[
+        pytest.param("/core", id="v1-core"),
+        pytest.param("/homeassistant", id="v1-legacy"),
+        pytest.param("/v2/core", id="v2-core"),
+    ],
+)
+async def fixture_core_api_client_with_root(
+    request: pytest.FixtureRequest,
+    api_client: TestClient,
+    api_client_v2: TestClient,
+) -> tuple[TestClient, str]:
+    """Fixture providing (client, path_root) for Home Assistant Core API endpoints.
+
+    Parametrizes over all three registered access paths:
+      v1-core:   /core/...          (canonical v1 path)
+      v1-legacy: /homeassistant/... (legacy v1 alias, same handlers)
+      v2-core:   /v2/core/...       (canonical v2 path)
+    """
+    root: str = request.param
+    client = api_client_v2 if root.startswith("/v2") else api_client
+    return client, root
+
+
+@pytest.fixture(
     name="app_api_client_with_root",
     params=[pytest.param("/addons", id="v1"), pytest.param("/v2/apps", id="v2")],
 )

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -124,7 +124,7 @@ async def _common_test_api_advanced_logs(
 
 @pytest.fixture
 async def advanced_logs_tester(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     journald_logs: MagicMock,
     coresys: CoreSys,
     os_available,
@@ -138,14 +138,22 @@ async def advanced_logs_tester(
         async def test_my_logs(advanced_logs_tester):
             await advanced_logs_tester("/path/prefix", "syslog_identifier")
     """
+    api_client, api_prefix = api_client_with_prefix
 
     async def test_logs(
         path_prefix: str,
         syslog_identifier: str,
         formatter: LogFormatter = LogFormatter.PLAIN,
+        *,
+        v2_path_prefix: str | None = None,
     ):
+        effective_path = (
+            v2_path_prefix
+            if (api_prefix and v2_path_prefix is not None)
+            else path_prefix
+        )
         await _common_test_api_advanced_logs(
-            path_prefix,
+            f"{api_prefix}{effective_path}",
             syslog_identifier,
             formatter,
             api_client,

--- a/tests/api/test_addons.py
+++ b/tests/api/test_addons.py
@@ -80,7 +80,9 @@ async def test_api_app_logs(
     advanced_logs_tester: Callable[[str, str], Awaitable[None]],
 ):
     """Test app logs."""
-    await advanced_logs_tester("/addons/local_ssh", "addon_local_ssh")
+    await advanced_logs_tester(
+        "/addons/local_ssh", "addon_local_ssh", v2_path_prefix="/apps/local_ssh"
+    )
 
 
 async def test_api_app_logs_not_installed(api_client: TestClient):

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -82,12 +82,13 @@ def fixture_mock_check_login(coresys: CoreSys):
 
 
 async def test_password_reset(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     caplog: pytest.LogCaptureFixture,
     websession: MagicMock,
 ):
     """Test password reset api."""
+    api_client, prefix = api_client_with_prefix
     coresys.homeassistant.api._access_token = "abc123"  # pylint: disable=protected-access
     # pylint: disable-next=protected-access
     coresys.homeassistant.api._access_token_expires = datetime.now(tz=UTC) + timedelta(
@@ -96,7 +97,7 @@ async def test_password_reset(
 
     websession.request = MagicMock(return_value=MockResponse(status=200))
     resp = await api_client.post(
-        "/auth/reset", json={"username": "john", "password": "doe"}
+        f"{prefix}/auth/reset", json={"username": "john", "password": "doe"}
     )
     assert resp.status == 200
     assert "Successful password reset for 'john'" in caplog.text
@@ -116,7 +117,7 @@ async def test_password_reset(
     ],
 )
 async def test_failed_password_reset(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     caplog: pytest.LogCaptureFixture,
     websession: MagicMock,
@@ -124,6 +125,7 @@ async def test_failed_password_reset(
     expected_log: str,
 ):
     """Test failed password reset."""
+    api_client, prefix = api_client_with_prefix
     coresys.homeassistant.api._access_token = "abc123"  # pylint: disable=protected-access
     # pylint: disable-next=protected-access
     coresys.homeassistant.api._access_token_expires = datetime.now(tz=UTC) + timedelta(
@@ -132,7 +134,7 @@ async def test_failed_password_reset(
 
     websession.request = request_mock
     resp = await api_client.post(
-        "/auth/reset", json={"username": "john", "password": "doe"}
+        f"{prefix}/auth/reset", json={"username": "john", "password": "doe"}
     )
     assert resp.status == 400
     body = await resp.json()
@@ -149,11 +151,14 @@ async def test_failed_password_reset(
 
 
 async def test_list_users(
-    api_client: TestClient, coresys: CoreSys, ha_ws_client: AsyncMock
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    ha_ws_client: AsyncMock,
 ):
     """Test list users api."""
+    api_client, prefix = api_client_with_prefix
     ha_ws_client.async_send_command.return_value = LIST_USERS_RESPONSE
-    resp = await api_client.get("/auth/list")
+    resp = await api_client.get(f"{prefix}/auth/list")
     assert resp.status == 200
     result = await resp.json()
     assert result["data"]["users"] == [
@@ -169,15 +174,16 @@ async def test_list_users(
 
 
 async def test_list_users_ws_error(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     ha_ws_client: AsyncMock,
     caplog: pytest.LogCaptureFixture,
 ):
     """Test WS error when listing users via API."""
+    api_client, prefix = api_client_with_prefix
     ha_ws_client.async_send_command = AsyncMock(
         side_effect=HomeAssistantWSError("fail")
     )
-    resp = await api_client.get("/auth/list")
+    resp = await api_client.get(f"{prefix}/auth/list")
     assert resp.status == 500
     result = await resp.json()
     assert result == {
@@ -350,9 +356,14 @@ async def test_auth_app_no_auth_access(
     assert resp.status == 403
 
 
-async def test_non_app_token_no_auth_access(api_client: TestClient):
+async def test_non_app_token_no_auth_access(
+    api_client_with_prefix: tuple[TestClient, str],
+):
     """Test auth where app is not allowed to access auth API."""
-    resp = await api_client.post("/auth", json={"username": "test", "password": "pass"})
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.post(
+        f"{prefix}/auth", json={"username": "test", "password": "pass"}
+    )
     assert resp.status == 403
 
 

--- a/tests/api/test_discovery.py
+++ b/tests/api/test_discovery.py
@@ -41,12 +41,13 @@ async def test_api_discovery_forbidden(
     "skip_state", [AppState.ERROR, AppState.STOPPED, AppState.STARTUP]
 )
 async def test_api_list_discovery(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     install_app_ssh: App,
     skip_state: AppState,
 ):
     """Test listing discovery messages only returns ones for healthy services."""
+    api_client, prefix = api_client_with_prefix
     with (
         patch(
             "supervisor.utils.common.read_json_or_yaml_file",
@@ -63,7 +64,7 @@ async def test_api_list_discovery(
     ]
 
     install_app_ssh.state = AppState.STARTED
-    resp = await api_client.get("/discovery")
+    resp = await api_client.get(f"{prefix}/discovery")
     assert resp.status == 200
     result = await resp.json()
     assert result["data"]["discovery"] == [
@@ -76,7 +77,7 @@ async def test_api_list_discovery(
     ]
 
     install_app_ssh.state = skip_state
-    resp = await api_client.get("/discovery")
+    resp = await api_client.get(f"{prefix}/discovery")
     assert resp.status == 200
     result = await resp.json()
     assert result["data"]["discovery"] == []
@@ -148,9 +149,12 @@ async def test_api_invalid_discovery(api_client: TestClient, install_app_ssh: Ap
     ("method", "url"),
     [("get", "/discovery/bad"), ("delete", "/discovery/bad")],
 )
-async def test_discovery_not_found(api_client: TestClient, method: str, url: str):
+async def test_discovery_not_found(
+    api_client_with_prefix: tuple[TestClient, str], method: str, url: str
+):
     """Test discovery not found error."""
-    resp = await api_client.request(method, url)
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.request(method, f"{prefix}{url}")
     assert resp.status == 404
     resp = await resp.json()
     assert resp["message"] == "Discovery message not found"

--- a/tests/api/test_dns.py
+++ b/tests/api/test_dns.py
@@ -13,24 +13,25 @@ from tests.dbus_service_mocks.resolved import Resolved as ResolvedService
 
 
 async def test_llmnr_mdns_info(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ):
     """Test llmnr and mdns in info api."""
+    api_client, prefix = api_client_with_prefix
     resolved_service: ResolvedService = all_dbus_services["resolved"]
 
     # pylint: disable=protected-access
     coresys.host.sys_dbus._resolved = Resolved()
     # pylint: enable=protected-access
 
-    resp = await api_client.get("/dns/info")
+    resp = await api_client.get(f"{prefix}/dns/info")
     result = await resp.json()
     assert result["data"]["llmnr"] is False
     assert result["data"]["mdns"] is False
 
     await coresys.dbus.resolved.connect(coresys.dbus.bus)
-    resp = await api_client.get("/dns/info")
+    resp = await api_client.get(f"{prefix}/dns/info")
     result = await resp.json()
     assert result["data"]["llmnr"] is True
     assert result["data"]["mdns"] is True
@@ -38,20 +39,24 @@ async def test_llmnr_mdns_info(
     resolved_service.emit_properties_changed({"LLMNR": "no", "MulticastDNS": "no"})
     await resolved_service.ping()
 
-    resp = await api_client.get("/dns/info")
+    resp = await api_client.get(f"{prefix}/dns/info")
     result = await resp.json()
     assert result["data"]["llmnr"] is False
     assert result["data"]["mdns"] is False
 
 
-async def test_options(api_client: TestClient, coresys: CoreSys):
+async def test_options(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test options api."""
+    api_client, prefix = api_client_with_prefix
     assert coresys.plugins.dns.servers == []
     assert coresys.plugins.dns.fallback is True
 
     with patch.object(type(coresys.plugins.dns), "restart") as restart:
         await api_client.post(
-            "/dns/options", json={"servers": ["dns://8.8.8.8"], "fallback": False}
+            f"{prefix}/dns/options",
+            json={"servers": ["dns://8.8.8.8"], "fallback": False},
         )
 
         assert coresys.plugins.dns.servers == ["dns://8.8.8.8"]
@@ -59,7 +64,7 @@ async def test_options(api_client: TestClient, coresys: CoreSys):
         restart.assert_called_once()
 
         restart.reset_mock()
-        await api_client.post("/dns/options", json={"fallback": True})
+        await api_client.post(f"{prefix}/dns/options", json={"fallback": True})
 
         assert coresys.plugins.dns.servers == ["dns://8.8.8.8"]
         assert coresys.plugins.dns.fallback is True

--- a/tests/api/test_docker.py
+++ b/tests/api/test_docker.py
@@ -12,9 +12,10 @@ from tests.dbus_service_mocks.base import DBusServiceMock
 
 
 @pytest.mark.asyncio
-async def test_api_docker_info(api_client: TestClient):
+async def test_api_docker_info(api_client_with_prefix: tuple[TestClient, str]):
     """Test docker info api."""
-    resp = await api_client.get("/docker/info")
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.get(f"{prefix}/docker/info")
     result = await resp.json()
 
     assert result["data"]["logging"] == "journald"
@@ -22,70 +23,80 @@ async def test_api_docker_info(api_client: TestClient):
     assert result["data"]["version"] == "1.0.0"
 
 
-async def test_api_network_enable_ipv6(coresys: CoreSys, api_client: TestClient):
+async def test_api_network_enable_ipv6(
+    coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
+):
     """Test setting docker network for enabled IPv6."""
+    api_client, prefix = api_client_with_prefix
     assert coresys.docker.config.enable_ipv6 is None
 
-    resp = await api_client.post("/docker/options", json={"enable_ipv6": True})
+    resp = await api_client.post(f"{prefix}/docker/options", json={"enable_ipv6": True})
     assert resp.status == 200
 
     assert coresys.docker.config.enable_ipv6 is True
 
-    resp = await api_client.get("/docker/info")
+    resp = await api_client.get(f"{prefix}/docker/info")
     assert resp.status == 200
     body = await resp.json()
     assert body["data"]["enable_ipv6"] is True
 
 
-async def test_api_network_mtu(coresys: CoreSys, api_client: TestClient):
+async def test_api_network_mtu(
+    coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
+):
     """Test setting docker network MTU."""
+    api_client, prefix = api_client_with_prefix
     assert coresys.docker.config.mtu is None
 
-    resp = await api_client.post("/docker/options", json={"mtu": 1450})
+    resp = await api_client.post(f"{prefix}/docker/options", json={"mtu": 1450})
     assert resp.status == 200
 
     assert coresys.docker.config.mtu == 1450
 
-    resp = await api_client.get("/docker/info")
+    resp = await api_client.get(f"{prefix}/docker/info")
     assert resp.status == 200
     body = await resp.json()
     assert body["data"]["mtu"] == 1450
 
     # Test setting MTU to None
-    resp = await api_client.post("/docker/options", json={"mtu": None})
+    resp = await api_client.post(f"{prefix}/docker/options", json={"mtu": None})
     assert resp.status == 200
 
     assert coresys.docker.config.mtu is None
 
-    resp = await api_client.get("/docker/info")
+    resp = await api_client.get(f"{prefix}/docker/info")
     assert resp.status == 200
     body = await resp.json()
     assert body["data"]["mtu"] is None
 
 
-async def test_api_network_combined_options(coresys: CoreSys, api_client: TestClient):
+async def test_api_network_combined_options(
+    coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
+):
     """Test setting both IPv6 and MTU together."""
+    api_client, prefix = api_client_with_prefix
     assert coresys.docker.config.enable_ipv6 is None
     assert coresys.docker.config.mtu is None
 
     resp = await api_client.post(
-        "/docker/options", json={"enable_ipv6": True, "mtu": 1400}
+        f"{prefix}/docker/options", json={"enable_ipv6": True, "mtu": 1400}
     )
     assert resp.status == 200
 
     assert coresys.docker.config.enable_ipv6 is True
     assert coresys.docker.config.mtu == 1400
 
-    resp = await api_client.get("/docker/info")
+    resp = await api_client.get(f"{prefix}/docker/info")
     assert resp.status == 200
     body = await resp.json()
     assert body["data"]["enable_ipv6"] is True
     assert body["data"]["mtu"] == 1400
 
 
-async def test_registry_not_found(api_client: TestClient):
+async def test_registry_not_found(api_client_with_prefix: tuple[TestClient, str]):
     """Test registry not found error."""
-    resp = await api_client.delete("/docker/registries/bad")
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.delete(f"{prefix}/docker/registries/bad")
     assert resp.status == 404
     body = await resp.json()
     assert body["message"] == "Hostname bad does not exist in registries"
@@ -93,17 +104,18 @@ async def test_registry_not_found(api_client: TestClient):
 
 @pytest.mark.parametrize("os_available", ["17.0.rc1"], indirect=True)
 async def test_api_migrate_docker_storage_driver(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     os_agent_services: dict[str, DBusServiceMock],
     os_available,
 ):
     """Test Docker storage driver migration."""
+    api_client, prefix = api_client_with_prefix
     system_service: SystemService = os_agent_services["agent_system"]
     system_service.MigrateDockerStorageDriver.calls.clear()
 
     resp = await api_client.post(
-        "/docker/migrate-storage-driver",
+        f"{prefix}/docker/migrate-storage-driver",
         json={"storage_driver": "overlayfs"},
     )
     assert resp.status == 200
@@ -121,24 +133,26 @@ async def test_api_migrate_docker_storage_driver(
 
 @pytest.mark.parametrize("os_available", ["17.0.rc1"], indirect=True)
 async def test_api_migrate_docker_storage_driver_invalid_backend(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     os_available,
 ):
     """Test 400 is returned for invalid storage driver."""
+    api_client, prefix = api_client_with_prefix
     resp = await api_client.post(
-        "/docker/migrate-storage-driver",
+        f"{prefix}/docker/migrate-storage-driver",
         json={"storage_driver": "invalid"},
     )
     assert resp.status == 400
 
 
 async def test_api_migrate_docker_storage_driver_not_os(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
 ):
     """Test 404 is returned if not running on HAOS."""
+    api_client, prefix = api_client_with_prefix
     resp = await api_client.post(
-        "/docker/migrate-storage-driver",
+        f"{prefix}/docker/migrate-storage-driver",
         json={"storage_driver": "overlayfs"},
     )
     assert resp.status == 404
@@ -146,13 +160,14 @@ async def test_api_migrate_docker_storage_driver_not_os(
 
 @pytest.mark.parametrize("os_available", ["16.2"], indirect=True)
 async def test_api_migrate_docker_storage_driver_old_os(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     os_available,
 ):
     """Test 404 is returned if OS is older than 17.0."""
+    api_client, prefix = api_client_with_prefix
     resp = await api_client.post(
-        "/docker/migrate-storage-driver",
+        f"{prefix}/docker/migrate-storage-driver",
         json={"storage_driver": "overlayfs"},
     )
     assert resp.status == 404

--- a/tests/api/test_hardware.py
+++ b/tests/api/test_hardware.py
@@ -10,17 +10,21 @@ from supervisor.hardware.data import Device
 
 
 @pytest.mark.asyncio
-async def test_api_hardware_info(api_client: TestClient):
+async def test_api_hardware_info(api_client_with_prefix: tuple[TestClient, str]):
     """Test docker info api."""
-    resp = await api_client.get("/hardware/info")
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.get(f"{prefix}/hardware/info")
     result = await resp.json()
 
     assert result["result"] == "ok"
 
 
 @pytest.mark.asyncio
-async def test_api_hardware_info_device(api_client: TestClient, coresys: CoreSys):
+async def test_api_hardware_info_device(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test docker info api."""
+    api_client, prefix = api_client_with_prefix
     coresys.hardware.update_device(
         Device(
             "sda",
@@ -34,7 +38,7 @@ async def test_api_hardware_info_device(api_client: TestClient, coresys: CoreSys
         )
     )
 
-    resp = await api_client.get("/hardware/info")
+    resp = await api_client.get(f"{prefix}/hardware/info")
     result = await resp.json()
 
     assert result["result"] == "ok"
@@ -42,11 +46,14 @@ async def test_api_hardware_info_device(api_client: TestClient, coresys: CoreSys
     assert result["data"]["devices"][-1]["by_id"] == "/dev/serial/by-id/test"
 
 
-async def test_api_hardware_info_drives(api_client: TestClient, coresys: CoreSys):
+async def test_api_hardware_info_drives(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test drive info."""
+    api_client, prefix = api_client_with_prefix
     await coresys.dbus.udisks2.connect(coresys.dbus.bus)
 
-    resp = await api_client.get("/hardware/info")
+    resp = await api_client.get(f"{prefix}/hardware/info")
     result = await resp.json()
 
     assert result["result"] == "ok"

--- a/tests/api/test_homeassistant.py
+++ b/tests/api/test_homeassistant.py
@@ -34,6 +34,7 @@ async def test_api_core_logs(
     await advanced_logs_tester(
         f"/{'homeassistant' if legacy_route else 'core'}",
         "homeassistant",
+        v2_path_prefix="/core",
     )
 
 

--- a/tests/api/test_homeassistant.py
+++ b/tests/api/test_homeassistant.py
@@ -38,15 +38,18 @@ async def test_api_core_logs(
     )
 
 
-async def test_api_stats(api_client: TestClient, container: DockerContainer):
+async def test_api_stats(
+    core_api_client_with_root: tuple[TestClient, str], container: DockerContainer
+):
     """Test stats."""
+    api_client, root = core_api_client_with_root
     container.show.return_value["State"]["Status"] = "running"
     container.show.return_value["State"]["Running"] = True
     container.stats = AsyncMock(
         return_value=[load_json_fixture("container_stats.json")]
     )
 
-    resp = await api_client.get("/homeassistant/stats")
+    resp = await api_client.get(f"{root}/stats")
     assert resp.status == 200
     result = await resp.json()
     assert result["data"]["cpu_percent"] == 90.0
@@ -55,9 +58,10 @@ async def test_api_stats(api_client: TestClient, container: DockerContainer):
     assert result["data"]["memory_percent"] == 1.49
 
 
-async def test_api_set_options(api_client: TestClient):
+async def test_api_set_options(core_api_client_with_root: tuple[TestClient, str]):
     """Test setting options for homeassistant."""
-    resp = await api_client.get("/homeassistant/info")
+    api_client, root = core_api_client_with_root
+    resp = await api_client.get(f"{root}/info")
     assert resp.status == 200
     result = await resp.json()
     assert result["data"]["watchdog"] is True
@@ -65,21 +69,24 @@ async def test_api_set_options(api_client: TestClient):
 
     with patch.object(HomeAssistant, "save_data") as save_data:
         resp = await api_client.post(
-            "/homeassistant/options",
+            f"{root}/options",
             json={"backups_exclude_database": True, "watchdog": False},
         )
         assert resp.status == 200
         save_data.assert_called_once()
 
-    resp = await api_client.get("/homeassistant/info")
+    resp = await api_client.get(f"{root}/info")
     assert resp.status == 200
     result = await resp.json()
     assert result["data"]["watchdog"] is False
     assert result["data"]["backups_exclude_database"] is True
 
 
-async def test_api_set_image(api_client: TestClient, coresys: CoreSys):
+async def test_api_set_image(
+    core_api_client_with_root: tuple[TestClient, str], coresys: CoreSys
+):
     """Test changing the image for homeassistant."""
+    api_client, root = core_api_client_with_root
     assert (
         coresys.homeassistant.image == "ghcr.io/home-assistant/qemux86-64-homeassistant"
     )
@@ -87,7 +94,7 @@ async def test_api_set_image(api_client: TestClient, coresys: CoreSys):
 
     with patch.object(HomeAssistant, "save_data"):
         resp = await api_client.post(
-            "/homeassistant/options",
+            f"{root}/options",
             json={"image": "test_image"},
         )
 
@@ -97,7 +104,7 @@ async def test_api_set_image(api_client: TestClient, coresys: CoreSys):
 
     with patch.object(HomeAssistant, "save_data"):
         resp = await api_client.post(
-            "/homeassistant/options",
+            f"{root}/options",
             json={"image": "ghcr.io/home-assistant/qemux86-64-homeassistant"},
         )
 
@@ -109,19 +116,22 @@ async def test_api_set_image(api_client: TestClient, coresys: CoreSys):
 
 
 async def test_api_restart(
-    api_client: TestClient, container: DockerContainer, tmp_supervisor_data: Path
+    core_api_client_with_root: tuple[TestClient, str],
+    container: DockerContainer,
+    tmp_supervisor_data: Path,
 ):
     """Test restarting homeassistant."""
+    api_client, root = core_api_client_with_root
     safe_mode_marker = tmp_supervisor_data / "homeassistant" / "safe-mode"
 
     with patch.object(HomeAssistantCore, "_block_till_run"):
-        await api_client.post("/homeassistant/restart")
+        await api_client.post(f"{root}/restart")
 
     container.restart.assert_called_once()
     assert not safe_mode_marker.exists()
 
     with patch.object(HomeAssistantCore, "_block_till_run"):
-        await api_client.post("/homeassistant/restart", json={"safe_mode": True})
+        await api_client.post(f"{root}/restart", json={"safe_mode": True})
 
     assert container.restart.call_count == 2
     assert safe_mode_marker.exists()
@@ -129,24 +139,25 @@ async def test_api_restart(
 
 @pytest.mark.usefixtures("path_extern")
 async def test_api_rebuild(
-    api_client: TestClient,
+    core_api_client_with_root: tuple[TestClient, str],
     coresys: CoreSys,
     container: DockerContainer,
     tmp_supervisor_data: Path,
 ):
     """Test rebuilding homeassistant."""
+    api_client, root = core_api_client_with_root
     coresys.homeassistant.version = AwesomeVersion("2023.09.0")
     safe_mode_marker = tmp_supervisor_data / "homeassistant" / "safe-mode"
 
     with patch.object(HomeAssistantCore, "_block_till_run"):
-        await api_client.post("/homeassistant/rebuild")
+        await api_client.post(f"{root}/rebuild")
 
     assert container.delete.call_count == 2
     container.start.assert_called_once()
     assert not safe_mode_marker.exists()
 
     with patch.object(HomeAssistantCore, "_block_till_run"):
-        await api_client.post("/homeassistant/rebuild", json={"safe_mode": True})
+        await api_client.post(f"{root}/rebuild", json={"safe_mode": True})
 
     assert container.delete.call_count == 4
     assert container.start.call_count == 2
@@ -155,12 +166,13 @@ async def test_api_rebuild(
 
 @pytest.mark.parametrize("action", ["rebuild", "restart", "stop", "update"])
 async def test_migration_blocks_stopping_core(
-    api_client: TestClient, coresys: CoreSys, action: str
+    core_api_client_with_root: tuple[TestClient, str], coresys: CoreSys, action: str
 ):
     """Test that an offline db migration in progress stops users from stopping/restarting core."""
+    api_client, root = core_api_client_with_root
     coresys.homeassistant.api.get_api_state.return_value = APIState("NOT_RUNNING", True)
 
-    resp = await api_client.post(f"/homeassistant/{action}")
+    resp = await api_client.post(f"{root}/{action}")
     assert resp.status == 503
     result = await resp.json()
     assert (
@@ -169,30 +181,39 @@ async def test_migration_blocks_stopping_core(
     )
 
 
-async def test_force_rebuild_during_migration(api_client: TestClient, coresys: CoreSys):
+async def test_force_rebuild_during_migration(
+    core_api_client_with_root: tuple[TestClient, str], coresys: CoreSys
+):
     """Test force option rebuilds even during a migration."""
+    api_client, root = core_api_client_with_root
     coresys.homeassistant.api.get_api_state.return_value = APIState("NOT_RUNNING", True)
 
     with patch.object(HomeAssistantCore, "rebuild") as rebuild:
-        await api_client.post("/homeassistant/rebuild", json={"force": True})
+        await api_client.post(f"{root}/rebuild", json={"force": True})
         rebuild.assert_called_once()
 
 
-async def test_force_restart_during_migration(api_client: TestClient, coresys: CoreSys):
+async def test_force_restart_during_migration(
+    core_api_client_with_root: tuple[TestClient, str], coresys: CoreSys
+):
     """Test force option restarts even during a migration."""
+    api_client, root = core_api_client_with_root
     coresys.homeassistant.api.get_api_state.return_value = APIState("NOT_RUNNING", True)
 
     with patch.object(HomeAssistantCore, "restart") as restart:
-        await api_client.post("/homeassistant/restart", json={"force": True})
+        await api_client.post(f"{root}/restart", json={"force": True})
         restart.assert_called_once()
 
 
-async def test_force_stop_during_migration(api_client: TestClient, coresys: CoreSys):
+async def test_force_stop_during_migration(
+    core_api_client_with_root: tuple[TestClient, str], coresys: CoreSys
+):
     """Test force option stops even during a migration."""
+    api_client, root = core_api_client_with_root
     coresys.homeassistant.api.get_api_state.return_value = APIState("NOT_RUNNING", True)
 
     with patch.object(HomeAssistantCore, "stop") as stop:
-        await api_client.post("/homeassistant/stop", json={"force": True})
+        await api_client.post(f"{root}/stop", json={"force": True})
         stop.assert_called_once()
 
 
@@ -201,13 +222,14 @@ async def test_force_stop_during_migration(api_client: TestClient, coresys: Core
     [(True, True, False), (False, False, True)],
 )
 async def test_home_assistant_background_update(
-    api_client: TestClient,
+    core_api_client_with_root: tuple[TestClient, str],
     coresys: CoreSys,
     make_backup: bool,
     backup_called: bool,
     update_called: bool,
 ):
     """Test background update of Home Assistant."""
+    api_client, root = core_api_client_with_root
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     event = asyncio.Event()
     mock_update_called = mock_backup_called = False
@@ -233,7 +255,7 @@ async def test_home_assistant_background_update(
         ),
     ):
         resp = await api_client.post(
-            "/core/update",
+            f"{root}/update",
             json={"background": True, "backup": make_backup, "version": "2025.8.3"},
         )
 
@@ -248,9 +270,10 @@ async def test_home_assistant_background_update(
 
 
 async def test_background_home_assistant_update_fails_fast(
-    api_client: TestClient, coresys: CoreSys
+    core_api_client_with_root: tuple[TestClient, str], coresys: CoreSys
 ):
     """Test background Home Assistant update returns error not job if validation doesn't succeed."""
+    api_client, root = core_api_client_with_root
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
 
     with (
@@ -261,7 +284,7 @@ async def test_background_home_assistant_update_fails_fast(
         ),
     ):
         resp = await api_client.post(
-            "/core/update",
+            f"{root}/update",
             json={"background": True, "version": "2025.8.3"},
         )
 
@@ -272,9 +295,12 @@ async def test_background_home_assistant_update_fails_fast(
 
 @pytest.mark.usefixtures("tmp_supervisor_data")
 async def test_api_progress_updates_home_assistant_update(
-    api_client: TestClient, coresys: CoreSys, ha_ws_client: AsyncMock
+    core_api_client_with_root: tuple[TestClient, str],
+    coresys: CoreSys,
+    ha_ws_client: AsyncMock,
 ):
     """Test progress updates sent to Home Assistant for updates."""
+    api_client, root = core_api_client_with_root
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     coresys.core.set_state(CoreState.RUNNING)
 
@@ -293,7 +319,7 @@ async def test_api_progress_updates_home_assistant_update(
         ),
         patch.object(HomeAssistantAPI, "check_frontend_available", return_value=True),
     ):
-        resp = await api_client.post("/core/update", json={"version": "2025.8.3"})
+        resp = await api_client.post(f"{root}/update", json={"version": "2025.8.3"})
 
     assert resp.status == 200
 
@@ -368,12 +394,15 @@ async def test_api_progress_updates_home_assistant_update(
 
 @pytest.mark.usefixtures("path_extern")
 async def test_config_check(
-    api_client: TestClient, coresys: CoreSys, container: DockerContainer
+    core_api_client_with_root: tuple[TestClient, str],
+    coresys: CoreSys,
+    container: DockerContainer,
 ):
     """Test config check API."""
+    api_client, root = core_api_client_with_root
     coresys.homeassistant.version = AwesomeVersion("2025.1.0")
 
-    result = await api_client.post("/core/check")
+    result = await api_client.post(f"{root}/check")
     assert result.status == 200
 
     coresys.docker.containers.create.assert_called_once_with(
@@ -431,22 +460,28 @@ async def test_config_check(
 
 
 @pytest.mark.usefixtures("path_extern")
-async def test_config_check_error(api_client: TestClient, container: DockerContainer):
+async def test_config_check_error(
+    core_api_client_with_root: tuple[TestClient, str], container: DockerContainer
+):
     """Test config check API strips color coding from log output on error."""
+    api_client, root = core_api_client_with_root
     container.log.return_value = [
         "\x1b[36mTest logs 1\x1b[0m\n",
         "\x1b[36mTest logs 2\x1b[0m\n",
     ]
     container.wait.return_value = {"StatusCode": 1}
 
-    result = await api_client.post("/core/check")
+    result = await api_client.post(f"{root}/check")
     assert result.status == 400
     resp = await result.json()
     assert resp["message"] == "Test logs 1\nTest logs 2\n"
 
 
-async def test_update_frontend_check_success(api_client: TestClient, coresys: CoreSys):
+async def test_update_frontend_check_success(
+    core_api_client_with_root: tuple[TestClient, str], coresys: CoreSys
+):
     """Test that update succeeds when frontend check passes."""
+    api_client, root = core_api_client_with_root
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     coresys.homeassistant.version = AwesomeVersion("2025.8.0")
 
@@ -462,19 +497,20 @@ async def test_update_frontend_check_success(api_client: TestClient, coresys: Co
         patch.object(HomeAssistantAPI, "check_frontend_available", return_value=True),
         patch.object(DockerInterface, "cleanup") as mock_cleanup,
     ):
-        resp = await api_client.post("/core/update", json={"version": "2025.8.3"})
+        resp = await api_client.post(f"{root}/update", json={"version": "2025.8.3"})
 
     assert resp.status == 200
     mock_cleanup.assert_called_once()
 
 
 async def test_update_frontend_check_fails_triggers_rollback(
-    api_client: TestClient,
+    core_api_client_with_root: tuple[TestClient, str],
     coresys: CoreSys,
     caplog: pytest.LogCaptureFixture,
     tmp_supervisor_data: Path,
 ):
     """Test that update triggers rollback when frontend check fails."""
+    api_client, root = core_api_client_with_root
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     coresys.homeassistant.version = AwesomeVersion("2025.8.0")
 
@@ -504,7 +540,7 @@ async def test_update_frontend_check_fails_triggers_rollback(
         patch.object(HomeAssistantAPI, "check_frontend_available", return_value=False),
         patch.object(DockerInterface, "cleanup") as mock_cleanup,
     ):
-        resp = await api_client.post("/core/update", json={"version": "2025.8.3"})
+        resp = await api_client.post(f"{root}/update", json={"version": "2025.8.3"})
 
     # Update should trigger rollback, which succeeds and returns 200
     assert resp.status == 200
@@ -521,12 +557,13 @@ async def test_update_frontend_check_fails_triggers_rollback(
 
 
 async def test_update_get_config_error_triggers_rollback(
-    api_client: TestClient,
+    core_api_client_with_root: tuple[TestClient, str],
     coresys: CoreSys,
     caplog: pytest.LogCaptureFixture,
     tmp_supervisor_data: Path,
 ):
     """Test that update triggers rollback when get_config raises HomeAssistantError."""
+    api_client, root = core_api_client_with_root
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     coresys.homeassistant.version = AwesomeVersion("2025.8.0")
 
@@ -553,7 +590,7 @@ async def test_update_get_config_error_triggers_rollback(
         ) as mock_check_frontend,
         patch.object(DockerInterface, "cleanup") as mock_cleanup,
     ):
-        resp = await api_client.post("/core/update", json={"version": "2025.8.3"})
+        resp = await api_client.post(f"{root}/update", json={"version": "2025.8.3"})
 
     assert resp.status == 200
     assert "HomeAssistant update failed -> rollback!" in caplog.text

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -38,8 +38,11 @@ async def fixture_coresys_disk_info(coresys: CoreSys) -> AsyncGenerator[CoreSys]
 
 
 @pytest.mark.asyncio
-async def test_api_host_info(api_client: TestClient, coresys_disk_info: CoreSys):
+async def test_api_host_info(
+    api_client_with_prefix: tuple[TestClient, str], coresys_disk_info: CoreSys
+):
     """Test host info api."""
+    api_client, prefix = api_client_with_prefix
     coresys = coresys_disk_info
     dt_utc = datetime(2026, 2, 17, 1, 23, 45, 678901, tzinfo=UTC)
 
@@ -47,7 +50,7 @@ async def test_api_host_info(api_client: TestClient, coresys_disk_info: CoreSys)
     await coresys.dbus.agent.update()
 
     with time_machine.travel(dt_utc, tick=False):
-        resp = await api_client.get("/host/info")
+        resp = await api_client.get(f"{prefix}/host/info")
         result = await resp.json()
 
     assert result["data"]["apparmor_version"] == "2.13.2"
@@ -55,9 +58,12 @@ async def test_api_host_info(api_client: TestClient, coresys_disk_info: CoreSys)
 
 
 async def test_api_host_features(
-    api_client: TestClient, coresys_disk_info: CoreSys, dbus_is_connected
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys_disk_info: CoreSys,
+    dbus_is_connected,
 ):
     """Test host info features."""
+    api_client, prefix = api_client_with_prefix
     coresys = coresys_disk_info
 
     coresys.host.sys_dbus.systemd.is_connected = False
@@ -68,7 +74,7 @@ async def test_api_host_features(
     coresys.host.sys_dbus.resolved.is_connected = False
     coresys.host.sys_dbus.udisks2.is_connected = False
 
-    resp = await api_client.get("/host/info")
+    resp = await api_client.get(f"{prefix}/host/info")
     result = await resp.json()
     assert "reboot" not in result["data"]["features"]
     assert "services" not in result["data"]["features"]
@@ -82,7 +88,7 @@ async def test_api_host_features(
 
     coresys.host.sys_dbus.systemd.is_connected = True
     coresys.host.supported_features.cache_clear()
-    resp = await api_client.get("/host/info")
+    resp = await api_client.get(f"{prefix}/host/info")
     result = await resp.json()
     assert "reboot" in result["data"]["features"]
     assert "services" in result["data"]["features"]
@@ -90,49 +96,52 @@ async def test_api_host_features(
 
     coresys.host.sys_dbus.network.is_connected = True
     coresys.host.supported_features.cache_clear()
-    resp = await api_client.get("/host/info")
+    resp = await api_client.get(f"{prefix}/host/info")
     result = await resp.json()
     assert "network" in result["data"]["features"]
 
     coresys.host.sys_dbus.hostname.is_connected = True
     coresys.host.supported_features.cache_clear()
-    resp = await api_client.get("/host/info")
+    resp = await api_client.get(f"{prefix}/host/info")
     result = await resp.json()
     assert "hostname" in result["data"]["features"]
 
     coresys.host.sys_dbus.timedate.is_connected = True
     coresys.host.supported_features.cache_clear()
-    resp = await api_client.get("/host/info")
+    resp = await api_client.get(f"{prefix}/host/info")
     result = await resp.json()
     assert "timedate" in result["data"]["features"]
 
     coresys.host.sys_dbus.agent.is_connected = True
     coresys.host.supported_features.cache_clear()
-    resp = await api_client.get("/host/info")
+    resp = await api_client.get(f"{prefix}/host/info")
     result = await resp.json()
     assert "os_agent" in result["data"]["features"]
 
     coresys.host.sys_dbus.resolved.is_connected = True
     coresys.host.supported_features.cache_clear()
-    resp = await api_client.get("/host/info")
+    resp = await api_client.get(f"{prefix}/host/info")
     result = await resp.json()
     assert "resolved" in result["data"]["features"]
 
     coresys.host.sys_dbus.udisks2.is_connected = True
     coresys.host.supported_features.cache_clear()
-    resp = await api_client.get("/host/info")
+    resp = await api_client.get(f"{prefix}/host/info")
     result = await resp.json()
     assert "disk" in result["data"]["features"]
 
 
-async def test_api_llmnr_mdns_info(api_client: TestClient, coresys_disk_info: CoreSys):
+async def test_api_llmnr_mdns_info(
+    api_client_with_prefix: tuple[TestClient, str], coresys_disk_info: CoreSys
+):
     """Test llmnr and mdns details in info."""
+    api_client, prefix = api_client_with_prefix
     coresys = coresys_disk_info
     # pylint: disable=protected-access
     coresys.host.sys_dbus._resolved = Resolved()
     # pylint: enable=protected-access
 
-    resp = await api_client.get("/host/info")
+    resp = await api_client.get(f"{prefix}/host/info")
     result = await resp.json()
     assert result["data"]["broadcast_llmnr"] is None
     assert result["data"]["broadcast_mdns"] is None
@@ -140,23 +149,29 @@ async def test_api_llmnr_mdns_info(api_client: TestClient, coresys_disk_info: Co
 
     await coresys.dbus.resolved.connect(coresys.dbus.bus)
 
-    resp = await api_client.get("/host/info")
+    resp = await api_client.get(f"{prefix}/host/info")
     result = await resp.json()
     assert result["data"]["broadcast_llmnr"] is True
     assert result["data"]["broadcast_mdns"] is False
     assert result["data"]["llmnr_hostname"] == "homeassistant"
 
 
-async def test_api_boot_ids_info(api_client: TestClient, journald_logs: MagicMock):
+async def test_api_boot_ids_info(
+    api_client_with_prefix: tuple[TestClient, str], journald_logs: MagicMock
+):
     """Test getting boot IDs."""
-    resp = await api_client.get("/host/logs/boots")
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.get(f"{prefix}/host/logs/boots")
     result = await resp.json()
     assert result["data"] == {"boots": {"0": "ccc", "-1": "bbb", "-2": "aaa"}}
 
 
-async def test_api_identifiers_info(api_client: TestClient, journald_logs: MagicMock):
+async def test_api_identifiers_info(
+    api_client_with_prefix: tuple[TestClient, str], journald_logs: MagicMock
+):
     """Test getting syslog identifiers."""
-    resp = await api_client.get("/host/logs/identifiers")
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.get(f"{prefix}/host/logs/identifiers")
     result = await resp.json()
     assert result["data"] == {
         "identifiers": ["hassio_supervisor", "hassos-config", "kernel"]
@@ -164,30 +179,34 @@ async def test_api_identifiers_info(api_client: TestClient, journald_logs: Magic
 
 
 async def test_api_virtualization_info(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
     coresys_disk_info: CoreSys,
 ):
     """Test getting virtualization info."""
+    api_client, prefix = api_client_with_prefix
     systemd_service: SystemdService = all_dbus_services["systemd"]
 
-    resp = await api_client.get("/host/info")
+    resp = await api_client.get(f"{prefix}/host/info")
     result = await resp.json()
     assert result["data"]["virtualization"] == ""
 
     systemd_service.virtualization = "vmware"
     await coresys_disk_info.dbus.systemd.update()
 
-    resp = await api_client.get("/host/info")
+    resp = await api_client.get(f"{prefix}/host/info")
     result = await resp.json()
     assert result["data"]["virtualization"] == "vmware"
 
 
 async def test_advanced_logs(
-    api_client: TestClient, coresys: CoreSys, journald_logs: MagicMock
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    journald_logs: MagicMock,
 ):
     """Test advanced logging API entries with identifier and custom boot."""
-    await api_client.get("/host/logs")
+    api_client, prefix = api_client_with_prefix
+    await api_client.get(f"{prefix}/host/logs")
     journald_logs.assert_called_once_with(
         params={"SYSLOG_IDENTIFIER": coresys.host.logs.default_identifiers},
         range_header=DEFAULT_RANGE,
@@ -197,7 +216,7 @@ async def test_advanced_logs(
     journald_logs.reset_mock()
 
     identifier = "dropbear"
-    await api_client.get(f"/host/logs/identifiers/{identifier}")
+    await api_client.get(f"{prefix}/host/logs/identifiers/{identifier}")
     journald_logs.assert_called_once_with(
         params={"SYSLOG_IDENTIFIER": identifier},
         range_header=DEFAULT_RANGE,
@@ -207,7 +226,7 @@ async def test_advanced_logs(
     journald_logs.reset_mock()
 
     bootid = "798cc03bcd77465482b6a1c43dc6a5fc"
-    await api_client.get(f"/host/logs/boots/{bootid}")
+    await api_client.get(f"{prefix}/host/logs/boots/{bootid}")
     journald_logs.assert_called_once_with(
         params={
             "_BOOT_ID": bootid,
@@ -219,7 +238,7 @@ async def test_advanced_logs(
 
     journald_logs.reset_mock()
 
-    await api_client.get(f"/host/logs/boots/{bootid}/identifiers/{identifier}")
+    await api_client.get(f"{prefix}/host/logs/boots/{bootid}/identifiers/{identifier}")
     journald_logs.assert_called_once_with(
         params={"_BOOT_ID": bootid, "SYSLOG_IDENTIFIER": identifier},
         range_header=DEFAULT_RANGE,
@@ -229,7 +248,7 @@ async def test_advanced_logs(
     journald_logs.reset_mock()
 
     headers = {"Range": "entries=:-19:10"}
-    await api_client.get("/host/logs", headers=headers)
+    await api_client.get(f"{prefix}/host/logs", headers=headers)
     journald_logs.assert_called_once_with(
         params={"SYSLOG_IDENTIFIER": coresys.host.logs.default_identifiers},
         range_header=headers["Range"],
@@ -238,7 +257,7 @@ async def test_advanced_logs(
 
     journald_logs.reset_mock()
 
-    await api_client.get("/host/logs/follow")
+    await api_client.get(f"{prefix}/host/logs/follow")
     journald_logs.assert_called_once_with(
         params={
             "SYSLOG_IDENTIFIER": coresys.host.logs.default_identifiers,
@@ -249,19 +268,20 @@ async def test_advanced_logs(
     )
 
     # Host logs don't have a /latest endpoint
-    resp = await api_client.get("/host/logs/latest")
+    resp = await api_client.get(f"{prefix}/host/logs/latest")
     assert resp.status == 404
 
 
 async def test_advaced_logs_query_parameters(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     journald_logs: MagicMock,
     journal_logs_reader: MagicMock,
 ):
     """Test advanced logging API entries controlled by query parameters."""
+    api_client, prefix = api_client_with_prefix
     # Check lines query parameter
-    await api_client.get("/host/logs?lines=53")
+    await api_client.get(f"{prefix}/host/logs?lines=53")
     journald_logs.assert_called_once_with(
         params={"SYSLOG_IDENTIFIER": coresys.host.logs.default_identifiers},
         range_header="entries=:-52:53",
@@ -271,7 +291,7 @@ async def test_advaced_logs_query_parameters(
     journald_logs.reset_mock()
 
     # Check verbose logs formatter via query parameter
-    await api_client.get("/host/logs?verbose")
+    await api_client.get(f"{prefix}/host/logs?verbose")
     journald_logs.assert_called_once_with(
         params={"SYSLOG_IDENTIFIER": coresys.host.logs.default_identifiers},
         range_header=DEFAULT_RANGE,
@@ -284,7 +304,7 @@ async def test_advaced_logs_query_parameters(
 
     # Query parameters should take precedence over headers
     await api_client.get(
-        "/host/logs?lines=53&verbose",
+        f"{prefix}/host/logs?lines=53&verbose",
         headers={
             "Range": "entries=:-19:10",
             "Accept": "text/plain",
@@ -301,7 +321,7 @@ async def test_advaced_logs_query_parameters(
     journald_logs.reset_mock()
 
     # Check no_colors query parameter
-    await api_client.get("/host/logs?no_colors")
+    await api_client.get(f"{prefix}/host/logs?no_colors")
     journald_logs.assert_called_once_with(
         params={"SYSLOG_IDENTIFIER": coresys.host.logs.default_identifiers},
         range_header=DEFAULT_RANGE,
@@ -311,10 +331,13 @@ async def test_advaced_logs_query_parameters(
 
 
 async def test_advanced_logs_boot_id_offset(
-    api_client: TestClient, coresys: CoreSys, journald_logs: MagicMock
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    journald_logs: MagicMock,
 ):
     """Test advanced logging API when using an offset as boot ID."""
-    await api_client.get("/host/logs/boots/0")
+    api_client, prefix = api_client_with_prefix
+    await api_client.get(f"{prefix}/host/logs/boots/0")
     journald_logs.assert_called_once_with(
         params={
             "_BOOT_ID": "ccc",
@@ -326,7 +349,7 @@ async def test_advanced_logs_boot_id_offset(
 
     journald_logs.reset_mock()
 
-    await api_client.get("/host/logs/boots/-2")
+    await api_client.get(f"{prefix}/host/logs/boots/-2")
     journald_logs.assert_called_once_with(
         params={
             "_BOOT_ID": "aaa",
@@ -338,7 +361,7 @@ async def test_advanced_logs_boot_id_offset(
 
     journald_logs.reset_mock()
 
-    await api_client.get("/host/logs/boots/2")
+    await api_client.get(f"{prefix}/host/logs/boots/2")
     journald_logs.assert_called_once_with(
         params={
             "_BOOT_ID": "bbb",
@@ -353,51 +376,57 @@ async def test_advanced_logs_boot_id_offset(
 
 async def test_advanced_logs_formatters(
     journald_gateway: MagicMock,
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     journal_logs_reader: MagicMock,
 ):
     """Test advanced logs formatters varying on Accept header."""
+    api_client, prefix = api_client_with_prefix
 
-    await api_client.get("/host/logs")
+    await api_client.get(f"{prefix}/host/logs")
     journal_logs_reader.assert_called_once_with(ANY, LogFormatter.VERBOSE, False)
 
     journal_logs_reader.reset_mock()
 
     headers = {"Accept": "text/x-log"}
-    await api_client.get("/host/logs", headers=headers)
+    await api_client.get(f"{prefix}/host/logs", headers=headers)
     journal_logs_reader.assert_called_once_with(ANY, LogFormatter.VERBOSE, False)
 
     journal_logs_reader.reset_mock()
 
-    await api_client.get("/host/logs/identifiers/test")
+    await api_client.get(f"{prefix}/host/logs/identifiers/test")
     journal_logs_reader.assert_called_once_with(ANY, LogFormatter.PLAIN, False)
 
     journal_logs_reader.reset_mock()
 
     headers = {"Accept": "text/x-log"}
-    await api_client.get("/host/logs/identifiers/test", headers=headers)
+    await api_client.get(f"{prefix}/host/logs/identifiers/test", headers=headers)
     journal_logs_reader.assert_called_once_with(ANY, LogFormatter.VERBOSE, False)
 
     journal_logs_reader.reset_mock()
 
-    await api_client.get("/host/logs/identifiers/test", skip_auto_headers={"Accept"})
+    await api_client.get(
+        f"{prefix}/host/logs/identifiers/test", skip_auto_headers={"Accept"}
+    )
     journal_logs_reader.assert_called_once_with(ANY, LogFormatter.PLAIN, False)
 
 
-async def test_advanced_logs_errors(coresys: CoreSys, api_client: TestClient):
+async def test_advanced_logs_errors(
+    coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
+):
     """Test advanced logging API errors."""
+    api_client, prefix = api_client_with_prefix
     with patch("supervisor.host.logs.SYSTEMD_JOURNAL_GATEWAYD_SOCKET") as socket:
         socket.is_socket.return_value = False
         await coresys.host.logs.post_init()
-        resp = await api_client.get("/host/logs")
+        resp = await api_client.get(f"{prefix}/host/logs")
         assert resp.content_type == "text/plain"
         assert resp.status == 400
         content = await resp.text()
         assert content == "No systemd-journal-gatewayd Unix socket available"
 
     headers = {"Accept": "application/json"}
-    resp = await api_client.get("/host/logs", headers=headers)
+    resp = await api_client.get(f"{prefix}/host/logs", headers=headers)
     assert resp.content_type == "text/plain"
     assert resp.status == 400
     content = await resp.text()
@@ -407,8 +436,11 @@ async def test_advanced_logs_errors(coresys: CoreSys, api_client: TestClient):
     )
 
 
-async def test_disk_usage_api(api_client: TestClient, coresys: CoreSys):
+async def test_disk_usage_api(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test disk usage API endpoint."""
+    api_client, prefix = api_client_with_prefix
     # Mock the disk usage methods
     with (
         patch.object(coresys.hardware.disk, "disk_usage") as mock_disk_usage,
@@ -488,7 +520,7 @@ async def test_disk_usage_api(api_client: TestClient, coresys: CoreSys):
         ]
 
         # Test default max_depth=1
-        resp = await api_client.get("/host/disks/default/usage")
+        resp = await api_client.get(f"{prefix}/host/disks/default/usage")
         assert resp.status == 200
         result = await resp.json()
 
@@ -552,9 +584,10 @@ async def test_disk_usage_api(api_client: TestClient, coresys: CoreSys):
 
 
 async def test_disk_usage_api_with_custom_depth(
-    api_client: TestClient, coresys: CoreSys
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
 ):
     """Test disk usage API endpoint with custom max_depth parameter."""
+    api_client, prefix = api_client_with_prefix
     with (
         patch.object(coresys.hardware.disk, "disk_usage") as mock_disk_usage,
         patch.object(coresys.hardware.disk, "get_dir_sizes") as mock_dir_sizes,
@@ -699,7 +732,7 @@ async def test_disk_usage_api_with_custom_depth(
         ]
 
         # Test with custom max_depth=2
-        resp = await api_client.get("/host/disks/default/usage?max_depth=2")
+        resp = await api_client.get(f"{prefix}/host/disks/default/usage?max_depth=2")
         assert resp.status == 200
         result = await resp.json()
         assert result["data"]["used_bytes"] == 500000000
@@ -711,8 +744,11 @@ async def test_disk_usage_api_with_custom_depth(
         assert call_args[0][1] == 2  # max_depth parameter
 
 
-async def test_disk_usage_api_invalid_depth(api_client: TestClient, coresys: CoreSys):
+async def test_disk_usage_api_invalid_depth(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test disk usage API endpoint with invalid max_depth parameter."""
+    api_client, prefix = api_client_with_prefix
     with (
         patch.object(coresys.hardware.disk, "disk_usage") as mock_disk_usage,
         patch.object(coresys.hardware.disk, "get_dir_sizes") as mock_dir_sizes,
@@ -757,7 +793,9 @@ async def test_disk_usage_api_invalid_depth(api_client: TestClient, coresys: Cor
         ]
 
         # Test with invalid max_depth (non-integer)
-        resp = await api_client.get("/host/disks/default/usage?max_depth=invalid")
+        resp = await api_client.get(
+            f"{prefix}/host/disks/default/usage?max_depth=invalid"
+        )
         assert resp.status == 200
         result = await resp.json()
         assert result["data"]["used_bytes"] == 500000000
@@ -770,9 +808,10 @@ async def test_disk_usage_api_invalid_depth(api_client: TestClient, coresys: Cor
 
 
 async def test_disk_usage_api_empty_directories(
-    api_client: TestClient, coresys: CoreSys
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
 ):
     """Test disk usage API endpoint with empty directories."""
+    api_client, prefix = api_client_with_prefix
     with (
         patch.object(coresys.hardware.disk, "disk_usage") as mock_disk_usage,
         patch.object(coresys.hardware.disk, "get_dir_sizes") as mock_dir_sizes,
@@ -818,7 +857,7 @@ async def test_disk_usage_api_empty_directories(
             },
         ]
 
-        resp = await api_client.get("/host/disks/default/usage")
+        resp = await api_client.get(f"{prefix}/host/disks/default/usage")
         assert resp.status == 200
         result = await resp.json()
 
@@ -836,14 +875,15 @@ async def test_disk_usage_api_empty_directories(
 
 @pytest.mark.parametrize("action", ["reboot", "shutdown"])
 async def test_migration_blocks_shutdown(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     action: str,
 ):
     """Test that an offline db migration in progress stops users from shuting down or rebooting system."""
+    api_client, prefix = api_client_with_prefix
     coresys.homeassistant.api.get_api_state.return_value = APIState("NOT_RUNNING", True)
 
-    resp = await api_client.post(f"/host/{action}")
+    resp = await api_client.post(f"{prefix}/host/{action}")
     assert resp.status == 503
     result = await resp.json()
     assert (
@@ -852,21 +892,25 @@ async def test_migration_blocks_shutdown(
     )
 
 
-async def test_force_reboot_during_migration(api_client: TestClient, coresys: CoreSys):
+async def test_force_reboot_during_migration(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test force option reboots even during a migration."""
+    api_client, prefix = api_client_with_prefix
     coresys.homeassistant.api.get_api_state.return_value = APIState("NOT_RUNNING", True)
 
     with patch.object(SystemControl, "reboot") as reboot:
-        await api_client.post("/host/reboot", json={"force": True})
+        await api_client.post(f"{prefix}/host/reboot", json={"force": True})
         reboot.assert_called_once()
 
 
 async def test_force_shutdown_during_migration(
-    api_client: TestClient, coresys: CoreSys
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
 ):
     """Test force option shutdown even during a migration."""
+    api_client, prefix = api_client_with_prefix
     coresys.homeassistant.api.get_api_state.return_value = APIState("NOT_RUNNING", True)
 
     with patch.object(SystemControl, "shutdown") as shutdown:
-        await api_client.post("/host/shutdown", json={"force": True})
+        await api_client.post(f"{prefix}/host/shutdown", json={"force": True})
         shutdown.assert_called_once()

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -272,7 +272,7 @@ async def test_advanced_logs(
     assert resp.status == 404
 
 
-async def test_advaced_logs_query_parameters(
+async def test_advanced_logs_query_parameters(
     api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     journald_logs: MagicMock,

--- a/tests/api/test_ingress.py
+++ b/tests/api/test_ingress.py
@@ -23,11 +23,14 @@ async def fixture_real_websession(
     await session.close()
 
 
-async def test_validate_session(api_client: TestClient, coresys: CoreSys):
+async def test_validate_session(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test validating ingress session."""
+    api_client, prefix = api_client_with_prefix
     with patch("aiohttp.web_request.BaseRequest.__getitem__", return_value=None):
         resp = await api_client.post(
-            "/ingress/validate_session",
+            f"{prefix}/ingress/validate_session",
             json={"session": "non-existing"},
         )
         assert resp.status == 401
@@ -36,7 +39,7 @@ async def test_validate_session(api_client: TestClient, coresys: CoreSys):
         "aiohttp.web_request.BaseRequest.__getitem__",
         return_value=coresys.homeassistant,
     ):
-        resp = await api_client.post("/ingress/session")
+        resp = await api_client.post(f"{prefix}/ingress/session")
         result = await resp.json()
 
         assert "session" in result["data"]
@@ -46,7 +49,7 @@ async def test_validate_session(api_client: TestClient, coresys: CoreSys):
         valid_time = coresys.ingress.sessions[session]
 
         resp = await api_client.post(
-            "/ingress/validate_session",
+            f"{prefix}/ingress/validate_session",
             json={"session": session},
         )
         assert resp.status == 200
@@ -56,12 +59,15 @@ async def test_validate_session(api_client: TestClient, coresys: CoreSys):
 
 
 async def test_validate_session_with_user_id(
-    api_client: TestClient, coresys: CoreSys, ha_ws_client: AsyncMock
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    ha_ws_client: AsyncMock,
 ):
     """Test validating ingress session with user ID passed."""
+    api_client, prefix = api_client_with_prefix
     with patch("aiohttp.web_request.BaseRequest.__getitem__", return_value=None):
         resp = await api_client.post(
-            "/ingress/validate_session",
+            f"{prefix}/ingress/validate_session",
             json={"session": "non-existing"},
         )
         assert resp.status == 401
@@ -74,7 +80,9 @@ async def test_validate_session_with_user_id(
             {"id": "some-id", "name": "Some Name", "username": "sn"}
         ]
 
-        resp = await api_client.post("/ingress/session", json={"user_id": "some-id"})
+        resp = await api_client.post(
+            f"{prefix}/ingress/session", json={"user_id": "some-id"}
+        )
         result = await resp.json()
 
         assert {"type": "config/auth/list"} in [
@@ -88,7 +96,7 @@ async def test_validate_session_with_user_id(
         valid_time = coresys.ingress.sessions[session]
 
         resp = await api_client.post(
-            "/ingress/validate_session",
+            f"{prefix}/ingress/validate_session",
             json={"session": session},
         )
         assert resp.status == 200
@@ -103,9 +111,12 @@ async def test_validate_session_with_user_id(
 
 
 async def test_ingress_proxy_no_content_type_for_empty_body_responses(
-    api_client: TestClient, coresys: CoreSys, real_websession: aiohttp.ClientSession
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    real_websession: aiohttp.ClientSession,
 ):
     """Test that empty body responses don't get Content-Type header."""
+    api_client, prefix = api_client_with_prefix
 
     # Create a mock app backend server that returns various status codes
     async def mock_app_handler(request: web.Request) -> web.Response:
@@ -146,7 +157,7 @@ async def test_ingress_proxy_no_content_type_for_empty_body_responses(
 
     try:
         # Create ingress session
-        resp = await api_client.post("/ingress/session")
+        resp = await api_client.post(f"{prefix}/ingress/session")
         result = await resp.json()
         session = result["data"]["session"]
 
@@ -162,7 +173,7 @@ async def test_ingress_proxy_no_content_type_for_empty_body_responses(
         with patch.object(coresys.ingress, "get", return_value=mock_app):
             # Test 204 No Content - should NOT have Content-Type
             resp = await api_client.get(
-                f"/ingress/{ingress_token}/204",
+                f"{prefix}/ingress/{ingress_token}/204",
                 cookies={"ingress_session": session},
             )
             assert resp.status == 204
@@ -170,7 +181,7 @@ async def test_ingress_proxy_no_content_type_for_empty_body_responses(
 
             # Test 304 Not Modified - should NOT have Content-Type
             resp = await api_client.get(
-                f"/ingress/{ingress_token}/304",
+                f"{prefix}/ingress/{ingress_token}/304",
                 cookies={"ingress_session": session},
             )
             assert resp.status == 304
@@ -179,7 +190,7 @@ async def test_ingress_proxy_no_content_type_for_empty_body_responses(
             # Test HEAD request - SHOULD have Content-Type (same as GET)
             # per RFC 9110: HEAD should return same headers as GET
             resp = await api_client.head(
-                f"/ingress/{ingress_token}/head",
+                f"{prefix}/ingress/{ingress_token}/head",
                 cookies={"ingress_session": session},
             )
             assert resp.status == 200
@@ -191,7 +202,7 @@ async def test_ingress_proxy_no_content_type_for_empty_body_responses(
 
             # Test 200 OK with body - SHOULD have Content-Type
             resp = await api_client.get(
-                f"/ingress/{ingress_token}/200",
+                f"{prefix}/ingress/{ingress_token}/200",
                 cookies={"ingress_session": session},
             )
             assert resp.status == 200
@@ -202,7 +213,7 @@ async def test_ingress_proxy_no_content_type_for_empty_body_responses(
 
             # Test 200 OK without explicit Content-Type - SHOULD get default
             resp = await api_client.get(
-                f"/ingress/{ingress_token}/200-no-content-type",
+                f"{prefix}/ingress/{ingress_token}/200-no-content-type",
                 cookies={"ingress_session": session},
             )
             assert resp.status == 200
@@ -212,7 +223,7 @@ async def test_ingress_proxy_no_content_type_for_empty_body_responses(
 
             # Test 200 OK with JSON - SHOULD preserve Content-Type
             resp = await api_client.get(
-                f"/ingress/{ingress_token}/200-json",
+                f"{prefix}/ingress/{ingress_token}/200-json",
                 cookies={"ingress_session": session},
             )
             assert resp.status == 200

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -12,39 +12,46 @@ from supervisor.jobs.const import ATTR_IGNORE_CONDITIONS, JobCondition
 from supervisor.jobs.decorator import Job
 
 
-async def test_api_jobs_info(api_client: TestClient):
+async def test_api_jobs_info(api_client_with_prefix: tuple[TestClient, str]):
     """Test jobs info api."""
-    resp = await api_client.get("/jobs/info")
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.get(f"{prefix}/jobs/info")
     result = await resp.json()
 
     assert result["data"][ATTR_IGNORE_CONDITIONS] == []
     assert result["data"]["jobs"] == []
 
 
-async def test_api_jobs_options(api_client: TestClient, coresys: CoreSys):
+async def test_api_jobs_options(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test jobs options api."""
+    api_client, prefix = api_client_with_prefix
     resp = await api_client.post(
-        "/jobs/options", json={ATTR_IGNORE_CONDITIONS: [JobCondition.HEALTHY]}
+        f"{prefix}/jobs/options", json={ATTR_IGNORE_CONDITIONS: [JobCondition.HEALTHY]}
     )
     result = await resp.json()
     assert result["result"] == "ok"
 
-    resp = await api_client.get("/jobs/info")
+    resp = await api_client.get(f"{prefix}/jobs/info")
     result = await resp.json()
     assert result["data"][ATTR_IGNORE_CONDITIONS] == [JobCondition.HEALTHY]
 
     assert coresys.jobs.save_data.called
 
 
-async def test_api_jobs_reset(api_client: TestClient, coresys: CoreSys):
+async def test_api_jobs_reset(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test jobs reset api."""
+    api_client, prefix = api_client_with_prefix
     resp = await api_client.post(
-        "/jobs/options", json={ATTR_IGNORE_CONDITIONS: [JobCondition.HEALTHY]}
+        f"{prefix}/jobs/options", json={ATTR_IGNORE_CONDITIONS: [JobCondition.HEALTHY]}
     )
     result = await resp.json()
     assert result["result"] == "ok"
 
-    resp = await api_client.get("/jobs/info")
+    resp = await api_client.get(f"{prefix}/jobs/info")
     result = await resp.json()
     assert result["data"][ATTR_IGNORE_CONDITIONS] == [JobCondition.HEALTHY]
 
@@ -52,7 +59,7 @@ async def test_api_jobs_reset(api_client: TestClient, coresys: CoreSys):
     assert coresys.jobs.ignore_conditions == [JobCondition.HEALTHY]
 
     coresys.jobs.save_data.reset_mock()
-    resp = await api_client.post("/jobs/reset")
+    resp = await api_client.post(f"{prefix}/jobs/reset")
     result = await resp.json()
     assert result["result"] == "ok"
 
@@ -234,9 +241,12 @@ async def test_job_manual_cleanup(api_client: TestClient, coresys: CoreSys):
     ("method", "url"),
     [("get", "/jobs/bad"), ("delete", "/jobs/bad")],
 )
-async def test_job_not_found(api_client: TestClient, method: str, url: str):
+async def test_job_not_found(
+    api_client_with_prefix: tuple[TestClient, str], method: str, url: str
+):
     """Test job not found error."""
-    resp = await api_client.request(method, url)
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.request(method, f"{prefix}{url}")
     assert resp.status == 404
     body = await resp.json()
     assert body["message"] == "Job does not exist"

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -12,6 +12,99 @@ from supervisor.jobs.const import ATTR_IGNORE_CONDITIONS, JobCondition
 from supervisor.jobs.decorator import Job
 
 
+class _JobsTreeTestHelper:
+    """Helper class for test_jobs_tree_representation."""
+
+    def __init__(self, coresys: CoreSys):
+        """Initialize the test class."""
+        self.coresys = coresys
+        self.event = asyncio.Event()
+
+    @Job(name="test_jobs_tree_outer")
+    async def test_jobs_tree_outer(self):
+        """Outer test method."""
+        self.coresys.jobs.current.progress = 50
+        await self.test_jobs_tree_inner()
+
+    @Job(name="test_jobs_tree_inner")
+    async def test_jobs_tree_inner(self):
+        """Inner test method."""
+        await self.event.wait()
+
+    @Job(name="test_jobs_tree_alt", cleanup=False)
+    async def test_jobs_tree_alt(self):
+        """Alternate test method."""
+        self.coresys.jobs.current.stage = "init"
+        await self.test_jobs_tree_internal()
+        self.coresys.jobs.current.stage = "end"
+
+    @Job(name="test_jobs_tree_internal", internal=True)
+    async def test_jobs_tree_internal(self):
+        """Internal test method."""
+        await self.event.wait()
+
+
+class _JobManualCleanupTestHelper:
+    """Helper class for test_job_manual_cleanup."""
+
+    def __init__(self, coresys: CoreSys):
+        """Initialize the test class."""
+        self.coresys = coresys
+        self.event = asyncio.Event()
+        self.job_id: str | None = None
+
+    @Job(name="test_job_manual_cleanup", cleanup=False)
+    async def test_job_manual_cleanup(self) -> None:
+        """Job that requires manual cleanup."""
+        self.job_id = self.coresys.jobs.current.uuid
+        await self.event.wait()
+
+
+class _JobsSortedTestHelper:
+    """Helper class for test_jobs_sorted."""
+
+    def __init__(self, coresys: CoreSys):
+        """Initialize the test class."""
+        self.coresys = coresys
+
+    @Job(name="test_jobs_sorted_1", cleanup=False)
+    async def test_jobs_sorted_1(self):
+        """Sorted test method 1."""
+        await self.test_jobs_sorted_inner_1()
+        await self.test_jobs_sorted_inner_2()
+
+    @Job(name="test_jobs_sorted_inner_1", cleanup=False)
+    async def test_jobs_sorted_inner_1(self):
+        """Sorted test inner method 1."""
+
+    @Job(name="test_jobs_sorted_inner_2", cleanup=False)
+    async def test_jobs_sorted_inner_2(self):
+        """Sorted test inner method 2."""
+
+    @Job(name="test_jobs_sorted_2", cleanup=False)
+    async def test_jobs_sorted_2(self):
+        """Sorted test method 2."""
+
+
+class _JobWithErrorTestHelper:
+    """Helper class for test_job_with_error."""
+
+    def __init__(self, coresys: CoreSys):
+        """Initialize the test class."""
+        self.coresys = coresys
+
+    @Job(name="test_jobs_api_error_outer", cleanup=False)
+    async def test_jobs_api_error_outer(self):
+        """Error test outer method."""
+        self.coresys.jobs.current.stage = "test"
+        await self.test_jobs_api_error_inner()
+
+    @Job(name="test_jobs_api_error_inner", cleanup=False)
+    async def test_jobs_api_error_inner(self):
+        """Error test inner method."""
+        raise SupervisorError("bad")
+
+
 async def test_api_jobs_info(api_client_with_prefix: tuple[TestClient, str]):
     """Test jobs info api."""
     api_client, prefix = api_client_with_prefix
@@ -67,46 +160,17 @@ async def test_api_jobs_reset(
     coresys.jobs.save_data.assert_called_once()
 
 
-async def test_jobs_tree_representation(api_client: TestClient, coresys: CoreSys):
+async def test_jobs_tree_representation(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test jobs are correctly represented in a tree."""
-
-    class TestClass:
-        """Test class."""
-
-        def __init__(self, coresys: CoreSys):
-            """Initialize the test class."""
-            self.coresys = coresys
-            self.event = asyncio.Event()
-
-        @Job(name="test_jobs_tree_outer")
-        async def test_jobs_tree_outer(self):
-            """Outer test method."""
-            coresys.jobs.current.progress = 50
-            await self.test_jobs_tree_inner()
-
-        @Job(name="test_jobs_tree_inner")
-        async def test_jobs_tree_inner(self):
-            """Inner test method."""
-            await self.event.wait()
-
-        @Job(name="test_jobs_tree_alt", cleanup=False)
-        async def test_jobs_tree_alt(self):
-            """Alternate test method."""
-            coresys.jobs.current.stage = "init"
-            await self.test_jobs_tree_internal()
-            coresys.jobs.current.stage = "end"
-
-        @Job(name="test_jobs_tree_internal", internal=True)
-        async def test_jobs_tree_internal(self):
-            """Internal test method."""
-            await self.event.wait()
-
-    test = TestClass(coresys)
+    api_client, prefix = api_client_with_prefix
+    test = _JobsTreeTestHelper(coresys)
     outer_task = asyncio.create_task(test.test_jobs_tree_outer())
     alt_task = asyncio.create_task(test.test_jobs_tree_alt())
     await asyncio.sleep(0)
 
-    resp = await api_client.get("/jobs/info")
+    resp = await api_client.get(f"{prefix}/jobs/info")
     result = await resp.json()
     assert result["data"]["jobs"] == [
         {
@@ -151,7 +215,7 @@ async def test_jobs_tree_representation(api_client: TestClient, coresys: CoreSys
     test.event.set()
     await asyncio.sleep(0)
 
-    resp = await api_client.get("/jobs/info")
+    resp = await api_client.get(f"{prefix}/jobs/info")
     result = await resp.json()
     assert result["data"]["jobs"] == [
         {
@@ -171,30 +235,17 @@ async def test_jobs_tree_representation(api_client: TestClient, coresys: CoreSys
     await alt_task
 
 
-async def test_job_manual_cleanup(api_client: TestClient, coresys: CoreSys):
+async def test_job_manual_cleanup(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test manually cleaning up a job via API."""
-
-    class TestClass:
-        """Test class."""
-
-        def __init__(self, coresys: CoreSys):
-            """Initialize the test class."""
-            self.coresys = coresys
-            self.event = asyncio.Event()
-            self.job_id: str | None = None
-
-        @Job(name="test_job_manual_cleanup", cleanup=False)
-        async def test_job_manual_cleanup(self) -> None:
-            """Job that requires manual cleanup."""
-            self.job_id = coresys.jobs.current.uuid
-            await self.event.wait()
-
-    test = TestClass(coresys)
+    api_client, prefix = api_client_with_prefix
+    test = _JobManualCleanupTestHelper(coresys)
     task = asyncio.create_task(test.test_job_manual_cleanup())
     await asyncio.sleep(0)
 
     # Check the job details
-    resp = await api_client.get(f"/jobs/{test.job_id}")
+    resp = await api_client.get(f"{prefix}/jobs/{test.job_id}")
     assert resp.status == 200
     result = await resp.json()
     assert result["data"] == {
@@ -211,7 +262,7 @@ async def test_job_manual_cleanup(api_client: TestClient, coresys: CoreSys):
     }
 
     # Only done jobs can be deleted via API
-    resp = await api_client.delete(f"/jobs/{test.job_id}")
+    resp = await api_client.delete(f"{prefix}/jobs/{test.job_id}")
     assert resp.status == 400
     result = await resp.json()
     assert result["message"] == f"Job {test.job_id} is not done!"
@@ -221,17 +272,17 @@ async def test_job_manual_cleanup(api_client: TestClient, coresys: CoreSys):
     await task
 
     # Check that it is now done
-    resp = await api_client.get(f"/jobs/{test.job_id}")
+    resp = await api_client.get(f"{prefix}/jobs/{test.job_id}")
     assert resp.status == 200
     result = await resp.json()
     assert result["data"]["done"] is True
 
     # Delete it
-    resp = await api_client.delete(f"/jobs/{test.job_id}")
+    resp = await api_client.delete(f"{prefix}/jobs/{test.job_id}")
     assert resp.status == 200
 
     # Confirm it no longer exists
-    resp = await api_client.get(f"/jobs/{test.job_id}")
+    resp = await api_client.get(f"{prefix}/jobs/{test.job_id}")
     assert resp.status == 404
     result = await resp.json()
     assert result["message"] == "Job does not exist"
@@ -252,39 +303,16 @@ async def test_job_not_found(
     assert body["message"] == "Job does not exist"
 
 
-async def test_jobs_sorted(api_client: TestClient, coresys: CoreSys):
+async def test_jobs_sorted(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test jobs are sorted by datetime in results."""
-
-    class TestClass:
-        """Test class."""
-
-        def __init__(self, coresys: CoreSys):
-            """Initialize the test class."""
-            self.coresys = coresys
-
-        @Job(name="test_jobs_sorted_1", cleanup=False)
-        async def test_jobs_sorted_1(self):
-            """Sorted test method 1."""
-            await self.test_jobs_sorted_inner_1()
-            await self.test_jobs_sorted_inner_2()
-
-        @Job(name="test_jobs_sorted_inner_1", cleanup=False)
-        async def test_jobs_sorted_inner_1(self):
-            """Sorted test inner method 1."""
-
-        @Job(name="test_jobs_sorted_inner_2", cleanup=False)
-        async def test_jobs_sorted_inner_2(self):
-            """Sorted test inner method 2."""
-
-        @Job(name="test_jobs_sorted_2", cleanup=False)
-        async def test_jobs_sorted_2(self):
-            """Sorted test method 2."""
-
-    test = TestClass(coresys)
+    api_client, prefix = api_client_with_prefix
+    test = _JobsSortedTestHelper(coresys)
     await test.test_jobs_sorted_1()
     await test.test_jobs_sorted_2()
 
-    resp = await api_client.get("/jobs/info")
+    resp = await api_client.get(f"{prefix}/jobs/info")
     result = await resp.json()
     assert result["data"]["jobs"] == [
         {
@@ -340,34 +368,16 @@ async def test_jobs_sorted(api_client: TestClient, coresys: CoreSys):
 
 
 async def test_job_with_error(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
 ):
     """Test job output with an error."""
-
-    class TestClass:
-        """Test class."""
-
-        def __init__(self, coresys: CoreSys):
-            """Initialize the test class."""
-            self.coresys = coresys
-
-        @Job(name="test_jobs_api_error_outer", cleanup=False)
-        async def test_jobs_api_error_outer(self):
-            """Error test outer method."""
-            coresys.jobs.current.stage = "test"
-            await self.test_jobs_api_error_inner()
-
-        @Job(name="test_jobs_api_error_inner", cleanup=False)
-        async def test_jobs_api_error_inner(self):
-            """Error test inner method."""
-            raise SupervisorError("bad")
-
-    test = TestClass(coresys)
+    api_client, prefix = api_client_with_prefix
+    test = _JobWithErrorTestHelper(coresys)
     with pytest.raises(SupervisorError):
         await test.test_jobs_api_error_outer()
 
-    resp = await api_client.get("/jobs/info")
+    resp = await api_client.get(f"{prefix}/jobs/info")
     result = await resp.json()
     assert result["data"]["jobs"] == [
         {

--- a/tests/api/test_mounts.py
+++ b/tests/api/test_mounts.py
@@ -37,16 +37,17 @@ async def fixture_mount(
     yield mount
 
 
-async def test_api_mounts_info(api_client: TestClient):
+async def test_api_mounts_info(api_client_with_prefix: tuple[TestClient, str]):
     """Test mounts info api."""
-    resp = await api_client.get("/mounts")
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.get(f"{prefix}/mounts")
     result = await resp.json()
 
     assert result["data"]["mounts"] == []
 
 
 async def test_api_create_mount(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     tmp_supervisor_data,
     path_extern,
@@ -54,8 +55,9 @@ async def test_api_create_mount(
     mock_is_mount,
 ):
     """Test creating a mount via API."""
+    api_client, prefix = api_client_with_prefix
     resp = await api_client.post(
-        "/mounts",
+        f"{prefix}/mounts",
         json={
             "name": "backup_test",
             "type": "cifs",
@@ -68,7 +70,7 @@ async def test_api_create_mount(
     result = await resp.json()
     assert result["result"] == "ok"
 
-    resp = await api_client.get("/mounts")
+    resp = await api_client.get(f"{prefix}/mounts")
     result = await resp.json()
 
     assert result["data"]["mounts"] == [
@@ -87,10 +89,13 @@ async def test_api_create_mount(
     coresys.mounts.save_data.assert_called_once()
 
 
-async def test_api_create_error_mount_exists(api_client: TestClient, mount):
+async def test_api_create_error_mount_exists(
+    api_client_with_prefix: tuple[TestClient, str], mount
+):
     """Test create mount API errors when mount exists."""
+    api_client, prefix = api_client_with_prefix
     resp = await api_client.post(
-        "/mounts",
+        f"{prefix}/mounts",
         json={
             "name": "backup_test",
             "type": "cifs",
@@ -106,13 +111,14 @@ async def test_api_create_error_mount_exists(api_client: TestClient, mount):
 
 
 async def test_api_create_dbus_error_mount_not_added(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     all_dbus_services: dict[str, DBusServiceMock],
     tmp_supervisor_data,
     path_extern,
     mount_propagation,
 ):
     """Test mount not added to list of mounts if a dbus error occurs."""
+    api_client, prefix = api_client_with_prefix
     systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
     systemd_service.response_get_unit = DBusError(
@@ -121,7 +127,7 @@ async def test_api_create_dbus_error_mount_not_added(
     systemd_service.response_start_transient_unit = DBusError(ErrorType.FAILED, "fail")
 
     resp = await api_client.post(
-        "/mounts",
+        f"{prefix}/mounts",
         json={
             "name": "backup_test",
             "type": "cifs",
@@ -135,7 +141,7 @@ async def test_api_create_dbus_error_mount_not_added(
     assert result["result"] == "error"
     assert result["message"] == "Could not mount backup_test due to: fail"
 
-    resp = await api_client.get("/mounts")
+    resp = await api_client.get(f"{prefix}/mounts")
     result = await resp.json()
     assert result["data"]["mounts"] == []
 
@@ -148,7 +154,7 @@ async def test_api_create_dbus_error_mount_not_added(
     systemd_unit_service.active_state = ["failed", "failed", "inactive"]
 
     resp = await api_client.post(
-        "/mounts",
+        f"{prefix}/mounts",
         json={
             "name": "backup_test",
             "type": "cifs",
@@ -165,21 +171,22 @@ async def test_api_create_dbus_error_mount_not_added(
         == "Mounting backup_test did not succeed. Check host logs for errors from mount or systemd unit mnt-data-supervisor-mounts-backup_test.mount for details."
     )
 
-    resp = await api_client.get("/mounts")
+    resp = await api_client.get(f"{prefix}/mounts")
     result = await resp.json()
     assert result["data"]["mounts"] == []
 
 
 @pytest.mark.parametrize("os_available", ["9.5"], indirect=True)
 async def test_api_create_mount_fails_os_out_of_date(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     os_available,
     mount_propagation,
 ):
     """Test creating a mount via API fails when mounting isn't supported due to OS version."""
+    api_client, prefix = api_client_with_prefix
     resp = await api_client.post(
-        "/mounts",
+        f"{prefix}/mounts",
         json={
             "name": "backup_test",
             "type": "cifs",
@@ -198,13 +205,14 @@ async def test_api_create_mount_fails_os_out_of_date(
 
 
 async def test_api_create_mount_fails_missing_mount_propagation(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     os_available,
 ):
     """Test creating a mount via API fails when mounting isn't supported due to container config."""
+    api_client, prefix = api_client_with_prefix
     resp = await api_client.post(
-        "/mounts",
+        f"{prefix}/mounts",
         json={
             "name": "backup_test",
             "type": "cifs",
@@ -223,18 +231,19 @@ async def test_api_create_mount_fails_missing_mount_propagation(
 
 
 async def test_api_update_mount(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     all_dbus_services: dict[str, DBusServiceMock],
     mount,
     mock_is_mount,
 ):
     """Test updating a mount via API."""
+    api_client, prefix = api_client_with_prefix
     systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
     systemd_service.mock_systemd_unit = systemd_unit_service
     resp = await api_client.put(
-        "/mounts/backup_test",
+        f"{prefix}/mounts/backup_test",
         json={
             "type": "cifs",
             "usage": "backup",
@@ -245,7 +254,7 @@ async def test_api_update_mount(
     result = await resp.json()
     assert result["result"] == "ok"
 
-    resp = await api_client.get("/mounts")
+    resp = await api_client.get(f"{prefix}/mounts")
     result = await resp.json()
 
     assert result["data"]["mounts"] == [
@@ -265,7 +274,7 @@ async def test_api_update_mount(
 
 
 async def test_api_update_dbus_error_mount_remains(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     all_dbus_services: dict[str, DBusServiceMock],
     mount,
     tmp_supervisor_data,
@@ -273,6 +282,7 @@ async def test_api_update_dbus_error_mount_remains(
     mount_propagation,
 ):
     """Test mount remains in list with unsuccessful state if dbus error occurs during update."""
+    api_client, prefix = api_client_with_prefix
     systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
     systemd_unit_service.active_state = ["failed", "inactive"]
@@ -283,7 +293,7 @@ async def test_api_update_dbus_error_mount_remains(
     systemd_service.response_start_transient_unit = DBusError(ErrorType.FAILED, "fail")
 
     resp = await api_client.put(
-        "/mounts/backup_test",
+        f"{prefix}/mounts/backup_test",
         json={
             "type": "cifs",
             "usage": "backup",
@@ -296,7 +306,7 @@ async def test_api_update_dbus_error_mount_remains(
     assert result["result"] == "error"
     assert result["message"] == "Could not mount backup_test due to: fail"
 
-    resp = await api_client.get("/mounts")
+    resp = await api_client.get(f"{prefix}/mounts")
     result = await resp.json()
     assert result["data"]["mounts"] == [
         {
@@ -328,7 +338,7 @@ async def test_api_update_dbus_error_mount_remains(
     ]
 
     resp = await api_client.put(
-        "/mounts/backup_test",
+        f"{prefix}/mounts/backup_test",
         json={
             "type": "cifs",
             "usage": "backup",
@@ -344,7 +354,7 @@ async def test_api_update_dbus_error_mount_remains(
         == "Mounting backup_test did not succeed. Check host logs for errors from mount or systemd unit mnt-data-supervisor-mounts-backup_test.mount for details."
     )
 
-    resp = await api_client.get("/mounts")
+    resp = await api_client.get(f"{prefix}/mounts")
     result = await resp.json()
     assert result["data"]["mounts"] == [
         {
@@ -362,16 +372,17 @@ async def test_api_update_dbus_error_mount_remains(
 
 
 async def test_api_reload_mount(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     all_dbus_services: dict[str, DBusServiceMock],
     mount,
     mock_is_mount,
 ):
     """Test reloading a mount via API."""
+    api_client, prefix = api_client_with_prefix
     systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_service.ReloadOrRestartUnit.calls.clear()
 
-    resp = await api_client.post("/mounts/backup_test/reload")
+    resp = await api_client.post(f"{prefix}/mounts/backup_test/reload")
     result = await resp.json()
     assert result["result"] == "ok"
 
@@ -381,20 +392,21 @@ async def test_api_reload_mount(
 
 
 async def test_api_delete_mount(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     all_dbus_services: dict[str, DBusServiceMock],
     mount,
 ):
     """Test deleting a mount via API."""
+    api_client, prefix = api_client_with_prefix
     systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
     systemd_service.mock_systemd_unit = systemd_unit_service
-    resp = await api_client.delete("/mounts/backup_test")
+    resp = await api_client.delete(f"{prefix}/mounts/backup_test")
     result = await resp.json()
     assert result["result"] == "ok"
 
-    resp = await api_client.get("/mounts")
+    resp = await api_client.get(f"{prefix}/mounts")
     result = await resp.json()
 
     assert result["data"]["mounts"] == []
@@ -403,7 +415,7 @@ async def test_api_delete_mount(
 
 
 async def test_api_create_backup_mount_sets_default(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     tmp_supervisor_data,
     path_extern,
@@ -411,11 +423,12 @@ async def test_api_create_backup_mount_sets_default(
     mock_is_mount,
 ):
     """Test creating backup mounts sets default if not set."""
+    api_client, prefix = api_client_with_prefix
     await coresys.mounts.load()
     assert coresys.mounts.default_backup_mount is None
 
     resp = await api_client.post(
-        "/mounts",
+        f"{prefix}/mounts",
         json={
             "name": "backup_test",
             "type": "cifs",
@@ -430,7 +443,7 @@ async def test_api_create_backup_mount_sets_default(
 
     # Confirm the default does not change if mount created after its been set
     resp = await api_client.post(
-        "/mounts",
+        f"{prefix}/mounts",
         json={
             "name": "backup_test_2",
             "type": "cifs",
@@ -445,20 +458,21 @@ async def test_api_create_backup_mount_sets_default(
 
 
 async def test_update_backup_mount_changes_default(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     all_dbus_services: dict[str, DBusServiceMock],
     mount,
     mock_is_mount,
 ):
     """Test updating a backup mount may unset the default."""
+    api_client, prefix = api_client_with_prefix
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
     systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_service.mock_systemd_unit = systemd_unit_service
 
     # Make another backup mount for testing
     resp = await api_client.post(
-        "/mounts",
+        f"{prefix}/mounts",
         json={
             "name": "other_backup_test",
             "type": "cifs",
@@ -472,7 +486,7 @@ async def test_update_backup_mount_changes_default(
 
     # Changing this mount should have no effect on the default
     resp = await api_client.put(
-        "/mounts/other_backup_test",
+        f"{prefix}/mounts/other_backup_test",
         json={
             "type": "cifs",
             "usage": "media",
@@ -486,7 +500,7 @@ async def test_update_backup_mount_changes_default(
 
     # Changing this one to non-backup should unset the default
     resp = await api_client.put(
-        "/mounts/backup_test",
+        f"{prefix}/mounts/backup_test",
         json={
             "type": "cifs",
             "usage": "media",
@@ -500,20 +514,21 @@ async def test_update_backup_mount_changes_default(
 
 
 async def test_delete_backup_mount_changes_default(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     all_dbus_services: dict[str, DBusServiceMock],
     mount,
     mock_is_mount,
 ):
     """Test deleting a backup mount may unset the default."""
+    api_client, prefix = api_client_with_prefix
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
     systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_service.mock_systemd_unit = systemd_unit_service
 
     # Make another backup mount for testing
     resp = await api_client.post(
-        "/mounts",
+        f"{prefix}/mounts",
         json={
             "name": "other_backup_test",
             "type": "cifs",
@@ -526,20 +541,20 @@ async def test_delete_backup_mount_changes_default(
     assert result["result"] == "ok"
 
     # Deleting this one should have no effect on the default
-    resp = await api_client.delete("/mounts/other_backup_test")
+    resp = await api_client.delete(f"{prefix}/mounts/other_backup_test")
     result = await resp.json()
     assert result["result"] == "ok"
     assert coresys.mounts.default_backup_mount.name == "backup_test"
 
     # Deleting this current default should unset it
-    resp = await api_client.delete("/mounts/backup_test")
+    resp = await api_client.delete(f"{prefix}/mounts/backup_test")
     result = await resp.json()
     assert result["result"] == "ok"
     assert coresys.mounts.default_backup_mount is None
 
 
 async def test_backup_mounts_reload_backups(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     all_dbus_services: dict[str, DBusServiceMock],
     tmp_supervisor_data,
@@ -548,6 +563,7 @@ async def test_backup_mounts_reload_backups(
     mock_is_mount,
 ):
     """Test actions on a backup mount reload backups."""
+    api_client, prefix = api_client_with_prefix
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
     systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_service.mock_systemd_unit = systemd_unit_service
@@ -556,7 +572,7 @@ async def test_backup_mounts_reload_backups(
     with patch.object(BackupManager, "reload") as reload:
         # Only creating a backup mount triggers reload
         resp = await api_client.post(
-            "/mounts",
+            f"{prefix}/mounts",
             json={
                 "name": "media_test",
                 "type": "cifs",
@@ -571,7 +587,7 @@ async def test_backup_mounts_reload_backups(
         reload.assert_not_called()
 
         resp = await api_client.post(
-            "/mounts",
+            f"{prefix}/mounts",
             json={
                 "name": "backup_test",
                 "type": "cifs",
@@ -588,7 +604,7 @@ async def test_backup_mounts_reload_backups(
         # Only updating a backup mount triggers reload
         reload.reset_mock()
         resp = await api_client.put(
-            "/mounts/media_test",
+            f"{prefix}/mounts/media_test",
             json={
                 "type": "cifs",
                 "usage": "media",
@@ -602,7 +618,7 @@ async def test_backup_mounts_reload_backups(
         reload.assert_not_called()
 
         resp = await api_client.put(
-            "/mounts/backup_test",
+            f"{prefix}/mounts/backup_test",
             json={
                 "type": "cifs",
                 "usage": "backup",
@@ -617,13 +633,13 @@ async def test_backup_mounts_reload_backups(
 
         # Only reloading a backup mount triggers reload
         reload.reset_mock()
-        resp = await api_client.post("/mounts/media_test/reload")
+        resp = await api_client.post(f"{prefix}/mounts/media_test/reload")
         result = await resp.json()
         assert result["result"] == "ok"
         await asyncio.sleep(0)
         reload.assert_not_called()
 
-        resp = await api_client.post("/mounts/backup_test/reload")
+        resp = await api_client.post(f"{prefix}/mounts/backup_test/reload")
         result = await resp.json()
         assert result["result"] == "ok"
         await asyncio.sleep(0)
@@ -631,23 +647,29 @@ async def test_backup_mounts_reload_backups(
 
         # Only deleting a backup mount triggers reload
         reload.reset_mock()
-        resp = await api_client.delete("/mounts/media_test")
+        resp = await api_client.delete(f"{prefix}/mounts/media_test")
         result = await resp.json()
         assert result["result"] == "ok"
         await asyncio.sleep(0)
         reload.assert_not_called()
 
-        resp = await api_client.delete("/mounts/backup_test")
+        resp = await api_client.delete(f"{prefix}/mounts/backup_test")
         result = await resp.json()
         assert result["result"] == "ok"
         await asyncio.sleep(0)
         reload.assert_called_once()
 
 
-async def test_options(api_client: TestClient, coresys: CoreSys, mount, mock_is_mount):
+async def test_options(
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    mount,
+    mock_is_mount,
+):
     """Test changing options."""
+    api_client, prefix = api_client_with_prefix
     resp = await api_client.post(
-        "/mounts",
+        f"{prefix}/mounts",
         json={
             "name": "other_backup_test",
             "type": "cifs",
@@ -660,7 +682,7 @@ async def test_options(api_client: TestClient, coresys: CoreSys, mount, mock_is_
     assert result["result"] == "ok"
 
     resp = await api_client.post(
-        "/mounts",
+        f"{prefix}/mounts",
         json={
             "name": "media_test",
             "type": "cifs",
@@ -676,7 +698,7 @@ async def test_options(api_client: TestClient, coresys: CoreSys, mount, mock_is_
 
     # Not a backup mount, will fail
     resp = await api_client.post(
-        "/mounts/options",
+        f"{prefix}/mounts/options",
         json={
             "default_backup_mount": "media_test",
         },
@@ -686,7 +708,7 @@ async def test_options(api_client: TestClient, coresys: CoreSys, mount, mock_is_
 
     # Mount doesn't exist, will fail
     resp = await api_client.post(
-        "/mounts/options",
+        f"{prefix}/mounts/options",
         json={
             "default_backup_mount": "junk",
         },
@@ -699,7 +721,7 @@ async def test_options(api_client: TestClient, coresys: CoreSys, mount, mock_is_
 
     # Changes to new backup mount
     resp = await api_client.post(
-        "/mounts/options",
+        f"{prefix}/mounts/options",
         json={
             "default_backup_mount": "other_backup_test",
         },
@@ -712,7 +734,7 @@ async def test_options(api_client: TestClient, coresys: CoreSys, mount, mock_is_
 
     # Unsets default backup mount
     resp = await api_client.post(
-        "/mounts/options",
+        f"{prefix}/mounts/options",
         json={
             "default_backup_mount": None,
         },
@@ -725,15 +747,16 @@ async def test_options(api_client: TestClient, coresys: CoreSys, mount, mock_is_
 
 
 async def test_api_create_mount_fails_special_chars(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     tmp_supervisor_data,
     path_extern,
     mount_propagation,
 ):
     """Test creating a mount via API fails with special characters."""
+    api_client, prefix = api_client_with_prefix
     resp = await api_client.post(
-        "/mounts",
+        f"{prefix}/mounts",
         json={
             "name": "Überwachungskameras",
             "type": "cifs",
@@ -749,7 +772,7 @@ async def test_api_create_mount_fails_special_chars(
 
 
 async def test_api_create_read_only_cifs_mount(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     tmp_supervisor_data,
     path_extern,
@@ -757,8 +780,9 @@ async def test_api_create_read_only_cifs_mount(
     mock_is_mount,
 ):
     """Test creating a read-only cifs mount via API."""
+    api_client, prefix = api_client_with_prefix
     resp = await api_client.post(
-        "/mounts",
+        f"{prefix}/mounts",
         json={
             "name": "media_test",
             "type": "cifs",
@@ -772,7 +796,7 @@ async def test_api_create_read_only_cifs_mount(
     result = await resp.json()
     assert result["result"] == "ok"
 
-    resp = await api_client.get("/mounts")
+    resp = await api_client.get(f"{prefix}/mounts")
     result = await resp.json()
 
     assert result["data"]["mounts"] == [
@@ -792,7 +816,7 @@ async def test_api_create_read_only_cifs_mount(
 
 
 async def test_api_create_read_only_nfs_mount(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     tmp_supervisor_data,
     path_extern,
@@ -800,8 +824,9 @@ async def test_api_create_read_only_nfs_mount(
     mock_is_mount,
 ):
     """Test creating a read-only nfs mount via API."""
+    api_client, prefix = api_client_with_prefix
     resp = await api_client.post(
-        "/mounts",
+        f"{prefix}/mounts",
         json={
             "name": "media_test",
             "type": "nfs",
@@ -814,7 +839,7 @@ async def test_api_create_read_only_nfs_mount(
     result = await resp.json()
     assert result["result"] == "ok"
 
-    resp = await api_client.get("/mounts")
+    resp = await api_client.get(f"{prefix}/mounts")
     result = await resp.json()
 
     assert result["data"]["mounts"] == [
@@ -833,15 +858,16 @@ async def test_api_create_read_only_nfs_mount(
 
 
 async def test_api_read_only_backup_mount_invalid(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     tmp_supervisor_data,
     path_extern,
     mount_propagation,
 ):
     """Test cannot create a read-only backup mount."""
+    api_client, prefix = api_client_with_prefix
     resp = await api_client.post(
-        "/mounts",
+        f"{prefix}/mounts",
         json={
             "name": "backup_test",
             "type": "cifs",
@@ -866,9 +892,12 @@ async def test_api_read_only_backup_mount_invalid(
         ("post", "/mounts/bad/reload"),
     ],
 )
-async def test_mount_not_found(api_client: TestClient, method: str, url: str):
+async def test_mount_not_found(
+    api_client_with_prefix: tuple[TestClient, str], method: str, url: str
+):
     """Test mount not found error."""
-    resp = await api_client.request(method, url)
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.request(method, f"{prefix}{url}")
     assert resp.status == 404
     resp = await resp.json()
     assert resp["message"] == "No mount exists with name bad"

--- a/tests/api/test_network.py
+++ b/tests/api/test_network.py
@@ -24,9 +24,12 @@ from tests.dbus_service_mocks.network_manager import (
 from tests.dbus_service_mocks.network_settings import Settings as SettingsService
 
 
-async def test_api_network_info(api_client: TestClient, coresys: CoreSys):
+async def test_api_network_info(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test network manager api."""
-    resp = await api_client.get("/network/info")
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.get(f"{prefix}/network/info")
     result = await resp.json()
     assert TEST_INTERFACE_ETH_NAME in (
         inet["interface"] for inet in result["data"]["interfaces"]
@@ -71,9 +74,12 @@ async def test_api_network_info(api_client: TestClient, coresys: CoreSys):
 @pytest.mark.parametrize(
     "interface_id", ["default", TEST_INTERFACE_ETH_NAME, TEST_INTERFACE_ETH_MAC]
 )
-async def test_api_network_interface_info(api_client: TestClient, interface_id: str):
+async def test_api_network_interface_info(
+    api_client_with_prefix: tuple[TestClient, str], interface_id: str
+):
     """Test network manager api."""
-    resp = await api_client.get(f"/network/interface/{interface_id}/info")
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.get(f"{prefix}/network/interface/{interface_id}/info")
     result = await resp.json()
     assert result["data"]["ipv4"]["address"][-1] == "192.168.2.148/24"
     assert result["data"]["ipv4"]["gateway"] == "192.168.2.1"
@@ -98,19 +104,20 @@ async def test_api_network_interface_info(api_client: TestClient, interface_id: 
     "interface_id", [TEST_INTERFACE_ETH_NAME, TEST_INTERFACE_ETH_MAC]
 )
 async def test_api_network_interface_update_mac_or_name(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     network_manager_service: NetworkManagerService,
     connection_settings_service: ConnectionSettingsService,
     interface_id: str,
 ):
     """Test network manager API update with name or MAC address."""
+    api_client, prefix = api_client_with_prefix
     network_manager_service.CheckConnectivity.calls.clear()
     connection_settings_service.Update.calls.clear()
     assert coresys.dbus.network.get(interface_id).settings.ipv4.method == "auto"
 
     resp = await api_client.post(
-        f"/network/interface/{interface_id}/update",
+        f"{prefix}/network/interface/{interface_id}/update",
         json={
             "ipv4": {
                 "method": "static",
@@ -133,18 +140,19 @@ async def test_api_network_interface_update_mac_or_name(
 
 
 async def test_api_network_interface_update_ethernet(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     network_manager_service: NetworkManagerService,
     connection_settings_service: ConnectionSettingsService,
 ):
     """Test network manager API update with name or MAC address."""
+    api_client, prefix = api_client_with_prefix
     network_manager_service.CheckConnectivity.calls.clear()
     connection_settings_service.Update.calls.clear()
 
     # Full static configuration (represents frontend static config)
     resp = await api_client.post(
-        f"/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
+        f"{prefix}/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
         json={
             "ipv4": {
                 "method": "static",
@@ -171,7 +179,7 @@ async def test_api_network_interface_update_ethernet(
 
     # Partial static configuration, clears other settings (e.g. by CLI)
     resp = await api_client.post(
-        f"/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
+        f"{prefix}/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
         json={
             "ipv4": {
                 "method": "static",
@@ -195,7 +203,7 @@ async def test_api_network_interface_update_ethernet(
 
     # Auto configuration, clears all settings (represents frontend auto config)
     resp = await api_client.post(
-        f"/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
+        f"{prefix}/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
         json={
             "ipv4": {
                 "method": "auto",
@@ -219,7 +227,7 @@ async def test_api_network_interface_update_ethernet(
 
     # Update route metric
     resp = await api_client.post(
-        f"/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
+        f"{prefix}/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
         json={
             "ipv4": {
                 "route_metric": 100,
@@ -236,10 +244,13 @@ async def test_api_network_interface_update_ethernet(
     assert settings["ipv4"]["route-metric"] == Variant("i", 100)
 
 
-async def test_api_network_interface_update_wifi(api_client: TestClient):
+async def test_api_network_interface_update_wifi(
+    api_client_with_prefix: tuple[TestClient, str],
+):
     """Test network interface WiFi API."""
+    api_client, prefix = api_client_with_prefix
     resp = await api_client.post(
-        f"/network/interface/{TEST_INTERFACE_WLAN_NAME}/update",
+        f"{prefix}/network/interface/{TEST_INTERFACE_WLAN_NAME}/update",
         json={
             "enabled": True,
             "ipv4": {
@@ -255,12 +266,15 @@ async def test_api_network_interface_update_wifi(api_client: TestClient):
     assert result["result"] == "ok"
 
 
-async def test_api_network_interface_update_wifi_error(api_client: TestClient):
+async def test_api_network_interface_update_wifi_error(
+    api_client_with_prefix: tuple[TestClient, str],
+):
     """Test network interface WiFi API error handling."""
+    api_client, prefix = api_client_with_prefix
     # Simulate frontend WiFi interface edit where the user did not select
     # a WiFi SSID.
     resp = await api_client.post(
-        f"/network/interface/{TEST_INTERFACE_WLAN_NAME}/update",
+        f"{prefix}/network/interface/{TEST_INTERFACE_WLAN_NAME}/update",
         json={
             "enabled": True,
             "ipv4": {
@@ -280,17 +294,18 @@ async def test_api_network_interface_update_wifi_error(api_client: TestClient):
 
 
 async def test_api_network_interface_update_mdns(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     network_manager_service: NetworkManagerService,
     connection_settings_service: ConnectionSettingsService,
 ):
     """Test network manager API update with mDNS/LLMNR mode."""
+    api_client, prefix = api_client_with_prefix
     network_manager_service.CheckConnectivity.calls.clear()
     connection_settings_service.Update.calls.clear()
 
     resp = await api_client.post(
-        f"/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
+        f"{prefix}/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
         json={
             "mdns": "resolve",
             "llmnr": "off",
@@ -306,39 +321,48 @@ async def test_api_network_interface_update_mdns(
     assert settings["connection"]["llmnr"] == Variant("i", 0)
 
 
-async def test_api_network_interface_update_remove(api_client: TestClient):
+async def test_api_network_interface_update_remove(
+    api_client_with_prefix: tuple[TestClient, str],
+):
     """Test network manager api."""
+    api_client, prefix = api_client_with_prefix
     resp = await api_client.post(
-        f"/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
+        f"{prefix}/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
         json={"enabled": False},
     )
     result = await resp.json()
     assert result["result"] == "ok"
 
 
-async def test_api_network_interface_info_invalid(api_client: TestClient):
+async def test_api_network_interface_info_invalid(
+    api_client_with_prefix: tuple[TestClient, str],
+):
     """Test network manager api."""
-    resp = await api_client.get("/network/interface/invalid/info")
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.get(f"{prefix}/network/interface/invalid/info")
     result = await resp.json()
 
     assert result["message"]
     assert result["result"] == "error"
 
 
-async def test_api_network_interface_update_invalid(api_client: TestClient):
+async def test_api_network_interface_update_invalid(
+    api_client_with_prefix: tuple[TestClient, str],
+):
     """Test network manager api."""
-    resp = await api_client.post("/network/interface/invalid/update", json={})
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.post(f"{prefix}/network/interface/invalid/update", json={})
     result = await resp.json()
     assert result["message"] == "Interface invalid does not exist"
 
     resp = await api_client.post(
-        f"/network/interface/{TEST_INTERFACE_ETH_NAME}/update", json={}
+        f"{prefix}/network/interface/{TEST_INTERFACE_ETH_NAME}/update", json={}
     )
     result = await resp.json()
     assert result["message"] == "You need to supply at least one option to update"
 
     resp = await api_client.post(
-        f"/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
+        f"{prefix}/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
         json={"ipv4": {"nameservers": "1.1.1.1"}},
     )
     result = await resp.json()
@@ -348,7 +372,7 @@ async def test_api_network_interface_update_invalid(api_client: TestClient):
     )
 
     resp = await api_client.post(
-        f"/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
+        f"{prefix}/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
         json={"ipv4": {"gateway": "invalid"}},
     )
     result = await resp.json()
@@ -358,7 +382,7 @@ async def test_api_network_interface_update_invalid(api_client: TestClient):
     )
 
     resp = await api_client.post(
-        f"/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
+        f"{prefix}/network/interface/{TEST_INTERFACE_ETH_NAME}/update",
         json={"ipv6": {"gateway": "invalid"}},
     )
     result = await resp.json()
@@ -368,11 +392,14 @@ async def test_api_network_interface_update_invalid(api_client: TestClient):
     )
 
 
-async def test_api_network_wireless_scan(api_client: TestClient):
+async def test_api_network_wireless_scan(
+    api_client_with_prefix: tuple[TestClient, str],
+):
     """Test network manager api."""
+    api_client, prefix = api_client_with_prefix
     with patch("asyncio.sleep", return_value=AsyncMock()):
         resp = await api_client.get(
-            f"/network/interface/{TEST_INTERFACE_WLAN_NAME}/accesspoints"
+            f"{prefix}/network/interface/{TEST_INTERFACE_WLAN_NAME}/accesspoints"
         )
     result = await resp.json()
 
@@ -384,13 +411,14 @@ async def test_api_network_wireless_scan(api_client: TestClient):
 
 
 async def test_api_network_reload(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     network_manager_service: NetworkManagerService,
 ):
     """Test network manager reload api."""
+    api_client, prefix = api_client_with_prefix
     network_manager_service.CheckConnectivity.calls.clear()
-    resp = await api_client.post("/network/reload")
+    resp = await api_client.post(f"{prefix}/network/reload")
     result = await resp.json()
 
     assert result["result"] == "ok"
@@ -399,15 +427,16 @@ async def test_api_network_reload(
 
 
 async def test_api_network_vlan(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     network_manager_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ):
     """Test creating a vlan."""
+    api_client, prefix = api_client_with_prefix
     settings_service: SettingsService = network_manager_services["network_settings"]
     settings_service.AddConnection.calls.clear()
     resp = await api_client.post(
-        f"/network/interface/{TEST_INTERFACE_ETH_NAME}/vlan/1",
+        f"{prefix}/network/interface/{TEST_INTERFACE_ETH_NAME}/vlan/1",
         json={"ipv4": {"method": "auto"}, "llmnr": "off"},
     )
     result = await resp.json()
@@ -434,7 +463,7 @@ async def test_api_network_vlan(
     # Check if trying to recreate an existing VLAN raises an exception
     result = await resp.json()
     resp = await api_client.post(
-        f"/network/interface/{TEST_INTERFACE_ETH_NAME}/vlan/10",
+        f"{prefix}/network/interface/{TEST_INTERFACE_ETH_NAME}/vlan/10",
         json={"ipv4": {"method": "auto"}},
     )
     result = await resp.json()
@@ -452,10 +481,11 @@ async def test_api_network_vlan(
     ],
 )
 async def test_network_interface_not_found(
-    api_client: TestClient, method: str, url: str
+    api_client_with_prefix: tuple[TestClient, str], method: str, url: str
 ):
     """Test network interface not found error."""
-    resp = await api_client.request(method, url)
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.request(method, f"{prefix}{url}")
     assert resp.status == 404
     body = await resp.json()
     assert body["message"] == "Interface bad does not exist"

--- a/tests/api/test_os.py
+++ b/tests/api/test_os.py
@@ -32,9 +32,10 @@ async def fixture_boards_service(
     yield os_agent_services["agent_boards"]
 
 
-async def test_api_os_info(api_client: TestClient):
+async def test_api_os_info(api_client_with_prefix: tuple[TestClient, str]):
     """Test os info api."""
-    resp = await api_client.get("/os/info")
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.get(f"{prefix}/os/info")
     result = await resp.json()
 
     for attr in (
@@ -49,20 +50,24 @@ async def test_api_os_info(api_client: TestClient):
         assert attr in result["data"]
 
 
-async def test_api_os_info_with_agent(api_client: TestClient, coresys: CoreSys):
+async def test_api_os_info_with_agent(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test os info api for data disk."""
-    resp = await api_client.get("/os/info")
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.get(f"{prefix}/os/info")
     result = await resp.json()
 
     assert result["data"]["data_disk"] == "BJTD4R-0x97cde291"
 
 
 async def test_api_os_info_boot_slots(
-    api_client: TestClient, coresys: CoreSys, os_available
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys, os_available
 ):
     """Test os info api for boot slots."""
+    api_client, prefix = api_client_with_prefix
     await coresys.os.load()
-    resp = await api_client.get("/os/info")
+    resp = await api_client.get(f"{prefix}/os/info")
     result = await resp.json()
 
     assert result["data"]["boot_slots"] == {
@@ -81,21 +86,27 @@ async def test_api_os_info_boot_slots(
     ids=["non-existent", "unavailable drive by path", "unavailable drive by id"],
 )
 async def test_api_os_datadisk_move_fail(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     new_disk: str,
     os_available,
 ):
     """Test datadisk move to non-existent or invalid devices."""
-    resp = await api_client.post("/os/datadisk/move", json={"device": new_disk})
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.post(
+        f"{prefix}/os/datadisk/move", json={"device": new_disk}
+    )
     result = await resp.json()
 
     assert result["message"] == f"'{new_disk}' not a valid data disk target!"
 
 
-async def test_api_os_datadisk_list(api_client: TestClient, coresys: CoreSys):
+async def test_api_os_datadisk_list(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test datadisk list function."""
-    resp = await api_client.get("/os/datadisk/list")
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.get(f"{prefix}/os/datadisk/list")
     result = await resp.json()
 
     assert result["data"]["devices"] == ["SSK-SSK-Storage-DF56419883D56"]
@@ -118,18 +129,21 @@ async def test_api_os_datadisk_list(api_client: TestClient, coresys: CoreSys):
     ids=["by drive id", "by device path"],
 )
 async def test_api_os_datadisk_migrate(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     os_agent_services: dict[str, DBusServiceMock],
     new_disk: str,
     os_available,
 ):
     """Test migrating datadisk."""
+    api_client, prefix = api_client_with_prefix
     datadisk_service: DataDiskService = os_agent_services["agent_datadisk"]
     datadisk_service.ChangeDevice.calls.clear()
 
     with patch.object(SystemControl, "reboot") as reboot:
-        resp = await api_client.post("/os/datadisk/move", json={"device": new_disk})
+        resp = await api_client.post(
+            f"{prefix}/os/datadisk/move", json={"device": new_disk}
+        )
         assert resp.status == 200
 
         assert datadisk_service.ChangeDevice.calls == [("/dev/sda",)]
@@ -137,16 +151,17 @@ async def test_api_os_datadisk_migrate(
 
 
 async def test_api_os_datadisk_wipe(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     os_agent_services: dict[str, DBusServiceMock],
     os_available,
 ):
     """Test datadisk wipe."""
+    api_client, prefix = api_client_with_prefix
     system_service: SystemService = os_agent_services["agent_system"]
     system_service.ScheduleWipeDevice.calls.clear()
 
     with patch.object(SystemControl, "reboot") as reboot:
-        resp = await api_client.post("/os/datadisk/wipe")
+        resp = await api_client.post(f"{prefix}/os/datadisk/wipe")
         assert resp.status == 200
 
         assert system_service.ScheduleWipeDevice.calls == [()]
@@ -154,58 +169,67 @@ async def test_api_os_datadisk_wipe(
 
 
 async def test_api_set_boot_slot(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     all_dbus_services: dict[str, DBusServiceMock],
     coresys: CoreSys,
     os_available,
 ):
     """Test changing the boot slot via API."""
+    api_client, prefix = api_client_with_prefix
     rauc_service: RaucService = all_dbus_services["rauc"]
+    rauc_service.Mark.calls.clear()
     await coresys.os.load()
 
     with patch.object(SystemControl, "reboot") as reboot:
-        resp = await api_client.post("/os/boot-slot", json={"boot_slot": "A"})
+        resp = await api_client.post(f"{prefix}/os/boot-slot", json={"boot_slot": "A"})
         assert resp.status == 200
 
         reboot.assert_called_once()
         assert rauc_service.Mark.calls == [("active", "kernel.0")]
 
 
-async def test_api_set_boot_slot_invalid(api_client: TestClient):
+async def test_api_set_boot_slot_invalid(
+    api_client_with_prefix: tuple[TestClient, str],
+):
     """Test invalid calls to set boot slot."""
-    resp = await api_client.post("/os/boot-slot", json={"boot_slot": "C"})
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.post(f"{prefix}/os/boot-slot", json={"boot_slot": "C"})
     assert resp.status == 400
     result = await resp.json()
     assert "expected BootSlot or one of 'A', 'B'" in result["message"]
 
-    resp = await api_client.post("/os/boot-slot", json={"boot_slot": "A"})
+    resp = await api_client.post(f"{prefix}/os/boot-slot", json={"boot_slot": "A"})
     assert resp.status == 400
     result = await resp.json()
     assert "no Home Assistant OS available" in result["message"]
 
 
 async def test_api_set_boot_slot_error(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     all_dbus_services: dict[str, DBusServiceMock],
     coresys: CoreSys,
     capture_exception: Mock,
     os_available,
 ):
     """Test changing the boot slot via API."""
+    api_client, prefix = api_client_with_prefix
     rauc_service: RaucService = all_dbus_services["rauc"]
     rauc_service.response_mark = DBusError(ErrorType.FAILED, "fail")
     await coresys.os.load()
 
-    resp = await api_client.post("/os/boot-slot", json={"boot_slot": "A"})
+    resp = await api_client.post(f"{prefix}/os/boot-slot", json={"boot_slot": "A"})
     assert resp.status == 400
     result = await resp.json()
     assert result["message"] == "Can't mark A as active!"
     capture_exception.assert_called_once()
 
 
-async def test_api_board_yellow_info(api_client: TestClient, coresys: CoreSys):
+async def test_api_board_yellow_info(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test yellow board info."""
-    resp = await api_client.get("/os/boards/yellow")
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.get(f"{prefix}/os/boards/yellow")
     assert resp.status == 200
 
     result = await resp.json()
@@ -213,17 +237,18 @@ async def test_api_board_yellow_info(api_client: TestClient, coresys: CoreSys):
     assert result["data"]["heartbeat_led"] is True
     assert result["data"]["power_led"] is True
 
-    assert (await api_client.get("/os/boards/green")).status == 400
-    assert (await api_client.get("/os/boards/supervised")).status == 400
-    assert (await api_client.get("/os/boards/not-real")).status == 400
+    assert (await api_client.get(f"{prefix}/os/boards/green")).status == 400
+    assert (await api_client.get(f"{prefix}/os/boards/supervised")).status == 400
+    assert (await api_client.get(f"{prefix}/os/boards/not-real")).status == 400
 
 
 async def test_api_board_yellow_options(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     os_agent_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ):
     """Test yellow board options."""
+    api_client, prefix = api_client_with_prefix
     yellow_service: YellowService = os_agent_services["agent_boards_yellow"]
 
     assert coresys.dbus.agent.board.yellow.disk_led is True
@@ -232,7 +257,7 @@ async def test_api_board_yellow_options(
     assert len(coresys.resolution.issues) == 0
     with patch.object(BoardProxy, "save_data") as save_data:
         resp = await api_client.post(
-            "/os/boards/yellow",
+            f"{prefix}/os/boards/yellow",
             json={"disk_led": False, "heartbeat_led": False, "power_led": False},
         )
         assert resp.status == 200
@@ -254,14 +279,17 @@ async def test_api_board_yellow_options(
 
 
 async def test_api_board_green_info(
-    api_client: TestClient, coresys: CoreSys, boards_service: BoardsService
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    boards_service: BoardsService,
 ):
     """Test green board info."""
+    api_client, prefix = api_client_with_prefix
     await mock_dbus_services({"agent_boards_green": None}, coresys.dbus.bus)
     boards_service.board = "Green"
     await coresys.dbus.agent.board.connect(coresys.dbus.bus)
 
-    resp = await api_client.get("/os/boards/green")
+    resp = await api_client.get(f"{prefix}/os/boards/green")
     assert resp.status == 200
 
     result = await resp.json()
@@ -269,17 +297,18 @@ async def test_api_board_green_info(
     assert result["data"]["power_led"] is True
     assert result["data"]["system_health_led"] is True
 
-    assert (await api_client.get("/os/boards/yellow")).status == 400
-    assert (await api_client.get("/os/boards/supervised")).status == 400
-    assert (await api_client.get("/os/boards/not-real")).status == 400
+    assert (await api_client.get(f"{prefix}/os/boards/yellow")).status == 400
+    assert (await api_client.get(f"{prefix}/os/boards/supervised")).status == 400
+    assert (await api_client.get(f"{prefix}/os/boards/not-real")).status == 400
 
 
 async def test_api_board_green_options(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     boards_service: BoardsService,
 ):
     """Test yellow board options."""
+    api_client, prefix = api_client_with_prefix
     green_service: GreenService = (
         await mock_dbus_services({"agent_boards_green": None}, coresys.dbus.bus)
     )["agent_boards_green"]
@@ -292,7 +321,7 @@ async def test_api_board_green_options(
     assert len(coresys.resolution.issues) == 0
     with patch.object(BoardProxy, "save_data") as save_data:
         resp = await api_client.post(
-            "/os/boards/green",
+            f"{prefix}/os/boards/green",
             json={
                 "activity_led": False,
                 "power_led": False,
@@ -310,9 +339,12 @@ async def test_api_board_green_options(
 
 
 async def test_api_board_supervised_info(
-    api_client: TestClient, coresys: CoreSys, boards_service: BoardsService
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    boards_service: BoardsService,
 ):
     """Test supervised board info."""
+    api_client, prefix = api_client_with_prefix
     await mock_dbus_services({"agent_boards_supervised": None}, coresys.dbus.bus)
     boards_service.board = "Supervised"
     await coresys.dbus.agent.board.connect(coresys.dbus.bus)
@@ -320,34 +352,42 @@ async def test_api_board_supervised_info(
     with patch("supervisor.os.manager.CPE.get_product", return_value=["not-hassos"]):
         await coresys.os.load()
 
-        assert (await api_client.get("/os/boards/supervised")).status == 200
-        assert (await api_client.post("/os/boards/supervised", json={})).status == 405
-        assert (await api_client.get("/os/boards/yellow")).status == 400
-        assert (await api_client.get("/os/boards/not-real")).status == 400
+        assert (await api_client.get(f"{prefix}/os/boards/supervised")).status == 200
+        assert (
+            await api_client.post(f"{prefix}/os/boards/supervised", json={})
+        ).status == 405
+        assert (await api_client.get(f"{prefix}/os/boards/yellow")).status == 400
+        assert (await api_client.get(f"{prefix}/os/boards/not-real")).status == 400
 
 
 async def test_api_board_other_info(
-    api_client: TestClient, coresys: CoreSys, boards_service: BoardsService
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    boards_service: BoardsService,
 ):
     """Test info for other board without dbus object."""
+    api_client, prefix = api_client_with_prefix
     boards_service.board = "not-real"
     await coresys.dbus.agent.board.connect(coresys.dbus.bus)
 
     with patch.object(OSManager, "board", new=PropertyMock(return_value="not-real")):
-        assert (await api_client.get("/os/boards/not-real")).status == 200
-        assert (await api_client.post("/os/boards/not-real", json={})).status == 405
-        assert (await api_client.get("/os/boards/yellow")).status == 400
-        assert (await api_client.get("/os/boards/supervised")).status == 400
+        assert (await api_client.get(f"{prefix}/os/boards/not-real")).status == 200
+        assert (
+            await api_client.post(f"{prefix}/os/boards/not-real", json={})
+        ).status == 405
+        assert (await api_client.get(f"{prefix}/os/boards/yellow")).status == 400
+        assert (await api_client.get(f"{prefix}/os/boards/supervised")).status == 400
 
 
 @pytest.mark.parametrize("os_available", ["15.0"], indirect=True)
 async def test_api_config_swap_info(
-    api_client: TestClient, coresys: CoreSys, os_available
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys, os_available
 ):
     """Test swap info."""
+    api_client, prefix = api_client_with_prefix
     await coresys.dbus.agent.swap.connect(coresys.dbus.bus)
 
-    resp = await api_client.get("/os/config/swap")
+    resp = await api_client.get(f"{prefix}/os/config/swap")
 
     assert resp.status == 200
     result = await resp.json()
@@ -357,12 +397,13 @@ async def test_api_config_swap_info(
 
 @pytest.mark.parametrize("os_available", ["15.0"], indirect=True)
 async def test_api_config_swap_options(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     os_agent_services: dict[str, DBusServiceMock],
     os_available,
 ):
     """Test swap setting."""
+    api_client, prefix = api_client_with_prefix
     swap_service: SwapService = os_agent_services["agent_swap"]
     await coresys.dbus.agent.swap.connect(coresys.dbus.bus)
 
@@ -370,7 +411,7 @@ async def test_api_config_swap_options(
     assert coresys.dbus.agent.swap.swappiness == 1
 
     resp = await api_client.post(
-        "/os/config/swap",
+        f"{prefix}/os/config/swap",
         json={
             "swap_size": "2M",
             "swappiness": 10,
@@ -394,7 +435,7 @@ async def test_api_config_swap_options(
 
     # test setting only the swap size
     resp = await api_client.post(
-        "/os/config/swap",
+        f"{prefix}/os/config/swap",
         json={
             "swap_size": "10M",
         },
@@ -408,7 +449,7 @@ async def test_api_config_swap_options(
 
     # test setting only the swappiness
     resp = await api_client.post(
-        "/os/config/swap",
+        f"{prefix}/os/config/swap",
         json={
             "swappiness": 100,
         },
@@ -423,17 +464,18 @@ async def test_api_config_swap_options(
 
 @pytest.mark.parametrize("os_available", ["15.0"], indirect=True)
 async def test_api_config_swap_options_no_reboot(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     os_agent_services: dict[str, DBusServiceMock],
     os_available,
 ):
     """Test no resolution is shown when setting are submitted empty or unchanged."""
+    api_client, prefix = api_client_with_prefix
     await coresys.dbus.agent.swap.connect(coresys.dbus.bus)
 
     # empty options
     resp = await api_client.post(
-        "/os/config/swap",
+        f"{prefix}/os/config/swap",
         json={},
     )
     assert resp.status == 200
@@ -448,7 +490,7 @@ async def test_api_config_swap_options_no_reboot(
 
     # no change
     resp = await api_client.post(
-        "/os/config/swap",
+        f"{prefix}/os/config/swap",
         json={
             "swappiness": coresys.dbus.agent.swap.swappiness,
             "swap_size": coresys.dbus.agent.swap.swap_size,
@@ -466,18 +508,19 @@ async def test_api_config_swap_options_no_reboot(
 
 
 async def test_api_config_swap_not_os(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     os_agent_services: dict[str, DBusServiceMock],
 ):
     """Test 404 is returned for swap endpoints if not running on HAOS."""
+    api_client, prefix = api_client_with_prefix
     await coresys.dbus.agent.swap.connect(coresys.dbus.bus)
 
-    resp = await api_client.get("/os/config/swap")
+    resp = await api_client.get(f"{prefix}/os/config/swap")
     assert resp.status == 404
 
     resp = await api_client.post(
-        "/os/config/swap",
+        f"{prefix}/os/config/swap",
         json={
             "swap_size": "2M",
             "swappiness": 10,
@@ -488,19 +531,20 @@ async def test_api_config_swap_not_os(
 
 @pytest.mark.parametrize("os_available", ["14.2"], indirect=True)
 async def test_api_config_swap_old_os(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     os_agent_services: dict[str, DBusServiceMock],
     os_available,
 ):
     """Test 404 is returned for swap endpoints if OS is older than 15.0."""
+    api_client, prefix = api_client_with_prefix
     await coresys.dbus.agent.swap.connect(coresys.dbus.bus)
 
-    resp = await api_client.get("/os/config/swap")
+    resp = await api_client.get(f"{prefix}/os/config/swap")
     assert resp.status == 404
 
     resp = await api_client.post(
-        "/os/config/swap",
+        f"{prefix}/os/config/swap",
         json={
             "swap_size": "2M",
             "swappiness": 10,

--- a/tests/api/test_resolution.py
+++ b/tests/api/test_resolution.py
@@ -26,15 +26,18 @@ from supervisor.resolution.data import Issue, Suggestion
 
 
 @pytest.mark.asyncio
-async def test_api_resolution_base(coresys: CoreSys, api_client: TestClient):
+async def test_api_resolution_base(
+    coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
+):
     """Test resolution manager api."""
+    api_client, prefix = api_client_with_prefix
     coresys.resolution.add_unsupported_reason(UnsupportedReason.OS)
     coresys.resolution.add_suggestion(
         Suggestion(SuggestionType.CLEAR_FULL_BACKUP, ContextType.SYSTEM)
     )
     coresys.resolution.create_issue(IssueType.FREE_SPACE, ContextType.SYSTEM)
 
-    resp = await api_client.get("/resolution/info")
+    resp = await api_client.get(f"{prefix}/resolution/info")
     result = await resp.json()
     assert UnsupportedReason.OS in result["data"][ATTR_UNSUPPORTED]
     assert (
@@ -45,23 +48,25 @@ async def test_api_resolution_base(coresys: CoreSys, api_client: TestClient):
 
 @pytest.mark.asyncio
 async def test_api_resolution_dismiss_suggestion(
-    coresys: CoreSys, api_client: TestClient
+    coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
 ):
     """Test resolution manager dismiss suggestion api."""
+    api_client, prefix = api_client_with_prefix
     coresys.resolution.add_suggestion(
         clear_backup := Suggestion(SuggestionType.CLEAR_FULL_BACKUP, ContextType.SYSTEM)
     )
 
     assert coresys.resolution.suggestions[-1].type == SuggestionType.CLEAR_FULL_BACKUP
-    await api_client.delete(f"/resolution/suggestion/{clear_backup.uuid}")
+    await api_client.delete(f"{prefix}/resolution/suggestion/{clear_backup.uuid}")
     assert clear_backup not in coresys.resolution.suggestions
 
 
 @pytest.mark.asyncio
 async def test_api_resolution_apply_suggestion(
-    coresys: CoreSys, api_client: TestClient
+    coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
 ):
     """Test resolution manager suggestion apply api."""
+    api_client, prefix = api_client_with_prefix
     coresys.resolution.add_suggestion(
         clear_backup := Suggestion(SuggestionType.CLEAR_FULL_BACKUP, ContextType.SYSTEM)
     )
@@ -76,8 +81,8 @@ async def test_api_resolution_apply_suggestion(
     coresys.backups.do_backup_full = mock_backups
     coresys.resolution.healthcheck = mock_health
 
-    await api_client.post(f"/resolution/suggestion/{clear_backup.uuid}")
-    await api_client.post(f"/resolution/suggestion/{create_backup.uuid}")
+    await api_client.post(f"{prefix}/resolution/suggestion/{clear_backup.uuid}")
+    await api_client.post(f"{prefix}/resolution/suggestion/{create_backup.uuid}")
 
     assert clear_backup not in coresys.resolution.suggestions
     assert create_backup not in coresys.resolution.suggestions
@@ -90,66 +95,81 @@ async def test_api_resolution_apply_suggestion(
 
 
 @pytest.mark.asyncio
-async def test_api_resolution_dismiss_issue(coresys: CoreSys, api_client: TestClient):
+async def test_api_resolution_dismiss_issue(
+    coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
+):
     """Test resolution manager issue apply api."""
+    api_client, prefix = api_client_with_prefix
     coresys.resolution.add_issue(
         updated_failed := Issue(IssueType.UPDATE_FAILED, ContextType.SYSTEM)
     )
 
     assert coresys.resolution.issues[-1].type == IssueType.UPDATE_FAILED
-    await api_client.delete(f"/resolution/issue/{updated_failed.uuid}")
+    await api_client.delete(f"{prefix}/resolution/issue/{updated_failed.uuid}")
     assert updated_failed not in coresys.resolution.issues
 
 
 @pytest.mark.asyncio
-async def test_api_resolution_unhealthy(coresys: CoreSys, api_client: TestClient):
+async def test_api_resolution_unhealthy(
+    coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
+):
     """Test resolution manager api."""
+    api_client, prefix = api_client_with_prefix
     coresys.resolution.add_unhealthy_reason(UnhealthyReason.DOCKER)
 
-    resp = await api_client.get("/resolution/info")
+    resp = await api_client.get(f"{prefix}/resolution/info")
     result = await resp.json()
     assert result["data"][ATTR_UNHEALTHY][-1] == UnhealthyReason.DOCKER
 
 
 @pytest.mark.asyncio
-async def test_api_resolution_check_options(coresys: CoreSys, api_client: TestClient):
+async def test_api_resolution_check_options(
+    coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
+):
     """Test client API with checks options."""
+    api_client, prefix = api_client_with_prefix
     free_space = coresys.resolution.check.get("free_space")
 
     assert free_space.enabled
     await api_client.post(
-        f"/resolution/check/{free_space.slug}/options", json={"enabled": False}
+        f"{prefix}/resolution/check/{free_space.slug}/options", json={"enabled": False}
     )
     assert not free_space.enabled
 
     await api_client.post(
-        f"/resolution/check/{free_space.slug}/options", json={"enabled": True}
+        f"{prefix}/resolution/check/{free_space.slug}/options", json={"enabled": True}
     )
     assert free_space.enabled
 
 
 @pytest.mark.asyncio
-async def test_api_resolution_check_run(coresys: CoreSys, api_client: TestClient):
+async def test_api_resolution_check_run(
+    coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
+):
     """Test client API with run check."""
+    api_client, prefix = api_client_with_prefix
     await coresys.core.set_state(CoreState.RUNNING)
     free_space = coresys.resolution.check.get("free_space")
 
     free_space.run_check = AsyncMock()
 
-    await api_client.post(f"/resolution/check/{free_space.slug}/run")
+    await api_client.post(f"{prefix}/resolution/check/{free_space.slug}/run")
 
     assert free_space.run_check.called
 
 
 async def test_api_resolution_suggestions_for_issue(
-    coresys: CoreSys, api_client: TestClient
+    coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
 ):
     """Test getting suggestions that fix an issue."""
+    api_client, prefix = api_client_with_prefix
     coresys.resolution.add_issue(
         corrupt_repo := Issue(IssueType.CORRUPT_REPOSITORY, ContextType.STORE, "repo_1")
     )
 
-    resp = await api_client.get(f"/resolution/issue/{corrupt_repo.uuid}/suggestions")
+    resp = await api_client.get(
+        f"{prefix}/resolution/issue/{corrupt_repo.uuid}/suggestions"
+    )
     result = await resp.json()
 
     assert result["data"]["suggestions"] == []
@@ -165,7 +185,9 @@ async def test_api_resolution_suggestions_for_issue(
         )
     )
 
-    resp = await api_client.get(f"/resolution/issue/{corrupt_repo.uuid}/suggestions")
+    resp = await api_client.get(
+        f"{prefix}/resolution/issue/{corrupt_repo.uuid}/suggestions"
+    )
     result = await resp.json()
 
     suggestion = [
@@ -185,9 +207,12 @@ async def test_api_resolution_suggestions_for_issue(
     ("method", "url"),
     [("delete", "/resolution/issue/bad"), ("get", "/resolution/issue/bad/suggestions")],
 )
-async def test_issue_not_found(api_client: TestClient, method: str, url: str):
+async def test_issue_not_found(
+    api_client_with_prefix: tuple[TestClient, str], method: str, url: str
+):
     """Test issue not found error."""
-    resp = await api_client.request(method, url)
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.request(method, f"{prefix}{url}")
     assert resp.status == 404
     body = await resp.json()
     assert body["message"] == "Issue bad does not exist"
@@ -199,9 +224,12 @@ async def test_issue_not_found(api_client: TestClient, method: str, url: str):
     ("method", "url"),
     [("delete", "/resolution/suggestion/bad"), ("post", "/resolution/suggestion/bad")],
 )
-async def test_suggestion_not_found(api_client: TestClient, method: str, url: str):
+async def test_suggestion_not_found(
+    api_client_with_prefix: tuple[TestClient, str], method: str, url: str
+):
     """Test suggestion not found error."""
-    resp = await api_client.request(method, url)
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.request(method, f"{prefix}{url}")
     assert resp.status == 404
     body = await resp.json()
     assert body["message"] == "Suggestion bad does not exist"
@@ -213,9 +241,12 @@ async def test_suggestion_not_found(api_client: TestClient, method: str, url: st
     ("method", "url"),
     [("post", "/resolution/check/bad/options"), ("post", "/resolution/check/bad/run")],
 )
-async def test_check_not_found(api_client: TestClient, method: str, url: str):
+async def test_check_not_found(
+    api_client_with_prefix: tuple[TestClient, str], method: str, url: str
+):
     """Test check not found error."""
-    resp = await api_client.request(method, url)
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.request(method, f"{prefix}{url}")
     assert resp.status == HTTPStatus.NOT_FOUND
     body = await resp.json()
     assert body["message"] == "Check 'bad' does not exist"

--- a/tests/api/test_security.py
+++ b/tests/api/test_security.py
@@ -2,37 +2,47 @@
 
 from unittest.mock import AsyncMock
 
+from aiohttp.test_utils import TestClient
 import pytest
 
 from supervisor.coresys import CoreSys
 
 
 @pytest.mark.asyncio
-async def test_api_security_options_force_security(api_client, coresys: CoreSys):
+async def test_api_security_options_force_security(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test security options force security."""
+    api_client, prefix = api_client_with_prefix
     assert not coresys.security.force
 
-    await api_client.post("/security/options", json={"force_security": True})
+    await api_client.post(f"{prefix}/security/options", json={"force_security": True})
 
     assert coresys.security.force
 
 
 @pytest.mark.asyncio
-async def test_api_security_options_pwned(api_client, coresys: CoreSys):
+async def test_api_security_options_pwned(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test security options pwned."""
+    api_client, prefix = api_client_with_prefix
     assert coresys.security.pwned
 
-    await api_client.post("/security/options", json={"pwned": False})
+    await api_client.post(f"{prefix}/security/options", json={"pwned": False})
 
     assert not coresys.security.pwned
 
 
 @pytest.mark.asyncio
 async def test_api_integrity_check(
-    api_client, coresys: CoreSys, supervisor_internet: AsyncMock
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    supervisor_internet: AsyncMock,
 ):
     """Test security integrity check - now deprecated."""
-    resp = await api_client.post("/security/integrity")
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.post(f"{prefix}/security/integrity")
 
     # CodeNotary integrity check has been removed, should return 410 Gone
     assert resp.status == 410

--- a/tests/api/test_services.py
+++ b/tests/api/test_services.py
@@ -14,9 +14,12 @@ from tests.const import TEST_ADDON_SLUG
     ("method", "url"),
     [("get", "/services/bad"), ("post", "/services/bad"), ("delete", "/services/bad")],
 )
-async def test_service_not_found(api_client: TestClient, method: str, url: str):
+async def test_service_not_found(
+    api_client_with_prefix: tuple[TestClient, str], method: str, url: str
+):
     """Test service not found error."""
-    resp = await api_client.request(method, url)
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.request(method, f"{prefix}{url}")
     assert resp.status == 404
     body = await resp.json()
     assert body["message"] == "Service does not exist"

--- a/tests/api/test_supervisor.py
+++ b/tests/api/test_supervisor.py
@@ -27,19 +27,25 @@ from tests.dbus_service_mocks.os_agent import OSAgent as OSAgentService
 REPO_URL = "https://github.com/awesome-developer/awesome-repo"
 
 
-async def test_api_supervisor_options_debug(api_client: TestClient, coresys: CoreSys):
+async def test_api_supervisor_options_debug(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test security options force security."""
+    api_client, prefix = api_client_with_prefix
     assert not coresys.config.debug
 
-    await api_client.post("/supervisor/options", json={"debug": True})
+    await api_client.post(f"{prefix}/supervisor/options", json={"debug": True})
 
     assert coresys.config.debug
 
 
 async def test_api_supervisor_options_add_repository(
-    api_client: TestClient, coresys: CoreSys, supervisor_internet: AsyncMock
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    supervisor_internet: AsyncMock,
 ):
     """Test add a repository via POST /supervisor/options REST API."""
+    api_client, prefix = api_client_with_prefix
     assert REPO_URL not in coresys.store.repository_urls
 
     with (
@@ -47,7 +53,7 @@ async def test_api_supervisor_options_add_repository(
         patch("supervisor.store.repository.RepositoryGit.validate", return_value=True),
     ):
         response = await api_client.post(
-            "/supervisor/options", json={"addons_repositories": [REPO_URL]}
+            f"{prefix}/supervisor/options", json={"addons_repositories": [REPO_URL]}
         )
 
     assert response.status == 200
@@ -55,14 +61,17 @@ async def test_api_supervisor_options_add_repository(
 
 
 async def test_api_supervisor_options_remove_repository(
-    api_client: TestClient, coresys: CoreSys, test_repository: Repository
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    test_repository: Repository,
 ):
     """Test remove a repository via POST /supervisor/options REST API."""
+    api_client, prefix = api_client_with_prefix
     assert test_repository.source in coresys.store.repository_urls
     assert test_repository.slug in coresys.store.repositories
 
     response = await api_client.post(
-        "/supervisor/options", json={"addons_repositories": []}
+        f"{prefix}/supervisor/options", json={"addons_repositories": []}
     )
 
     assert response.status == 200
@@ -72,16 +81,19 @@ async def test_api_supervisor_options_remove_repository(
 
 @pytest.mark.parametrize("git_error", [None, StoreGitError()])
 async def test_api_supervisor_options_repositories_skipped_on_error(
-    api_client: TestClient, coresys: CoreSys, git_error: StoreGitError
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    git_error: StoreGitError,
 ):
     """Test repositories skipped on error via POST /supervisor/options REST API."""
+    api_client, prefix = api_client_with_prefix
     with (
         patch("supervisor.store.repository.RepositoryGit.load", side_effect=git_error),
         patch("supervisor.store.repository.RepositoryGit.validate", return_value=False),
         patch("supervisor.store.repository.RepositoryCustom.remove"),
     ):
         response = await api_client.post(
-            "/supervisor/options", json={"addons_repositories": [REPO_URL]}
+            f"{prefix}/supervisor/options", json={"addons_repositories": [REPO_URL]}
         )
 
     assert response.status == 400
@@ -90,16 +102,17 @@ async def test_api_supervisor_options_repositories_skipped_on_error(
 
 
 async def test_api_supervisor_options_repo_error_with_config_change(
-    api_client: TestClient, coresys: CoreSys
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
 ):
     """Test config change with add repository error via POST /supervisor/options REST API."""
+    api_client, prefix = api_client_with_prefix
     assert not coresys.config.debug
 
     with patch(
         "supervisor.store.repository.RepositoryGit.load", side_effect=StoreGitError()
     ):
         response = await api_client.post(
-            "/supervisor/options",
+            f"{prefix}/supervisor/options",
             json={"debug": True, "addons_repositories": [REPO_URL]},
         )
 
@@ -112,12 +125,15 @@ async def test_api_supervisor_options_repo_error_with_config_change(
 
 
 async def test_api_supervisor_options_auto_update(
-    api_client: TestClient, coresys: CoreSys
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
 ):
     """Test disabling auto update via api."""
+    api_client, prefix = api_client_with_prefix
     assert coresys.updater.auto_update is True
 
-    response = await api_client.post("/supervisor/options", json={"auto_update": False})
+    response = await api_client.post(
+        f"{prefix}/supervisor/options", json={"auto_update": False}
+    )
 
     assert response.status == 200
 
@@ -125,11 +141,12 @@ async def test_api_supervisor_options_auto_update(
 
 
 async def test_api_supervisor_options_diagnostics(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     os_agent_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ):
     """Test changing diagnostics."""
+    api_client, prefix = api_client_with_prefix
     os_agent_service: OSAgentService = os_agent_services["os_agent"]
     os_agent_service.Diagnostics = False
     await os_agent_service.ping()
@@ -137,7 +154,7 @@ async def test_api_supervisor_options_diagnostics(
 
     with patch("supervisor.utils.sentry.sentry_sdk.init") as sentry_init:
         response = await api_client.post(
-            "/supervisor/options", json={"diagnostics": True}
+            f"{prefix}/supervisor/options", json={"diagnostics": True}
         )
         assert response.status == 200
         sentry_init.assert_called_once()
@@ -147,7 +164,7 @@ async def test_api_supervisor_options_diagnostics(
 
     with patch("supervisor.api.supervisor.close_sentry") as close_sentry:
         response = await api_client.post(
-            "/supervisor/options", json={"diagnostics": False}
+            f"{prefix}/supervisor/options", json={"diagnostics": False}
         )
         assert response.status == 200
         close_sentry.assert_called_once()
@@ -162,13 +179,16 @@ async def test_api_supervisor_logs(advanced_logs_tester):
 
 
 async def test_api_supervisor_fallback(
-    api_client: TestClient, journald_logs: MagicMock, docker_logs: MagicMock
+    api_client_with_prefix: tuple[TestClient, str],
+    journald_logs: MagicMock,
+    docker_logs: MagicMock,
 ):
     """Check that supervisor logs read from container logs if reading from journald gateway fails badly."""
+    api_client, prefix = api_client_with_prefix
     journald_logs.side_effect = HassioError("Something bad happened!")
 
     with patch("supervisor.api._LOGGER.exception") as logger:
-        resp = await api_client.get("/supervisor/logs")
+        resp = await api_client.get(f"{prefix}/supervisor/logs")
         logger.assert_called_once_with(
             "Failed to get supervisor logs using advanced_logs API"
         )
@@ -184,7 +204,7 @@ async def test_api_supervisor_fallback(
     # check fallback also works for the /follow endpoint (no mock reset needed)
 
     with patch("supervisor.api._LOGGER.exception") as logger:
-        resp = await api_client.get("/supervisor/logs/follow")
+        resp = await api_client.get(f"{prefix}/supervisor/logs/follow")
         logger.assert_called_once_with(
             "Failed to get supervisor logs using advanced_logs API"
         )
@@ -195,7 +215,7 @@ async def test_api_supervisor_fallback(
     # check the /latest endpoint as well
 
     with patch("supervisor.api._LOGGER.exception") as logger:
-        resp = await api_client.get("/supervisor/logs/latest")
+        resp = await api_client.get(f"{prefix}/supervisor/logs/latest")
         logger.assert_called_once_with(
             "Failed to get supervisor logs using advanced_logs API"
         )
@@ -207,7 +227,7 @@ async def test_api_supervisor_fallback(
     journald_logs.side_effect = OSError("Something bad happened!")
 
     with patch("supervisor.api._LOGGER.exception") as logger:
-        resp = await api_client.get("/supervisor/logs")
+        resp = await api_client.get(f"{prefix}/supervisor/logs")
         logger.assert_called_once_with(
             "Failed to get supervisor logs using advanced_logs API"
         )
@@ -216,15 +236,18 @@ async def test_api_supervisor_fallback(
 
 
 async def test_api_supervisor_fallback_log_capture(
-    api_client: TestClient, journald_logs: MagicMock, docker_logs: MagicMock
+    api_client_with_prefix: tuple[TestClient, str],
+    journald_logs: MagicMock,
+    docker_logs: MagicMock,
 ):
     """Check that Sentry log capture is executed only for unexpected errors."""
+    api_client, prefix = api_client_with_prefix
     journald_logs.side_effect = HostNotSupportedError(
         "No systemd-journal-gatewayd Unix socket available!"
     )
 
     with patch("supervisor.api.async_capture_exception") as capture_exception:
-        await api_client.get("/supervisor/logs")
+        await api_client.get(f"{prefix}/supervisor/logs")
         capture_exception.assert_not_called()
 
     journald_logs.reset_mock()
@@ -232,43 +255,50 @@ async def test_api_supervisor_fallback_log_capture(
     journald_logs.side_effect = HassioError("Something bad happened!")
 
     with patch("supervisor.api.async_capture_exception") as capture_exception:
-        await api_client.get("/supervisor/logs")
+        await api_client.get(f"{prefix}/supervisor/logs")
         capture_exception.assert_called_once()
 
 
 async def test_api_supervisor_reload(
-    api_client: TestClient, supervisor_internet: AsyncMock, websession: MagicMock
+    api_client_with_prefix: tuple[TestClient, str],
+    supervisor_internet: AsyncMock,
+    websession: MagicMock,
 ):
     """Test supervisor reload."""
-    resp = await api_client.post("/supervisor/reload")
+    api_client, prefix = api_client_with_prefix
+    resp = await api_client.post(f"{prefix}/supervisor/reload")
     assert resp.status == 200
     assert await resp.json() == {"result": "ok", "data": {}}
 
 
 async def test_api_supervisor_options_timezone(
-    api_client: TestClient, coresys: CoreSys
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
 ):
     """Test setting supervisor timezone via API."""
+    api_client, prefix = api_client_with_prefix
     assert coresys.timezone == "Etc/UTC"
 
     resp = await api_client.post(
-        "/supervisor/options", json={"timezone": "Europe/Zurich"}
+        f"{prefix}/supervisor/options", json={"timezone": "Europe/Zurich"}
     )
     assert resp.status == 200
 
     assert coresys.timezone == "Europe/Zurich"
 
 
-async def test_api_supervisor_options_country(api_client: TestClient, coresys: CoreSys):
+async def test_api_supervisor_options_country(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
     """Test setting supervisor country via API."""
+    api_client, prefix = api_client_with_prefix
     assert coresys.config.country is None
 
-    resp = await api_client.post("/supervisor/options", json={"country": "CH"})
+    resp = await api_client.post(f"{prefix}/supervisor/options", json={"country": "CH"})
     assert resp.status == 200
 
     assert coresys.config.country == "CH"
 
-    resp = await api_client.get("/supervisor/info")
+    resp = await api_client.get(f"{prefix}/supervisor/info")
     assert resp.status == 200
     body = await resp.json()
     assert body["data"]["country"] == "CH"
@@ -280,18 +310,22 @@ async def test_api_supervisor_options_country(api_client: TestClient, coresys: C
     indirect=["blockbuster"],
 )
 async def test_api_supervisor_options_blocking_io(
-    api_client: TestClient, coresys: CoreSys, option_value: str, config_value: bool
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    option_value: str,
+    config_value: bool,
 ):
     """Test setting supervisor detect blocking io option."""
+    api_client, prefix = api_client_with_prefix
     # This should not fail with a blocking error yet
     time.sleep(0)
 
     resp = await api_client.post(
-        "/supervisor/options", json={"detect_blocking_io": option_value}
+        f"{prefix}/supervisor/options", json={"detect_blocking_io": option_value}
     )
     assert resp.status == 200
 
-    resp = await api_client.get("/supervisor/info")
+    resp = await api_client.get(f"{prefix}/supervisor/info")
     assert resp.status == 200
     body = await resp.json()
     assert body["data"]["detect_blocking_io"] is True
@@ -303,11 +337,11 @@ async def test_api_supervisor_options_blocking_io(
         time.sleep(0)
 
     resp = await api_client.post(
-        "/supervisor/options", json={"detect_blocking_io": "off"}
+        f"{prefix}/supervisor/options", json={"detect_blocking_io": "off"}
     )
     assert resp.status == 200
 
-    resp = await api_client.get("/supervisor/info")
+    resp = await api_client.get(f"{prefix}/supervisor/info")
     assert resp.status == 200
     body = await resp.json()
     assert body["data"]["detect_blocking_io"] is False
@@ -319,9 +353,12 @@ async def test_api_supervisor_options_blocking_io(
 
 @pytest.mark.usefixtures("tmp_supervisor_data")
 async def test_api_progress_updates_supervisor_update(
-    api_client: TestClient, coresys: CoreSys, ha_ws_client: AsyncMock
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    ha_ws_client: AsyncMock,
 ):
     """Test progress updates sent to Home Assistant for updates."""
+    api_client, prefix = api_client_with_prefix
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     coresys.core.set_state(CoreState.RUNNING)
 
@@ -345,7 +382,7 @@ async def test_api_progress_updates_supervisor_update(
         patch.object(Supervisor, "update_apparmor"),
         patch.object(Core, "stop"),
     ):
-        resp = await api_client.post("/supervisor/update")
+        resp = await api_client.post(f"{prefix}/supervisor/update")
 
     assert resp.status == 200
 
@@ -413,15 +450,18 @@ async def test_api_progress_updates_supervisor_update(
     ]
 
 
-async def test_api_supervisor_stats(api_client: TestClient, container: DockerContainer):
+async def test_api_supervisor_stats(
+    api_client_with_prefix: tuple[TestClient, str], container: DockerContainer
+):
     """Test supervisor stats."""
+    api_client, prefix = api_client_with_prefix
     container.show.return_value["State"]["Status"] = "running"
     container.show.return_value["State"]["Running"] = True
     container.stats = AsyncMock(
         return_value=[load_json_fixture("container_stats.json")]
     )
 
-    resp = await api_client.get("/supervisor/stats")
+    resp = await api_client.get(f"{prefix}/supervisor/stats")
     assert resp.status == 200
     result = await resp.json()
     assert result["data"]["cpu_percent"] == 90.0
@@ -431,14 +471,17 @@ async def test_api_supervisor_stats(api_client: TestClient, container: DockerCon
 
 
 async def test_supervisor_api_stats_failure(
-    api_client: TestClient, coresys: CoreSys, caplog: pytest.LogCaptureFixture
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    caplog: pytest.LogCaptureFixture,
 ):
     """Test supervisor stats failure."""
+    api_client, prefix = api_client_with_prefix
     coresys.docker.containers.get.side_effect = aiodocker.DockerError(
         500, {"message": "fail"}
     )
 
-    resp = await api_client.get("/supervisor/stats")
+    resp = await api_client.get(f"{prefix}/supervisor/stats")
     assert resp.status == 500
     body = await resp.json()
     assert (
@@ -485,14 +528,15 @@ async def test_api_supervisor_options_feature_flags_enable(
 
 
 async def test_api_supervisor_options_feature_flags_disable(
-    api_client: TestClient, coresys: CoreSys
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
 ):
     """Test disabling a feature flag via supervisor options."""
+    api_client, prefix = api_client_with_prefix
     coresys.config.set_feature_flag(FeatureFlag.SUPERVISOR_V2_API, True)
     assert coresys.config.feature_flags.get(FeatureFlag.SUPERVISOR_V2_API) is True
 
     response = await api_client.post(
-        "/supervisor/options",
+        f"{prefix}/supervisor/options",
         json={"feature_flags": {"supervisor_v2_api": False}},
     )
     assert response.status == 200
@@ -500,13 +544,16 @@ async def test_api_supervisor_options_feature_flags_disable(
 
 
 async def test_api_supervisor_options_feature_flags_partial_update(
-    api_client: TestClient, coresys: CoreSys
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
 ):
     """Test that omitting a feature flag in options leaves its state unchanged."""
+    api_client, prefix = api_client_with_prefix
     coresys.config.set_feature_flag(FeatureFlag.SUPERVISOR_V2_API, True)
 
     # Post options without mentioning feature_flags at all
-    response = await api_client.post("/supervisor/options", json={"debug": False})
+    response = await api_client.post(
+        f"{prefix}/supervisor/options", json={"debug": False}
+    )
     assert response.status == 200
 
     # The feature flag should remain True
@@ -514,11 +561,12 @@ async def test_api_supervisor_options_feature_flags_partial_update(
 
 
 async def test_api_supervisor_options_feature_flags_unknown_flag(
-    api_client: TestClient,
+    api_client_with_prefix: tuple[TestClient, str],
 ):
     """Test that an unknown feature flag name is rejected."""
+    api_client, prefix = api_client_with_prefix
     response = await api_client.post(
-        "/supervisor/options",
+        f"{prefix}/supervisor/options",
         json={"feature_flags": {"unknown_feature": True}},
     )
     assert response.status == 400


### PR DESCRIPTION
## Summary

This PR adds clean v2 API support to the Supervisor REST API without duplicating route definitions, and expands the test suite to verify both versions.

## Changes

### API Registration Refactor (`supervisor/api/__init__.py`, `supervisor/api/const.py`)

- Add `AppVersion` StrEnum (`V1`, `V2`) to `supervisor/api/const.py`
- Replace `self.v2_app` with a `versions` property (`dict[AppVersion, web.Application]`) computed dynamically so test fixtures that reassign `self.webapp` are automatically reflected in V1
- All `_register_*` methods now accept a required `app: web.Application` parameter; version-specific routes are gated with `if app is self.versions[AppVersion.V1/V2]:`
- `load()` loops over `enabled_versions` (V1 always, V2 when feature-flagged) and calls each registration method once per version — no duplication
- `_register_panel()` is called once outside the loop, always pinned to V1 — frontend static assets are V1-only
- Static resources are registered before `webapp.add_subapp()` to avoid registering into a frozen router
- Fold `_register_v2_apps` / `_register_v2_backups` / `_register_v2_store` into their respective unified methods

### Dual v1/v2 Test Coverage (`tests/api/`)

All 163 tests across 17 API modules that register identically on both versions now run against both via `api_client_with_prefix`.

**New fixtures in `tests/api/conftest.py`:**
- `api_client_v2` — TestClient with `SUPERVISOR_V2_API` feature flag enabled
- `api_client_with_prefix` — parametrizes over v1 (`""`) and v2 (`"/v2"`); use for APIs with identical behavior on both versions
- `core_api_client_with_root` — 3-way parametrize for Home Assistant Core endpoints: `/core` (v1 canonical), `/homeassistant` (v1 legacy alias), `/v2/core` (v2 canonical)
- `advanced_logs_tester` updated to use `api_client_with_prefix` so log-endpoint tests are auto-parametrized; accepts optional `v2_path_prefix` kwarg for paths that differ by version

**Tests intentionally kept V1-only:**
- `test_auth` / `test_discovery`: use indirect `api_client` parametrize for addon security context
- `test_panel`: frontend static assets are V1-only
- `test_jobs` (4 tests): inner `@Job`-decorated classes register names into the global `_JOB_NAMES` set — fixed by promoting them to module-level helpers (`_JobsTreeTestHelper` etc.) so registration only fires once at import time, enabling dual-version parametrization