### PR TITLE
Tighten mypy and fix findings under the new flags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -331,7 +331,7 @@ jobs:
       - name: Run mypy
         run: |
           . venv/bin/activate
-          mypy --ignore-missing-imports supervisor
+          mypy supervisor
 
   pytest:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,11 +224,11 @@ overgeneral-exceptions = ["builtins.BaseException", "builtins.Exception"]
 max-positional-arguments = 10
 
 [tool.mypy]
-ignore_missing_imports = true
 warn_unreachable = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 enable_error_code = ["exhaustive-match", "possibly-undefined"]
+disable_error_code = ["import-not-found", "import-untyped"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,13 @@ overgeneral-exceptions = ["builtins.BaseException", "builtins.Exception"]
 [tool.pylint.DESIGN]
 max-positional-arguments = 10
 
+[tool.mypy]
+ignore_missing_imports = true
+warn_unreachable = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+enable_error_code = ["exhaustive-match", "possibly-undefined"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 norecursedirs = [".git"]

--- a/supervisor/coresys.py
+++ b/supervisor/coresys.py
@@ -632,12 +632,10 @@ class CoreSys:
         self, coroutine: Coroutine, *, eager_start: bool | None = None
     ) -> asyncio.Task:
         """Create an async task."""
-        # eager_start kwarg works but wasn't added for mypy visibility until 3.14
-        # can remove the type ignore then
         return self.loop.create_task(
             coroutine,
             context=self._create_context(),
-            eager_start=eager_start,  # type: ignore
+            eager_start=eager_start,
         )
 
     def call_later(

--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -332,16 +332,17 @@ class DockerInterface(JobGroup, ABC):
                 )
                 await async_capture_exception(err)
 
+        # Get credentials for private registries to pass to aiodocker.
+        # Done before registering the listener so a failure here does not
+        # leak a stale event listener.
+        credentials, pull_image_name = self._get_credentials(image)
+
         listener = self.sys_bus.register_event(
             BusEvent.DOCKER_IMAGE_PULL_UPDATE, process_pull_event
         )
 
         _LOGGER.info("Downloading docker image %s with tag %s.", image, version)
-        credentials: dict = {}
         try:
-            # Get credentials for private registries to pass to aiodocker
-            credentials, pull_image_name = self._get_credentials(image)
-
             # Pull new image, passing credentials to aiodocker
             docker_image = await self.sys_docker.pull_image(
                 current_job.uuid,

--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -337,6 +337,7 @@ class DockerInterface(JobGroup, ABC):
         )
 
         _LOGGER.info("Downloading docker image %s with tag %s.", image, version)
+        credentials: dict = {}
         try:
             # Get credentials for private registries to pass to aiodocker
             credentials, pull_image_name = self._get_credentials(image)

--- a/supervisor/host/configuration.py
+++ b/supervisor/host/configuration.py
@@ -267,7 +267,8 @@ class Interface:
                 return InterfaceMethod.AUTO
             case NMInterfaceMethod.MANUAL:
                 return InterfaceMethod.STATIC
-        return InterfaceMethod.DISABLED
+            case _:
+                return InterfaceMethod.DISABLED
 
     @staticmethod
     def _map_nm_addr_gen_mode(addr_gen_mode: int | None) -> InterfaceAddrGenMode:
@@ -333,7 +334,8 @@ class Interface:
                 return InterfaceType.WIRELESS
             case DeviceType.VLAN.value:
                 return InterfaceType.VLAN
-        raise ValueError(f"Invalid device type: {device_type}")
+            case _:
+                raise ValueError(f"Invalid device type: {device_type}")
 
     @staticmethod
     def _map_nm_wifi(inet: NetworkInterface) -> WifiConfig | None:

--- a/supervisor/misc/scheduler.py
+++ b/supervisor/misc/scheduler.py
@@ -73,19 +73,22 @@ class Scheduler(CoreSysAttributes):
 
     def _schedule_task(self, task: _Task) -> None:
         """Schedule a task on loop."""
-        if isinstance(task.interval, (int, float)):
-            task.next = self.sys_call_later(task.interval, self._run_task, task)
-        else:
-            today = datetime.combine(date.today(), task.interval)
-            tomorrow = datetime.combine(date.today() + timedelta(days=1), task.interval)
+        match task.interval:
+            case int() | float():
+                task.next = self.sys_call_later(task.interval, self._run_task, task)
+            case time():
+                today = datetime.combine(date.today(), task.interval)
+                tomorrow = datetime.combine(
+                    date.today() + timedelta(days=1), task.interval
+                )
 
-            # Check if we run it today or next day
-            if today > datetime.today():
-                calc = today
-            else:
-                calc = tomorrow
+                # Check if we run it today or next day
+                if today > datetime.today():
+                    calc = today
+                else:
+                    calc = tomorrow
 
-            task.next = self.sys_call_at(calc, self._run_task, task)
+                task.next = self.sys_call_at(calc, self._run_task, task)
 
     async def shutdown(self, timeout=10) -> None:
         """Shutdown all task inside the scheduler."""

--- a/supervisor/misc/scheduler.py
+++ b/supervisor/misc/scheduler.py
@@ -75,7 +75,7 @@ class Scheduler(CoreSysAttributes):
         """Schedule a task on loop."""
         if isinstance(task.interval, (int, float)):
             task.next = self.sys_call_later(task.interval, self._run_task, task)
-        elif isinstance(task.interval, time):
+        else:
             today = datetime.combine(date.today(), task.interval)
             tomorrow = datetime.combine(date.today() + timedelta(days=1), task.interval)
 
@@ -86,13 +86,6 @@ class Scheduler(CoreSysAttributes):
                 calc = tomorrow
 
             task.next = self.sys_call_at(calc, self._run_task, task)
-        else:
-            _LOGGER.critical(
-                "Unknown interval %s (type: %s) for scheduler %s",
-                task.interval,
-                type(task.interval),
-                task.id,
-            )
 
     async def shutdown(self, timeout=10) -> None:
         """Shutdown all task inside the scheduler."""

--- a/supervisor/mounts/mount.py
+++ b/supervisor/mounts/mount.py
@@ -151,7 +151,8 @@ class Mount(CoreSysAttributes, ABC):
                 return PurePath(PATH_MEDIA, self.name)
             case MountUsage.SHARE:
                 return PurePath(PATH_SHARE, self.name)
-        return None
+            case _:
+                return None
 
     @property
     def failed_issue(self) -> Issue:

--- a/supervisor/mounts/mount.py
+++ b/supervisor/mounts/mount.py
@@ -151,7 +151,7 @@ class Mount(CoreSysAttributes, ABC):
                 return PurePath(PATH_MEDIA, self.name)
             case MountUsage.SHARE:
                 return PurePath(PATH_SHARE, self.name)
-            case _:
+            case MountUsage.BACKUP | None:
                 return None
 
     @property

--- a/supervisor/os/manager.py
+++ b/supervisor/os/manager.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from datetime import datetime
 import logging
 from pathlib import Path, PurePath
-from typing import cast
 
 import aiohttp
 from awesomeversion import AwesomeVersion, AwesomeVersionException
@@ -58,8 +57,8 @@ class SlotStatus:
             device=PurePath(data["device"]),
             bundle_compatible=data.get("bundle.compatible"),
             sha256=data.get("sha256"),
-            size=cast(int | None, data.get("size")),
-            installed_count=cast(int | None, data.get("installed.count")),
+            size=data.get("size"),
+            installed_count=data.get("installed.count"),
             bundle_version=AwesomeVersion(data["bundle.version"])
             if "bundle.version" in data
             else None,
@@ -67,7 +66,7 @@ class SlotStatus:
             if "installed.timestamp" in data
             else None,
             status=data.get("status"),
-            activated_count=cast(int | None, data.get("activated.count")),
+            activated_count=data.get("activated.count"),
             activated_timestamp=datetime.fromisoformat(data["activated.timestamp"])
             if "activated.timestamp" in data
             else None,

--- a/supervisor/store/repository.py
+++ b/supervisor/store/repository.py
@@ -186,8 +186,7 @@ class RepositoryGit(Repository, ABC):
                 repository_file = Path(self._git.path / f"repository{filetype}")
                 if repository_file.exists():
                     break
-
-            if not repository_file.exists():
+            else:
                 return False
 
             # If valid?


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Tightens mypy in CI by enabling `warn_unreachable`, `warn_redundant_casts`, `warn_unused_ignores`, and the `exhaustive-match` and `possibly-undefined` error codes, then fixes every finding the new flags surfaced. Each fix is a separate commit so the rationale per finding is clear in `git log`.

The new flags caught a handful of real things — a never-reachable `_LOGGER.critical` fallback in the scheduler, an unbound `credentials` local on the docker pull error path, an unbound `repository_file` if `FILE_SUFFIX_CONFIGURATION` were ever empty, three `match` statements that fell through to a trailing `return`/`raise` instead of declaring a wildcard arm — plus stylistic noise (a stale `# type: ignore` for `eager_start` from before 3.14, three redundant `cast(int | None, …)` calls already covered by the source `TypedDict`).

The `[tool.mypy]` config follows the pattern Home Assistant Core uses: instead of `--ignore-missing-imports` (which globally suppresses import resolution errors), we set `disable_error_code = ["import-not-found", "import-untyped"]`. That keeps the five known untyped third-party deps quiet (`pyudev`, `log_rate_limit`, `pulsectl`, `cpe`, `atomicwrites`) and lets the CI invocation drop the CLI flag.

The scheduler dispatch was rewritten as `match task.interval: case int() | float(): ... case time(): ...`. With `exhaustive-match` enabled, broadening `_Task.interval` (e.g. `float | time | str`) now produces a build error pointing at this match, so future contributors can't silently expand the type without handling every case.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
