### PR TITLE
Queue main builder runs instead of cancelling

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -42,7 +42,10 @@ env:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  # Cancel in-progress runs only for PRs; queue runs on main so that wheels
+  # builds published from sequential merges don't clobber each other and leave
+  # downstream CI without the wheels for the latest requirements.txt.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   init:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `Build supervisor` workflow set `concurrency.cancel-in-progress: true` unconditionally. That is the right behavior for `pull_request` runs (only the latest commit's CI matters), but on `push` to `main` it actively breaks things: when several PRs merge in quick succession and one of them touches `requirements.txt`, the wheels publish step from the in-flight run is killed mid-upload. Subsequent CI runs and downstream consumers then can't install the wheels for the latest requirements. A recent example was [run 25097950984](https://github.com/home-assistant/supervisor/actions/runs/25097950984), where the original attempt was cancelled by a follow-up merge before it could finish publishing wheels for the gitpython 3.1.49 bump.

Scope `cancel-in-progress` to `pull_request` events. Pushes to `main` keep the same concurrency group, so they serialize behind each other instead of stomping each other; PR runs continue to collapse to the latest commit as before.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
