### PR TITLE
Enable Unix socket Core API by default on Core 2026.5.1+

### DIFF
--- a/supervisor/homeassistant/api.py
+++ b/supervisor/homeassistant/api.py
@@ -27,6 +27,7 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 CORE_UNIX_SOCKET_MIN_VERSION: AwesomeVersion = AwesomeVersion(
     "2026.4.0.dev202603250907"
 )
+CORE_UNIX_SOCKET_DEFAULT_VERSION: AwesomeVersion = AwesomeVersion("2026.5.1")
 GET_CORE_STATE_MIN_VERSION: AwesomeVersion = AwesomeVersion("2023.8.0.dev20230720")
 
 
@@ -56,15 +57,26 @@ class HomeAssistantAPI(CoreSysAttributes):
     def supports_unix_socket(self) -> bool:
         """Return True if the installed Core version supports Unix socket communication.
 
+        Enabled by default for Core >= CORE_UNIX_SOCKET_DEFAULT_VERSION; for
+        older versions down to CORE_UNIX_SOCKET_MIN_VERSION it is gated behind
+        the UNIX_SOCKET_CORE_API feature flag.
+
         Used to decide whether to configure the env var when starting Core.
         """
-        return (
-            self.sys_config.feature_flags.get(FeatureFlag.UNIX_SOCKET_CORE_API, False)
-            and self.sys_homeassistant.version is not None
-            and self.sys_homeassistant.version != LANDINGPAGE
-            and version_is_new_enough(
+        if (
+            self.sys_homeassistant.version is None
+            or self.sys_homeassistant.version == LANDINGPAGE
+            or not version_is_new_enough(
                 self.sys_homeassistant.version, CORE_UNIX_SOCKET_MIN_VERSION
             )
+        ):
+            return False
+        if version_is_new_enough(
+            self.sys_homeassistant.version, CORE_UNIX_SOCKET_DEFAULT_VERSION
+        ):
+            return True
+        return self.sys_config.feature_flags.get(
+            FeatureFlag.UNIX_SOCKET_CORE_API, False
         )
 
     @property

--- a/tests/homeassistant/test_api.py
+++ b/tests/homeassistant/test_api.py
@@ -105,6 +105,9 @@ async def test_get_config_api_error(coresys: CoreSys):
     [
         ("2026.4.0", True, True),
         ("2026.4.0", False, False),
+        ("2026.5.1", True, True),
+        ("2026.5.1", False, True),
+        ("2026.6.0", False, True),
         ("2024.1.0", True, False),
         (LANDINGPAGE, True, False),
     ],


### PR DESCRIPTION
## Proposed change

Enable Unix socket communication between Supervisor and Home Assistant Core by default on Core 2026.5.1 and newer. The `UNIX_SOCKET_CORE_API` feature flag was previously the only way to opt into the Unix socket transport. Now that the implementation has settled, it is enabled automatically on recent Core versions.

A new `CORE_UNIX_SOCKET_DEFAULT_VERSION` (2026.5.1) is introduced alongside the existing `CORE_UNIX_SOCKET_MIN_VERSION`. Behavior by Core version:

- `>= 2026.5.1`: Unix socket is used unconditionally (feature flag ignored).
- `>= 2026.4.0.dev202603250907` and `< 2026.5.1`: opt-in via the `UNIX_SOCKET_CORE_API` feature flag, preserving the existing behavior for early dev builds.
- Older versions: TCP transport, as before.

The default version is intentionally set to a Core release that has not shipped yet. Because Core gets rebuilt on update, no extra container rebuild is required to pick up the new default — users transition the moment they update to 2026.5.1 or newer. 2026.5.1 also resolves an outstanding Core-side bug in the Unix socket path (home-assistant/core#169911), so making it the cutoff ensures the default-on behavior only kicks in once that fix is in place.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: #6801
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
