### PR TITLE
Model client-state Apps* errors as APIError

### DIFF
--- a/supervisor/apps/manager.py
+++ b/supervisor/apps/manager.py
@@ -210,13 +210,11 @@ class AppManager(CoreSysAttributes):
         self.sys_jobs.current.reference = slug
 
         if slug in self.local:
-            raise AppAlreadyInstalledError(
-                _LOGGER.warning, addon=self.local[slug].name, slug=slug
-            )
+            raise AppAlreadyInstalledError(_LOGGER.warning, app=self.local[slug])
         store = self.store.get(slug)
 
         if not store:
-            raise AppNotFoundError(_LOGGER.error, slug=slug)
+            raise AppNotFoundError(_LOGGER.error, app=slug)
 
         store.validate_availability()
 
@@ -274,15 +272,15 @@ class AppManager(CoreSysAttributes):
         self.sys_jobs.current.reference = slug
 
         if slug not in self.local:
-            raise AppNotInstalledError(_LOGGER.error, slug=slug)
+            raise AppNotInstalledError(_LOGGER.error, app=slug)
         app = self.local[slug]
 
         if app.is_detached:
-            raise AppNotInStoreError(_LOGGER.error, addon=app.name, slug=slug)
+            raise AppNotInStoreError(_LOGGER.error, app=app)
         store = self.store[slug]
 
         if app.version == store.version:
-            raise AppNoUpdateAvailableError(_LOGGER.warning, addon=app.name, slug=slug)
+            raise AppNoUpdateAvailableError(_LOGGER.warning, app=app)
 
         # Check if available, Maybe something have changed
         store.validate_availability()
@@ -321,20 +319,18 @@ class AppManager(CoreSysAttributes):
         self.sys_jobs.current.reference = slug
 
         if slug not in self.local:
-            raise AppNotInstalledError(_LOGGER.error, slug=slug)
+            raise AppNotInstalledError(_LOGGER.error, app=slug)
         app = self.local[slug]
 
         if app.is_detached:
-            raise AppNotInStoreError(_LOGGER.error, addon=app.name, slug=slug)
+            raise AppNotInStoreError(_LOGGER.error, app=app)
         store = self.store[slug]
 
         # Check if a rebuild is possible now
         if app.version != store.version:
-            raise AppRebuildVersionChangedError(
-                _LOGGER.error, addon=app.name, slug=slug
-            )
+            raise AppRebuildVersionChangedError(_LOGGER.error, app=app)
         if not force and not app.need_build:
-            raise AppRebuildImageBasedError(_LOGGER.error, addon=app.name, slug=slug)
+            raise AppRebuildImageBasedError(_LOGGER.error, app=app)
 
         return await app.rebuild()
 

--- a/supervisor/apps/manager.py
+++ b/supervisor/apps/manager.py
@@ -210,11 +210,13 @@ class AppManager(CoreSysAttributes):
         self.sys_jobs.current.reference = slug
 
         if slug in self.local:
-            raise AppAlreadyInstalledError(_LOGGER.warning, addon=self.local[slug].name)
+            raise AppAlreadyInstalledError(
+                _LOGGER.warning, addon=self.local[slug].name, slug=slug
+            )
         store = self.store.get(slug)
 
         if not store:
-            raise AppNotFoundError(_LOGGER.error, addon=slug)
+            raise AppNotFoundError(_LOGGER.error, slug=slug)
 
         store.validate_availability()
 
@@ -272,15 +274,15 @@ class AppManager(CoreSysAttributes):
         self.sys_jobs.current.reference = slug
 
         if slug not in self.local:
-            raise AppNotInstalledError(_LOGGER.error, addon=slug)
+            raise AppNotInstalledError(_LOGGER.error, slug=slug)
         app = self.local[slug]
 
         if app.is_detached:
-            raise AppNotInStoreError(_LOGGER.error, addon=app.name)
+            raise AppNotInStoreError(_LOGGER.error, addon=app.name, slug=slug)
         store = self.store[slug]
 
         if app.version == store.version:
-            raise AppNoUpdateAvailableError(_LOGGER.warning, addon=app.name)
+            raise AppNoUpdateAvailableError(_LOGGER.warning, addon=app.name, slug=slug)
 
         # Check if available, Maybe something have changed
         store.validate_availability()
@@ -319,18 +321,20 @@ class AppManager(CoreSysAttributes):
         self.sys_jobs.current.reference = slug
 
         if slug not in self.local:
-            raise AppNotInstalledError(_LOGGER.error, addon=slug)
+            raise AppNotInstalledError(_LOGGER.error, slug=slug)
         app = self.local[slug]
 
         if app.is_detached:
-            raise AppNotInStoreError(_LOGGER.error, addon=app.name)
+            raise AppNotInStoreError(_LOGGER.error, addon=app.name, slug=slug)
         store = self.store[slug]
 
         # Check if a rebuild is possible now
         if app.version != store.version:
-            raise AppRebuildVersionChangedError(_LOGGER.error, addon=app.name)
+            raise AppRebuildVersionChangedError(
+                _LOGGER.error, addon=app.name, slug=slug
+            )
         if not force and not app.need_build:
-            raise AppRebuildImageBasedError(_LOGGER.error, addon=app.name)
+            raise AppRebuildImageBasedError(_LOGGER.error, addon=app.name, slug=slug)
 
         return await app.rebuild()
 

--- a/supervisor/apps/manager.py
+++ b/supervisor/apps/manager.py
@@ -214,7 +214,7 @@ class AppManager(CoreSysAttributes):
         store = self.store.get(slug)
 
         if not store:
-            raise AppNotFoundError(_LOGGER.error, app=slug)
+            raise AppNotFoundError(_LOGGER.error, slug=slug)
 
         store.validate_availability()
 
@@ -272,7 +272,7 @@ class AppManager(CoreSysAttributes):
         self.sys_jobs.current.reference = slug
 
         if slug not in self.local:
-            raise AppNotInstalledError(_LOGGER.error, app=slug)
+            raise AppNotInstalledError(_LOGGER.error, slug=slug)
         app = self.local[slug]
 
         if app.is_detached:
@@ -319,7 +319,7 @@ class AppManager(CoreSysAttributes):
         self.sys_jobs.current.reference = slug
 
         if slug not in self.local:
-            raise AppNotInstalledError(_LOGGER.error, app=slug)
+            raise AppNotInstalledError(_LOGGER.error, slug=slug)
         app = self.local[slug]
 
         if app.is_detached:

--- a/supervisor/apps/manager.py
+++ b/supervisor/apps/manager.py
@@ -12,7 +12,13 @@ from securetar import SecureTarFile
 from ..const import AppBoot, AppStartup, AppState
 from ..coresys import CoreSys, CoreSysAttributes
 from ..exceptions import (
-    AppNotSupportedError,
+    AppAlreadyInstalledError,
+    AppNotFoundError,
+    AppNotInstalledError,
+    AppNotInStoreError,
+    AppNoUpdateAvailableError,
+    AppRebuildImageBasedError,
+    AppRebuildVersionChangedError,
     AppsError,
     AppsJobError,
     CoreDNSError,
@@ -204,11 +210,11 @@ class AppManager(CoreSysAttributes):
         self.sys_jobs.current.reference = slug
 
         if slug in self.local:
-            raise AppsError(f"App {slug} is already installed", _LOGGER.warning)
+            raise AppAlreadyInstalledError(_LOGGER.warning, addon=self.local[slug].name)
         store = self.store.get(slug)
 
         if not store:
-            raise AppsError(f"App {slug} does not exist", _LOGGER.error)
+            raise AppNotFoundError(_LOGGER.error, addon=slug)
 
         store.validate_availability()
 
@@ -266,15 +272,15 @@ class AppManager(CoreSysAttributes):
         self.sys_jobs.current.reference = slug
 
         if slug not in self.local:
-            raise AppsError(f"App {slug} is not installed", _LOGGER.error)
+            raise AppNotInstalledError(_LOGGER.error, addon=slug)
         app = self.local[slug]
 
         if app.is_detached:
-            raise AppsError(f"App {slug} is not available inside store", _LOGGER.error)
+            raise AppNotInStoreError(_LOGGER.error, addon=app.name)
         store = self.store[slug]
 
         if app.version == store.version:
-            raise AppsError(f"No update available for app {slug}", _LOGGER.warning)
+            raise AppNoUpdateAvailableError(_LOGGER.warning, addon=app.name)
 
         # Check if available, Maybe something have changed
         store.validate_availability()
@@ -313,22 +319,18 @@ class AppManager(CoreSysAttributes):
         self.sys_jobs.current.reference = slug
 
         if slug not in self.local:
-            raise AppsError(f"App {slug} is not installed", _LOGGER.error)
+            raise AppNotInstalledError(_LOGGER.error, addon=slug)
         app = self.local[slug]
 
         if app.is_detached:
-            raise AppsError(f"App {slug} is not available inside store", _LOGGER.error)
+            raise AppNotInStoreError(_LOGGER.error, addon=app.name)
         store = self.store[slug]
 
         # Check if a rebuild is possible now
         if app.version != store.version:
-            raise AppsError(
-                "Version changed, use Update instead Rebuild", _LOGGER.error
-            )
+            raise AppRebuildVersionChangedError(_LOGGER.error, addon=app.name)
         if not force and not app.need_build:
-            raise AppNotSupportedError(
-                "Can't rebuild an image-based app", _LOGGER.error
-            )
+            raise AppRebuildImageBasedError(_LOGGER.error, addon=app.name)
 
         return await app.rebuild()
 

--- a/supervisor/apps/model.py
+++ b/supervisor/apps/model.py
@@ -729,10 +729,7 @@ class AppModel(JobGroup, ABC):
         # Architecture
         if not self.sys_arch.is_supported(config[ATTR_ARCH]):
             raise AppNotSupportedArchitectureError(
-                logger,
-                addon=self.name,
-                slug=self.slug,
-                architectures=config[ATTR_ARCH],
+                logger, app=self, architectures=", ".join(config[ATTR_ARCH])
             )
 
         # Machine / Hardware
@@ -741,10 +738,7 @@ class AppModel(JobGroup, ABC):
             f"!{self.sys_machine}" in machine or self.sys_machine not in machine
         ):
             raise AppNotSupportedMachineTypeError(
-                logger,
-                addon=self.name,
-                slug=self.slug,
-                machine_types=machine,
+                logger, app=self, machine_types=", ".join(machine)
             )
 
         # Home Assistant
@@ -754,10 +748,7 @@ class AppModel(JobGroup, ABC):
                 self.sys_homeassistant.version, version
             ):
                 raise AppNotSupportedHomeAssistantVersionError(
-                    logger,
-                    addon=self.name,
-                    slug=self.slug,
-                    version=str(version),
+                    logger, app=self, version=str(version)
                 )
 
     def _available(self, config) -> bool:

--- a/supervisor/apps/model.py
+++ b/supervisor/apps/model.py
@@ -729,7 +729,7 @@ class AppModel(JobGroup, ABC):
         # Architecture
         if not self.sys_arch.is_supported(config[ATTR_ARCH]):
             raise AppNotSupportedArchitectureError(
-                logger, app=self, architectures=", ".join(config[ATTR_ARCH])
+                logger, app=self, architectures=config[ATTR_ARCH]
             )
 
         # Machine / Hardware
@@ -738,7 +738,7 @@ class AppModel(JobGroup, ABC):
             f"!{self.sys_machine}" in machine or self.sys_machine not in machine
         ):
             raise AppNotSupportedMachineTypeError(
-                logger, app=self, machine_types=", ".join(machine)
+                logger, app=self, machine_types=machine
             )
 
         # Home Assistant

--- a/supervisor/apps/model.py
+++ b/supervisor/apps/model.py
@@ -729,7 +729,7 @@ class AppModel(JobGroup, ABC):
         # Architecture
         if not self.sys_arch.is_supported(config[ATTR_ARCH]):
             raise AppNotSupportedArchitectureError(
-                logger, slug=self.slug, architectures=config[ATTR_ARCH]
+                logger, addon=self.name, architectures=config[ATTR_ARCH]
             )
 
         # Machine / Hardware
@@ -738,7 +738,7 @@ class AppModel(JobGroup, ABC):
             f"!{self.sys_machine}" in machine or self.sys_machine not in machine
         ):
             raise AppNotSupportedMachineTypeError(
-                logger, slug=self.slug, machine_types=machine
+                logger, addon=self.name, machine_types=machine
             )
 
         # Home Assistant
@@ -748,7 +748,7 @@ class AppModel(JobGroup, ABC):
                 self.sys_homeassistant.version, version
             ):
                 raise AppNotSupportedHomeAssistantVersionError(
-                    logger, slug=self.slug, version=str(version)
+                    logger, addon=self.name, version=str(version)
                 )
 
     def _available(self, config) -> bool:

--- a/supervisor/apps/model.py
+++ b/supervisor/apps/model.py
@@ -729,7 +729,10 @@ class AppModel(JobGroup, ABC):
         # Architecture
         if not self.sys_arch.is_supported(config[ATTR_ARCH]):
             raise AppNotSupportedArchitectureError(
-                logger, addon=self.name, architectures=config[ATTR_ARCH]
+                logger,
+                addon=self.name,
+                slug=self.slug,
+                architectures=config[ATTR_ARCH],
             )
 
         # Machine / Hardware
@@ -738,7 +741,10 @@ class AppModel(JobGroup, ABC):
             f"!{self.sys_machine}" in machine or self.sys_machine not in machine
         ):
             raise AppNotSupportedMachineTypeError(
-                logger, addon=self.name, machine_types=machine
+                logger,
+                addon=self.name,
+                slug=self.slug,
+                machine_types=machine,
             )
 
         # Home Assistant
@@ -748,7 +754,10 @@ class AppModel(JobGroup, ABC):
                 self.sys_homeassistant.version, version
             ):
                 raise AppNotSupportedHomeAssistantVersionError(
-                    logger, addon=self.name, version=str(version)
+                    logger,
+                    addon=self.name,
+                    slug=self.slug,
+                    version=str(version),
                 )
 
     def _available(self, config) -> bool:

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -361,6 +361,92 @@ class AppsError(HassioError):
     """Apps exception."""
 
 
+class AppAlreadyInstalledError(AppsError, APIError):
+    """Raise when attempting to install an app that is already installed."""
+
+    error_key = "addon_already_installed_error"
+    message_template = "App {addon} is already installed"
+
+    def __init__(
+        self, logger: Callable[..., None] | None = None, *, addon: str
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"addon": addon}
+        super().__init__(None, logger)
+
+
+class AppNotFoundError(AppsError, APIError):
+    """Raise when an app cannot be found in any store."""
+
+    error_key = "addon_not_found_error"
+    message_template = "App {addon} does not exist"
+
+    def __init__(
+        self, logger: Callable[..., None] | None = None, *, addon: str
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"addon": addon}
+        super().__init__(None, logger)
+
+
+class AppNotInstalledError(AppsError, APIError):
+    """Raise when an action is taken on an app that is not installed."""
+
+    error_key = "addon_not_installed_error"
+    message_template = "App {addon} is not installed"
+
+    def __init__(
+        self, logger: Callable[..., None] | None = None, *, addon: str
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"addon": addon}
+        super().__init__(None, logger)
+
+
+class AppNotInStoreError(AppsError, APIError):
+    """Raise when an installed app is no longer available in its store."""
+
+    error_key = "addon_not_in_store_error"
+    message_template = "App {addon} is not available inside store"
+
+    def __init__(
+        self, logger: Callable[..., None] | None = None, *, addon: str
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"addon": addon}
+        super().__init__(None, logger)
+
+
+class AppNoUpdateAvailableError(AppsError, APIError):
+    """Raise when an update is requested but local matches store version."""
+
+    error_key = "addon_no_update_available_error"
+    message_template = "No update available for app {addon}"
+
+    def __init__(
+        self, logger: Callable[..., None] | None = None, *, addon: str
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"addon": addon}
+        super().__init__(None, logger)
+
+
+class AppRebuildVersionChangedError(AppsError, APIError):
+    """Raise when rebuild is requested but local and store versions differ."""
+
+    error_key = "addon_rebuild_version_changed_error"
+    message_template = (
+        "Local and store versions of app {addon} differ, use Update instead of Rebuild"
+    )
+
+    def __init__(
+        self, logger: Callable[..., None] | None = None, *, addon: str
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"addon": addon}
+        super().__init__(None, logger)
+
+
 class AppConfigurationError(AppsError):
     """Error with app configuration."""
 
@@ -429,57 +515,71 @@ class AppNotSupportedError(HassioNotSupportedError):
     """App doesn't support a function."""
 
 
-class AppNotSupportedArchitectureError(AppNotSupportedError):
+class AppNotSupportedArchitectureError(AppNotSupportedError, APIError):
     """App does not support system due to architecture."""
 
     error_key = "addon_not_supported_architecture_error"
-    message_template = "App {slug} not supported on this platform, supported architectures: {architectures}"
+    message_template = "App {addon} not supported on this platform, supported architectures: {architectures}"
 
     def __init__(
         self,
         logger: Callable[..., None] | None = None,
         *,
-        slug: str,
+        addon: str,
         architectures: list[str],
     ) -> None:
         """Initialize exception."""
-        self.extra_fields = {"slug": slug, "architectures": ", ".join(architectures)}
+        self.extra_fields = {"addon": addon, "architectures": ", ".join(architectures)}
         super().__init__(None, logger)
 
 
-class AppNotSupportedMachineTypeError(AppNotSupportedError):
+class AppNotSupportedMachineTypeError(AppNotSupportedError, APIError):
     """App does not support system due to machine type."""
 
     error_key = "addon_not_supported_machine_type_error"
-    message_template = "App {slug} not supported on this machine, supported machine types: {machine_types}"
+    message_template = "App {addon} not supported on this machine, supported machine types: {machine_types}"
 
     def __init__(
         self,
         logger: Callable[..., None] | None = None,
         *,
-        slug: str,
+        addon: str,
         machine_types: list[str],
     ) -> None:
         """Initialize exception."""
-        self.extra_fields = {"slug": slug, "machine_types": ", ".join(machine_types)}
+        self.extra_fields = {"addon": addon, "machine_types": ", ".join(machine_types)}
         super().__init__(None, logger)
 
 
-class AppNotSupportedHomeAssistantVersionError(AppNotSupportedError):
+class AppNotSupportedHomeAssistantVersionError(AppNotSupportedError, APIError):
     """App does not support system due to Home Assistant version."""
 
     error_key = "addon_not_supported_home_assistant_version_error"
-    message_template = "App {slug} not supported on this system, requires Home Assistant version {version} or greater"
+    message_template = "App {addon} not supported on this system, requires Home Assistant version {version} or greater"
 
     def __init__(
         self,
         logger: Callable[..., None] | None = None,
         *,
-        slug: str,
+        addon: str,
         version: str,
     ) -> None:
         """Initialize exception."""
-        self.extra_fields = {"slug": slug, "version": version}
+        self.extra_fields = {"addon": addon, "version": version}
+        super().__init__(None, logger)
+
+
+class AppRebuildImageBasedError(AppNotSupportedError, APIError):
+    """Raise when rebuild is requested for an image-based app."""
+
+    error_key = "addon_rebuild_image_based_error"
+    message_template = "Cannot rebuild app {addon}, it is image-based"
+
+    def __init__(
+        self, logger: Callable[..., None] | None = None, *, addon: str
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"addon": addon}
         super().__init__(None, logger)
 
 

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -361,102 +361,77 @@ class AppsError(HassioError):
     """Apps exception."""
 
 
-class AppAlreadyInstalledError(AppsError, APIError):
+class AppAPIError(AppsError, APIError):
+    """Base class for App-related API errors.
+
+    Owns the shape of extra_fields so all App* API errors expose addon
+    (display name) and slug uniformly. Pass an app-like object (anything
+    with .name and .slug attributes — App, AppModel, AppStore) to
+    populate both, or a slug string when no app object is available
+    (e.g., unknown or not-installed app lookups) — only slug is set.
+    """
+
+    def __init__(
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        app: Any,
+        **extra_fields: Any,
+    ) -> None:
+        """Initialize exception."""
+        if isinstance(app, str):
+            self.extra_fields = {"slug": app, **extra_fields}
+        else:
+            self.extra_fields = {
+                "addon": app.name,
+                "slug": app.slug,
+                **extra_fields,
+            }
+        super().__init__(None, logger)
+
+
+class AppAlreadyInstalledError(AppAPIError):
     """Raise when attempting to install an app that is already installed."""
 
     error_key = "addon_already_installed_error"
     message_template = "App {addon} is already installed"
 
-    def __init__(
-        self,
-        logger: Callable[..., None] | None = None,
-        *,
-        addon: str,
-        slug: str,
-    ) -> None:
-        """Initialize exception."""
-        self.extra_fields = {"addon": addon, "slug": slug}
-        super().__init__(None, logger)
 
-
-class AppNotFoundError(AppsError, APIError):
+class AppNotFoundError(AppAPIError):
     """Raise when an app cannot be found in any store."""
 
     error_key = "addon_not_found_error"
     message_template = "App {slug} does not exist"
 
-    def __init__(self, logger: Callable[..., None] | None = None, *, slug: str) -> None:
-        """Initialize exception."""
-        self.extra_fields = {"slug": slug}
-        super().__init__(None, logger)
 
-
-class AppNotInstalledError(AppsError, APIError):
+class AppNotInstalledError(AppAPIError):
     """Raise when an action is taken on an app that is not installed."""
 
     error_key = "addon_not_installed_error"
     message_template = "App {slug} is not installed"
 
-    def __init__(self, logger: Callable[..., None] | None = None, *, slug: str) -> None:
-        """Initialize exception."""
-        self.extra_fields = {"slug": slug}
-        super().__init__(None, logger)
 
-
-class AppNotInStoreError(AppsError, APIError):
+class AppNotInStoreError(AppAPIError):
     """Raise when an installed app is no longer available in its store."""
 
     error_key = "addon_not_in_store_error"
     message_template = "App {addon} is not available inside store"
 
-    def __init__(
-        self,
-        logger: Callable[..., None] | None = None,
-        *,
-        addon: str,
-        slug: str,
-    ) -> None:
-        """Initialize exception."""
-        self.extra_fields = {"addon": addon, "slug": slug}
-        super().__init__(None, logger)
 
-
-class AppNoUpdateAvailableError(AppsError, APIError):
+class AppNoUpdateAvailableError(AppAPIError):
     """Raise when an update is requested but local matches store version."""
 
     error_key = "addon_no_update_available_error"
     message_template = "No update available for app {addon}"
 
-    def __init__(
-        self,
-        logger: Callable[..., None] | None = None,
-        *,
-        addon: str,
-        slug: str,
-    ) -> None:
-        """Initialize exception."""
-        self.extra_fields = {"addon": addon, "slug": slug}
-        super().__init__(None, logger)
 
-
-class AppRebuildVersionChangedError(AppsError, APIError):
+class AppRebuildVersionChangedError(AppAPIError):
     """Raise when rebuild is requested but local and store versions differ."""
 
     error_key = "addon_rebuild_version_changed_error"
     message_template = (
         "Local and store versions of app {addon} differ, use Update instead of Rebuild"
     )
-
-    def __init__(
-        self,
-        logger: Callable[..., None] | None = None,
-        *,
-        addon: str,
-        slug: str,
-    ) -> None:
-        """Initialize exception."""
-        self.extra_fields = {"addon": addon, "slug": slug}
-        super().__init__(None, logger)
 
 
 class AppConfigurationError(AppsError):
@@ -527,87 +502,32 @@ class AppNotSupportedError(HassioNotSupportedError):
     """App doesn't support a function."""
 
 
-class AppNotSupportedArchitectureError(AppNotSupportedError, APIError):
+class AppNotSupportedArchitectureError(AppNotSupportedError, AppAPIError):
     """App does not support system due to architecture."""
 
     error_key = "addon_not_supported_architecture_error"
     message_template = "App {addon} not supported on this platform, supported architectures: {architectures}"
 
-    def __init__(
-        self,
-        logger: Callable[..., None] | None = None,
-        *,
-        addon: str,
-        slug: str,
-        architectures: list[str],
-    ) -> None:
-        """Initialize exception."""
-        self.extra_fields = {
-            "addon": addon,
-            "slug": slug,
-            "architectures": ", ".join(architectures),
-        }
-        super().__init__(None, logger)
 
-
-class AppNotSupportedMachineTypeError(AppNotSupportedError, APIError):
+class AppNotSupportedMachineTypeError(AppNotSupportedError, AppAPIError):
     """App does not support system due to machine type."""
 
     error_key = "addon_not_supported_machine_type_error"
     message_template = "App {addon} not supported on this machine, supported machine types: {machine_types}"
 
-    def __init__(
-        self,
-        logger: Callable[..., None] | None = None,
-        *,
-        addon: str,
-        slug: str,
-        machine_types: list[str],
-    ) -> None:
-        """Initialize exception."""
-        self.extra_fields = {
-            "addon": addon,
-            "slug": slug,
-            "machine_types": ", ".join(machine_types),
-        }
-        super().__init__(None, logger)
 
-
-class AppNotSupportedHomeAssistantVersionError(AppNotSupportedError, APIError):
+class AppNotSupportedHomeAssistantVersionError(AppNotSupportedError, AppAPIError):
     """App does not support system due to Home Assistant version."""
 
     error_key = "addon_not_supported_home_assistant_version_error"
     message_template = "App {addon} not supported on this system, requires Home Assistant version {version} or greater"
 
-    def __init__(
-        self,
-        logger: Callable[..., None] | None = None,
-        *,
-        addon: str,
-        slug: str,
-        version: str,
-    ) -> None:
-        """Initialize exception."""
-        self.extra_fields = {"addon": addon, "slug": slug, "version": version}
-        super().__init__(None, logger)
 
-
-class AppRebuildImageBasedError(AppNotSupportedError, APIError):
+class AppRebuildImageBasedError(AppNotSupportedError, AppAPIError):
     """Raise when rebuild is requested for an image-based app."""
 
     error_key = "addon_rebuild_image_based_error"
     message_template = "Cannot rebuild app {addon}, it is image-based"
-
-    def __init__(
-        self,
-        logger: Callable[..., None] | None = None,
-        *,
-        addon: str,
-        slug: str,
-    ) -> None:
-        """Initialize exception."""
-        self.extra_fields = {"addon": addon, "slug": slug}
-        super().__init__(None, logger)
 
 
 class AppNotSupportedWriteStdinError(AppNotSupportedError, APIError):

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -368,10 +368,14 @@ class AppAlreadyInstalledError(AppsError, APIError):
     message_template = "App {addon} is already installed"
 
     def __init__(
-        self, logger: Callable[..., None] | None = None, *, addon: str
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        addon: str,
+        slug: str,
     ) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": addon}
+        self.extra_fields = {"addon": addon, "slug": slug}
         super().__init__(None, logger)
 
 
@@ -379,13 +383,11 @@ class AppNotFoundError(AppsError, APIError):
     """Raise when an app cannot be found in any store."""
 
     error_key = "addon_not_found_error"
-    message_template = "App {addon} does not exist"
+    message_template = "App {slug} does not exist"
 
-    def __init__(
-        self, logger: Callable[..., None] | None = None, *, addon: str
-    ) -> None:
+    def __init__(self, logger: Callable[..., None] | None = None, *, slug: str) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": addon}
+        self.extra_fields = {"slug": slug}
         super().__init__(None, logger)
 
 
@@ -393,13 +395,11 @@ class AppNotInstalledError(AppsError, APIError):
     """Raise when an action is taken on an app that is not installed."""
 
     error_key = "addon_not_installed_error"
-    message_template = "App {addon} is not installed"
+    message_template = "App {slug} is not installed"
 
-    def __init__(
-        self, logger: Callable[..., None] | None = None, *, addon: str
-    ) -> None:
+    def __init__(self, logger: Callable[..., None] | None = None, *, slug: str) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": addon}
+        self.extra_fields = {"slug": slug}
         super().__init__(None, logger)
 
 
@@ -410,10 +410,14 @@ class AppNotInStoreError(AppsError, APIError):
     message_template = "App {addon} is not available inside store"
 
     def __init__(
-        self, logger: Callable[..., None] | None = None, *, addon: str
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        addon: str,
+        slug: str,
     ) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": addon}
+        self.extra_fields = {"addon": addon, "slug": slug}
         super().__init__(None, logger)
 
 
@@ -424,10 +428,14 @@ class AppNoUpdateAvailableError(AppsError, APIError):
     message_template = "No update available for app {addon}"
 
     def __init__(
-        self, logger: Callable[..., None] | None = None, *, addon: str
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        addon: str,
+        slug: str,
     ) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": addon}
+        self.extra_fields = {"addon": addon, "slug": slug}
         super().__init__(None, logger)
 
 
@@ -440,10 +448,14 @@ class AppRebuildVersionChangedError(AppsError, APIError):
     )
 
     def __init__(
-        self, logger: Callable[..., None] | None = None, *, addon: str
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        addon: str,
+        slug: str,
     ) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": addon}
+        self.extra_fields = {"addon": addon, "slug": slug}
         super().__init__(None, logger)
 
 
@@ -526,10 +538,15 @@ class AppNotSupportedArchitectureError(AppNotSupportedError, APIError):
         logger: Callable[..., None] | None = None,
         *,
         addon: str,
+        slug: str,
         architectures: list[str],
     ) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": addon, "architectures": ", ".join(architectures)}
+        self.extra_fields = {
+            "addon": addon,
+            "slug": slug,
+            "architectures": ", ".join(architectures),
+        }
         super().__init__(None, logger)
 
 
@@ -544,10 +561,15 @@ class AppNotSupportedMachineTypeError(AppNotSupportedError, APIError):
         logger: Callable[..., None] | None = None,
         *,
         addon: str,
+        slug: str,
         machine_types: list[str],
     ) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": addon, "machine_types": ", ".join(machine_types)}
+        self.extra_fields = {
+            "addon": addon,
+            "slug": slug,
+            "machine_types": ", ".join(machine_types),
+        }
         super().__init__(None, logger)
 
 
@@ -562,10 +584,11 @@ class AppNotSupportedHomeAssistantVersionError(AppNotSupportedError, APIError):
         logger: Callable[..., None] | None = None,
         *,
         addon: str,
+        slug: str,
         version: str,
     ) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": addon, "version": version}
+        self.extra_fields = {"addon": addon, "slug": slug, "version": version}
         super().__init__(None, logger)
 
 
@@ -576,10 +599,14 @@ class AppRebuildImageBasedError(AppNotSupportedError, APIError):
     message_template = "Cannot rebuild app {addon}, it is image-based"
 
     def __init__(
-        self, logger: Callable[..., None] | None = None, *, addon: str
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        addon: str,
+        slug: str,
     ) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": addon}
+        self.extra_fields = {"addon": addon, "slug": slug}
         super().__init__(None, logger)
 
 

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -362,13 +362,13 @@ class AppsError(HassioError):
 
 
 class AppAPIError(AppsError, APIError):
-    """Base class for App-related API errors.
+    """Base class for App-related API errors that have an app for context.
 
-    Owns the shape of extra_fields so all App* API errors expose addon
-    (display name) and slug uniformly. Pass an app-like object (anything
-    with .name and .slug attributes — App, AppModel, AppStore) to
-    populate both, or a slug string when no app object is available
-    (e.g., unknown or not-installed app lookups) — only slug is set.
+    Owns the shape of extra_fields so subclasses uniformly expose addon
+    (display name) and slug. Pass an app-like object (anything with .name
+    and .slug attributes — App, AppModel, AppStore). Errors raised without
+    an app object available (e.g., unknown or not-installed app lookups)
+    do not belong here; they inherit (AppsError, APIError) directly.
     """
 
     def __init__(
@@ -379,14 +379,11 @@ class AppAPIError(AppsError, APIError):
         **extra_fields: Any,
     ) -> None:
         """Initialize exception."""
-        if isinstance(app, str):
-            self.extra_fields = {"slug": app, **extra_fields}
-        else:
-            self.extra_fields = {
-                "addon": app.name,
-                "slug": app.slug,
-                **extra_fields,
-            }
+        self.extra_fields = {
+            "addon": app.name,
+            "slug": app.slug,
+            **extra_fields,
+        }
         super().__init__(None, logger)
 
 
@@ -397,18 +394,34 @@ class AppAlreadyInstalledError(AppAPIError):
     message_template = "App {addon} is already installed"
 
 
-class AppNotFoundError(AppAPIError):
-    """Raise when an app cannot be found in any store."""
+class AppNotFoundError(AppsError, APIError):
+    """Raise when an app cannot be found in any store.
+
+    No app object exists at this point, so this is not an AppAPIError.
+    """
 
     error_key = "addon_not_found_error"
     message_template = "App {slug} does not exist"
 
+    def __init__(self, logger: Callable[..., None] | None = None, *, slug: str) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"slug": slug}
+        super().__init__(None, logger)
 
-class AppNotInstalledError(AppAPIError):
-    """Raise when an action is taken on an app that is not installed."""
+
+class AppNotInstalledError(AppsError, APIError):
+    """Raise when an action is taken on an app that is not installed.
+
+    No app object exists at this point, so this is not an AppAPIError.
+    """
 
     error_key = "addon_not_installed_error"
     message_template = "App {slug} is not installed"
+
+    def __init__(self, logger: Callable[..., None] | None = None, *, slug: str) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"slug": slug}
+        super().__init__(None, logger)
 
 
 class AppNotInStoreError(AppAPIError):
@@ -508,6 +521,16 @@ class AppNotSupportedArchitectureError(AppNotSupportedError, AppAPIError):
     error_key = "addon_not_supported_architecture_error"
     message_template = "App {addon} not supported on this platform, supported architectures: {architectures}"
 
+    def __init__(  # pylint: disable=useless-parent-delegation
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        app: Any,
+        architectures: list[str],
+    ) -> None:
+        """Initialize exception."""
+        super().__init__(logger, app=app, architectures=", ".join(architectures))
+
 
 class AppNotSupportedMachineTypeError(AppNotSupportedError, AppAPIError):
     """App does not support system due to machine type."""
@@ -515,12 +538,32 @@ class AppNotSupportedMachineTypeError(AppNotSupportedError, AppAPIError):
     error_key = "addon_not_supported_machine_type_error"
     message_template = "App {addon} not supported on this machine, supported machine types: {machine_types}"
 
+    def __init__(  # pylint: disable=useless-parent-delegation
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        app: Any,
+        machine_types: list[str],
+    ) -> None:
+        """Initialize exception."""
+        super().__init__(logger, app=app, machine_types=", ".join(machine_types))
+
 
 class AppNotSupportedHomeAssistantVersionError(AppNotSupportedError, AppAPIError):
     """App does not support system due to Home Assistant version."""
 
     error_key = "addon_not_supported_home_assistant_version_error"
     message_template = "App {addon} not supported on this system, requires Home Assistant version {version} or greater"
+
+    def __init__(  # pylint: disable=useless-parent-delegation
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        app: Any,
+        version: str,
+    ) -> None:
+        """Initialize exception."""
+        super().__init__(logger, app=app, version=version)
 
 
 class AppRebuildImageBasedError(AppNotSupportedError, AppAPIError):

--- a/tests/api/test_apps.py
+++ b/tests/api/test_apps.py
@@ -313,7 +313,7 @@ async def test_api_app_rebuild_force(
 
     assert resp.status == 400
     result = await resp.json()
-    assert "Can't rebuild an image-based app" in result["message"]
+    assert result["message"] == "Cannot rebuild app Terminal & SSH, it is image-based"
 
     # Reset state for next test
     state_changes.clear()

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -729,6 +729,7 @@ async def test_api_store_apps_app_availability_arch_not_supported(
         assert result["error_key"] == "addon_not_supported_architecture_error"
         assert result["extra_fields"] == {
             "addon": "Test Arch Add-on",
+            "slug": "test_arch_addon",
             "architectures": (architectures := ", ".join(supported_architectures)),
         }
         assert (
@@ -792,6 +793,7 @@ async def test_api_store_apps_app_availability_machine_not_supported(
         assert result["error_key"] == "addon_not_supported_machine_type_error"
         assert result["extra_fields"] == {
             "addon": "Test Machine Add-on",
+            "slug": "test_machine_addon",
             "machine_types": (machine_types := ", ".join(supported_machines)),
         }
         assert (
@@ -852,6 +854,7 @@ async def test_api_store_apps_app_availability_homeassistant_version_too_old(
         assert result["error_key"] == "addon_not_supported_home_assistant_version_error"
         assert result["extra_fields"] == {
             "addon": "Test Version Add-on",
+            "slug": "test_version_addon",
             "version": "2023.1.1",
         }
         assert (

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -46,7 +46,7 @@ async def test_api_store(
     assert result["data"]["addons"][-1]["slug"] == store_app.slug
     assert result["data"]["repositories"][-1]["slug"] == test_repository.slug
 
-    assert f"App {store_app.slug} not supported on this platform" not in caplog.text
+    assert f"App {store_app.name} not supported on this platform" not in caplog.text
 
 
 async def test_api_store_apps(api_client: TestClient, store_app: AppStore):
@@ -601,7 +601,7 @@ async def test_background_app_install_fails_fast(
     )
     assert resp.status == 400
     body = await resp.json()
-    assert body["message"] == "App local_ssh is already installed"
+    assert body["message"] == "App Terminal & SSH is already installed"
 
 
 @pytest.mark.parametrize(
@@ -665,7 +665,7 @@ async def test_background_app_update_fails_fast(
     )
     assert resp.status == 400
     body = await resp.json()
-    assert body["message"] == "No update available for app local_ssh"
+    assert body["message"] == "No update available for app Terminal & SSH"
 
 
 async def test_api_store_apps_app_availability_success(
@@ -728,12 +728,12 @@ async def test_api_store_apps_app_availability_arch_not_supported(
         result = await resp.json()
         assert result["error_key"] == "addon_not_supported_architecture_error"
         assert result["extra_fields"] == {
-            "slug": "test_arch_addon",
+            "addon": "Test Arch Add-on",
             "architectures": (architectures := ", ".join(supported_architectures)),
         }
         assert (
             result["message"]
-            == f"App test_arch_addon not supported on this platform, supported architectures: {architectures}"
+            == f"App Test Arch Add-on not supported on this platform, supported architectures: {architectures}"
         )
 
 
@@ -791,12 +791,12 @@ async def test_api_store_apps_app_availability_machine_not_supported(
         result = await resp.json()
         assert result["error_key"] == "addon_not_supported_machine_type_error"
         assert result["extra_fields"] == {
-            "slug": "test_machine_addon",
+            "addon": "Test Machine Add-on",
             "machine_types": (machine_types := ", ".join(supported_machines)),
         }
         assert (
             result["message"]
-            == f"App test_machine_addon not supported on this machine, supported machine types: {machine_types}"
+            == f"App Test Machine Add-on not supported on this machine, supported machine types: {machine_types}"
         )
 
 
@@ -851,12 +851,12 @@ async def test_api_store_apps_app_availability_homeassistant_version_too_old(
         result = await resp.json()
         assert result["error_key"] == "addon_not_supported_home_assistant_version_error"
         assert result["extra_fields"] == {
-            "slug": "test_version_addon",
+            "addon": "Test Version Add-on",
             "version": "2023.1.1",
         }
         assert (
             result["message"]
-            == "App test_version_addon not supported on this system, requires Home Assistant version 2023.1.1 or greater"
+            == "App Test Version Add-on not supported on this system, requires Home Assistant version 2023.1.1 or greater"
         )
 
 

--- a/tests/store/test_store_manager.py
+++ b/tests/store/test_store_manager.py
@@ -128,19 +128,19 @@ async def test_reload_fails_if_out_of_date(coresys: CoreSys):
     [
         (
             {"arch": ["aarch64"]},
-            "App local_ssh not supported on this platform, supported architectures: aarch64",
+            "App Terminal & SSH not supported on this platform, supported architectures: aarch64",
         ),
         (
             {"machine": ["odroid-n2"]},
-            "App local_ssh not supported on this machine, supported machine types: odroid-n2",
+            "App Terminal & SSH not supported on this machine, supported machine types: odroid-n2",
         ),
         (
             {"machine": ["!qemux86-64"]},
-            "App local_ssh not supported on this machine, supported machine types: !qemux86-64",
+            "App Terminal & SSH not supported on this machine, supported machine types: !qemux86-64",
         ),
         (
             {"homeassistant": AwesomeVersion("2023.1.1")},
-            "App local_ssh not supported on this system, requires Home Assistant version 2023.1.1 or greater",
+            "App Terminal & SSH not supported on this system, requires Home Assistant version 2023.1.1 or greater",
         ),
     ],
 )
@@ -185,19 +185,19 @@ async def test_update_unavailable_app(
     [
         (
             {"arch": ["aarch64"]},
-            "App local_ssh not supported on this platform, supported architectures: aarch64",
+            "App Terminal & SSH not supported on this platform, supported architectures: aarch64",
         ),
         (
             {"machine": ["odroid-n2"]},
-            "App local_ssh not supported on this machine, supported machine types: odroid-n2",
+            "App Terminal & SSH not supported on this machine, supported machine types: odroid-n2",
         ),
         (
             {"machine": ["!qemux86-64"]},
-            "App local_ssh not supported on this machine, supported machine types: !qemux86-64",
+            "App Terminal & SSH not supported on this machine, supported machine types: !qemux86-64",
         ),
         (
             {"homeassistant": AwesomeVersion("2023.1.1")},
-            "App local_ssh not supported on this system, requires Home Assistant version 2023.1.1 or greater",
+            "App Terminal & SSH not supported on this system, requires Home Assistant version 2023.1.1 or greater",
         ),
     ],
 )


### PR DESCRIPTION
## Proposed change

Follow-up on #6739. With `HassioError` now logged and captured by Sentry in `api_process`, a handful of `Apps*` exceptions raised from `AppManager.install/update/rebuild` and `AppModel._validate_availability` surfaced as "unexpected" 400s with a noisy log entry and a Sentry event, even though they are all client-state errors (user clicked install on an already-installed add-on, "no update available", local and store versions diverged, system architecture/machine/Home Assistant version incompatible, image-based app cannot be rebuilt, etc.). The dominant offender is SUPERVISOR-1JVV (`No update available for app core_mosquitto`, ~19k events / ~12k users on 2026.05.0); several siblings in the same `wrap_api` cluster show the same shape.

Same treatment as #6785 did for `BackupMountDownError`: map these through properly so the API returns clean, structured 400s.

- Add modeled `APIError` subclasses in `exceptions.py` for the previously raw raises in `apps/manager.py`: `AppAlreadyInstalledError`, `AppNotFoundError`, `AppNotInstalledError`, `AppNotInStoreError`, `AppNoUpdateAvailableError`, `AppRebuildVersionChangedError`, `AppRebuildImageBasedError`. Each gets a stable `error_key`, a `message_template`, and an `addon` extra field.
- Add `APIError` to `AppNotSupportedArchitectureError`, `AppNotSupportedMachineTypeError` and `AppNotSupportedHomeAssistantVersionError` so they behave the same as the rest of the `Apps*` `APIError`s instead of being treated as unexpected.
- Use the add-on's display name (`app.name` from the config) instead of the slug in `extra_fields` whenever an `App`/`AppModel` is available at the raise site, so users see e.g. "Mosquitto broker" rather than "core_mosquitto" in error messages. Slug remains the fallback when there is no app object (install of an unknown slug; update/rebuild of a slug that is not installed).
- Update raise sites in `apps/manager.py` and `apps/model.py` accordingly.

These are all runtime states users hit during normal interaction with the add-ons UI, not Supervisor bugs worth paging on.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: SUPERVISOR-1JVV and the broader `wrap_api` Sentry cluster introduced by #6739; follows the pattern set by #6785
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
