### PR TITLE
Improve and extend frontend probe after update with WebSocket check

### DIFF
--- a/supervisor/homeassistant/api.py
+++ b/supervisor/homeassistant/api.py
@@ -368,32 +368,3 @@ class HomeAssistantAPI(CoreSysAttributes):
         if state := await self.get_api_state():
             return state.core_state == "RUNNING" or state.offline_db_migration
         return False
-
-    async def check_frontend_available(self) -> bool:
-        """Check if the frontend is accessible by fetching the root path.
-
-        Caller should make sure that Home Assistant Core is running before
-        calling this method.
-
-        Returns:
-            True if the frontend responds successfully, False otherwise.
-
-        """
-        try:
-            async with self.make_request("get", "", timeout=30) as resp:
-                # Frontend should return HTML content
-                if resp.status == 200:
-                    content_type = resp.headers.get(hdrs.CONTENT_TYPE, "")
-                    if "text/html" in content_type:
-                        _LOGGER.debug("Frontend is accessible and serving HTML")
-                        return True
-                    _LOGGER.warning(
-                        "Frontend responded but with unexpected content type: %s",
-                        content_type,
-                    )
-                    return False
-                _LOGGER.warning("Frontend returned status %s", resp.status)
-                return False
-        except HomeAssistantAPIError as err:
-            _LOGGER.debug("Cannot reach frontend: %s", err)
-            return False

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -45,6 +45,7 @@ from .const import (
     WATCHDOG_THROTTLE_MAX_CALLS,
     WATCHDOG_THROTTLE_PERIOD,
 )
+from .frontend_check import verify_frontend
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -333,17 +334,19 @@ class HomeAssistantCore(JobGroup):
                 # The API stopped responding between the update and now
                 self._error_state = True
             else:
-                # Verify that the frontend is loaded
-                if "frontend" not in data.get("components", []):
-                    _LOGGER.error("API responds but frontend is not loaded")
+                components = data.get("components", [])
+                # Verify that the integrations needed to serve the frontend
+                # are loaded
+                for required in ("http", "frontend", "websocket_api"):
+                    if required not in components:
+                        _LOGGER.error("API responds but %s is not loaded", required)
+                        self._error_state = True
+                # Probe the public HTTP/WS endpoints as an external client
+                # would, to catch cases where integrations are listed as
+                # loaded but the endpoints don't actually function.
+                if not self._error_state and not await verify_frontend(self.coresys):
                     self._error_state = True
-                # Check that the frontend is actually accessible
-                elif not await self.sys_homeassistant.api.check_frontend_available():
-                    _LOGGER.error(
-                        "Frontend component loaded but frontend is not accessible"
-                    )
-                    self._error_state = True
-                else:
+                if not self._error_state:
                     # Health checks passed, clean up old image
                     with suppress(DockerError):
                         await self.instance.cleanup(old_image=old_image)

--- a/supervisor/homeassistant/frontend_check.py
+++ b/supervisor/homeassistant/frontend_check.py
@@ -1,0 +1,85 @@
+"""External frontend availability probes for Home Assistant Core.
+
+These probes intentionally bypass the Supervisor-internal API layer
+(authentication, Unix socket transport, retries) so they exercise the
+same code paths an external HTTP/WebSocket client would. The goal is
+to detect cases where Core's HTTP API responds but the user-facing
+frontend or WebSocket endpoint is broken (e.g. due to a custom http
+component override masking websocket_api).
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+import logging
+
+import aiohttp
+from aiohttp import hdrs
+
+from ..coresys import CoreSys
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+_PROBE_TIMEOUT = aiohttp.ClientTimeout(total=30)
+_WS_RECEIVE_TIMEOUT = 10.0
+
+
+async def check_frontend(coresys: CoreSys) -> bool:
+    """Verify the frontend serves HTML on the root path."""
+    url = f"{coresys.homeassistant.api_url}/"
+    try:
+        async with coresys.websession.get(
+            url, timeout=_PROBE_TIMEOUT, ssl=False
+        ) as resp:
+            if resp.status != 200:
+                _LOGGER.error("Frontend returned status %s", resp.status)
+                return False
+            content_type = resp.headers.get(hdrs.CONTENT_TYPE, "")
+            if "text/html" not in content_type:
+                _LOGGER.error(
+                    "Frontend responded with unexpected content type: %s",
+                    content_type,
+                )
+                return False
+    except (aiohttp.ClientError, TimeoutError) as err:
+        _LOGGER.error("Cannot reach frontend at %s: %s", url, err)
+        return False
+
+    _LOGGER.debug("Frontend is accessible and serving HTML")
+    return True
+
+
+async def check_websocket(coresys: CoreSys) -> bool:
+    """Verify the WebSocket endpoint accepts a handshake.
+
+    We don't authenticate. A working endpoint sends an `auth_required`
+    text frame immediately after the upgrade; that's enough to confirm
+    websocket_api is wired up and functional.
+    """
+    url = coresys.homeassistant.ws_url
+    ws: aiohttp.ClientWebSocketResponse | None = None
+    try:
+        ws = await coresys.websession.ws_connect(url, ssl=False)
+        msg = await ws.receive(timeout=_WS_RECEIVE_TIMEOUT)
+        if msg.type != aiohttp.WSMsgType.TEXT:
+            _LOGGER.error("WebSocket handshake returned non-text message: %s", msg.type)
+            return False
+        data = msg.json()
+        if data.get("type") != "auth_required":
+            _LOGGER.error("WebSocket did not send auth_required, got: %s", data)
+            return False
+    except (aiohttp.ClientError, TimeoutError, ValueError) as err:
+        _LOGGER.error("WebSocket probe to %s failed: %s", url, err)
+        return False
+    finally:
+        if ws is not None:
+            with suppress(Exception):
+                await ws.close()
+
+    _LOGGER.debug("WebSocket endpoint accepted handshake")
+    return True
+
+
+async def verify_frontend(coresys: CoreSys) -> bool:
+    """Run both frontend probes; return True only if both succeed."""
+    return await check_frontend(coresys) and await check_websocket(coresys)

--- a/supervisor/homeassistant/frontend_check.py
+++ b/supervisor/homeassistant/frontend_check.py
@@ -10,6 +10,7 @@ component override masking websocket_api).
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import suppress
 import logging
 
@@ -21,6 +22,7 @@ from ..coresys import CoreSys
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 _PROBE_TIMEOUT = aiohttp.ClientTimeout(total=30)
+_WS_HANDSHAKE_TIMEOUT = 30.0
 _WS_RECEIVE_TIMEOUT = 10.0
 
 
@@ -59,13 +61,16 @@ async def check_websocket(coresys: CoreSys) -> bool:
     url = coresys.homeassistant.ws_url
     ws: aiohttp.ClientWebSocketResponse | None = None
     try:
-        ws = await coresys.websession.ws_connect(url, ssl=False)
+        ws = await asyncio.wait_for(
+            coresys.websession.ws_connect(url, ssl=False),
+            timeout=_WS_HANDSHAKE_TIMEOUT,
+        )
         msg = await ws.receive(timeout=_WS_RECEIVE_TIMEOUT)
         if msg.type != aiohttp.WSMsgType.TEXT:
             _LOGGER.error("WebSocket handshake returned non-text message: %s", msg.type)
             return False
         data = msg.json()
-        if data.get("type") != "auth_required":
+        if not isinstance(data, dict) or data.get("type") != "auth_required":
             _LOGGER.error("WebSocket did not send auth_required, got: %s", data)
             return False
     except (aiohttp.ClientError, TimeoutError, ValueError) as err:

--- a/tests/api/test_homeassistant.py
+++ b/tests/api/test_homeassistant.py
@@ -17,6 +17,7 @@ from supervisor.docker.interface import DockerInterface
 from supervisor.exceptions import HomeAssistantError
 from supervisor.homeassistant.api import APIState, HomeAssistantAPI
 from supervisor.homeassistant.const import WSEvent
+import supervisor.homeassistant.core as ha_core
 from supervisor.homeassistant.core import HomeAssistantCore
 from supervisor.homeassistant.module import HomeAssistant
 from supervisor.resolution.const import ContextType, IssueType
@@ -315,9 +316,11 @@ async def test_api_progress_updates_home_assistant_update(
             new=PropertyMock(return_value=AwesomeVersion("2025.8.0")),
         ),
         patch.object(
-            HomeAssistantAPI, "get_config", return_value={"components": ["frontend"]}
+            HomeAssistantAPI,
+            "get_config",
+            return_value={"components": ["http", "frontend", "websocket_api"]},
         ),
-        patch.object(HomeAssistantAPI, "check_frontend_available", return_value=True),
+        patch.object(ha_core, "verify_frontend", AsyncMock(return_value=True)),
     ):
         resp = await api_client.post(f"{root}/update", json={"version": "2025.8.3"})
 
@@ -492,9 +495,11 @@ async def test_update_frontend_check_success(
             new=PropertyMock(return_value=AwesomeVersion("2025.8.0")),
         ),
         patch.object(
-            HomeAssistantAPI, "get_config", return_value={"components": ["frontend"]}
+            HomeAssistantAPI,
+            "get_config",
+            return_value={"components": ["http", "frontend", "websocket_api"]},
         ),
-        patch.object(HomeAssistantAPI, "check_frontend_available", return_value=True),
+        patch.object(ha_core, "verify_frontend", AsyncMock(return_value=True)),
         patch.object(DockerInterface, "cleanup") as mock_cleanup,
     ):
         resp = await api_client.post(f"{root}/update", json={"version": "2025.8.3"})
@@ -509,7 +514,7 @@ async def test_update_frontend_check_fails_triggers_rollback(
     caplog: pytest.LogCaptureFixture,
     tmp_supervisor_data: Path,
 ):
-    """Test that update triggers rollback when frontend check fails."""
+    """Test that update triggers rollback when health probes fail."""
     api_client, root = core_api_client_with_root
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     coresys.homeassistant.version = AwesomeVersion("2025.8.0")
@@ -535,16 +540,17 @@ async def test_update_frontend_check_fails_triggers_rollback(
             new=PropertyMock(return_value=AwesomeVersion("2025.8.0")),
         ),
         patch.object(
-            HomeAssistantAPI, "get_config", return_value={"components": ["frontend"]}
+            HomeAssistantAPI,
+            "get_config",
+            return_value={"components": ["http", "frontend", "websocket_api"]},
         ),
-        patch.object(HomeAssistantAPI, "check_frontend_available", return_value=False),
+        patch.object(ha_core, "verify_frontend", AsyncMock(return_value=False)),
         patch.object(DockerInterface, "cleanup") as mock_cleanup,
     ):
         resp = await api_client.post(f"{root}/update", json={"version": "2025.8.3"})
 
     # Update should trigger rollback, which succeeds and returns 200
     assert resp.status == 200
-    assert "Frontend component loaded but frontend is not accessible" in caplog.text
     assert "HomeAssistant update failed -> rollback!" in caplog.text
     # Should have called update twice (once for update, once for rollback)
     assert update_call_count == 2
@@ -553,6 +559,57 @@ async def test_update_frontend_check_fails_triggers_rollback(
         Issue(IssueType.UPDATE_ROLLBACK, ContextType.CORE) in coresys.resolution.issues
     )
     # Old image should not be cleaned up so rollback doesn't need to re-download
+    mock_cleanup.assert_not_called()
+
+
+async def test_update_websocket_api_missing_triggers_rollback(
+    core_api_client_with_root: tuple[TestClient, str],
+    coresys: CoreSys,
+    caplog: pytest.LogCaptureFixture,
+    tmp_supervisor_data: Path,
+):
+    """Test that update triggers rollback when websocket_api component is not loaded."""
+    api_client, root = core_api_client_with_root
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    coresys.homeassistant.version = AwesomeVersion("2025.8.0")
+
+    update_call_count = 0
+
+    async def mock_update(*args, **kwargs):
+        nonlocal update_call_count
+        update_call_count += 1
+        if update_call_count == 1:
+            coresys.homeassistant.version = AwesomeVersion("2025.8.3")
+        elif update_call_count == 2:
+            coresys.homeassistant.version = AwesomeVersion("2025.8.0")
+
+    with (
+        patch.object(DockerInterface, "update", new=mock_update),
+        patch.object(
+            DockerHomeAssistant,
+            "version",
+            new=PropertyMock(return_value=AwesomeVersion("2025.8.0")),
+        ),
+        patch.object(
+            HomeAssistantAPI,
+            "get_config",
+            return_value={"components": ["http", "frontend"]},
+        ),
+        patch.object(
+            ha_core, "verify_frontend", AsyncMock(return_value=True)
+        ) as mock_frontend_check,
+        patch.object(DockerInterface, "cleanup") as mock_cleanup,
+    ):
+        resp = await api_client.post(f"{root}/update", json={"version": "2025.8.3"})
+
+    assert resp.status == 200
+    assert "API responds but websocket_api is not loaded" in caplog.text
+    assert "HomeAssistant update failed -> rollback!" in caplog.text
+    assert update_call_count == 2
+    mock_frontend_check.assert_not_called()
+    assert (
+        Issue(IssueType.UPDATE_ROLLBACK, ContextType.CORE) in coresys.resolution.issues
+    )
     mock_cleanup.assert_not_called()
 
 
@@ -586,8 +643,8 @@ async def test_update_get_config_error_triggers_rollback(
         ),
         patch.object(HomeAssistantAPI, "get_config", side_effect=HomeAssistantError),
         patch.object(
-            HomeAssistantAPI, "check_frontend_available", return_value=True
-        ) as mock_check_frontend,
+            ha_core, "verify_frontend", AsyncMock(return_value=True)
+        ) as mock_frontend_check,
         patch.object(DockerInterface, "cleanup") as mock_cleanup,
     ):
         resp = await api_client.post(f"{root}/update", json={"version": "2025.8.3"})
@@ -595,7 +652,7 @@ async def test_update_get_config_error_triggers_rollback(
     assert resp.status == 200
     assert "HomeAssistant update failed -> rollback!" in caplog.text
     assert update_call_count == 2
-    mock_check_frontend.assert_not_called()
+    mock_frontend_check.assert_not_called()
     assert (
         Issue(IssueType.UPDATE_ROLLBACK, ContextType.CORE) in coresys.resolution.issues
     )

--- a/tests/homeassistant/test_api.py
+++ b/tests/homeassistant/test_api.py
@@ -3,7 +3,6 @@
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from aiohttp import hdrs
 from awesomeversion import AwesomeVersion
 import pytest
 
@@ -16,49 +15,6 @@ from supervisor.homeassistant.api import APIState, HomeAssistantAPI
 from supervisor.homeassistant.const import LANDINGPAGE
 
 from tests.common import MockResponse
-
-# --- check_frontend_available ---
-
-
-@pytest.mark.parametrize(
-    ("status", "content_type", "expected"),
-    [
-        (200, "text/html; charset=utf-8", True),
-        (404, "text/html", False),
-        (200, "application/json", False),
-    ],
-)
-async def test_check_frontend_available(
-    coresys: CoreSys, status: int, content_type: str, expected: bool
-):
-    """Test frontend availability based on HTTP status and content type."""
-    mock_response = MagicMock()
-    mock_response.status = status
-    mock_response.headers = {hdrs.CONTENT_TYPE: content_type}
-
-    @asynccontextmanager
-    async def mock_make_request(*args, **kwargs):
-        yield mock_response
-
-    with patch.object(
-        type(coresys.homeassistant.api), "make_request", new=mock_make_request
-    ):
-        assert await coresys.homeassistant.api.check_frontend_available() is expected
-
-
-async def test_check_frontend_available_api_error(coresys: CoreSys):
-    """Test frontend availability check handles API errors gracefully."""
-
-    @asynccontextmanager
-    async def mock_make_request(*args, **kwargs):
-        raise HomeAssistantAPIError("Connection failed")
-        yield  # pragma: no cover
-
-    with patch.object(
-        type(coresys.homeassistant.api), "make_request", new=mock_make_request
-    ):
-        assert await coresys.homeassistant.api.check_frontend_available() is False
-
 
 # --- get_config / get_core_state ---
 

--- a/tests/homeassistant/test_frontend_check.py
+++ b/tests/homeassistant/test_frontend_check.py
@@ -95,6 +95,17 @@ async def test_check_websocket_connect_error(coresys: CoreSys, websession: Magic
     assert await check_websocket(coresys) is False
 
 
+async def test_check_websocket_non_dict_payload(
+    coresys: CoreSys, websession: MagicMock
+):
+    """Websocket check returns False when payload is valid JSON but not an object."""
+    msg = MagicMock()
+    msg.type = aiohttp.WSMsgType.TEXT
+    msg.json.return_value = ["auth_required"]
+    websession.ws_connect = AsyncMock(return_value=_mock_ws(msg))
+    assert await check_websocket(coresys) is False
+
+
 # --- verify_frontend ---
 
 

--- a/tests/homeassistant/test_frontend_check.py
+++ b/tests/homeassistant/test_frontend_check.py
@@ -1,0 +1,121 @@
+"""Test external frontend probes."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+
+from supervisor.coresys import CoreSys
+from supervisor.homeassistant.frontend_check import (
+    check_frontend,
+    check_websocket,
+    verify_frontend,
+)
+
+
+@asynccontextmanager
+async def _mock_response(status: int, content_type: str):
+    resp = MagicMock()
+    resp.status = status
+    resp.headers = {"Content-Type": content_type}
+    yield resp
+
+
+def _mock_ws(receive_msg) -> AsyncMock:
+    ws = AsyncMock()
+    ws.receive = AsyncMock(return_value=receive_msg)
+    ws.close = AsyncMock()
+    return ws
+
+
+# --- check_frontend ---
+
+
+async def test_check_frontend_ok(coresys: CoreSys, websession: MagicMock):
+    """Frontend check returns True for HTML 200."""
+    websession.get = MagicMock(return_value=_mock_response(200, "text/html"))
+    assert await check_frontend(coresys) is True
+
+
+async def test_check_frontend_wrong_status(coresys: CoreSys, websession: MagicMock):
+    """Frontend check returns False on non-200 status."""
+    websession.get = MagicMock(return_value=_mock_response(503, "text/html"))
+    assert await check_frontend(coresys) is False
+
+
+async def test_check_frontend_wrong_content_type(
+    coresys: CoreSys, websession: MagicMock
+):
+    """Frontend check returns False when content-type is not HTML."""
+    websession.get = MagicMock(return_value=_mock_response(200, "application/json"))
+    assert await check_frontend(coresys) is False
+
+
+async def test_check_frontend_connection_error(coresys: CoreSys, websession: MagicMock):
+    """Frontend check returns False on connection errors."""
+    websession.get = MagicMock(side_effect=aiohttp.ClientConnectionError("boom"))
+    assert await check_frontend(coresys) is False
+
+
+# --- check_websocket ---
+
+
+async def test_check_websocket_ok(coresys: CoreSys, websession: MagicMock):
+    """Websocket check returns True when auth_required is received."""
+    msg = MagicMock()
+    msg.type = aiohttp.WSMsgType.TEXT
+    msg.json.return_value = {"type": "auth_required"}
+    websession.ws_connect = AsyncMock(return_value=_mock_ws(msg))
+    assert await check_websocket(coresys) is True
+
+
+async def test_check_websocket_close_frame(coresys: CoreSys, websession: MagicMock):
+    """Websocket check returns False on close frame (issue #6802 case)."""
+    msg = MagicMock()
+    msg.type = aiohttp.WSMsgType.CLOSE
+    websession.ws_connect = AsyncMock(return_value=_mock_ws(msg))
+    assert await check_websocket(coresys) is False
+
+
+async def test_check_websocket_unexpected_message(
+    coresys: CoreSys, websession: MagicMock
+):
+    """Websocket check returns False when first frame is not auth_required."""
+    msg = MagicMock()
+    msg.type = aiohttp.WSMsgType.TEXT
+    msg.json.return_value = {"type": "result"}
+    websession.ws_connect = AsyncMock(return_value=_mock_ws(msg))
+    assert await check_websocket(coresys) is False
+
+
+async def test_check_websocket_connect_error(coresys: CoreSys, websession: MagicMock):
+    """Websocket check returns False if the handshake fails."""
+    websession.ws_connect = AsyncMock(side_effect=aiohttp.ClientConnectionError("nope"))
+    assert await check_websocket(coresys) is False
+
+
+# --- verify_frontend ---
+
+
+@pytest.mark.parametrize(
+    ("frontend_ok", "ws_ok", "expected"),
+    [(True, True, True), (False, True, False), (True, False, False)],
+)
+async def test_verify_frontend(
+    coresys: CoreSys,
+    websession: MagicMock,
+    frontend_ok: bool,
+    ws_ok: bool,
+    expected: bool,
+):
+    """verify_frontend is True only if both probes succeed."""
+    websession.get = MagicMock(
+        return_value=_mock_response(200 if frontend_ok else 500, "text/html")
+    )
+    msg = MagicMock()
+    msg.type = aiohttp.WSMsgType.TEXT
+    msg.json.return_value = {"type": "auth_required" if ws_ok else "result"}
+    websession.ws_connect = AsyncMock(return_value=_mock_ws(msg))
+
+    assert await verify_frontend(coresys) is expected


### PR DESCRIPTION
## Proposed change

The post-update health check introduced in #6311 added `HomeAssistantAPI.check_frontend_available`, which fetched the frontend through the existing Supervisor-internal API connection to Core. Since #6742 that connection optionally runs over a Unix socket with no authentication, so the request no longer exercises the same transport, auth and routing path that an external HTTP client uses.

Move the frontend probe out of `HomeAssistantAPI` into a small `frontend_check` module that talks to Core's TCP endpoints via the plain websession with no authentication, mirroring what an external client would see.

While doing this, extend the post-update verification to also probe the WebSocket endpoint: open `/api/websocket` and confirm the first frame is the `auth_required` text message. This catches the kind of WebSocket breakage seen in #6802, where `api/config` still listed `websocket_api` as loaded and `GET /` still returned HTML, but the WebSocket handshake completed with an immediate close frame and the frontend was unusable.

The component check now also requires `http` to be loaded, in addition to `frontend` and `websocket_api`, and iterates so every missing component is logged.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #6802
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
