### PR TITLE
hardware: cache GPIO mount paths on load to avoid blocking stat

### DIFF
--- a/supervisor/docker/app.py
+++ b/supervisor/docker/app.py
@@ -474,9 +474,7 @@ class DockerApp(DockerInterface):
 
         # GPIO support
         if self.app.with_gpio and self.sys_hardware.helper.support_gpio:
-            for gpio_path in ("/sys/class/gpio", "/sys/devices/platform/soc"):
-                if not Path(gpio_path).exists():
-                    continue
+            for gpio_path in self.sys_hardware.helper.gpio_mount_paths:
                 mounts.append(
                     DockerMount(
                         type=MountType.BIND,

--- a/supervisor/hardware/helper.py
+++ b/supervisor/hardware/helper.py
@@ -18,6 +18,14 @@ _RE_BOOT_TIME: re.Pattern = re.compile(r"btime (\d+)")
 
 _RE_HIDE_SYSFS: re.Pattern = re.compile(r"/sys/devices/virtual/(?:tty|block|vc)/.*")
 
+# Candidate sysfs paths to expose to GPIO-enabled add-ons. Which subset
+# exists is determined by the kernel at boot and does not change at runtime,
+# so we resolve it once during hardware load.
+_GPIO_CANDIDATE_PATHS: tuple[str, ...] = (
+    "/sys/class/gpio",
+    "/sys/devices/platform/soc",
+)
+
 
 class HwHelper(CoreSysAttributes):
     """Representation of an interface to procfs, sysfs and udev."""
@@ -26,6 +34,7 @@ class HwHelper(CoreSysAttributes):
         """Init hardware object."""
         self.coresys = coresys
         self._last_boot: datetime | None = None
+        self._gpio_mount_paths: tuple[str, ...] = ()
 
     @property
     def support_audio(self) -> bool:
@@ -36,6 +45,17 @@ class HwHelper(CoreSysAttributes):
     def support_gpio(self) -> bool:
         """Return True if device support GPIOs."""
         return bool(self.sys_hardware.filter_devices(subsystem=UdevSubsystem.GPIO))
+
+    @property
+    def gpio_mount_paths(self) -> tuple[str, ...]:
+        """Return existing sysfs paths to mount for GPIO add-ons."""
+        return self._gpio_mount_paths
+
+    async def load(self) -> None:
+        """Resolve hardware state that depends on blocking I/O."""
+        self._gpio_mount_paths = await self.sys_run_in_executor(
+            lambda: tuple(path for path in _GPIO_CANDIDATE_PATHS if Path(path).exists())
+        )
 
     @property
     def support_usb(self) -> bool:

--- a/supervisor/hardware/manager.py
+++ b/supervisor/hardware/manager.py
@@ -161,6 +161,7 @@ class HardwareManager(CoreSysAttributes):
     async def load(self) -> None:
         """Load hardware backend."""
         self._import_devices()
+        await self.helper.load()
         await self.monitor.load()
 
     async def unload(self) -> None:


### PR DESCRIPTION
## Proposed change

Building the app container mount list called `Path.exists()` on candidate GPIO sysfs paths (`/sys/class/gpio`, `/sys/devices/platform/soc`) from inside `DockerApp.mounts`, which is invoked on the event loop. With blockbuster enabled (`ha su options --detect-blocking-io on`) starting the Advanced SSH & Web Terminal add-on raised `BlockingError: Blocking call to os.stat`, e.g.:

```
File "/usr/src/supervisor/supervisor/docker/app.py", line 478, in mounts
    if not Path(gpio_path).exists():
...
blockbuster.blockbuster.BlockingError: Blocking call to os.stat
```

Whether these sysfs paths exist is determined by the kernel at boot and does not change at runtime. Resolve them once in a new `HwHelper.load()` (invoked from `HardwareManager.load()`) and expose the result via `helper.gpio_mount_paths`. `DockerApp.mounts` stays a plain sync property and just iterates the cached tuple.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
