### PR TITLE
Treat JobException as a client-side API error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ good-names = ["id", "i", "j", "k", "ex", "Run", "_", "fp", "T", "os"]
 # cyclic-import - doesn't test if both import on load
 # duplicate-code - unavoidable
 # locally-disabled - it spams too much
+# too-many-ancestors - it's too strict.
 # too-many-* - are not enforced for the sake of readability
 # too-few-* - same as too-many-*
 # unused-argument - generic callbacks and setup methods create a lot of warnings
@@ -61,6 +62,7 @@ disable = [
   "no-else-return",
   "not-context-manager",
   "too-few-public-methods",
+  "too-many-ancestors",
   "too-many-arguments",
   "too-many-branches",
   "too-many-instance-attributes",

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -278,7 +278,7 @@ class CliUpdateError(CliError):
     """Error on update of a HA cli."""
 
 
-class CliJobError(CliError, PluginJobError):
+class CliJobError(CliError, PluginJobError):  # pylint: disable=too-many-ancestors
     """Raise on job error with cli plugin."""
 
 
@@ -293,7 +293,7 @@ class ObserverUpdateError(ObserverError):
     """Error on update of a Observer."""
 
 
-class ObserverJobError(ObserverError, PluginJobError):
+class ObserverJobError(ObserverError, PluginJobError):  # pylint: disable=too-many-ancestors
     """Raise on job error with observer plugin."""
 
 
@@ -320,7 +320,7 @@ class MulticastUpdateError(MulticastError):
     """Error on update of a multicast."""
 
 
-class MulticastJobError(MulticastError, PluginJobError):
+class MulticastJobError(MulticastError, PluginJobError):  # pylint: disable=too-many-ancestors
     """Raise on job error with multicast plugin."""
 
 
@@ -335,7 +335,7 @@ class CoreDNSUpdateError(CoreDNSError):
     """Error on update of a CoreDNS."""
 
 
-class CoreDNSJobError(CoreDNSError, PluginJobError):
+class CoreDNSJobError(CoreDNSError, PluginJobError):  # pylint: disable=too-many-ancestors
     """Raise on job error with dns plugin."""
 
 
@@ -350,7 +350,7 @@ class AudioUpdateError(AudioError):
     """Error on update of a Audio."""
 
 
-class AudioJobError(AudioError, PluginJobError):
+class AudioJobError(AudioError, PluginJobError):  # pylint: disable=too-many-ancestors
     """Raise on job error with audio plugin."""
 
 

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -134,8 +134,14 @@ class APIUnknownSupervisorError(APIError):
 # JobManager
 
 
-class JobException(HassioError):
-    """Base job exception."""
+class JobException(APIError):
+    """Base job exception.
+
+    Job condition and concurrency failures are considered handled from the
+    Supervisor's point of view and reported to the caller as client-side
+    errors. Inheriting APIError lets api_process surface them with their
+    explicit message (see #6739) instead of treating them as unexpected.
+    """
 
 
 class JobConditionException(JobException):

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -278,7 +278,7 @@ class CliUpdateError(CliError):
     """Error on update of a HA cli."""
 
 
-class CliJobError(CliError, PluginJobError):  # pylint: disable=too-many-ancestors
+class CliJobError(CliError, PluginJobError):
     """Raise on job error with cli plugin."""
 
 
@@ -293,7 +293,7 @@ class ObserverUpdateError(ObserverError):
     """Error on update of a Observer."""
 
 
-class ObserverJobError(ObserverError, PluginJobError):  # pylint: disable=too-many-ancestors
+class ObserverJobError(ObserverError, PluginJobError):
     """Raise on job error with observer plugin."""
 
 
@@ -320,7 +320,7 @@ class MulticastUpdateError(MulticastError):
     """Error on update of a multicast."""
 
 
-class MulticastJobError(MulticastError, PluginJobError):  # pylint: disable=too-many-ancestors
+class MulticastJobError(MulticastError, PluginJobError):
     """Raise on job error with multicast plugin."""
 
 
@@ -335,7 +335,7 @@ class CoreDNSUpdateError(CoreDNSError):
     """Error on update of a CoreDNS."""
 
 
-class CoreDNSJobError(CoreDNSError, PluginJobError):  # pylint: disable=too-many-ancestors
+class CoreDNSJobError(CoreDNSError, PluginJobError):
     """Raise on job error with dns plugin."""
 
 
@@ -350,7 +350,7 @@ class AudioUpdateError(AudioError):
     """Error on update of a Audio."""
 
 
-class AudioJobError(AudioError, PluginJobError):  # pylint: disable=too-many-ancestors
+class AudioJobError(AudioError, PluginJobError):
     """Raise on job error with audio plugin."""
 
 
@@ -1025,7 +1025,7 @@ class ResolutionFixupJobError(ResolutionFixupError, JobException):
     """Raise on job error."""
 
 
-class ResolutionCheckNotFound(ResolutionNotFound, APINotFound):  # pylint: disable=too-many-ancestors
+class ResolutionCheckNotFound(ResolutionNotFound, APINotFound):
     """Raise if check does not exist."""
 
     error_key = "resolution_check_not_found_error"
@@ -1039,7 +1039,7 @@ class ResolutionCheckNotFound(ResolutionNotFound, APINotFound):  # pylint: disab
         super().__init__(None, logger)
 
 
-class ResolutionIssueNotFound(ResolutionNotFound, APINotFound):  # pylint: disable=too-many-ancestors
+class ResolutionIssueNotFound(ResolutionNotFound, APINotFound):
     """Raise if issue does not exist."""
 
     error_key = "resolution_issue_not_found_error"
@@ -1051,7 +1051,7 @@ class ResolutionIssueNotFound(ResolutionNotFound, APINotFound):  # pylint: disab
         super().__init__(None, logger)
 
 
-class ResolutionSuggestionNotFound(ResolutionNotFound, APINotFound):  # pylint: disable=too-many-ancestors
+class ResolutionSuggestionNotFound(ResolutionNotFound, APINotFound):
     """Raise if suggestion does not exist."""
 
     error_key = "resolution_suggestion_not_found_error"

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -466,22 +466,27 @@ async def test_api_backup_errors(
 
 async def test_backup_immediate_errors(api_client: TestClient, coresys: CoreSys):
     """Test backup errors that return immediately even in background mode."""
-    await coresys.core.set_state(CoreState.FREEZE)
-    resp = await api_client.post(
-        "/backups/new/full",
-        json={"name": "Test", "background": True},
-    )
-    assert resp.status == 400
-    assert "freeze" in (await resp.json())["message"]
+    with patch("supervisor.api.utils.async_capture_exception") as capture_exception:
+        await coresys.core.set_state(CoreState.FREEZE)
+        resp = await api_client.post(
+            "/backups/new/full",
+            json={"name": "Test", "background": True},
+        )
+        assert resp.status == 400
+        assert "freeze" in (await resp.json())["message"]
 
-    await coresys.core.set_state(CoreState.RUNNING)
-    coresys.hardware.disk.get_disk_free_space = lambda x: 0.5
-    resp = await api_client.post(
-        "/backups/new/partial",
-        json={"name": "Test", "homeassistant": True, "background": True},
-    )
-    assert resp.status == 400
-    assert "not enough free space" in (await resp.json())["message"]
+        await coresys.core.set_state(CoreState.RUNNING)
+        coresys.hardware.disk.get_disk_free_space = lambda x: 0.5
+        resp = await api_client.post(
+            "/backups/new/partial",
+            json={"name": "Test", "homeassistant": True, "background": True},
+        )
+        assert resp.status == 400
+        assert "not enough free space" in (await resp.json())["message"]
+
+        # Job condition failures are user/environment driven; api_process
+        # must not capture them to Sentry.
+        capture_exception.assert_not_called()
 
 
 async def test_restore_immediate_errors(


### PR DESCRIPTION
## Proposed change

Job condition guards (system not running, no free space, mounting not supported, etc.) and concurrency rejections ("Another job is running") raised by the `@Job` decorator are explicit precondition failures with descriptive messages — they are handled errors from the Supervisor's point of view, not unexpected internal failures. `JobException` previously inherited `HassioError` directly, so `api_process` caught the resulting `*JobError` mixins (`BackupJobError`, `AppsJobError`, `StoreJobError`, `HassOSJobError`, `SupervisorJobError`, `HomeAssistantJobError`, `MountJobError`, etc.) in its `HassioError` branch — which since #6739 logs them as unexpected and captures them to Sentry.

This change makes `JobException` inherit `APIError` so `api_process` surfaces these through its `APIError` branch with the original message intact and skips the unexpected-error path. Status defaults to `APIError`'s 400, so the API contract is unchanged. All `*JobError` mixins automatically pick up `APIError` via MRO; no per-class changes are needed. `JobNotFound` continues to be wrapped to `APINotFound` (404) at `supervisor/api/jobs.py:30`, unaffected.

`test_backup_immediate_errors` is extended to assert `async_capture_exception` is not called for the freeze and free-space condition guards. The assertion was confirmed to fail against the prior `JobException(HassioError)` definition (caught by the `except HassioError` branch, which logs as "Unexpected error" and captures to Sentry) and pass with the new inheritance.

This addresses a large share of `2026.04.1` Sentry noise — `BackupJobError`, `AppsJobError`, `HomeAssistantJobError`, `HassOSJobError`, `SupervisorJobError`, `StoreJobError` and bare `JobException` issues, all with culprit `supervisor.api.utils.api_process.<locals>.wrap_api`.

The MRO change pushes five plugin-specific job error mixins (`CliJobError`, `ObserverJobError`, `MulticastJobError`, `CoreDNSJobError`, `AudioJobError`) past pylint's `too-many-ancestors` threshold. Three other classes (`ResolutionNotFound` subclasses) already needed inline `# pylint: disable=too-many-ancestors` annotations for the same diamond-inheritance reason. Since the project's pylint config already disables every other `too-many-*` rule "for the sake of readability" — and Home Assistant Core disables `too-many-ancestors` globally with the same rationale ("it's too strict.") — the rule is added to the global disable list in `pyproject.toml` and the eight inline annotations are dropped.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
