### PR TITLE
Drop redundant @pytest.mark.asyncio decorators

### DIFF
--- a/tests/api/middleware/test_security.py
+++ b/tests/api/middleware/test_security.py
@@ -64,7 +64,6 @@ async def fixture_plugin_tokens(coresys: CoreSys) -> None:
     # pylint: enable=protected-access
 
 
-@pytest.mark.asyncio
 async def test_api_security_system_initialize(api_system: TestClient, coresys: CoreSys):
     """Test security."""
     await coresys.core.set_state(CoreState.INITIALIZE)
@@ -75,7 +74,6 @@ async def test_api_security_system_initialize(api_system: TestClient, coresys: C
     assert result["result"] == "error"
 
 
-@pytest.mark.asyncio
 async def test_api_security_system_setup(api_system: TestClient, coresys: CoreSys):
     """Test security."""
     await coresys.core.set_state(CoreState.SETUP)
@@ -86,7 +84,6 @@ async def test_api_security_system_setup(api_system: TestClient, coresys: CoreSy
     assert result["result"] == "error"
 
 
-@pytest.mark.asyncio
 async def test_api_security_system_running(api_system: TestClient, coresys: CoreSys):
     """Test security."""
     await coresys.core.set_state(CoreState.RUNNING)
@@ -95,7 +92,6 @@ async def test_api_security_system_running(api_system: TestClient, coresys: Core
     assert resp.status == 200
 
 
-@pytest.mark.asyncio
 async def test_api_security_system_startup(api_system: TestClient, coresys: CoreSys):
     """Test security."""
     await coresys.core.set_state(CoreState.STARTUP)
@@ -104,7 +100,6 @@ async def test_api_security_system_startup(api_system: TestClient, coresys: Core
     assert resp.status == 200
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("request_path", "request_params", "fail_on_query_string"),
     [

--- a/tests/api/test_docker.py
+++ b/tests/api/test_docker.py
@@ -11,7 +11,6 @@ from tests.dbus_service_mocks.agent_system import System as SystemService
 from tests.dbus_service_mocks.base import DBusServiceMock
 
 
-@pytest.mark.asyncio
 async def test_api_docker_info(api_client_with_prefix: tuple[TestClient, str]):
     """Test docker info api."""
     api_client, prefix = api_client_with_prefix

--- a/tests/api/test_hardware.py
+++ b/tests/api/test_hardware.py
@@ -3,13 +3,11 @@
 from pathlib import Path
 
 from aiohttp.test_utils import TestClient
-import pytest
 
 from supervisor.coresys import CoreSys
 from supervisor.hardware.data import Device
 
 
-@pytest.mark.asyncio
 async def test_api_hardware_info(api_client_with_prefix: tuple[TestClient, str]):
     """Test docker info api."""
     api_client, prefix = api_client_with_prefix
@@ -19,7 +17,6 @@ async def test_api_hardware_info(api_client_with_prefix: tuple[TestClient, str])
     assert result["result"] == "ok"
 
 
-@pytest.mark.asyncio
 async def test_api_hardware_info_device(
     api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
 ):

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -39,7 +39,6 @@ async def fixture_coresys_disk_info(coresys: CoreSys) -> AsyncGenerator[CoreSys]
     yield coresys
 
 
-@pytest.mark.asyncio
 async def test_api_host_info(
     api_client_with_prefix: tuple[TestClient, str], coresys_disk_info: CoreSys
 ):

--- a/tests/api/test_resolution.py
+++ b/tests/api/test_resolution.py
@@ -25,7 +25,6 @@ from supervisor.resolution.const import (
 from supervisor.resolution.data import Issue, Suggestion
 
 
-@pytest.mark.asyncio
 async def test_api_resolution_base(
     coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
 ):
@@ -46,7 +45,6 @@ async def test_api_resolution_base(
     assert result["data"][ATTR_ISSUES][-1]["type"] == IssueType.FREE_SPACE
 
 
-@pytest.mark.asyncio
 async def test_api_resolution_dismiss_suggestion(
     coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
 ):
@@ -61,7 +59,6 @@ async def test_api_resolution_dismiss_suggestion(
     assert clear_backup not in coresys.resolution.suggestions
 
 
-@pytest.mark.asyncio
 async def test_api_resolution_apply_suggestion(
     coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
 ):
@@ -94,7 +91,6 @@ async def test_api_resolution_apply_suggestion(
         await coresys.resolution.apply_suggestion(clear_backup)
 
 
-@pytest.mark.asyncio
 async def test_api_resolution_dismiss_issue(
     coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
 ):
@@ -109,7 +105,6 @@ async def test_api_resolution_dismiss_issue(
     assert updated_failed not in coresys.resolution.issues
 
 
-@pytest.mark.asyncio
 async def test_api_resolution_unhealthy(
     coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
 ):
@@ -122,7 +117,6 @@ async def test_api_resolution_unhealthy(
     assert result["data"][ATTR_UNHEALTHY][-1] == UnhealthyReason.DOCKER
 
 
-@pytest.mark.asyncio
 async def test_api_resolution_check_options(
     coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
 ):
@@ -142,7 +136,6 @@ async def test_api_resolution_check_options(
     assert free_space.enabled
 
 
-@pytest.mark.asyncio
 async def test_api_resolution_check_run(
     coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
 ):

--- a/tests/api/test_security.py
+++ b/tests/api/test_security.py
@@ -3,12 +3,10 @@
 from unittest.mock import AsyncMock
 
 from aiohttp.test_utils import TestClient
-import pytest
 
 from supervisor.coresys import CoreSys
 
 
-@pytest.mark.asyncio
 async def test_api_security_options_force_security(
     api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
 ):
@@ -21,7 +19,6 @@ async def test_api_security_options_force_security(
     assert coresys.security.force
 
 
-@pytest.mark.asyncio
 async def test_api_security_options_pwned(
     api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
 ):
@@ -34,7 +31,6 @@ async def test_api_security_options_pwned(
     assert not coresys.security.pwned
 
 
-@pytest.mark.asyncio
 async def test_api_integrity_check(
     api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -33,7 +33,6 @@ from tests.const import TEST_ADDON_SLUG
 REPO_URL = "https://github.com/awesome-developer/awesome-repo"
 
 
-@pytest.mark.asyncio
 async def test_api_store(
     api_client: TestClient,
     store_app: AppStore,
@@ -50,7 +49,6 @@ async def test_api_store(
     assert f"App {store_app.slug} not supported on this platform" not in caplog.text
 
 
-@pytest.mark.asyncio
 async def test_api_store_apps(api_client: TestClient, store_app: AppStore):
     """Test /store/apps REST API."""
     resp = await api_client.get("/store/addons")
@@ -59,7 +57,6 @@ async def test_api_store_apps(api_client: TestClient, store_app: AppStore):
     assert result["data"]["addons"][-1]["slug"] == store_app.slug
 
 
-@pytest.mark.asyncio
 async def test_api_store_apps_app(
     store_app_api_client_with_root: tuple[TestClient, str], store_app: AppStore
 ):
@@ -70,7 +67,6 @@ async def test_api_store_apps_app(
     assert result["data"]["slug"] == store_app.slug
 
 
-@pytest.mark.asyncio
 async def test_api_store_apps_app_version(
     store_app_api_client_with_root: tuple[TestClient, str], store_app: AppStore
 ):
@@ -81,7 +77,6 @@ async def test_api_store_apps_app_version(
     assert result["data"]["slug"] == store_app.slug
 
 
-@pytest.mark.asyncio
 async def test_api_store_repositories(
     api_client: TestClient, test_repository: Repository
 ):
@@ -92,7 +87,6 @@ async def test_api_store_repositories(
     assert result["data"][-1]["slug"] == test_repository.slug
 
 
-@pytest.mark.asyncio
 async def test_api_store_repositories_repository(
     api_client: TestClient, test_repository: Repository
 ):

--- a/tests/resolution/test_resolution_manager.py
+++ b/tests/resolution/test_resolution_manager.py
@@ -34,7 +34,6 @@ def test_properies_unhealthy(coresys: CoreSys):
     assert not coresys.core.healthy
 
 
-@pytest.mark.asyncio
 async def test_resolution_dismiss_suggestion(coresys: CoreSys):
     """Test resolution manager suggestion apply api."""
     coresys.resolution.add_suggestion(
@@ -49,7 +48,6 @@ async def test_resolution_dismiss_suggestion(coresys: CoreSys):
         coresys.resolution.dismiss_suggestion(clear_backup)
 
 
-@pytest.mark.asyncio
 async def test_resolution_apply_suggestion(coresys: CoreSys):
     """Test resolution manager suggestion apply api."""
     coresys.resolution.add_suggestion(
@@ -79,7 +77,6 @@ async def test_resolution_apply_suggestion(coresys: CoreSys):
         await coresys.resolution.apply_suggestion(clear_backup)
 
 
-@pytest.mark.asyncio
 async def test_resolution_dismiss_issue(coresys: CoreSys):
     """Test resolution manager issue apply api."""
     coresys.resolution.add_issue(
@@ -94,7 +91,6 @@ async def test_resolution_dismiss_issue(coresys: CoreSys):
         coresys.resolution.dismiss_issue(updated_failed)
 
 
-@pytest.mark.asyncio
 async def test_resolution_create_issue_suggestion(coresys: CoreSys):
     """Test resolution manager issue and suggestion."""
     coresys.resolution.create_issue(
@@ -112,7 +108,6 @@ async def test_resolution_create_issue_suggestion(coresys: CoreSys):
     assert coresys.resolution.suggestions[-1].context == ContextType.CORE
 
 
-@pytest.mark.asyncio
 async def test_resolution_dismiss_unsupported(coresys: CoreSys):
     """Test resolution manager dismiss unsupported reason."""
     coresys.resolution.add_unsupported_reason(UnsupportedReason.SOFTWARE)

--- a/tests/store/test_custom_repository.py
+++ b/tests/store/test_custom_repository.py
@@ -189,7 +189,6 @@ async def test_error_on_repository_with_git_error(
     assert len(coresys.resolution.suggestions) == 0
 
 
-@pytest.mark.asyncio
 async def test_preinstall_valid_repository(
     coresys: CoreSys, store_manager: StoreManager
 ):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -26,7 +26,6 @@ def mock_api_state_fixture(coresys):
     yield mock_api_state
 
 
-@pytest.mark.asyncio
 async def test_auth_request_with_backend(coresys, mock_auth_backend, mock_api_state):
     """Make simple auth request."""
 
@@ -38,7 +37,6 @@ async def test_auth_request_with_backend(coresys, mock_auth_backend, mock_api_st
     assert mock_auth_backend.called
 
 
-@pytest.mark.asyncio
 async def test_auth_request_without_backend(coresys, mock_auth_backend, mock_api_state):
     """Make simple auth without request."""
 
@@ -50,7 +48,6 @@ async def test_auth_request_without_backend(coresys, mock_auth_backend, mock_api
     assert not mock_auth_backend.called
 
 
-@pytest.mark.asyncio
 async def test_auth_request_without_backend_cache(
     coresys, mock_auth_backend, mock_api_state
 ):
@@ -66,7 +63,6 @@ async def test_auth_request_without_backend_cache(
     assert not mock_auth_backend.called
 
 
-@pytest.mark.asyncio
 async def test_auth_request_with_backend_cache_update(
     coresys, mock_auth_backend, mock_api_state
 ):

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -2,13 +2,10 @@
 
 import asyncio
 
-import pytest
-
 from supervisor.const import BusEvent
 from supervisor.coresys import CoreSys
 
 
-@pytest.mark.asyncio
 async def test_bus_event(coresys: CoreSys) -> None:
     """Test bus events over the backend."""
     results = []
@@ -28,7 +25,6 @@ async def test_bus_event(coresys: CoreSys) -> None:
     assert results[-1] == "test"
 
 
-@pytest.mark.asyncio
 async def test_bus_event_not_called(coresys: CoreSys) -> None:
     """Test bus events over the backend."""
     results = []
@@ -44,7 +40,6 @@ async def test_bus_event_not_called(coresys: CoreSys) -> None:
     assert len(results) == 0
 
 
-@pytest.mark.asyncio
 async def test_bus_event_removed(coresys: CoreSys) -> None:
     """Test bus events over the backend and remove."""
     results = []


### PR DESCRIPTION
## Proposed change

The pytest config has `asyncio_mode = "auto"` set in `pyproject.toml`, which already auto-marks every `async def test_*` as a coroutine test. The 38 `@pytest.mark.asyncio` decorators sprinkled across the test suite are therefore no-ops, kept around from before that flag was set. This PR removes them together with the now-unused `import pytest` lines they were the only consumer of in three files.

Pure mechanical cleanup; no behavior changes. No new lines added, only deletions (-42 lines across 11 files).

Touched files:

- `tests/test_auth.py`, `tests/test_bus.py`
- `tests/store/test_custom_repository.py`
- `tests/resolution/test_resolution_manager.py`
- `tests/api/test_docker.py`, `tests/api/test_hardware.py`, `tests/api/test_host.py`, `tests/api/test_resolution.py`, `tests/api/test_security.py`, `tests/api/test_store.py`
- `tests/api/middleware/test_security.py`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
