### PR TITLE
Lower severity of WebSocket delivery failure messages to debug

### DIFF
--- a/supervisor/homeassistant/websocket.py
+++ b/supervisor/homeassistant/websocket.py
@@ -310,7 +310,7 @@ class HomeAssistantWebSocket(CoreSysAttributes):
         try:
             await self._ensure_connected()
         except HomeAssistantWSError as err:
-            _LOGGER.warning("Can't send WebSocket command: %s", err)
+            _LOGGER.debug("Can't send WebSocket command: %s", err)
             return
 
         # _ensure_connected guarantees self.client is set


### PR DESCRIPTION
## Proposed change

Demote the fire-and-forget WebSocket delivery failure log in `_async_send_command` from `WARNING` back to `DEBUG`. The level was raised in #6725 ("for better visibility"), but in practice the message is noisy during normal Core lifecycle events (restart, update): Supervisor fires `supervisor_job_start`/`supervisor_job_end` events towards Core while the container is intentionally not running, and each event logs a warning. The `DEBUG` line emitted by the API layer just above ("Core container is not running") already explains the cause, so the `WARNING` just restates it without adding signal.

Synchronous `async_send_command` callers still see raised exceptions, so genuine failures that callers care about are not hidden — only the fire-and-forget delivery noise is silenced. This restores the original `DEBUG` level introduced together with the raise-on-failure behavior in #6553.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6725, #6553
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
