### PR TITLE
Update Supervisor before installing Home Assistant Core

### DIFF
--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -30,6 +30,7 @@ from ..exceptions import (
     HomeAssistantStartupTimeout,
     HomeAssistantUpdateError,
     JobException,
+    SupervisorUpdateError,
 )
 from ..jobs import ChildJobSyncFilter
 from ..jobs.const import JOB_GROUP_HOME_ASSISTANT_CORE, JobConcurrency, JobThrottle
@@ -50,6 +51,7 @@ from .frontend_check import verify_frontend
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 SECONDS_BETWEEN_API_CHECKS: Final[int] = 5
+INSTALL_RETRY_WAIT_SECS: Final[int] = 30
 # Core Stage 1 and some wiggle room
 STARTUP_API_RESPONSE_TIMEOUT: Final[timedelta] = timedelta(minutes=10)
 # All stages plus event start timeout and some wiggle rooom
@@ -154,9 +156,10 @@ class HomeAssistantCore(JobGroup):
         while True:
             if not self.sys_updater.image_homeassistant:
                 _LOGGER.warning(
-                    "Found no information about Home Assistant. Retrying in 30sec"
+                    "Found no information about Home Assistant. Retrying in %ssec",
+                    INSTALL_RETRY_WAIT_SECS,
                 )
-                await asyncio.sleep(30)
+                await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
                 await self.sys_updater.reload()
                 continue
 
@@ -165,13 +168,16 @@ class HomeAssistantCore(JobGroup):
                     LANDINGPAGE, image=self.sys_updater.image_homeassistant
                 )
                 break
-            except (DockerError, JobException):
+            except DockerError, JobException:
                 pass
             except Exception as err:  # pylint: disable=broad-except
                 await async_capture_exception(err)
 
-            _LOGGER.warning("Failed to install landingpage, retrying after 30sec")
-            await asyncio.sleep(30)
+            _LOGGER.warning(
+                "Failed to install landingpage, retrying after %ssec",
+                INSTALL_RETRY_WAIT_SECS,
+            )
+            await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
 
         self.sys_homeassistant.version = LANDINGPAGE
         self.sys_homeassistant.set_image(self.sys_updater.image_homeassistant)
@@ -209,6 +215,32 @@ class HomeAssistantCore(JobGroup):
                     await self.sys_updater.reload()
 
                 if to_version := self.sys_homeassistant.latest_version:
+                    # Supervisor must always be updated before Core to avoid
+                    # incompatibilities between a newer Core and an older Supervisor.
+                    if self.sys_supervisor.need_update:
+                        if self.sys_updater.auto_update:
+                            _LOGGER.warning(
+                                "Supervisor has a pending update and must be updated"
+                                " before Home Assistant Core. Updating Supervisor first"
+                            )
+                            try:
+                                await self.sys_supervisor.update()
+                            except SupervisorUpdateError as err:
+                                _LOGGER.warning(
+                                    "Supervisor update failed, retrying in %ssec: %s",
+                                    INSTALL_RETRY_WAIT_SECS,
+                                    err,
+                                )
+                                await async_capture_exception(err)
+                                await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
+                                continue
+                        else:
+                            _LOGGER.warning(
+                                "Supervisor has a pending update but auto-update is"
+                                " disabled. Installing Home Assistant Core anyway —"
+                                " unknown issues may occur"
+                            )
+
                     try:
                         await self.instance.update(
                             to_version,
@@ -218,15 +250,16 @@ class HomeAssistantCore(JobGroup):
                             self.instance.version or to_version
                         )
                         break
-                    except (DockerError, JobException):
+                    except DockerError, JobException:
                         pass
                     except Exception as err:  # pylint: disable=broad-except
                         await async_capture_exception(err)
 
                 _LOGGER.warning(
-                    "Error on Home Assistant installation. Retrying in 30sec"
+                    "Error on Home Assistant installation. Retrying in %ssec",
+                    INSTALL_RETRY_WAIT_SECS,
                 )
-                await asyncio.sleep(30)
+                await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
         finally:
             stop_progress_log.set()
             await progress_task

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -214,46 +214,52 @@ class HomeAssistantCore(JobGroup):
                 if not self.sys_homeassistant.latest_version:
                     await self.sys_updater.reload()
 
-                if to_version := self.sys_homeassistant.latest_version:
-                    # Supervisor must always be updated before Core to avoid
-                    # incompatibilities between a newer Core and an older Supervisor.
-                    if self.sys_supervisor.need_update:
-                        if self.sys_updater.auto_update:
-                            _LOGGER.warning(
-                                "Supervisor has a pending update and must be updated"
-                                " before Home Assistant Core. Updating Supervisor first"
-                            )
-                            try:
-                                await self.sys_supervisor.update()
-                            except SupervisorUpdateError as err:
-                                _LOGGER.warning(
-                                    "Supervisor update failed, retrying in %ssec: %s",
-                                    INSTALL_RETRY_WAIT_SECS,
-                                    err,
-                                )
-                                await async_capture_exception(err)
-                                await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
-                                continue
-                        else:
-                            _LOGGER.warning(
-                                "Supervisor has a pending update but auto-update is"
-                                " disabled. Installing Home Assistant Core anyway —"
-                                " unknown issues may occur"
-                            )
+                if not (to_version := self.sys_homeassistant.latest_version):
+                    _LOGGER.warning(
+                        "Found no information about Home Assistant version. Retrying in"
+                        " %ssec",
+                        INSTALL_RETRY_WAIT_SECS,
+                    )
+                    await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
+                    continue
 
-                    try:
-                        await self.instance.update(
-                            to_version,
-                            image=self.sys_updater.image_homeassistant,
+                # Supervisor must always be updated before Core to avoid
+                # incompatibilities between a newer Core and an older Supervisor.
+                if self.sys_supervisor.need_update:
+                    if self.sys_updater.auto_update:
+                        _LOGGER.warning(
+                            "Supervisor has a pending update and must be updated"
+                            " before Home Assistant Core. Updating Supervisor first"
                         )
-                        self.sys_homeassistant.version = (
-                            self.instance.version or to_version
+                        try:
+                            await self.sys_supervisor.update()
+                        except SupervisorUpdateError as err:
+                            _LOGGER.warning(
+                                "Supervisor update failed, retrying in %ssec: %s",
+                                INSTALL_RETRY_WAIT_SECS,
+                                err,
+                            )
+                            await async_capture_exception(err)
+                            await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
+                            continue
+                    else:
+                        _LOGGER.warning(
+                            "Supervisor has a pending update but auto-update is"
+                            " disabled. Installing Home Assistant Core anyway —"
+                            " unknown issues may occur"
                         )
-                        break
-                    except DockerError, JobException:
-                        pass
-                    except Exception as err:  # pylint: disable=broad-except
-                        await async_capture_exception(err)
+
+                try:
+                    await self.instance.update(
+                        to_version,
+                        image=self.sys_updater.image_homeassistant,
+                    )
+                    self.sys_homeassistant.version = self.instance.version or to_version
+                    break
+                except DockerError, JobException:
+                    pass
+                except Exception as err:  # pylint: disable=broad-except
+                    await async_capture_exception(err)
 
                 _LOGGER.warning(
                     "Error on Home Assistant installation. Retrying in %ssec",

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -156,7 +156,7 @@ class HomeAssistantCore(JobGroup):
         while True:
             if not self.sys_updater.image_homeassistant:
                 _LOGGER.warning(
-                    "Found no information about Home Assistant. Retrying in %ssec",
+                    "Updater has no Home Assistant image information yet. Retrying in %ssec",
                     INSTALL_RETRY_WAIT_SECS,
                 )
                 await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
@@ -216,7 +216,7 @@ class HomeAssistantCore(JobGroup):
 
                 if not (to_version := self.sys_homeassistant.latest_version):
                     _LOGGER.warning(
-                        "Found no information about Home Assistant version. Retrying in"
+                        "Updater has no Home Assistant version information yet. Retrying in"
                         " %ssec",
                         INSTALL_RETRY_WAIT_SECS,
                     )
@@ -227,9 +227,9 @@ class HomeAssistantCore(JobGroup):
                 # incompatibilities between a newer Core and an older Supervisor.
                 if self.sys_supervisor.need_update:
                     if self.sys_updater.auto_update:
-                        _LOGGER.warning(
+                        _LOGGER.info(
                             "Supervisor has a pending update and must be updated"
-                            " before Home Assistant Core. Updating Supervisor first"
+                            " before installing Home Assistant Core. Updating Supervisor first"
                         )
                         try:
                             await self.sys_supervisor.update()

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -239,7 +239,6 @@ class HomeAssistantCore(JobGroup):
                                 INSTALL_RETRY_WAIT_SECS,
                                 err,
                             )
-                            await async_capture_exception(err)
                             await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
                             continue
                     else:

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -22,6 +22,7 @@ from supervisor.exceptions import (
     HomeAssistantCrashError,
     HomeAssistantError,
     HomeAssistantJobError,
+    SupervisorUpdateError,
 )
 from supervisor.homeassistant.api import APIState
 from supervisor.homeassistant.core import HomeAssistantCore
@@ -205,6 +206,118 @@ async def test_install_other_error(
     assert "Error on Home Assistant installation. Retrying in 30sec" in caplog.text
     capture_exception.assert_called_once_with(err)
     assert "Unhandled exception:" not in caplog.text
+
+
+async def test_install_supervisor_needs_update_auto_update_enabled(
+    coresys: CoreSys, capture_exception: Mock, caplog: pytest.LogCaptureFixture
+):
+    """Test install proceeds with supervisor update first when auto-update is enabled."""
+    with (
+        patch.object(HomeAssistantCore, "start"),
+        patch.object(DockerHomeAssistant, "cleanup"),
+        patch.object(
+            Updater,
+            "image_homeassistant",
+            new=PropertyMock(return_value="homeassistant"),
+        ),
+        patch.object(
+            Updater, "version_homeassistant", new=PropertyMock(return_value="2022.7.3")
+        ),
+        patch.object(
+            DockerInterface, "arch", new=PropertyMock(return_value=CpuArch.AMD64)
+        ),
+        patch.object(
+            type(coresys.supervisor), "need_update", new=PropertyMock(return_value=True)
+        ),
+        patch.object(
+            type(coresys.updater), "auto_update", new=PropertyMock(return_value=True)
+        ),
+        patch.object(coresys.supervisor, "update") as supervisor_update,
+        patch("supervisor.homeassistant.core.asyncio.sleep"),
+    ):
+        await coresys.homeassistant.core.install()
+        supervisor_update.assert_awaited_once()
+
+    assert (
+        "Supervisor has a pending update and must be updated before Home Assistant Core"
+        in caplog.text
+    )
+    capture_exception.assert_not_called()
+
+
+async def test_install_supervisor_needs_update_auto_update_disabled(
+    coresys: CoreSys, capture_exception: Mock, caplog: pytest.LogCaptureFixture
+):
+    """Test install proceeds with core anyway when supervisor needs update but auto-update is disabled."""
+    with (
+        patch.object(HomeAssistantCore, "start"),
+        patch.object(DockerHomeAssistant, "cleanup"),
+        patch.object(
+            Updater,
+            "image_homeassistant",
+            new=PropertyMock(return_value="homeassistant"),
+        ),
+        patch.object(
+            Updater, "version_homeassistant", new=PropertyMock(return_value="2022.7.3")
+        ),
+        patch.object(
+            DockerInterface, "arch", new=PropertyMock(return_value=CpuArch.AMD64)
+        ),
+        patch.object(
+            type(coresys.supervisor), "need_update", new=PropertyMock(return_value=True)
+        ),
+        patch.object(
+            type(coresys.updater), "auto_update", new=PropertyMock(return_value=False)
+        ),
+        patch.object(coresys.supervisor, "update") as supervisor_update,
+        patch("supervisor.homeassistant.core.asyncio.sleep"),
+    ):
+        await coresys.homeassistant.core.install()
+        supervisor_update.assert_not_called()
+
+    assert "Supervisor has a pending update but auto-update is disabled" in caplog.text
+    assert "unknown issues may occur" in caplog.text
+    capture_exception.assert_not_called()
+
+
+async def test_install_supervisor_update_fails_retries(
+    coresys: CoreSys, capture_exception: Mock, caplog: pytest.LogCaptureFixture
+):
+    """Test install retries after 30s when supervisor update fails."""
+    # Supervisor reports needing update on first pass, not on second
+    need_update_values = [True, False]
+    need_update_mock = PropertyMock(side_effect=need_update_values)
+
+    with (
+        patch.object(HomeAssistantCore, "start"),
+        patch.object(DockerHomeAssistant, "cleanup"),
+        patch.object(
+            Updater,
+            "image_homeassistant",
+            new=PropertyMock(return_value="homeassistant"),
+        ),
+        patch.object(
+            Updater, "version_homeassistant", new=PropertyMock(return_value="2022.7.3")
+        ),
+        patch.object(
+            DockerInterface, "arch", new=PropertyMock(return_value=CpuArch.AMD64)
+        ),
+        patch.object(type(coresys.supervisor), "need_update", new=need_update_mock),
+        patch.object(
+            type(coresys.updater), "auto_update", new=PropertyMock(return_value=True)
+        ),
+        patch.object(
+            coresys.supervisor,
+            "update",
+            side_effect=SupervisorUpdateError("update failed"),
+        ),
+        patch("supervisor.homeassistant.core.asyncio.sleep") as sleep,
+    ):
+        await coresys.homeassistant.core.install()
+        sleep.assert_any_await(30)
+
+    assert "Supervisor update failed, retrying in 30sec" in caplog.text
+    capture_exception.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -209,7 +209,7 @@ async def test_install_other_error(
 
 
 async def test_install_supervisor_needs_update_auto_update_enabled(
-    coresys: CoreSys, capture_exception: Mock, caplog: pytest.LogCaptureFixture
+    coresys: CoreSys, caplog: pytest.LogCaptureFixture
 ):
     """Test install proceeds with supervisor update first when auto-update is enabled."""
     with (
@@ -239,14 +239,13 @@ async def test_install_supervisor_needs_update_auto_update_enabled(
         supervisor_update.assert_awaited_once()
 
     assert (
-        "Supervisor has a pending update and must be updated before Home Assistant Core"
+        "Supervisor has a pending update and must be updated before installing Home Assistant Core"
         in caplog.text
     )
-    capture_exception.assert_not_called()
 
 
 async def test_install_supervisor_needs_update_auto_update_disabled(
-    coresys: CoreSys, capture_exception: Mock, caplog: pytest.LogCaptureFixture
+    coresys: CoreSys, caplog: pytest.LogCaptureFixture
 ):
     """Test install proceeds with core anyway when supervisor needs update but auto-update is disabled."""
     with (
@@ -277,11 +276,10 @@ async def test_install_supervisor_needs_update_auto_update_disabled(
 
     assert "Supervisor has a pending update but auto-update is disabled" in caplog.text
     assert "unknown issues may occur" in caplog.text
-    capture_exception.assert_not_called()
 
 
 async def test_install_supervisor_update_fails_retries(
-    coresys: CoreSys, capture_exception: Mock, caplog: pytest.LogCaptureFixture
+    coresys: CoreSys, caplog: pytest.LogCaptureFixture
 ):
     """Test install retries after 30s when supervisor update fails."""
     # Supervisor reports needing update on first pass, not on second
@@ -317,7 +315,6 @@ async def test_install_supervisor_update_fails_retries(
         sleep.assert_any_await(30)
 
     assert "Supervisor update failed, retrying in 30sec" in caplog.text
-    capture_exception.assert_called_once()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

During the `install()` loop in `HomeAssistantCore`, check if Supervisor has a pending update before attempting to install Home Assistant Core. Supervisor must always be updated first to avoid incompatibilities between a newer Core and an older Supervisor.

- If auto-update is enabled, attempt to update Supervisor first. On success the process restarts. On failure, log a warning, and retry after the standard install retry period.
- If auto-update is disabled, log a warning that unknown issues may occur and proceed with the Core install anyway — better to attempt than leave users with no UI.

Also extracts the repeated 30-second install retry wait into a shared `INSTALL_RETRY_WAIT_SECS` constant used across all `asyncio.sleep` calls and related log messages in `install()` and `install_landingpage()`.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #6762
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
