### PR TITLE
Skip post-update health check when Core was not running on entry

### DIFF
--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -280,7 +280,9 @@ class HomeAssistantCore(JobGroup):
             )
 
         old_image = self.sys_homeassistant.image
-        rollback = self.sys_homeassistant.version if not self.error_state else None
+        rollback_version = (
+            self.sys_homeassistant.version if not self.error_state else None
+        )
         running = await self.instance.is_running()
         exists = await self.instance.exists()
 
@@ -327,7 +329,17 @@ class HomeAssistantCore(JobGroup):
         with suppress(HomeAssistantError):
             await _update(to_version)
 
-        if not self.error_state and rollback:
+        # If Core wasn't running on entry, the caller is responsible for
+        # starting it (e.g. backup restore, which stops and removes Core
+        # before calling update() and starts it later in its own stage).
+        # _update() correspondingly skipped the start step, so there is no
+        # running Core to health-check. Returning early avoids a spurious
+        # rollback that would otherwise overwrite the freshly installed
+        # image with the previous version.
+        if not running:
+            return
+
+        if not self.error_state and rollback_version:
             try:
                 data = await self.sys_homeassistant.api.get_config()
             except HomeAssistantError:
@@ -353,7 +365,7 @@ class HomeAssistantCore(JobGroup):
                     return
 
         # Update going wrong, revert it
-        if self.error_state and rollback:
+        if self.error_state and rollback_version:
             _LOGGER.critical("HomeAssistant update failed -> rollback!")
             self.sys_resolution.create_issue(
                 IssueType.UPDATE_ROLLBACK, ContextType.CORE
@@ -370,7 +382,7 @@ class HomeAssistantCore(JobGroup):
                 _LOGGER.info(
                     "A backup of the logfile is stored in /config/home-assistant-rollback.log"
                 )
-            await _update(rollback)
+            await _update(rollback_version)
         else:
             self.sys_resolution.create_issue(IssueType.UPDATE_FAILED, ContextType.CORE)
             raise HomeAssistantUpdateError()

--- a/tests/api/test_homeassistant.py
+++ b/tests/api/test_homeassistant.py
@@ -22,6 +22,7 @@ from supervisor.homeassistant.core import HomeAssistantCore
 from supervisor.homeassistant.module import HomeAssistant
 from supervisor.resolution.const import ContextType, IssueType
 from supervisor.resolution.data import Issue
+from supervisor.updater import Updater
 
 from tests.common import AsyncIterator, load_json_fixture
 
@@ -489,6 +490,7 @@ async def test_update_frontend_check_success(
     coresys.homeassistant.version = AwesomeVersion("2025.8.0")
 
     with (
+        patch.object(DockerInterface, "is_running", AsyncMock(return_value=True)),
         patch.object(
             DockerHomeAssistant,
             "version",
@@ -534,6 +536,7 @@ async def test_update_frontend_check_fails_triggers_rollback(
 
     with (
         patch.object(DockerInterface, "update", new=mock_update),
+        patch.object(DockerInterface, "is_running", AsyncMock(return_value=True)),
         patch.object(
             DockerHomeAssistant,
             "version",
@@ -585,6 +588,7 @@ async def test_update_websocket_api_missing_triggers_rollback(
 
     with (
         patch.object(DockerInterface, "update", new=mock_update),
+        patch.object(DockerInterface, "is_running", AsyncMock(return_value=True)),
         patch.object(
             DockerHomeAssistant,
             "version",
@@ -636,6 +640,7 @@ async def test_update_get_config_error_triggers_rollback(
 
     with (
         patch.object(DockerInterface, "update", new=mock_update),
+        patch.object(DockerInterface, "is_running", AsyncMock(return_value=True)),
         patch.object(
             DockerHomeAssistant,
             "version",
@@ -657,3 +662,63 @@ async def test_update_get_config_error_triggers_rollback(
         Issue(IssueType.UPDATE_ROLLBACK, ContextType.CORE) in coresys.resolution.issues
     )
     mock_cleanup.assert_not_called()
+
+
+async def test_update_skips_health_check_when_core_not_running(
+    coresys: CoreSys,
+    caplog: pytest.LogCaptureFixture,
+    tmp_supervisor_data: Path,
+):
+    """Test that update skips health check and rollback when Core was stopped on entry.
+
+    Reproduces the backup-restore regression: the restore flow stops and
+    removes Core before calling core.update(); the post-update API check
+    must not fire because Core hasn't been started yet, otherwise it
+    triggers a spurious rollback that overwrites the restored image.
+    """
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    coresys.homeassistant.version = AwesomeVersion("2026.5.0b0")
+    coresys.homeassistant.set_image("ghcr.io/home-assistant/qemux86-64-homeassistant")
+
+    update_call_count = 0
+
+    async def mock_update(*args, **kwargs):
+        nonlocal update_call_count
+        update_call_count += 1
+        coresys.homeassistant.version = AwesomeVersion("2026.4.4")
+
+    with (
+        patch.object(DockerInterface, "update", new=mock_update),
+        patch.object(DockerInterface, "is_running", AsyncMock(return_value=False)),
+        patch.object(DockerInterface, "exists", AsyncMock(return_value=False)),
+        patch.object(
+            Updater,
+            "image_homeassistant",
+            new=PropertyMock(
+                return_value="ghcr.io/home-assistant/qemux86-64-homeassistant"
+            ),
+        ),
+        patch.object(
+            DockerHomeAssistant,
+            "version",
+            new=PropertyMock(return_value=AwesomeVersion("2026.4.4")),
+        ),
+        patch.object(HomeAssistantAPI, "get_config") as mock_get_config,
+        patch.object(ha_core, "verify_frontend", AsyncMock()) as mock_frontend,
+        patch.object(DockerInterface, "cleanup") as mock_cleanup,
+    ):
+        await coresys.homeassistant.core.update(AwesomeVersion("2026.4.4"))
+
+    # Only one update call: no rollback fired.
+    assert update_call_count == 1
+    assert "HomeAssistant update failed -> rollback!" not in caplog.text
+    # Health check must not run when Core wasn't running on entry.
+    mock_get_config.assert_not_called()
+    mock_frontend.assert_not_called()
+    # Caller (restore flow) is responsible for cleanup later.
+    mock_cleanup.assert_not_called()
+    assert (
+        Issue(IssueType.UPDATE_ROLLBACK, ContextType.CORE)
+        not in coresys.resolution.issues
+    )
+    assert coresys.homeassistant.version == AwesomeVersion("2026.4.4")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Fix a regression where restoring a backup leaves Home Assistant Core on the wrong version. PR #6726 removed an early return after a `HomeAssistantError` from the post-update `get_config()` call so that a Core that stopped responding after an update would correctly trigger a rollback. That early return was, however, also load-bearing for the backup restore flow: `Backup.restore_homeassistant()` stops and removes Core before invoking `core.update(target_version)` and starts Core later in its own `await_home_assistant_restart` stage. With Core not running, `_update()` correctly skips the start step, but the unconditional post-update `get_config()` then always raises, sets `error_state`, and triggers a spurious rollback that re-pulls the previous image and leaves the system on the wrong version after the restore completes.

This PR returns early from `update()` when Core was not running on entry. The caller is responsible for starting Core and there is no live API to health-check at this point. Genuine update failures (Core was running, the update broke it) are unaffected and still roll back. The local `rollback` is also renamed to `rollback_version` for clarity.

A regression test covering the restore scenario is added, and the existing rollback tests are updated to mock `is_running=True` (they previously relied on a default that no longer reaches the rollback path).

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #6820
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
