### PR TITLE
Default pytest --timeout=10 in pyproject.toml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -380,7 +380,6 @@ jobs:
           . venv/bin/activate
           pytest \
             -qq \
-            --timeout=10 \
             --durations=10 \
             --cov supervisor \
             -o console_output_style=count \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,6 +230,9 @@ log_format = "%(asctime)s.%(msecs)03d %(levelname)-8s %(threadName)s %(name)s:%(
 log_date_format = "%Y-%m-%d %H:%M:%S"
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "auto"
+# 10s default timeout per test; per-test overrides via
+# @pytest.mark.timeout(N).
+timeout = 10
 filterwarnings = [
   "error",
   "ignore:pkg_resources is deprecated as an API:DeprecationWarning:dirhash",

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
 [testenv:tests]
 basepython = python3
 commands =
-    pytest --timeout=10 tests
+    pytest tests
 
 [testenv:ruff]
 basepython = python3


### PR DESCRIPTION
## Proposed change
CI and tox both passed `--timeout=10` to pytest explicitly, but a plain local `pytest` invocation had no timeout. Move the setting into `[tool.pytest.ini_options]` in `pyproject.toml` so it applies everywhere (pytest auto-discovers the config from the repo root) and drop the now-redundant `--timeout=10` flags from `.github/workflows/ci.yaml` and `tox.ini`. `@pytest.mark.timeout(N)` remains available for per-test overrides.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
