### PR TITLE
Don't limit CI concurrency on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,8 @@ env:
   MYPY_CACHE_VERSION: 1
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Separate job to pre-populate the base dependency cache


### PR DESCRIPTION
## Proposed change

The CI workflow used a blanket `cancel-in-progress: true`, which makes sense for PR runs (collapse to the latest commit) but means pushes to `main` cancel each other when several PRs merge in quick succession. There is no shared state between CI runs that would justify either cancelling or serializing them — each run is independent — and we'd rather see every commit on `main` get a full check.

Make the concurrency group unique per `run_id` for non-PR events so pushes to `main` neither cancel nor queue, while PRs keep the existing cancel-on-new-push behavior through the shared per-ref group.

This mirrors the spirit of #6782, which addressed the same blanket cancellation in the builder workflow (though there the fix was to queue rather than run in parallel, since the builder publishes wheels).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
