### PR TITLE
Skip system-checks fan-out in test_events_on_issue_changes

### DIFF
--- a/tests/resolution/test_resolution_manager.py
+++ b/tests/resolution/test_resolution_manager.py
@@ -273,9 +273,15 @@ async def test_events_on_issue_changes(
         "issue_changed", issue_expected | {"suggestions": [suggestion_expected]}
     ) in [call.args[0] for call in ha_ws_client.async_send_command.call_args_list]
 
-    # Applying a suggestion should only fire an issue removed event
+    # Applying a suggestion should only fire an issue removed event.
+    # Mock healthcheck to avoid running the system-checks fan-out, which is
+    # not relevant to this assertion (ISSUE_REMOVED is fired by dismiss_issue
+    # inside the fixup, before apply_suggestion calls healthcheck).
     ha_ws_client.async_send_command.reset_mock()
-    with patch("shutil.disk_usage", return_value=(42, 42, 2 * (1024.0**3))):
+    with (
+        patch("shutil.disk_usage", return_value=(42, 42, 2 * (1024.0**3))),
+        patch.object(coresys.resolution, "healthcheck", new_callable=AsyncMock),
+    ):
         await coresys.resolution.apply_suggestion(suggestion)
 
     await asyncio.sleep(0)


### PR DESCRIPTION
## Proposed change

`tests/resolution/test_resolution_manager.py::test_events_on_issue_changes` ends with `await coresys.resolution.apply_suggestion(suggestion)` and asserts the resulting `ISSUE_REMOVED` event. `ISSUE_REMOVED` is fired by `dismiss_issue` inside `FixupBase.__call__`, before `apply_suggestion` calls `healthcheck()`. The `healthcheck()` afterwards is incidental to this test's intent, but it fans out into `check_system()` which runs `CheckDNSServer` (A and AAAA) — real `aiodns.DNSResolver.query_dns()` probes against the NetworkManager mock's stub nameserver `192.168.30.1`, each blocking ~10 s on the default aiodns timeout. The file took ~21 s to run.

The slowness has been latent since #3818 (Aug 2022), which added the `apply_suggestion` step at the end of `test_events_on_issue_changes` two days after the DNS check landed in its current form (#3811). The default 24 h `JobThrottle` on `CheckDNSServer.run_check` tends to mask the cost in full-suite runs once any earlier test has tripped the throttle, which is likely why this slipped through.

Mock `coresys.resolution.healthcheck` at just this one `apply_suggestion` call rather than introducing a file-wide DNS mock. The patch is local to the slow call site, the test's assertion is unaffected, and other tests in the file aren't silently shielded from real DNS-check behavior. The file drops from ~21 s to ~2.5 s.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
