### PR TITLE
Remove legacy core_proxy middleware

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -70,7 +70,6 @@ class RestAPI(CoreSysAttributes):
                 self.security.block_bad_requests,
                 self.security.system_validation,
                 self.security.token_validation,
-                self.security.core_proxy,
             ],
             handler_args={
                 "max_line_size": MAX_LINE_SIZE,

--- a/supervisor/api/middleware/security.py
+++ b/supervisor/api/middleware/security.py
@@ -9,7 +9,6 @@ from urllib.parse import unquote
 
 from aiohttp.web import Request, StreamResponse, middleware
 from aiohttp.web_exceptions import HTTPBadRequest, HTTPForbidden, HTTPUnauthorized
-from awesomeversion import AwesomeVersion
 
 from ...addons.const import RE_SLUG
 from ...const import (
@@ -22,12 +21,9 @@ from ...const import (
     VALID_API_STATES,
 )
 from ...coresys import CoreSys, CoreSysAttributes
-from ...homeassistant.const import LANDINGPAGE
-from ...utils import version_is_new_enough
 from ..utils import api_return_error, extract_supervisor_token
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
-_CORE_VERSION: Final = AwesomeVersion("2023.3.4")
 
 # fmt: off
 
@@ -88,9 +84,6 @@ class _AppSecurityPatterns:
 
     # Per-role allowed path patterns for installed apps
     role_access: dict[str, re.Pattern[str]]
-
-    # Paths serving frontend assets (checked in core_proxy middleware)
-    supervisor_frontend: re.Pattern[str]
 
     # Paths that skip token validation entirely
     no_security_check: re.Pattern[str]
@@ -164,7 +157,6 @@ _V1_PATTERNS: Final = _AppSecurityPatterns(
         ),
         ROLE_ADMIN: re.compile(r".*"),
     },
-    supervisor_frontend=re.compile(r"^(?:" + _V1_FRONTEND_PATHS + r")$"),
     no_security_check=re.compile(
         r"^(?:"
         r"|/homeassistant/api/.*"
@@ -244,7 +236,6 @@ _V2_PATTERNS: Final = _AppSecurityPatterns(
         ),
         ROLE_ADMIN: re.compile(r".*"),
     },
-    supervisor_frontend=re.compile(r"^/v2(?:" + _V2_FRONTEND_PATHS + r")$"),
     no_security_check=re.compile(
         r"^/v2(?:"
         r"|/ingress/[-_A-Za-z0-9]+/.*"
@@ -382,49 +373,3 @@ class SecurityMiddleware(CoreSysAttributes):
 
         _LOGGER.error("Invalid token for access %s", request.path)
         raise HTTPForbidden()
-
-    @middleware
-    async def core_proxy(
-        self, request: Request, handler: Callable[[Request], Awaitable[StreamResponse]]
-    ) -> StreamResponse:
-        """Validate user from Core API proxy."""
-        if (
-            request[REQUEST_FROM] != self.sys_homeassistant
-            or self.sys_homeassistant.version == LANDINGPAGE
-            or version_is_new_enough(self.sys_homeassistant.version, _CORE_VERSION)
-        ):
-            return await handler(request)
-
-        authorization_index: int | None = None
-        content_type_index: int | None = None
-        user_request: bool = False
-        admin_request: bool = False
-        ingress_request: bool = False
-
-        for idx, (key, value) in enumerate(request.raw_headers):
-            if key in (b"Authorization", b"X-Hassio-Key"):
-                authorization_index = idx
-            elif key == b"Content-Type":
-                content_type_index = idx
-            elif key == b"X-Hass-User-ID":
-                user_request = True
-            elif key == b"X-Hass-Is-Admin":
-                admin_request = value == b"1"
-            elif key == b"X-Ingress-Path":
-                ingress_request = True
-
-        if (user_request or admin_request) and not ingress_request:
-            return await handler(request)
-
-        is_proxy_request = (
-            authorization_index is not None
-            and content_type_index is not None
-            and content_type_index - authorization_index == 1
-        )
-
-        patterns = _get_app_security_patterns(request)
-        if (
-            not patterns.supervisor_frontend.match(request.path) and is_proxy_request
-        ) or ingress_request:
-            raise HTTPBadRequest()
-        return await handler(request)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove the `core_proxy` middleware from the API security stack along with the symbols that only existed to support it.

`core_proxy` was Supervisor's side of the original Core-to-Supervisor proxy auth scheme: when Core forwarded a user-issued request to Supervisor under its privileged supervisor token, it tagged the request with `X-Hass-User-ID` and `X-Hass-Is-Admin` headers identifying the upstream user. Supervisor's `core_proxy` middleware inspected those headers, plus a header adjacency heuristic that fingerprinted aiohttp's proxy header layout, to distinguish forwarded requests from native Core calls and reject proxied requests that lacked user identity.

Core 2023.3.4 ([home-assistant/core#89379](https://github.com/home-assistant/core/pull/89379)) replaced that scheme: Core now does the path-level gating itself before proxying and no longer sends the `X-Hass-*` headers. Supervisor's middleware short-circuits for any Core newer than that. With the 2-year Core support policy introduced in #6148, every supported installation is well past 2023.3.4 and the middleware is unreachable in practice.

This PR drops the middleware along with its now-unused supports: the `_CORE_VERSION` constant, the `supervisor_frontend` pattern field on `_AppSecurityPatterns` (a duplicate of the frontend asset list already exempted via `no_security_check`), and the `AwesomeVersion` / `LANDINGPAGE` / `version_is_new_enough` imports it relied on. The frontend asset bypass itself is unchanged — it still lives in `no_security_check`, so logos, icons, and panel assets continue to be served without a token as before.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6148
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
