### PR TITLE
Return proper API errors when backup mount is down

### DIFF
--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -150,10 +150,7 @@ class BackupManager(FileConfiguration, JobGroup):
             location not in (DEFAULT, LOCATION_CLOUD_BACKUP, None)
             and not await (location_mount := cast(Mount, location)).is_mounted()
         ):
-            raise BackupMountDownError(
-                f"{location_mount.name} is down, cannot back-up to it",
-                _LOGGER.error,
-            )
+            raise BackupMountDownError(mount=location_mount.name)
 
     def _get_location_name(
         self,
@@ -384,10 +381,7 @@ class BackupManager(FileConfiguration, JobGroup):
             elif location:
                 location_mount = cast(Mount, location)
                 if not location_mount.local_where.is_mount():
-                    raise BackupMountDownError(
-                        f"{location_mount.name} is down, cannot copy to it",
-                        _LOGGER.error,
-                    )
+                    raise BackupMountDownError(mount=location_mount.name)
                 destination = location_mount.local_where
             else:
                 destination = self.sys_config.path_backup

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -1187,8 +1187,21 @@ class BackupInvalidError(BackupError):
     """Raise if backup or password provided is invalid."""
 
 
-class BackupMountDownError(BackupError):
+class BackupMountDownError(BackupError, APIError):
     """Raise if mount specified for backup is down."""
+
+    error_key = "backup_mount_down"
+    message_template = "Backup mount '{mount}' is down"
+
+    def __init__(
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        mount: str,
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"mount": mount}
+        super().__init__(None, logger)
 
 
 class BackupDataDiskBadMessageError(BackupError):

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -198,6 +198,44 @@ async def test_backup_to_default(api_client: TestClient, coresys: CoreSys):
     assert (mount_dir / f"{slug}.tar").exists()
 
 
+@pytest.mark.usefixtures(
+    "tmp_supervisor_data", "path_extern", "mount_propagation", "mock_is_mount"
+)
+async def test_backup_to_down_mount_returns_400(
+    api_client: TestClient, coresys: CoreSys, mock_is_mount: MagicMock
+):
+    """Backup to a down mount returns a structured 400 instead of an unexpected 400."""
+    await coresys.mounts.load()
+    (coresys.config.path_mounts / "backup_test").mkdir()
+    mount = Mount.from_dict(
+        coresys,
+        {
+            "name": "backup_test",
+            "type": "cifs",
+            "usage": "backup",
+            "server": "backup.local",
+            "share": "backups",
+        },
+    )
+    await coresys.mounts.create_mount(mount)
+    coresys.mounts.default_backup_mount = mount
+
+    mock_is_mount.return_value = False
+    await coresys.core.set_state(CoreState.RUNNING)
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+
+    resp = await api_client.post(
+        "/backups/new/full",
+        json={"name": "Mount test", "location": "backup_test"},
+    )
+    assert resp.status == 400
+    body = await resp.json()
+    assert body["result"] == "error"
+    assert body["message"] == "Backup mount 'backup_test' is down"
+    assert body["error_key"] == "backup_mount_down"
+    assert body["extra_fields"] == {"mount": "backup_test"}
+
+
 @pytest.mark.usefixtures("tmp_supervisor_data", "path_extern")
 async def test_api_freeze_thaw(
     api_client_with_prefix: tuple[TestClient, str],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up on #6739: with `HassioError` now logged and captured by Sentry in `api_process`, `BackupMountDownError` surfaced as an "unexpected" 400 with a noisy log entry and a Sentry event (SUPERVISOR-1JXW), even though the user had simply asked to back up to a mount that was not currently available.

Map this through properly so the API returns a clean, structured 400, matching the pattern used in #6776 (invalid hostnames) and #6777 (job exceptions):

- Make `BackupMountDownError` inherit from `APIError`, with `error_key="backup_mount_down"`, message template `"Backup mount '{mount}' is down"`, and the mount name in `extra_fields`. Clients now get a normalized, translatable message and a stable key instead of the raw `"<name> is down, cannot back-up to it"` / `"...cannot copy to it"` strings.
- Simplify both raise sites in `BackupManager` (`_check_location` and `_copy_to_location`) to just pass `mount=`. `@api_process` turns the result into a 400 without logging or Sentry capture, since this is now a modeled client-state error rather than an unexpected one.

The mount being down is a runtime state issue users hit when their NAS/CIFS share is briefly unreachable, not a Supervisor bug worth paging on.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes SUPERVISOR-1JXW
- This PR is related to issue: #6739, #6776, #6777
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
