### PR TITLE
Return proper API errors for invalid hostnames

### DIFF
--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -664,6 +664,23 @@ class HostLogError(HostError):
     """Internal error with host log."""
 
 
+class HostInvalidHostnameError(HostError, APIError):
+    """Hostname rejected by the host as semantically invalid."""
+
+    error_key = "host_invalid_hostname"
+    message_template = "Invalid hostname '{hostname}'"
+
+    def __init__(
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        hostname: str,
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"hostname": hostname}
+        super().__init__(None, logger)
+
+
 # Service / Discovery
 
 
@@ -743,6 +760,15 @@ class DBusInterfacePropertyError(DBusInterfaceError):
 
 class DBusInterfaceSignalError(DBusInterfaceError):
     """D-Bus signal not defined."""
+
+
+class DBusInvalidArgsError(DBusError):
+    """D-Bus argument value rejected by the service.
+
+    Distinct from DBusInterfaceMethodError: the method exists and the
+    argument types match the signature, but the service rejected an
+    argument's value as semantically invalid.
+    """
 
 
 class DBusParseError(DBusError):

--- a/supervisor/host/control.py
+++ b/supervisor/host/control.py
@@ -7,7 +7,11 @@ from awesomeversion import AwesomeVersion
 
 from ..const import HostFeature
 from ..coresys import CoreSysAttributes
-from ..exceptions import HostNotSupportedError
+from ..exceptions import (
+    DBusInvalidArgsError,
+    HostInvalidHostnameError,
+    HostNotSupportedError,
+)
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -73,7 +77,10 @@ class SystemControl(CoreSysAttributes):
         self._check_dbus(HostFeature.HOSTNAME)
 
         _LOGGER.info("Set hostname %s", hostname)
-        await self.sys_dbus.hostname.set_static_hostname(hostname)
+        try:
+            await self.sys_dbus.hostname.set_static_hostname(hostname)
+        except DBusInvalidArgsError as err:
+            raise HostInvalidHostnameError(hostname=hostname) from err
 
     async def set_datetime(self, new_time: datetime) -> None:
         """Update host clock with new (utc) datetime."""

--- a/supervisor/utils/dbus.py
+++ b/supervisor/utils/dbus.py
@@ -21,6 +21,7 @@ from ..exceptions import (
     DBusInterfaceMethodError,
     DBusInterfacePropertyError,
     DBusInterfaceSignalError,
+    DBusInvalidArgsError,
     DBusNoReplyError,
     DBusNotConnectedError,
     DBusObjectError,
@@ -84,12 +85,10 @@ class DBus:
             return DBusServiceUnkownError(err.text)
         if err.type == ErrorType.UNKNOWN_INTERFACE:
             return DBusInterfaceError(err.text)
-        if err.type in {
-            ErrorType.UNKNOWN_METHOD,
-            ErrorType.INVALID_SIGNATURE,
-            ErrorType.INVALID_ARGS,
-        }:
+        if err.type in {ErrorType.UNKNOWN_METHOD, ErrorType.INVALID_SIGNATURE}:
             return DBusInterfaceMethodError(err.text)
+        if err.type == ErrorType.INVALID_ARGS:
+            return DBusInvalidArgsError(err.text)
         if err.type == ErrorType.UNKNOWN_OBJECT:
             return DBusObjectError(err.text)
         if err.type in {ErrorType.UNKNOWN_PROPERTY, ErrorType.PROPERTY_READ_ONLY}:

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from unittest.mock import ANY, MagicMock, patch
 
 from aiohttp.test_utils import TestClient
+from dbus_fast import DBusError, ErrorType
 import pytest
 import time_machine
 
@@ -15,6 +16,7 @@ from supervisor.host.const import LogFormat, LogFormatter
 from supervisor.host.control import SystemControl
 
 from tests.dbus_service_mocks.base import DBusServiceMock
+from tests.dbus_service_mocks.hostname import Hostname as HostnameService
 from tests.dbus_service_mocks.systemd import Systemd as SystemdService
 
 DEFAULT_RANGE = "entries=:-99:100"
@@ -870,3 +872,22 @@ async def test_force_shutdown_during_migration(
     with patch.object(SystemControl, "shutdown") as shutdown:
         await api_client.post("/host/shutdown", json={"force": True})
         shutdown.assert_called_once()
+
+
+async def test_set_hostname_invalid_returns_400(
+    api_client: TestClient,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+):
+    """An INVALID_ARGS rejection from hostnamed becomes a 400 with a structured body."""
+    hostname_service: HostnameService = all_dbus_services["hostname"]
+    hostname_service.response_set_static_hostname = DBusError(
+        ErrorType.INVALID_ARGS, "Invalid static hostname 'bad name'"
+    )
+
+    resp = await api_client.post("/host/options", json={"hostname": "bad name"})
+    assert resp.status == 400
+    body = await resp.json()
+    assert body["result"] == "error"
+    assert body["message"] == "Invalid hostname 'bad name'"
+    assert body["error_key"] == "host_invalid_hostname"
+    assert body["extra_fields"] == {"hostname": "bad name"}

--- a/tests/dbus_service_mocks/hostname.py
+++ b/tests/dbus_service_mocks/hostname.py
@@ -2,6 +2,7 @@
 
 from json import dumps
 
+from dbus_fast import DBusError
 from dbus_fast.service import PropertyAccess, dbus_property
 
 from .base import DBusServiceMock, dbus_method
@@ -22,6 +23,7 @@ class Hostname(DBusServiceMock):
 
     object_path = "/org/freedesktop/hostname1"
     interface = "org.freedesktop.hostname1"
+    response_set_static_hostname: DBusError | None = None
 
     @dbus_property(access=PropertyAccess.READ)
     def Hostname(self) -> "s":
@@ -96,6 +98,9 @@ class Hostname(DBusServiceMock):
     @dbus_method()
     def SetStaticHostname(self, hostname: "s", interactive: "b") -> None:
         """Set static hostname."""
+        if isinstance(self.response_set_static_hostname, DBusError):
+            # pylint: disable=raising-bad-type
+            raise self.response_set_static_hostname
         self.emit_properties_changed({"StaticHostname": hostname})
 
     @dbus_method()

--- a/tests/host/test_control.py
+++ b/tests/host/test_control.py
@@ -1,8 +1,10 @@
 """Test host control."""
 
+from dbus_fast import DBusError, ErrorType
 import pytest
 
 from supervisor.coresys import CoreSys
+from supervisor.exceptions import HostInvalidHostnameError
 
 from tests.dbus_service_mocks.base import DBusServiceMock
 from tests.dbus_service_mocks.hostname import Hostname as HostnameService
@@ -23,6 +25,24 @@ async def test_set_hostname(
     assert hostname_service.SetStaticHostname.calls == [("test", False)]
     await hostname_service.ping()
     assert coresys.dbus.hostname.hostname == "test"
+
+
+async def test_set_hostname_rejected_by_host(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+):
+    """A hostname rejected by hostnamed surfaces as HostInvalidHostnameError."""
+    hostname_service: HostnameService = all_dbus_services["hostname"]
+    hostname_service.response_set_static_hostname = DBusError(
+        ErrorType.INVALID_ARGS, "Invalid static hostname 'bad name'"
+    )
+
+    with pytest.raises(HostInvalidHostnameError) as exc_info:
+        await coresys.host.control.set_hostname("bad name")
+
+    assert exc_info.value.error_key == "host_invalid_hostname"
+    assert exc_info.value.extra_fields == {"hostname": "bad name"}
+    assert str(exc_info.value) == "Invalid hostname 'bad name'"
 
 
 @pytest.mark.parametrize("os_available", ["16.2"], indirect=True)

--- a/tests/utils/test_dbus.py
+++ b/tests/utils/test_dbus.py
@@ -13,6 +13,8 @@ from supervisor.dbus.const import DBUS_OBJECT_BASE
 from supervisor.exceptions import (
     DBusFatalError,
     DBusInterfaceError,
+    DBusInterfaceMethodError,
+    DBusInvalidArgsError,
     DBusServiceUnkownError,
 )
 from supervisor.utils.dbus import DBus
@@ -190,3 +192,18 @@ def test_from_dbus_error():
     )
 
     assert type(DBus.from_dbus_error(dbus_fast_error)) is DBusServiceUnkownError
+
+
+@pytest.mark.parametrize(
+    "error_type,expected",
+    [
+        (ErrorType.UNKNOWN_METHOD, DBusInterfaceMethodError),
+        (ErrorType.INVALID_SIGNATURE, DBusInterfaceMethodError),
+        (ErrorType.INVALID_ARGS, DBusInvalidArgsError),
+    ],
+)
+def test_from_dbus_error_method_vs_args(
+    error_type: ErrorType, expected: type[Exception]
+):
+    """INVALID_ARGS must not collapse into DBusInterfaceMethodError."""
+    assert type(DBus.from_dbus_error(DBusFastDBusError(error_type, "boom"))) is expected


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

`POST /host/options` with an invalid hostname (containing a space, an underscore, longer than 64 chars, etc.) lets the request travel all the way to systemd-hostnamed, which rejects it with `org.freedesktop.DBus.Error.InvalidArgs` and a message like `"Invalid static hostname 'bad name'"`. Supervisor mapped that D-Bus `INVALID_ARGS` error to `DBusInterfaceMethodError` together with `UNKNOWN_METHOD` and `INVALID_SIGNATURE` — three semantically very different conditions in one bucket. The result was a generic 400 with hostnamed's raw English text and, since #6739, a Sentry event and an exception traceback in the Supervisor log for what is really just user input validation.

This PR keeps the validation where it belongs (hostnamed's `hostname_is_valid()`) and only fixes how the rejection is surfaced:

- Split `ErrorType.INVALID_ARGS` out of `DBusInterfaceMethodError` into a new `DBusInvalidArgsError`. `UNKNOWN_METHOD` / `INVALID_SIGNATURE` continue to map to `DBusInterfaceMethodError`. The distinction matters: one means the call is broken (method missing or types wrong, a code/host-support problem), the other means the call is valid but a value was rejected (a client-input problem).
- Add `HostInvalidHostnameError(HostError, APIError)` with `error_key="host_invalid_hostname"` and `extra_fields={"hostname": ...}`, following the same `(SomethingError, APIError)` multi-inheritance pattern as `ObserverPortConflict` and `AppConfigurationInvalidError`. This gives clients a stable, machine-readable key and the offending hostname instead of systemd's prose.
- Catch `DBusInvalidArgsError` in `SystemControl.set_hostname` and re-raise `HostInvalidHostnameError`. `@api_process` then returns a clean 400 with the structured body and, because the error is now a modeled `APIError`, skips the unexpected-error logging and Sentry capture path added in #6739.

Tests cover the three layers: the D-Bus error mapping (`INVALID_ARGS` no longer collapses into `DBusInterfaceMethodError`), the host-control translation (a mocked hostnamed rejection becomes `HostInvalidHostnameError` with the right `error_key` / `extra_fields` / message), and the API surface (`POST /host/options` returns 400 with the structured body).

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: follow-up on #6739
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
