### PR TITLE
Log when cidfile path cleanup fails

### DIFF
--- a/supervisor/docker/manager.py
+++ b/supervisor/docker/manager.py
@@ -485,11 +485,15 @@ class DockerAPI(CoreSysAttributes):
                 # Remove the file/directory if it exists e.g. as a leftover from unclean shutdown
                 # Note: Can be a directory if Docker auto-started container with restart policy
                 # before Supervisor could write the CID file
-                with suppress(OSError):
+                try:
                     if cidfile_path.is_dir():
                         cidfile_path.rmdir()
                     elif cidfile_path.is_file():
                         cidfile_path.unlink(missing_ok=True)
+                except OSError as err:
+                    _LOGGER.error(
+                        "Can't cleanup cidfile path %s: %s", cidfile_path, err
+                    )
 
                 # Create empty CID file before adding it to volumes to prevent Docker
                 # from creating it as a directory if container auto-starts


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

When preparing the cidfile path for a new container, Supervisor first tries to clean up any leftover at that path (a stale file from an unclean shutdown, or a directory auto-created by Docker when a previous container had a missing bind mount source). That cleanup was wrapped in `with suppress(OSError)`, which silently swallowed any failure. If `rmdir`/`unlink` then failed (e.g. the path is a non-empty directory, or a pending bind unmount still holds it busy), the subsequent `cidfile_path.touch()` raised `IsADirectoryError` with no breadcrumb to explain why the path was in an unexpected state.

Replace the bare `suppress(OSError)` with an explicit error log so the underlying failure shows up in the Supervisor log when the follow-up `touch()` blows up. Behavior is otherwise unchanged: a failed cleanup still falls through to `touch()` as before, and the resulting exception still propagates.

This was prompted by a Sentry report (`SUPERVISOR-1970`) of `IsADirectoryError: '/data/cid_files/hassio_audio.cid'` where the breadcrumbs show a normal attach → recreate flow but no indication of why the path was a directory at the time of `touch()`.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
