### PR TITLE
Run pytest in parallel with pytest-xdist

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -380,6 +380,8 @@ jobs:
           . venv/bin/activate
           pytest \
             -qq \
+            -n auto \
+            --dist=loadfile \
             --durations=10 \
             --cov supervisor \
             -o console_output_style=count \

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -7,6 +7,7 @@ pytest-aiohttp==1.1.0
 pytest-asyncio==1.3.0
 pytest-cov==7.1.0
 pytest-timeout==2.4.0
+pytest-xdist==3.8.0
 pytest==9.0.3
 ruff==0.15.12
 time-machine==3.2.0

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,7 +1,7 @@
 """Common test functions."""
 
 import asyncio
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from datetime import datetime
 from functools import partial
 from importlib import import_module
@@ -30,6 +30,29 @@ async def fire_bus_event(coresys: CoreSys, event: BusEvent, data: Any) -> None:
     bundles the gather so call sites stay short.
     """
     await asyncio.gather(*coresys.bus.fire_event(event, data))
+
+
+async def wait_for(
+    predicate: Callable[[], bool],
+    *,
+    timeout: float = 5.0,
+    interval: float = 0.01,
+) -> None:
+    """Poll a synchronous predicate until truthy or the deadline elapses.
+
+    Useful when a test fires a D-Bus signal (or another out-of-band
+    trigger) and needs to observe state mutated by the resulting async
+    chain — e.g. a signal handler that schedules its own follow-up
+    tasks. Completes the moment the predicate is true, so the wait
+    costs only what's actually needed; this avoids the choice between a
+    fixed sleep that's fast on idle and racy under load and a fixed
+    sleep that's robust under load and wasteful on idle.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not predicate():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError(f"Predicate did not become true within {timeout}s")
+        await asyncio.sleep(interval)
 
 
 def get_fixture_path(filename: str) -> Path:

--- a/tests/os/test_data_disk.py
+++ b/tests/os/test_data_disk.py
@@ -1,6 +1,5 @@
 """Test OS API."""
 
-import asyncio
 from dataclasses import replace
 from pathlib import PosixPath
 from unittest.mock import patch
@@ -16,7 +15,7 @@ from supervisor.os.data_disk import Disk
 from supervisor.resolution.const import ContextType, IssueType
 from supervisor.resolution.data import Issue
 
-from tests.common import mock_dbus_services
+from tests.common import mock_dbus_services, wait_for
 from tests.dbus_service_mocks.agent_datadisk import DataDisk as DataDiskService
 from tests.dbus_service_mocks.agent_system import System as SystemService
 from tests.dbus_service_mocks.base import DBusServiceMock
@@ -357,11 +356,13 @@ async def test_multiple_datadisk_add_remove_signals(
         },
     )
     await udisks2_service.ping()
-    await asyncio.sleep(0.2)
-
-    assert (
-        Issue(IssueType.MULTIPLE_DATA_DISKS, ContextType.SYSTEM, reference="/dev/sdb1")
-        in coresys.resolution.issues
+    await wait_for(
+        lambda: (
+            Issue(
+                IssueType.MULTIPLE_DATA_DISKS, ContextType.SYSTEM, reference="/dev/sdb1"
+            )
+            in coresys.resolution.issues
+        )
     )
 
     udisks2_service.InterfacesRemoved(
@@ -369,9 +370,7 @@ async def test_multiple_datadisk_add_remove_signals(
         ["org.freedesktop.UDisks2.Block", "org.freedesktop.UDisks2.Filesystem"],
     )
     await udisks2_service.ping()
-    await asyncio.sleep(0.2)
-
-    assert coresys.resolution.issues == []
+    await wait_for(lambda: coresys.resolution.issues == [])
 
 
 async def test_disabled_datadisk_add_remove_signals(
@@ -409,11 +408,13 @@ async def test_disabled_datadisk_add_remove_signals(
         },
     )
     await udisks2_service.ping()
-    await asyncio.sleep(0.2)
-
-    assert (
-        Issue(IssueType.DISABLED_DATA_DISK, ContextType.SYSTEM, reference="/dev/sdb1")
-        in coresys.resolution.issues
+    await wait_for(
+        lambda: (
+            Issue(
+                IssueType.DISABLED_DATA_DISK, ContextType.SYSTEM, reference="/dev/sdb1"
+            )
+            in coresys.resolution.issues
+        )
     )
 
     udisks2_service.InterfacesRemoved(
@@ -421,6 +422,4 @@ async def test_disabled_datadisk_add_remove_signals(
         ["org.freedesktop.UDisks2.Block", "org.freedesktop.UDisks2.Filesystem"],
     )
     await udisks2_service.ping()
-    await asyncio.sleep(0.2)
-
-    assert coresys.resolution.issues == []
+    await wait_for(lambda: coresys.resolution.issues == [])


### PR DESCRIPTION
## Proposed change

Run the pytest suite in parallel using pytest-xdist. Most of the suite's wall-clock time is spent in fixture setup (D-Bus session, mock services, CoreSys construction) rather than test bodies, but each test pays this setup cost on its own — so distributing tests across CPU cores translates almost directly to a wall-clock reduction.

`pytest-xdist==3.8.0` is added to `requirements_tests.txt` and CI invokes pytest with `-n auto --dist=loadfile`. `loadfile` keeps all tests of a single file on the same worker, which preserves locality for module-level imports/fixtures and keeps pytest's progress output readable. This is the same pattern Home Assistant Core has been running for a long time in its `pytest-full` job (`--numprocesses auto --dist=loadfile`), so the configuration is already battle-tested in a sibling project.

GitHub Actions standard runners ship 4 vCPUs, so `-n auto` will pick 4 workers in CI. On an 8-core local machine the full local run drops from ~280s to ~88s (~3.2x); on the 4-vCPU CI runner expect roughly a ~2x reduction.

The session-scoped `dbus_session` fixture spawns its own dbus-daemon, so each xdist worker gets an independent bus — no shared D-Bus state across workers. `pytest-cov` already handles xdist worker coverage merging via the standard `.coverage.*` files, so no coverage configuration changes are needed.

A second commit fixes a flake exposed by xdist in `test_multiple_datadisk_add_remove_signals` and `test_disabled_datadisk_add_remove_signals`. Those tests fire UDisks2 `InterfacesAdded`/`InterfacesRemoved` signals and used `await asyncio.sleep(0.2)` to wait for supervisor's signal handler chain to update `coresys.resolution.issues`. The 200 ms cushion is effectively only 100 ms because `DataDisk._udisks2_interface_added` itself sleeps 100 ms internally to wait for `UDisks2._interfaces_added` (a sibling subscriber on the same signal) to refresh the block-device cache before the check runs. Under contended xdist scheduling the assertion races the handler. Replaced the four `sleep+assert` sites with a small `tests.common.wait_for(predicate)` polling helper (10 ms interval, 5 s deadline) so the tests stay fast on idle and robust under load. The product-code sleep inside the handler is still a real smell — handler ordering shouldn't depend on a fixed sleep — but is left for a separate fix.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
