### PR TITLE
tests: enable flake8-pytest-style (PT) ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,6 +276,7 @@ lint.select = [
   "PLE",     # pylint
   "PLR",     # pylint
   "PLW",     # pylint
+  "PT",      # flake8-pytest-style
   "Q000",    # Double quotes found but single quotes preferred
   "RUF006",  # Store a reference to the return value of asyncio.create_task
   "S102",    # Use of exec detected

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -181,7 +181,7 @@ async def fixture_api_client_v2(aiohttp_client, coresys: CoreSys) -> TestClient:
     api.webapp = web.Application(middlewares=[_security_middleware])
     api.start = AsyncMock()
     await api.load()
-    yield await aiohttp_client(api.webapp)
+    return await aiohttp_client(api.webapp)
 
 
 @pytest.fixture(

--- a/tests/api/middleware/test_security.py
+++ b/tests/api/middleware/test_security.py
@@ -35,7 +35,7 @@ async def api_system(aiohttp_client, coresys: CoreSys) -> TestClient:
     api.webapp.middlewares.append(api.security.system_validation)
     api.webapp.router.add_get("/{all:.*}", mock_handler)
 
-    yield await aiohttp_client(api.webapp)
+    return await aiohttp_client(api.webapp)
 
 
 @pytest.fixture
@@ -52,7 +52,7 @@ async def api_token_validation(aiohttp_client, coresys: CoreSys) -> TestClient:
     api.webapp.router.add_post("/{all:.*}", mock_handler)
     api.webapp.router.add_delete("/{all:.*}", mock_handler)
 
-    yield await aiohttp_client(api.webapp)
+    return await aiohttp_client(api.webapp)
 
 
 @pytest.fixture(name="plugin_tokens")
@@ -162,7 +162,7 @@ async def test_bad_requests(
 
 
 @pytest.mark.parametrize(
-    "request_method,request_path,success_roles",
+    ("request_method", "request_path", "success_roles"),
     [
         ("post", "/auth/reset", {"admin"}),
         ("get", "/auth/list", {"admin"}),

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -272,7 +272,7 @@ async def test_api_freeze_thaw(
 
 
 @pytest.mark.parametrize(
-    "partial_backup,exclude_db_setting",
+    ("partial_backup", "exclude_db_setting"),
     [(False, True), (True, True), (False, False), (True, False)],
 )
 @pytest.mark.usefixtures("tmp_supervisor_data", "path_extern")
@@ -310,7 +310,7 @@ async def _get_job_info(api_client: TestClient, job_id: str) -> dict[str, Any]:
 
 
 @pytest.mark.parametrize(
-    "backup_type,options",
+    ("backup_type", "options"),
     [
         ("full", {}),
         (
@@ -396,7 +396,7 @@ async def test_api_backup_restore_background(
 
 
 @pytest.mark.parametrize(
-    "backup_type,options",
+    ("backup_type", "options"),
     [
         ("full", {}),
         (

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -36,7 +36,7 @@ async def fixture_coresys_disk_info(coresys: CoreSys) -> AsyncGenerator[CoreSys]
     coresys.hardware.disk.get_disk_total_space = lambda _: 50000
     coresys.hardware.disk.get_disk_used_space = lambda _: 45000
 
-    yield coresys
+    return coresys
 
 
 async def test_api_host_info(

--- a/tests/api/test_mounts.py
+++ b/tests/api/test_mounts.py
@@ -35,7 +35,7 @@ async def fixture_mount(
     coresys.mounts._mounts = {"backup_test": mount}  # pylint: disable=protected-access
     coresys.mounts.default_backup_mount = mount
     await coresys.mounts.load()
-    yield mount
+    return mount
 
 
 async def test_api_mounts_info(api_client_with_prefix: tuple[TestClient, str]):

--- a/tests/api/test_os.py
+++ b/tests/api/test_os.py
@@ -29,7 +29,7 @@ async def fixture_boards_service(
     os_agent_services: dict[str, DBusServiceMock],
 ) -> BoardsService:
     """Return mock Boards service."""
-    yield os_agent_services["agent_boards"]
+    return os_agent_services["agent_boards"]
 
 
 async def test_api_os_info(api_client_with_prefix: tuple[TestClient, str]):

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -359,7 +359,7 @@ async def test_listener_attached_on_install(coresys: CoreSys):
 
 
 @pytest.mark.parametrize(
-    "boot_timedelta,restart_count", [(timedelta(), 1), (timedelta(days=1), 0)]
+    ("boot_timedelta", "restart_count"), [(timedelta(), 1), (timedelta(days=1), 0)]
 )
 @pytest.mark.usefixtures("test_repository")
 async def test_watchdog_during_attach(

--- a/tests/apps/test_manager.py
+++ b/tests/apps/test_manager.py
@@ -85,7 +85,7 @@ async def fixture_install_app_example_image(
 
     app = App(coresys, store.slug)
     coresys.apps.local[app.slug] = app
-    yield app
+    return app
 
 
 async def test_image_added_removed_on_update(coresys: CoreSys, install_app_ssh: App):

--- a/tests/backups/conftest.py
+++ b/tests/backups/conftest.py
@@ -49,7 +49,7 @@ def partial_backup_mock(backup_mock):
         None: BackupLocation(path=Path("/"), protected=False, size_bytes=0)
     }
     backup_instance.validate_backup = AsyncMock()
-    yield backup_mock
+    return backup_mock
 
 
 @pytest.fixture
@@ -65,7 +65,7 @@ def full_backup_mock(backup_mock):
         None: BackupLocation(path=Path("/"), protected=False, size_bytes=0)
     }
     backup_instance.validate_backup = AsyncMock()
-    yield backup_mock
+    return backup_mock
 
 
 @pytest.fixture(name="backup_locations")

--- a/tests/backups/test_backup.py
+++ b/tests/backups/test_backup.py
@@ -57,8 +57,7 @@ async def test_new_backup_permission_error(coresys: CoreSys, tmp_path: Path):
         pytest.raises(BackupPermissionError),
     ):
         async with backup.create():
-            assert len(listdir(tmp_path)) == 1
-            assert backup.tarfile.exists()
+            pass
 
 
 async def test_new_backup_exists_error(coresys: CoreSys, tmp_path: Path):

--- a/tests/backups/test_backup.py
+++ b/tests/backups/test_backup.py
@@ -59,6 +59,9 @@ async def test_new_backup_permission_error(coresys: CoreSys, tmp_path: Path):
         async with backup.create():
             pass
 
+    assert not listdir(tmp_path)
+    assert not backup.tarfile.exists()
+
 
 async def test_new_backup_exists_error(coresys: CoreSys, tmp_path: Path):
     """Test if a permission error is correctly handled when a new backup is created."""

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -1723,7 +1723,7 @@ async def test_backup_to_mount_bypasses_free_space_condition(
 
 
 @pytest.mark.parametrize(
-    "partial_backup,exclude_db_setting",
+    ("partial_backup", "exclude_db_setting"),
     [(False, True), (True, True), (False, False), (True, False)],
 )
 @pytest.mark.usefixtures("tmp_supervisor_data", "path_extern")
@@ -1823,7 +1823,7 @@ async def test_backup_remove_error(
 
 
 @pytest.mark.parametrize(
-    "error_path,healthy_expected",
+    ("error_path", "healthy_expected"),
     [(Path("/data/backup"), False), (Path("/data/mounts/backup_test"), True)],
 )
 @pytest.mark.usefixtures("path_extern", "mount_propagation")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,14 +113,12 @@ def blockbuster(request: pytest.FixtureRequest) -> BlockBuster | None:
 async def path_extern(monkeypatch: pytest.MonkeyPatch) -> None:
     """Set external path env for tests."""
     monkeypatch.setenv("SUPERVISOR_SHARE", "/mnt/data/supervisor")
-    yield
 
 
 @pytest.fixture
 async def supervisor_name(monkeypatch: pytest.MonkeyPatch) -> None:
     """Set env for supervisor name."""
     monkeypatch.setenv("SUPERVISOR_NAME", "hassio_supervisor")
-    yield
 
 
 @pytest.fixture
@@ -302,7 +300,7 @@ async def fixture_network_manager_services(
     dbus_session_bus: MessageBus,
 ) -> dict[str, DBusServiceMock | dict[str, DBusServiceMock]]:
     """Mock all services network manager connects to."""
-    yield await mock_dbus_services(
+    return await mock_dbus_services(
         {
             "network_access_point": [
                 "/org/freedesktop/NetworkManager/AccessPoint/43099",
@@ -341,7 +339,7 @@ async def network_manager(
     """Mock Network Manager."""
     nm_obj = NetworkManager()
     await nm_obj.connect(dbus_session_bus)
-    yield nm_obj
+    return nm_obj
 
 
 @pytest.fixture
@@ -349,7 +347,7 @@ async def network_manager_service(
     network_manager_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> NetworkManagerService:
     """Return Network Manager service mock."""
-    yield network_manager_services["network_manager"]
+    return network_manager_services["network_manager"]
 
 
 @pytest.fixture
@@ -357,7 +355,7 @@ async def dns_manager_service(
     network_manager_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> AsyncGenerator[DnsManagerService]:
     """Return DNS Manager service mock."""
-    yield network_manager_services["network_dns_manager"]
+    return network_manager_services["network_dns_manager"]
 
 
 @pytest.fixture(name="active_connection_service")
@@ -365,7 +363,7 @@ async def fixture_active_connection_service(
     network_manager_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> ActiveConnectionService:
     """Return mock active connection service."""
-    yield network_manager_services["network_active_connection"][
+    return network_manager_services["network_active_connection"][
         DEFAULT_ACTIVE_CONNECTION_OBJECT_PATH
     ]
 
@@ -375,7 +373,7 @@ async def fixture_connection_settings_service(
     network_manager_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> ConnectionSettingsService:
     """Return mock connection settings service."""
-    yield network_manager_services["network_connection_settings"][
+    return network_manager_services["network_connection_settings"][
         DEFAULT_CONNECTION_SETTINGS_OBJECT_PATH
     ]
 
@@ -385,7 +383,7 @@ async def fixture_udisks2_services(
     dbus_session_bus: MessageBus,
 ) -> dict[str, DBusServiceMock | dict[str, DBusServiceMock]]:
     """Mock all services UDisks2 connects to."""
-    yield await mock_dbus_services(
+    return await mock_dbus_services(
         {
             "udisks2_block": [
                 "/org/freedesktop/UDisks2/block_devices/loop0",
@@ -436,7 +434,7 @@ async def fixture_os_agent_services(
     dbus_session_bus: MessageBus,
 ) -> dict[str, DBusServiceMock]:
     """Mock all services os agent connects to."""
-    yield await mock_dbus_services(
+    return await mock_dbus_services(
         {
             "os_agent": None,
             "agent_apparmor": None,
@@ -459,7 +457,7 @@ async def fixture_all_dbus_services(
     os_agent_services: dict[str, DBusServiceMock],
 ) -> dict[str, DBusServiceMock | dict[str, DBusServiceMock]]:
     """Mock all dbus services supervisor uses."""
-    yield (
+    return (
         (
             await mock_dbus_services(
                 {
@@ -699,7 +697,7 @@ async def api_client(
     api.webapp = web.Application(middlewares=[_security_middleware])
     api.start = AsyncMock()
     await api.load()
-    yield await aiohttp_client(api.webapp)
+    return await aiohttp_client(api.webapp)
 
 
 @pytest.fixture
@@ -707,7 +705,7 @@ def supervisor_internet(coresys: CoreSys) -> Generator[AsyncMock]:
     """Fixture which simluate Supervsior internet connection."""
     connectivity_check = AsyncMock(return_value=True)
     coresys.supervisor.check_and_update_connectivity = connectivity_check
-    yield connectivity_check
+    return connectivity_check
 
 
 @pytest.fixture
@@ -719,7 +717,7 @@ def websession(coresys: CoreSys) -> Generator[MagicMock]:
     """
     coresys._websession = MagicMock(spec_set=ClientSession)
     coresys.homeassistant.core.instance.is_running = AsyncMock(return_value=True)
-    yield coresys._websession
+    return coresys._websession
 
 
 @pytest.fixture
@@ -729,7 +727,7 @@ def mock_update_data(websession: MagicMock) -> Generator[MockResponse]:
     client_response = MockResponse(text=version_data)
     client_response.status = 200
     websession.get = MagicMock(return_value=client_response)
-    yield client_response
+    return client_response
 
 
 @pytest.fixture
@@ -761,7 +759,7 @@ def store_app(coresys: CoreSys, tmp_path, test_repository):
         load_json_fixture("app.json")
     )
     coresys.store.data.apps[app_obj.slug]["location"] = tmp_path
-    yield app_obj
+    return app_obj
 
 
 @pytest.fixture
@@ -795,7 +793,7 @@ async def install_app_ssh(coresys: CoreSys, test_repository):
 
     app = App(coresys, store.slug)
     coresys.apps.local[app.slug] = app
-    yield app
+    return app
 
 
 @pytest.fixture
@@ -807,7 +805,7 @@ async def install_app_example(coresys: CoreSys, test_repository):
 
     app = App(coresys, store.slug)
     coresys.apps.local[app.slug] = app
-    yield app
+    return app
 
 
 @pytest.fixture
@@ -834,7 +832,7 @@ async def mock_full_backup(coresys: CoreSys, tmp_path) -> Backup:
         ATTR_EXCLUDE_DATABASE: False,
     }
     coresys.backups._backups = {"test": mock_backup}
-    yield mock_backup
+    return mock_backup
 
 
 @pytest.fixture
@@ -861,7 +859,7 @@ async def mock_partial_backup(coresys: CoreSys, tmp_path) -> Backup:
         ATTR_EXCLUDE_DATABASE: False,
     }
     coresys.backups._backups = {"test": mock_backup}
-    yield mock_backup
+    return mock_backup
 
 
 @pytest.fixture
@@ -884,7 +882,7 @@ async def backups(
         }
         coresys.backups._backups[backup.slug] = backup
 
-    yield coresys.backups.list_backups
+    return coresys.backups.list_backups
 
 
 @pytest.fixture
@@ -909,7 +907,7 @@ async def docker_logs(container: DockerContainer, supervisor_name) -> AsyncMock:
     """Mock log output for a container from docker."""
     logs = load_fixture("logs_docker_container.txt")
     container.log.return_value = logs.splitlines()
-    yield container.log
+    return container.log
 
 
 @pytest.fixture
@@ -985,7 +983,7 @@ async def container(docker: DockerAPI) -> DockerContainer:
         "Pid": 12345,
     }
 
-    yield container_mock
+    return container_mock
 
 
 @pytest.fixture
@@ -1002,7 +1000,6 @@ async def mount_propagation(container: DockerContainer, coresys: CoreSys) -> Non
         }
     ]
     await coresys.supervisor.load()
-    yield
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -353,7 +353,7 @@ async def network_manager_service(
 @pytest.fixture
 async def dns_manager_service(
     network_manager_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
-) -> AsyncGenerator[DnsManagerService]:
+) -> DnsManagerService:
     """Return DNS Manager service mock."""
     return network_manager_services["network_dns_manager"]
 
@@ -701,7 +701,7 @@ async def api_client(
 
 
 @pytest.fixture
-def supervisor_internet(coresys: CoreSys) -> Generator[AsyncMock]:
+def supervisor_internet(coresys: CoreSys) -> AsyncMock:
     """Fixture which simluate Supervsior internet connection."""
     connectivity_check = AsyncMock(return_value=True)
     coresys.supervisor.check_and_update_connectivity = connectivity_check
@@ -709,7 +709,7 @@ def supervisor_internet(coresys: CoreSys) -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def websession(coresys: CoreSys) -> Generator[MagicMock]:
+def websession(coresys: CoreSys) -> MagicMock:
     """Fixture for global aiohttp SessionClient.
 
     Also mocks Core container is_running to return True so that
@@ -721,7 +721,7 @@ def websession(coresys: CoreSys) -> Generator[MagicMock]:
 
 
 @pytest.fixture
-def mock_update_data(websession: MagicMock) -> Generator[MockResponse]:
+def mock_update_data(websession: MagicMock) -> MockResponse:
     """Mock updater JSON data."""
     version_data = load_fixture("version_stable.json")
     client_response = MockResponse(text=version_data)

--- a/tests/dbus/agent/boards/test_board.py
+++ b/tests/dbus/agent/boards/test_board.py
@@ -14,7 +14,7 @@ from tests.dbus_service_mocks.agent_boards import Boards as BoardsService
 @pytest.fixture(name="boards_service", autouse=True)
 async def fixture_boards_service(dbus_session_bus: MessageBus) -> BoardsService:
     """Mock Boards dbus service."""
-    yield (await mock_dbus_services({"agent_boards": None}, dbus_session_bus))[
+    return (await mock_dbus_services({"agent_boards": None}, dbus_session_bus))[
         "agent_boards"
     ]
 

--- a/tests/dbus/agent/boards/test_green.py
+++ b/tests/dbus/agent/boards/test_green.py
@@ -14,7 +14,7 @@ from tests.dbus_service_mocks.agent_boards_green import Green as GreenService
 @pytest.fixture(name="green_service", autouse=True)
 async def fixture_green_service(dbus_session_bus: MessageBus) -> GreenService:
     """Mock Green Board dbus service."""
-    yield (await mock_dbus_services({"agent_boards_green": None}, dbus_session_bus))[
+    return (await mock_dbus_services({"agent_boards_green": None}, dbus_session_bus))[
         "agent_boards_green"
     ]
 

--- a/tests/dbus/agent/boards/test_yellow.py
+++ b/tests/dbus/agent/boards/test_yellow.py
@@ -14,7 +14,7 @@ from tests.dbus_service_mocks.agent_boards_yellow import Yellow as YellowService
 @pytest.fixture(name="yellow_service", autouse=True)
 async def fixture_yellow_service(dbus_session_bus: MessageBus) -> YellowService:
     """Mock Yellow Board dbus service."""
-    yield (await mock_dbus_services({"agent_boards_yellow": None}, dbus_session_bus))[
+    return (await mock_dbus_services({"agent_boards_yellow": None}, dbus_session_bus))[
         "agent_boards_yellow"
     ]
 

--- a/tests/dbus/agent/test_agent.py
+++ b/tests/dbus/agent/test_agent.py
@@ -16,7 +16,7 @@ async def fixture_os_agent_service(
     os_agent_services: dict[str, DBusServiceMock],
 ) -> OSAgentService:
     """Mock OS Agent dbus service."""
-    yield os_agent_services["os_agent"]
+    return os_agent_services["os_agent"]
 
 
 async def test_dbus_osagent(
@@ -44,7 +44,7 @@ async def test_dbus_osagent(
 
 
 @pytest.mark.parametrize(
-    "skip_service,error",
+    ("skip_service", "error"),
     [
         ("os_agent", "No OS-Agent support on the host"),
         (

--- a/tests/dbus/agent/test_apparmor.py
+++ b/tests/dbus/agent/test_apparmor.py
@@ -18,7 +18,7 @@ async def fixture_apparmor_service(
     os_agent_services: dict[str, DBusServiceMock],
 ) -> AppArmorService:
     """Mock AppArmor dbus service."""
-    yield os_agent_services["agent_apparmor"]
+    return os_agent_services["agent_apparmor"]
 
 
 async def test_dbus_osagent_apparmor(

--- a/tests/dbus/agent/test_cgroup.py
+++ b/tests/dbus/agent/test_cgroup.py
@@ -16,7 +16,7 @@ async def fixture_cgroup_service(
     os_agent_services: dict[str, DBusServiceMock],
 ) -> CGroupService:
     """Mock CGroup dbus service."""
-    yield os_agent_services["agent_cgroup"]
+    return os_agent_services["agent_cgroup"]
 
 
 async def test_dbus_osagent_cgroup_add_devices(

--- a/tests/dbus/agent/test_datadisk.py
+++ b/tests/dbus/agent/test_datadisk.py
@@ -17,7 +17,7 @@ async def fixture_datadisk_service(
     os_agent_services: dict[str, DBusServiceMock],
 ) -> DataDiskService:
     """Mock DataDisk dbus service."""
-    yield os_agent_services["agent_datadisk"]
+    return os_agent_services["agent_datadisk"]
 
 
 async def test_dbus_osagent_datadisk(

--- a/tests/dbus/agent/test_swap.py
+++ b/tests/dbus/agent/test_swap.py
@@ -14,7 +14,7 @@ async def fixture_swap_service(
     os_agent_services: dict[str, DBusServiceMock],
 ) -> SwapService:
     """Mock System dbus service."""
-    yield os_agent_services["agent_swap"]
+    return os_agent_services["agent_swap"]
 
 
 async def test_dbus_osagent_swap_size(

--- a/tests/dbus/agent/test_system.py
+++ b/tests/dbus/agent/test_system.py
@@ -15,7 +15,7 @@ async def fixture_system_service(
     os_agent_services: dict[str, DBusServiceMock],
 ) -> SystemService:
     """Mock System dbus service."""
-    yield os_agent_services["agent_system"]
+    return os_agent_services["agent_system"]
 
 
 async def test_dbus_osagent_system_wipe(

--- a/tests/dbus/network/setting/test_init.py
+++ b/tests/dbus/network/setting/test_init.py
@@ -33,7 +33,7 @@ async def fixture_dbus_interface(
     """Get connected dbus interface."""
     dbus_interface = NetworkInterface(device_object_path)
     await dbus_interface.connect(dbus_session_bus)
-    yield dbus_interface
+    return dbus_interface
 
 
 @pytest.mark.parametrize(
@@ -140,7 +140,7 @@ async def test_ipv6_disabled_is_link_local(
 
 
 @pytest.mark.parametrize(
-    ["version", "addr_gen_mode"],
+    ("version", "addr_gen_mode"),
     [
         ("1.38.0", 1),
         ("1.40.0", 3),

--- a/tests/dbus/network/test_accesspoint.py
+++ b/tests/dbus/network/test_accesspoint.py
@@ -16,7 +16,7 @@ async def fixture_access_point_service(
     dbus_session_bus: MessageBus,
 ) -> AccessPointService:
     """Mock Access Point service."""
-    yield (
+    return (
         await mock_dbus_services(
             {
                 "network_access_point": "/org/freedesktop/NetworkManager/AccessPoint/43099"

--- a/tests/dbus/network/test_dns.py
+++ b/tests/dbus/network/test_dns.py
@@ -17,7 +17,7 @@ async def fixture_dns_manager_service(
     dbus_session_bus: MessageBus,
 ) -> DnsManagerService:
     """Mock DnsManager dbus service."""
-    yield (await mock_dbus_services({"network_dns_manager": None}, dbus_session_bus))[
+    return (await mock_dbus_services({"network_dns_manager": None}, dbus_session_bus))[
         "network_dns_manager"
     ]
 

--- a/tests/dbus/network/test_interface.py
+++ b/tests/dbus/network/test_interface.py
@@ -20,7 +20,7 @@ async def fixture_device_eth0_service(
     network_manager_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> DeviceService:
     """Mock Device eth0 service."""
-    yield network_manager_services["network_device"][
+    return network_manager_services["network_device"][
         "/org/freedesktop/NetworkManager/Devices/1"
     ]
 
@@ -30,7 +30,7 @@ async def fixture_device_wlan0_service(
     network_manager_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> DeviceService:
     """Mock Device wlan0 service."""
-    yield network_manager_services["network_device"][
+    return network_manager_services["network_device"][
         "/org/freedesktop/NetworkManager/Devices/3"
     ]
 
@@ -40,7 +40,7 @@ async def fixture_device_unmanaged_service(
     dbus_session_bus: MessageBus,
 ) -> DeviceService:
     """Mock Device unmanaged service."""
-    yield (
+    return (
         await mock_dbus_services(
             {"network_device": "/org/freedesktop/NetworkManager/Devices/35"},
             dbus_session_bus,

--- a/tests/dbus/network/test_ip_configuration.py
+++ b/tests/dbus/network/test_ip_configuration.py
@@ -21,7 +21,7 @@ async def fixture_ip4config_service(dbus_session_bus: MessageBus) -> IP4ConfigSe
 
 
 @pytest.fixture(name="ip6config_service")
-async def fixture_ip6config_service(dbus_session_bus: MessageBus) -> IP4ConfigService:
+async def fixture_ip6config_service(dbus_session_bus: MessageBus) -> IP6ConfigService:
     """Mock IP6Config service."""
     return (await mock_dbus_services({"network_ip6config": None}, dbus_session_bus))[
         "network_ip6config"

--- a/tests/dbus/network/test_ip_configuration.py
+++ b/tests/dbus/network/test_ip_configuration.py
@@ -15,7 +15,7 @@ from tests.dbus_service_mocks.network_ip6config import IP6Config as IP6ConfigSer
 @pytest.fixture(name="ip4config_service")
 async def fixture_ip4config_service(dbus_session_bus: MessageBus) -> IP4ConfigService:
     """Mock IP4Config service."""
-    yield (await mock_dbus_services({"network_ip4config": None}, dbus_session_bus))[
+    return (await mock_dbus_services({"network_ip4config": None}, dbus_session_bus))[
         "network_ip4config"
     ]
 
@@ -23,7 +23,7 @@ async def fixture_ip4config_service(dbus_session_bus: MessageBus) -> IP4ConfigSe
 @pytest.fixture(name="ip6config_service")
 async def fixture_ip6config_service(dbus_session_bus: MessageBus) -> IP4ConfigService:
     """Mock IP6Config service."""
-    yield (await mock_dbus_services({"network_ip6config": None}, dbus_session_bus))[
+    return (await mock_dbus_services({"network_ip6config": None}, dbus_session_bus))[
         "network_ip6config"
     ]
 

--- a/tests/dbus/network/test_network_manager.py
+++ b/tests/dbus/network/test_network_manager.py
@@ -30,7 +30,7 @@ async def fixture_network_manager_service(
     network_manager_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> NetworkManagerService:
     """Mock NetworkManager dbus service."""
-    yield network_manager_services["network_manager"]
+    return network_manager_services["network_manager"]
 
 
 async def test_network_manager(

--- a/tests/dbus/network/test_settings.py
+++ b/tests/dbus/network/test_settings.py
@@ -14,7 +14,7 @@ from tests.dbus_service_mocks.network_settings import Settings as SettingsServic
 @pytest.fixture(name="settings_service")
 async def fixture_settings_service(dbus_session_bus: MessageBus) -> SettingsService:
     """Mock Settings service."""
-    yield (
+    return (
         await mock_dbus_services(
             {"network_settings": None, "network_connection_settings": None},
             dbus_session_bus,

--- a/tests/dbus/network/test_wireless.py
+++ b/tests/dbus/network/test_wireless.py
@@ -18,7 +18,7 @@ async def fixture_device_wireless_service(
     network_manager_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> DeviceWirelessService:
     """Mock Device Wireless service."""
-    yield network_manager_services["network_device_wireless"]
+    return network_manager_services["network_device_wireless"]
 
 
 async def test_wireless(

--- a/tests/dbus/test_enum.py
+++ b/tests/dbus/test_enum.py
@@ -80,7 +80,7 @@ def test_str_members_not_polluted():
 
 def test_str_non_str_raises_value_error():
     """Test non-string values raise ValueError."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="is not a valid SampleStrEnum"):
         SampleStrEnum(123)
 
 
@@ -151,7 +151,7 @@ def test_int_members_not_polluted():
 
 def test_int_non_int_raises_value_error():
     """Test non-integer values raise ValueError."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="is not a valid SampleIntEnum"):
         SampleIntEnum("abc")
 
 

--- a/tests/dbus/test_hostname.py
+++ b/tests/dbus/test_hostname.py
@@ -14,7 +14,7 @@ from tests.dbus_service_mocks.hostname import Hostname as HostnameService
 @pytest.fixture(name="hostname_service")
 async def fixture_hostname_service(dbus_session_bus: MessageBus) -> HostnameService:
     """Mock hostname dbus service."""
-    yield (await mock_dbus_services({"hostname": None}, dbus_session_bus))["hostname"]
+    return (await mock_dbus_services({"hostname": None}, dbus_session_bus))["hostname"]
 
 
 async def test_dbus_hostname_info(

--- a/tests/dbus/test_interface.py
+++ b/tests/dbus/test_interface.py
@@ -52,7 +52,7 @@ async def fixture_test_service(dbus_session_bus: MessageBus) -> TestInterface:
     await dbus_session_bus.request_name("service.test.TestInterface")
     service = TestInterface()
     service.export(dbus_session_bus)
-    yield service
+    return service
 
 
 @pytest.fixture(name="proxy")
@@ -65,7 +65,7 @@ async def fixture_proxy(
     proxy = ServiceTest()
     proxy.sync_properties = getattr(request, "param", True)
     await proxy.connect(dbus_session_bus)
-    yield proxy
+    return proxy
 
 
 async def test_dbus_proxy_connect(

--- a/tests/dbus/test_login.py
+++ b/tests/dbus/test_login.py
@@ -14,7 +14,7 @@ from tests.dbus_service_mocks.logind import Logind as LogindService
 @pytest.fixture(name="logind_service")
 async def fixture_logind_service(dbus_session_bus: MessageBus) -> LogindService:
     """Mock logind dbus service."""
-    yield (await mock_dbus_services({"logind": None}, dbus_session_bus))["logind"]
+    return (await mock_dbus_services({"logind": None}, dbus_session_bus))["logind"]
 
 
 async def test_reboot(logind_service: LogindService, dbus_session_bus: MessageBus):

--- a/tests/dbus/test_rauc.py
+++ b/tests/dbus/test_rauc.py
@@ -15,7 +15,7 @@ from tests.dbus_service_mocks.rauc import Rauc as RaucService
 @pytest.fixture(name="rauc_service")
 async def fixture_rauc_service(dbus_session_bus: MessageBus) -> RaucService:
     """Mock rauc dbus service."""
-    yield (await mock_dbus_services({"rauc": None}, dbus_session_bus))["rauc"]
+    return (await mock_dbus_services({"rauc": None}, dbus_session_bus))["rauc"]
 
 
 async def test_rauc_info(rauc_service: RaucService, dbus_session_bus: MessageBus):

--- a/tests/dbus/test_resolved.py
+++ b/tests/dbus/test_resolved.py
@@ -22,7 +22,7 @@ from tests.dbus_service_mocks.resolved import Resolved as ResolvedService
 @pytest.fixture(name="resolved_service")
 async def fixture_resolved_service(dbus_session_bus: MessageBus) -> ResolvedService:
     """Mock resolved dbus service."""
-    yield (await mock_dbus_services({"resolved": None}, dbus_session_bus))["resolved"]
+    return (await mock_dbus_services({"resolved": None}, dbus_session_bus))["resolved"]
 
 
 async def test_dbus_resolved_info(

--- a/tests/dbus/test_systemd.py
+++ b/tests/dbus/test_systemd.py
@@ -16,7 +16,7 @@ from tests.dbus_service_mocks.systemd import Systemd as SystemdService
 @pytest.fixture(name="systemd_service", autouse=True)
 async def fixture_systemd_service(dbus_session_bus: MessageBus) -> SystemdService:
     """Mock systemd dbus service."""
-    yield (await mock_dbus_services({"systemd": None}, dbus_session_bus))["systemd"]
+    return (await mock_dbus_services({"systemd": None}, dbus_session_bus))["systemd"]
 
 
 async def test_dbus_systemd_info(dbus_session_bus: MessageBus):

--- a/tests/dbus/test_timedate.py
+++ b/tests/dbus/test_timedate.py
@@ -16,7 +16,7 @@ from tests.dbus_service_mocks.timedate import TimeDate as TimeDateService
 @pytest.fixture(name="timedate_service")
 async def fixture_timedate_service(dbus_session_bus: MessageBus) -> TimeDateService:
     """Mock timedate dbus service."""
-    yield (await mock_dbus_services({"timedate": None}, dbus_session_bus))["timedate"]
+    return (await mock_dbus_services({"timedate": None}, dbus_session_bus))["timedate"]
 
 
 async def test_timedate_info(

--- a/tests/dbus/udisks2/test_block.py
+++ b/tests/dbus/udisks2/test_block.py
@@ -25,7 +25,7 @@ async def fixture_block_sda_service(
     udisks2_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> BlockService:
     """Mock sda Block service."""
-    yield udisks2_services["udisks2_block"][
+    return udisks2_services["udisks2_block"][
         "/org/freedesktop/UDisks2/block_devices/sda"
     ]
 
@@ -35,7 +35,7 @@ async def fixture_block_sda1_service(
     udisks2_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> BlockService:
     """Mock sda1 Block service."""
-    yield udisks2_services["udisks2_block"][
+    return udisks2_services["udisks2_block"][
         "/org/freedesktop/UDisks2/block_devices/sda1"
     ]
 

--- a/tests/dbus/udisks2/test_drive.py
+++ b/tests/dbus/udisks2/test_drive.py
@@ -17,7 +17,7 @@ async def fixture_drive_ssk_storage_service(
     dbus_session_bus: MessageBus,
 ) -> DriveService:
     """Mock SSK Storage Drive service."""
-    yield (
+    return (
         await mock_dbus_services(
             {
                 "udisks2_drive": "/org/freedesktop/UDisks2/drives/SSK_SSK_Storage_DF56419883D56"
@@ -32,7 +32,7 @@ async def fixture_drive_flash_disk_service(
     dbus_session_bus: MessageBus,
 ) -> DriveService:
     """Mock Flash Disk Drive service."""
-    yield (
+    return (
         await mock_dbus_services(
             {
                 "udisks2_drive": "/org/freedesktop/UDisks2/drives/Generic_Flash_Disk_61BCDDB6"

--- a/tests/dbus/udisks2/test_filesystem.py
+++ b/tests/dbus/udisks2/test_filesystem.py
@@ -18,7 +18,7 @@ async def fixture_filesystem_sda1_service(
     dbus_session_bus: MessageBus,
 ) -> FilesystemService:
     """Mock sda1 Filesystem service."""
-    yield (
+    return (
         await mock_dbus_services(
             {"udisks2_filesystem": "/org/freedesktop/UDisks2/block_devices/sda1"},
             dbus_session_bus,
@@ -31,7 +31,7 @@ async def fixture_filesystem_sdb1_service(
     dbus_session_bus: MessageBus,
 ) -> FilesystemService:
     """Mock sdb1 Filesystem service."""
-    yield (
+    return (
         await mock_dbus_services(
             {"udisks2_filesystem": "/org/freedesktop/UDisks2/block_devices/sdb1"},
             dbus_session_bus,

--- a/tests/dbus/udisks2/test_manager.py
+++ b/tests/dbus/udisks2/test_manager.py
@@ -26,7 +26,7 @@ async def fixture_udisks2_manager_service(
     udisks2_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> UDisks2ManagerService:
     """Mock UDisks2 Manager service."""
-    yield udisks2_services["udisks2_manager"]
+    return udisks2_services["udisks2_manager"]
 
 
 @pytest.fixture(name="udisks2_service")
@@ -34,7 +34,7 @@ async def fixture_udisks2_service(
     udisks2_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> UDisks2Service:
     """Mock UDisks2 base service."""
-    yield udisks2_services["udisks2"]
+    return udisks2_services["udisks2"]
 
 
 async def test_udisks2_manager_info(

--- a/tests/dbus/udisks2/test_nvme_controller.py
+++ b/tests/dbus/udisks2/test_nvme_controller.py
@@ -18,7 +18,7 @@ async def fixture_nvme_controller_service(
     dbus_session_bus: MessageBus,
 ) -> NVMeControllerService:
     """Mock NVMe Controller service."""
-    yield (
+    return (
         await mock_dbus_services(
             {
                 "udisks2_nvme_controller": "/org/freedesktop/UDisks2/drives/Samsung_SSD_970_EVO_Plus_2TB_S40123456789ABC"

--- a/tests/dbus/udisks2/test_partition.py
+++ b/tests/dbus/udisks2/test_partition.py
@@ -17,7 +17,7 @@ async def fixture_partition_sda1_service(
     dbus_session_bus: MessageBus,
 ) -> PartitionService:
     """Mock sda1 Partition service."""
-    yield (
+    return (
         await mock_dbus_services(
             {"udisks2_partition": "/org/freedesktop/UDisks2/block_devices/sda1"},
             dbus_session_bus,
@@ -30,7 +30,7 @@ async def fixture_partition_sdb_service(
     dbus_session_bus: MessageBus,
 ) -> PartitionService:
     """Mock sdb1 Partition service."""
-    yield (
+    return (
         await mock_dbus_services(
             {"udisks2_partition": "/org/freedesktop/UDisks2/block_devices/sdb1"},
             dbus_session_bus,

--- a/tests/dbus/udisks2/test_partition_table.py
+++ b/tests/dbus/udisks2/test_partition_table.py
@@ -19,7 +19,7 @@ async def fixture_partition_table_sda_service(
     dbus_session_bus: MessageBus,
 ) -> PartitionTableService:
     """Mock sda Partition Table service."""
-    yield (
+    return (
         await mock_dbus_services(
             {"udisks2_partition_table": "/org/freedesktop/UDisks2/block_devices/sda"},
             dbus_session_bus,
@@ -32,7 +32,7 @@ async def fixture_partition_table_sdb_service(
     dbus_session_bus: MessageBus,
 ) -> PartitionTableService:
     """Mock sdb Partition Table service."""
-    yield (
+    return (
         await mock_dbus_services(
             {"udisks2_partition_table": "/org/freedesktop/UDisks2/block_devices/sdb"},
             dbus_session_bus,

--- a/tests/docker/test_interface.py
+++ b/tests/docker/test_interface.py
@@ -38,7 +38,7 @@ from tests.common import AsyncIterator, load_json_fixture
 
 
 @pytest.mark.parametrize(
-    "cpu_arch, platform",
+    ("cpu_arch", "platform"),
     [
         (CpuArch.AARCH64, "linux/arm64"),
         (CpuArch.AMD64, "linux/amd64"),
@@ -83,7 +83,7 @@ async def test_docker_image_default_platform(
 
 
 @pytest.mark.parametrize(
-    "image,registry_key",
+    ("image", "registry_key"),
     [
         ("homeassistant/amd64-supervisor", DOCKER_HUB),
         ("ghcr.io/home-assistant/amd64-supervisor", "ghcr.io"),
@@ -191,7 +191,7 @@ async def test_pull_401_without_credentials_raises_docker_error(
 
 
 @pytest.mark.parametrize(
-    "attrs,expected",
+    ("attrs", "expected"),
     [
         ({"State": {"Status": "running"}}, ContainerState.RUNNING),
         ({"State": {"Status": "exited", "ExitCode": 0}}, ContainerState.STOPPED),
@@ -235,7 +235,7 @@ async def test_current_state_failures(coresys: CoreSys):
 
 
 @pytest.mark.parametrize(
-    "attrs,expected,expected_exit_code,fired_when_skip_down",
+    ("attrs", "expected", "expected_exit_code", "fired_when_skip_down"),
     [
         ({"State": {"Status": "running"}}, ContainerState.RUNNING, None, True),
         (
@@ -986,7 +986,9 @@ def _assert_docker_ratelimit_issue(coresys: CoreSys, expected: bool) -> None:
     assert present is expected
 
 
-@pytest.mark.parametrize("image,expected_exception,expect_issue", _RATE_LIMIT_PARAMS)
+@pytest.mark.parametrize(
+    ("image", "expected_exception", "expect_issue"), _RATE_LIMIT_PARAMS
+)
 async def test_install_pull_429_raises_registry_specific_exception(
     coresys: CoreSys,
     test_docker_interface: DockerInterface,
@@ -1018,7 +1020,9 @@ async def test_install_pull_429_raises_registry_specific_exception(
     capture_exception.assert_not_called()
 
 
-@pytest.mark.parametrize("image,expected_exception,expect_issue", _RATE_LIMIT_PARAMS)
+@pytest.mark.parametrize(
+    ("image", "expected_exception", "expect_issue"), _RATE_LIMIT_PARAMS
+)
 async def test_install_pull_500_with_toomanyrequests_body_treated_as_rate_limit(
     coresys: CoreSys,
     test_docker_interface: DockerInterface,
@@ -1053,7 +1057,9 @@ async def test_install_pull_500_with_toomanyrequests_body_treated_as_rate_limit(
     capture_exception.assert_not_called()
 
 
-@pytest.mark.parametrize("image,expected_exception,expect_issue", _RATE_LIMIT_PARAMS)
+@pytest.mark.parametrize(
+    ("image", "expected_exception", "expect_issue"), _RATE_LIMIT_PARAMS
+)
 async def test_install_streaming_pull_rate_limit(
     coresys: CoreSys,
     test_docker_interface: DockerInterface,

--- a/tests/docker/test_monitor.py
+++ b/tests/docker/test_monitor.py
@@ -16,7 +16,7 @@ from supervisor.docker.monitor import DockerContainerStateEvent
 
 
 @pytest.mark.parametrize(
-    "event,expected,expected_exit_code",
+    ("event", "expected", "expected_exit_code"),
     [
         (
             {

--- a/tests/hardware/test_helper.py
+++ b/tests/hardware/test_helper.py
@@ -4,7 +4,7 @@ import errno
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from pytest import LogCaptureFixture
+import pytest
 
 from supervisor.coresys import CoreSys
 from supervisor.hardware.data import Device
@@ -87,7 +87,7 @@ def test_hide_virtual_device(coresys: CoreSys):
     assert coresys.hardware.helper.hide_virtual_device(udev_device)
 
 
-async def test_last_boot_error(coresys: CoreSys, caplog: LogCaptureFixture):
+async def test_last_boot_error(coresys: CoreSys, caplog: pytest.LogCaptureFixture):
     """Test error reading last boot."""
     with patch(
         "supervisor.hardware.helper.Path.read_text", side_effect=(err := OSError())

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -497,7 +497,7 @@ async def test_restart_failures(
 
 
 @pytest.mark.parametrize(
-    "get_error,running",
+    ("get_error", "running"),
     [
         (aiodocker.DockerError(404, {"message": "missing"}), False),
         (aiodocker.DockerError(500, {"message": "fail"}), False),

--- a/tests/host/test_apparmor_control.py
+++ b/tests/host/test_apparmor_control.py
@@ -4,7 +4,7 @@ import errno
 from pathlib import Path
 from unittest.mock import patch
 
-from pytest import raises
+import pytest
 
 from supervisor.coresys import CoreSys
 from supervisor.exceptions import HostAppArmorError
@@ -20,12 +20,12 @@ async def test_load_profile_error(coresys: CoreSys):
         ),
     ):
         err.errno = errno.EBUSY
-        with raises(HostAppArmorError):
+        with pytest.raises(HostAppArmorError):
             await coresys.host.apparmor.load_profile("test", test_path)
         assert coresys.core.healthy is True
 
         err.errno = errno.EBADMSG
-        with raises(HostAppArmorError):
+        with pytest.raises(HostAppArmorError):
             await coresys.host.apparmor.load_profile("test", test_path)
         assert coresys.core.healthy is False
 
@@ -35,12 +35,12 @@ async def test_remove_profile_error(coresys: CoreSys, path_extern):
     coresys.host.apparmor._profiles.add("test")  # pylint: disable=protected-access
     with patch("supervisor.host.apparmor.Path.unlink", side_effect=(err := OSError())):
         err.errno = errno.EBUSY
-        with raises(HostAppArmorError):
+        with pytest.raises(HostAppArmorError):
             await coresys.host.apparmor.remove_profile("test")
         assert coresys.core.healthy is True
 
         err.errno = errno.EBADMSG
-        with raises(HostAppArmorError):
+        with pytest.raises(HostAppArmorError):
             await coresys.host.apparmor.remove_profile("test")
         assert coresys.core.healthy is False
 
@@ -53,11 +53,11 @@ def test_backup_profile_error(coresys: CoreSys, path_extern):
         "supervisor.host.apparmor.shutil.copyfile", side_effect=(err := OSError())
     ):
         err.errno = errno.EBUSY
-        with raises(HostAppArmorError):
+        with pytest.raises(HostAppArmorError):
             coresys.host.apparmor.backup_profile("test", test_path)
         assert coresys.core.healthy is True
 
         err.errno = errno.EBADMSG
-        with raises(HostAppArmorError):
+        with pytest.raises(HostAppArmorError):
             coresys.host.apparmor.backup_profile("test", test_path)
         assert coresys.core.healthy is False

--- a/tests/host/test_configuration.py
+++ b/tests/host/test_configuration.py
@@ -205,11 +205,8 @@ def test_equals_dbus_interface_vlan_missing_info():
     mock_network_interface.settings = Mock()
 
     # Should raise RuntimeError
-    try:
+    with pytest.raises(RuntimeError, match="^VLAN information missing$"):
         test_vlan_interface.equals_dbus_interface(mock_network_interface)
-        assert False, "Expected RuntimeError"
-    except RuntimeError as e:
-        assert str(e) == "VLAN information missing"
 
 
 def test_equals_dbus_interface_vlan_no_vlan_settings():
@@ -248,7 +245,7 @@ async def fixture_device_eth0_10_service(
     network_manager_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> DeviceService:
     """Mock Device eth0.10 service."""
-    yield network_manager_services["network_device"][
+    return network_manager_services["network_device"][
         "/org/freedesktop/NetworkManager/Devices/38"
     ]
 

--- a/tests/host/test_firewall.py
+++ b/tests/host/test_firewall.py
@@ -38,7 +38,7 @@ async def fixture_systemd_service(
     all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> SystemdService:
     """Return systemd service mock."""
-    yield all_dbus_services["systemd"]
+    return all_dbus_services["systemd"]
 
 
 @pytest.fixture(name="systemd_unit_service")
@@ -46,7 +46,7 @@ async def fixture_systemd_unit_service(
     all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> SystemdUnitService:
     """Return systemd unit service mock."""
-    yield all_dbus_services["systemd_unit"]
+    return all_dbus_services["systemd_unit"]
 
 
 async def test_apply_gateway_firewall_rules(

--- a/tests/host/test_logs.py
+++ b/tests/host/test_logs.py
@@ -154,13 +154,13 @@ async def test_boot_ids(
 
     # -1 is previous boot. We have 2 boots so -2 is too far
     assert await coresys.host.logs.get_boot_id(-1) == "b2aca10d5ca54fb1b6fb35c85a0efca9"
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Logs only contain"):
         await coresys.host.logs.get_boot_id(-2)
 
     # 1 is oldest boot and count up from there. We have 2 boots so 3 is too far
     assert await coresys.host.logs.get_boot_id(1) == "b2aca10d5ca54fb1b6fb35c85a0efca9"
     assert await coresys.host.logs.get_boot_id(2) == "b1c386a144fd44db8f855d7e907256f8"
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Logs only contain"):
         await coresys.host.logs.get_boot_id(3)
 
 
@@ -243,7 +243,7 @@ async def test_connection_refused_handled(
 
 
 @pytest.mark.parametrize(
-    "range_header,range_reparse",
+    ("range_header", "range_reparse"),
     [
         ("entries=:-99:", "entries=:-99:18446744073709551615"),
         ("entries=:-99:100", "entries=:-99:100"),

--- a/tests/host/test_manager.py
+++ b/tests/host/test_manager.py
@@ -18,7 +18,7 @@ async def fixture_systemd_service(
     all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> SystemdService:
     """Return systemd service mock."""
-    yield all_dbus_services["systemd"]
+    return all_dbus_services["systemd"]
 
 
 async def test_load(coresys: CoreSys, systemd_service: SystemdService):

--- a/tests/host/test_network.py
+++ b/tests/host/test_network.py
@@ -35,7 +35,7 @@ async def fixture_wireless_service(
     network_manager_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> DeviceWirelessService:
     """Return mock device wireless service."""
-    yield network_manager_services["network_device_wireless"]
+    return network_manager_services["network_device_wireless"]
 
 
 async def test_load(

--- a/tests/jobs/test_job_decorator.py
+++ b/tests/jobs/test_job_decorator.py
@@ -56,7 +56,7 @@ async def test_healthy(coresys: CoreSys, caplog: pytest.LogCaptureFixture):
 
 
 @pytest.mark.parametrize(
-    "connectivity,head_side_effect,host_result,system_result",
+    ("connectivity", "head_side_effect", "host_result", "system_result"),
     [
         (4, None, True, True),
         (4, ClientError(), True, None),

--- a/tests/jobs/test_job_manager.py
+++ b/tests/jobs/test_job_manager.py
@@ -76,10 +76,10 @@ async def test_update_job(coresys: CoreSys):
     job.stage = "stage"
     assert job.stage == "stage"
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must be <= 100"):
         job.progress = 110
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must be >= 0"):
         job.progress = -10
 
 

--- a/tests/misc/test_tasks.py
+++ b/tests/misc/test_tasks.py
@@ -34,7 +34,7 @@ async def fixture_tasks(
     coresys.homeassistant.version = AwesomeVersion("2023.12.0")
     container.show.return_value["State"]["Status"] = "running"
     container.show.return_value["State"]["Running"] = True
-    yield Tasks(coresys)
+    return Tasks(coresys)
 
 
 async def test_watchdog_homeassistant_api(

--- a/tests/mounts/test_manager.py
+++ b/tests/mounts/test_manager.py
@@ -61,7 +61,7 @@ async def fixture_mount(
     mount = Mount.from_dict(coresys, MEDIA_TEST_DATA)
     coresys.mounts._mounts = {"media_test": mount}  # pylint: disable=protected-access
     await coresys.mounts.load()
-    yield mount
+    return mount
 
 
 async def test_load(

--- a/tests/mounts/test_mount.py
+++ b/tests/mounts/test_mount.py
@@ -29,8 +29,8 @@ ERROR_NO_UNIT = DBusError("org.freedesktop.systemd1.NoSuchUnit", "error")
 
 
 @pytest.mark.parametrize(
-    "additional_data,expected_options",
-    (
+    ("additional_data", "expected_options"),
+    [
         (
             {"version": MountCifsVersion.LEGACY_1_0},
             ["vers=1.0"],
@@ -43,7 +43,7 @@ ERROR_NO_UNIT = DBusError("org.freedesktop.systemd1.NoSuchUnit", "error")
             {"version": None},
             [],
         ),
-    ),
+    ],
 )
 async def test_cifs_mount(
     coresys: CoreSys,

--- a/tests/plugins/test_dns.py
+++ b/tests/plugins/test_dns.py
@@ -465,14 +465,8 @@ async def test_dns_restart_triggers_connectivity_check(coresys: CoreSys):
         )
 
         # Wait a bit and verify connectivity check was NOT triggered
-        try:
+        with pytest.raises(TimeoutError):
             await asyncio.wait_for(connectivity_check_event.wait(), timeout=0.1)
-            assert False, (
-                "Connectivity check should not have been called for other containers"
-            )
-        except TimeoutError:
-            # This is expected - connectivity check should not be called
-            pass
 
         # Verify sleep was not called for other containers
         mock_sleep.assert_not_called()

--- a/tests/plugins/test_plugin_base.py
+++ b/tests/plugins/test_plugin_base.py
@@ -150,7 +150,7 @@ async def test_plugin_watchdog(coresys: CoreSys, plugin: PluginBase) -> None:
 
 
 @pytest.mark.parametrize(
-    "plugin,error",
+    ("plugin", "error"),
     [
         (PluginAudio, AudioError()),
         (PluginCli, CliError()),
@@ -298,7 +298,7 @@ async def test_plugin_load_missing_container(
 
 
 @pytest.mark.parametrize(
-    "plugin,error",
+    ("plugin", "error"),
     [
         (PluginAudio, AudioJobError),
         (PluginCli, CliJobError),

--- a/tests/resolution/check/test_check_disabled_data_disk.py
+++ b/tests/resolution/check/test_check_disabled_data_disk.py
@@ -21,7 +21,7 @@ async def fixture_sda1_block_service(
     udisks2_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> BlockService:
     """Return sda1 block service."""
-    yield udisks2_services["udisks2_block"][
+    return udisks2_services["udisks2_block"][
         "/org/freedesktop/UDisks2/block_devices/sda1"
     ]
 

--- a/tests/resolution/check/test_check_multiple_data_disks.py
+++ b/tests/resolution/check/test_check_multiple_data_disks.py
@@ -21,7 +21,7 @@ async def fixture_sda1_block_service(
     udisks2_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> BlockService:
     """Return sda1 block service."""
-    yield udisks2_services["udisks2_block"][
+    return udisks2_services["udisks2_block"][
         "/org/freedesktop/UDisks2/block_devices/sda1"
     ]
 

--- a/tests/resolution/check/test_check_network_interface_ipv4.py
+++ b/tests/resolution/check/test_check_network_interface_ipv4.py
@@ -27,7 +27,7 @@ async def test_base(coresys: CoreSys):
 
 
 @pytest.mark.parametrize(
-    "state_flags,issues",
+    ("state_flags", "issues"),
     [
         ({ConnectionStateFlags.IP4_READY}, set()),
         ({ConnectionStateFlags.IP6_READY}, TEST_ISSUES),
@@ -56,7 +56,7 @@ async def test_check(
 
 
 @pytest.mark.parametrize(
-    "state_flags,approved",
+    ("state_flags", "approved"),
     [
         ({ConnectionStateFlags.IP4_READY}, False),
         ({ConnectionStateFlags.IP6_READY}, True),

--- a/tests/resolution/evaluation/test_evaluate_home_assistant_core_version.py
+++ b/tests/resolution/evaluation/test_evaluate_home_assistant_core_version.py
@@ -15,7 +15,7 @@ from supervisor.resolution.evaluations.home_assistant_core_version import (
 
 
 @pytest.mark.parametrize(
-    "current,latest,expected",
+    ("current", "latest", "expected"),
     [
         ("2022.1.0", "2024.12.0", True),  # More than 24 months behind, unsupported
         ("2023.1.0", "2024.12.0", False),  # Less than 24 months behind, supported

--- a/tests/resolution/evaluation/test_evaluate_os_version.py
+++ b/tests/resolution/evaluation/test_evaluate_os_version.py
@@ -12,7 +12,7 @@ from supervisor.resolution.evaluations.os_version import EvaluateOSVersion
 
 
 @pytest.mark.parametrize(
-    "current,latest,expected",
+    ("current", "latest", "expected"),
     [
         ("10.0", "15.0", True),  # 5 major behind, should be unsupported
         ("10.0", "14.0", False),  # 4 major behind, should be supported

--- a/tests/store/test_custom_repository.py
+++ b/tests/store/test_custom_repository.py
@@ -89,6 +89,12 @@ async def test_error_on_invalid_repository(
 ):
     """Test invalid repository not added."""
     current = coresys.store.repository_urls
+    if use_update:
+        action = store_manager.update_repositories(
+            set(current) | {"http://example.com"}
+        )
+    else:
+        action = store_manager.add_repository("http://example.com")
     with (
         patch("supervisor.store.git.GitRepo.load", return_value=None),
         patch(
@@ -97,12 +103,7 @@ async def test_error_on_invalid_repository(
         ),
         pytest.raises(StoreError),
     ):
-        if use_update:
-            await store_manager.update_repositories(
-                set(current) | {"http://example.com"}
-            )
-        else:
-            await store_manager.add_repository("http://example.com")
+        await action
 
     assert "http://example.com" not in coresys.store.repository_urls
     assert len(coresys.resolution.suggestions) == 0
@@ -134,7 +135,7 @@ async def test_add_invalid_repository_file(
 
 
 @pytest.mark.parametrize(
-    "git_error,suggestion_type",
+    ("git_error", "suggestion_type"),
     [
         (StoreGitCloneError(), SuggestionType.EXECUTE_REMOVE),
         (StoreGitError(), SuggestionType.EXECUTE_RESET),
@@ -158,7 +159,7 @@ async def test_add_repository_with_git_error(
 
 
 @pytest.mark.parametrize(
-    "use_update,git_error",
+    ("use_update", "git_error"),
     [
         (True, StoreGitCloneError()),
         (True, StoreGitError()),
@@ -174,16 +175,17 @@ async def test_error_on_repository_with_git_error(
 ):
     """Test repo not added on git error."""
     current = coresys.store.repository_urls
+    if use_update:
+        action = store_manager.update_repositories(
+            set(current) | {"http://example.com"}
+        )
+    else:
+        action = store_manager.add_repository("http://example.com")
     with (
         patch("supervisor.store.git.GitRepo.load", side_effect=git_error),
         pytest.raises(StoreError),
     ):
-        if use_update:
-            await store_manager.update_repositories(
-                set(current) | {"http://example.com"}
-            )
-        else:
-            await store_manager.add_repository("http://example.com")
+        await action
 
     assert "http://example.com" not in coresys.store.repository_urls
     assert len(coresys.resolution.suggestions) == 0
@@ -243,16 +245,17 @@ async def test_remove_used_repository(
 
     assert store_app.repository in coresys.store.repositories
 
+    if use_update:
+        action = store_manager.update_repositories(set())
+    else:
+        action = store_manager.remove_repository(
+            coresys.store.repositories[store_app.repository]
+        )
     with pytest.raises(
         StoreError,
         match="Can't remove 'https://github.com/awesome-developer/awesome-repo'. It's used by installed apps",
     ):
-        if use_update:
-            await store_manager.update_repositories(set())
-        else:
-            await store_manager.remove_repository(
-                coresys.store.repositories[store_app.repository]
-            )
+        await action
 
 
 async def test_update_partial_error(coresys: CoreSys, store_manager: StoreManager):
@@ -321,18 +324,19 @@ async def test_add_repository_fails_if_out_of_date(
     coresys: CoreSys, store_manager: StoreManager, use_update: bool
 ):
     """Test adding a repository fails when supervisor not updated."""
+    if use_update:
+        action = store_manager.update_repositories(
+            set(coresys.store.repository_urls) | {"http://example.com"}
+        )
+    else:
+        action = store_manager.add_repository("http://example.com")
     with (
         patch.object(
             type(coresys.supervisor), "need_update", new=PropertyMock(return_value=True)
         ),
         pytest.raises(StoreJobError),
     ):
-        if use_update:
-            await store_manager.update_repositories(
-                set(coresys.store.repository_urls) | {"http://example.com"}
-            )
-        else:
-            await store_manager.add_repository("http://example.com")
+        await action
 
 
 @pytest.mark.parametrize("need_update", [True, False])

--- a/tests/store/test_repository_git.py
+++ b/tests/store/test_repository_git.py
@@ -112,12 +112,10 @@ async def test_git_load_error(coresys: CoreSys, tmp_path: Path, git_errors: Exce
     # Pretend we have a repo
     (tmp_path / ".git").mkdir()
 
-    with (
-        patch("git.Repo") as mock_repo,
-        pytest.raises(StoreGitError),
-    ):
+    with patch("git.Repo") as mock_repo:
         mock_repo.side_effect = git_errors
-        await repo.load()
+        with pytest.raises(StoreGitError):
+            await repo.load()
 
     assert len(coresys.resolution.suggestions) == 0
 
@@ -140,12 +138,10 @@ async def test_git_pull_missing_origin_remote(coresys: CoreSys, tmp_path: Path):
     mock_repo.active_branch.name = "main"
     repo.repo = mock_repo
 
-    with (
-        patch("git.Git") as mock_git,
-        pytest.raises(StoreGitError),
-    ):
+    with patch("git.Git") as mock_git:
         mock_git.return_value.ls_remote = MagicMock()
-        await repo.pull.__wrapped__(repo)
+        with pytest.raises(StoreGitError):
+            await repo.pull.__wrapped__(repo)
 
     # Verify resolution issue was created
     assert len(coresys.resolution.issues) == 1

--- a/tests/store/test_store_manager.py
+++ b/tests/store/test_store_manager.py
@@ -124,7 +124,7 @@ async def test_reload_fails_if_out_of_date(coresys: CoreSys):
 
 
 @pytest.mark.parametrize(
-    "config,log",
+    ("config", "log"),
     [
         (
             {"arch": ["aarch64"]},
@@ -181,7 +181,7 @@ async def test_update_unavailable_app(
 
 
 @pytest.mark.parametrize(
-    "config,log",
+    ("config", "log"),
     [
         (
             {"arch": ["aarch64"]},

--- a/tests/store/test_validate.py
+++ b/tests/store/test_validate.py
@@ -7,7 +7,7 @@ from supervisor.store.validate import repositories
 
 
 @pytest.mark.parametrize(
-    "repo_list,valid",
+    ("repo_list", "valid"),
     [
         (["core", "local"], True),
         (["https://github.com/hassio-addons/repository"], True),

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,7 +14,7 @@ def mock_auth_backend_fixture(coresys):
     mock_auth_backend = AsyncMock()
     coresys.auth._backend_login = mock_auth_backend
 
-    yield mock_auth_backend
+    return mock_auth_backend
 
 
 @pytest.fixture(name="mock_api_state", autouse=True)
@@ -23,7 +23,7 @@ def mock_api_state_fixture(coresys):
     mock_api_state = AsyncMock()
     coresys.homeassistant.api.check_api_state = mock_api_state
 
-    yield mock_api_state
+    return mock_api_state
 
 
 async def test_auth_request_with_backend(coresys, mock_auth_backend, mock_api_state):

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -25,7 +25,7 @@ from tests.common import MockResponse
 
 
 @pytest.mark.parametrize(
-    "side_effect,connectivity", [(ClientError(), False), (None, True)]
+    ("side_effect", "connectivity"), [(ClientError(), False), (None, True)]
 )
 async def test_connectivity_check(
     coresys: CoreSys,

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -67,7 +67,7 @@ async def test_fetch_versions(
 
 @pytest.mark.usefixtures("no_job_throttle")
 @pytest.mark.parametrize(
-    "version, expected",
+    ("version", "expected"),
     [
         ("3.1", "3.13"),
         ("4.5", "4.20"),

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -12,7 +12,7 @@ DNS_GOOD_V4 = [
     "DNS://1.1.1.1",  # cloudflare
     "dns://9.9.9.9",  # quad-9
 ]
-DNS_GOOD_V6 = [
+DNS_V6_UNSUPPORTED = [
     "dns://2606:4700:4700::1111",  # cloudflare
     "DNS://2606:4700:4700::1001",  # cloudflare
 ]
@@ -52,9 +52,13 @@ def test_dns_url_v4_good():
         assert validate.dns_url(url)
 
 
-@pytest.mark.parametrize("url", DNS_GOOD_V6)
-def test_dns_url_v6_good(url: str):
-    """Test the DNS validator with known-good IPv6 DNS URLs."""
+@pytest.mark.parametrize("url", DNS_V6_UNSUPPORTED)
+def test_dns_url_v6_rejected(url: str):
+    """Test the DNS validator rejects well-formed IPv6 DNS URLs.
+
+    IPv6 is currently not supported for DNS because it doesn't work with
+    the Docker network.
+    """
     with pytest.raises(vol.error.Invalid):
         validate.dns_url(url)
 
@@ -64,15 +68,15 @@ def test_dns_server_list_v4():
     assert validate.dns_server_list(DNS_GOOD_V4)
 
 
-def test_dns_server_list_v6():
-    """Test a list with v6 addresses."""
+def test_dns_server_list_v6_rejected():
+    """Test that lists of IPv6 DNS URLs are rejected."""
     with pytest.raises(vol.error.Invalid):
-        assert validate.dns_server_list(DNS_GOOD_V6)
+        assert validate.dns_server_list(DNS_V6_UNSUPPORTED)
 
 
 def test_dns_server_list_combined():
     """Test a list with both v4 and v6 addresses."""
-    combined = DNS_GOOD_V4 + DNS_GOOD_V6
+    combined = DNS_GOOD_V4 + DNS_V6_UNSUPPORTED
     # test the matches
     with pytest.raises(vol.error.Invalid):
         validate.dns_server_list(combined)
@@ -93,7 +97,7 @@ def test_dns_server_list_bad():
 
 def test_dns_server_list_bad_combined():
     """Test the bad list, combined with the good."""
-    combined = DNS_GOOD_V4 + DNS_GOOD_V6 + DNS_BAD
+    combined = DNS_GOOD_V4 + DNS_V6_UNSUPPORTED + DNS_BAD
 
     with pytest.raises(vol.error.Invalid):
         # bad list

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -52,11 +52,11 @@ def test_dns_url_v4_good():
         assert validate.dns_url(url)
 
 
-def test_dns_url_v6_good():
+@pytest.mark.parametrize("url", DNS_GOOD_V6)
+def test_dns_url_v6_good(url: str):
     """Test the DNS validator with known-good IPv6 DNS URLs."""
     with pytest.raises(vol.error.Invalid):
-        for url in DNS_GOOD_V6:
-            assert validate.dns_url(url)
+        validate.dns_url(url)
 
 
 def test_dns_server_list_v4():

--- a/tests/utils/test_dbus.py
+++ b/tests/utils/test_dbus.py
@@ -45,7 +45,7 @@ async def fixture_test_service(dbus_session_bus: MessageBus) -> TestInterface:
     await dbus_session_bus.request_name("service.test.TestInterface")
     service = TestInterface()
     service.export(dbus_session_bus)
-    yield service
+    return service
 
 
 async def test_missing_properties_interface(dbus_session_bus: MessageBus):
@@ -195,7 +195,7 @@ def test_from_dbus_error():
 
 
 @pytest.mark.parametrize(
-    "error_type,expected",
+    ("error_type", "expected"),
     [
         (ErrorType.UNKNOWN_METHOD, DBusInterfaceMethodError),
         (ErrorType.INVALID_SIGNATURE, DBusInterfaceMethodError),

--- a/tests/utils/test_exception_helper.py
+++ b/tests/utils/test_exception_helper.py
@@ -21,56 +21,56 @@ def _raise_key_error_from_value_error(value_message: str | None = None) -> None:
 
 
 def test_simple_chain_exception():
-    """Test simple chain of excepiton."""
+    """Test simple chain of exception."""
     with pytest.raises(ValueError, match="^$") as exc_info:
         _raise_value_error()
     assert check_exception_chain(exc_info.value, ValueError)
 
 
 def test_simple_chain_exception_not():
-    """Test simple chain of excepiton."""
+    """Test simple chain of exception."""
     with pytest.raises(ValueError, match="^$") as exc_info:
         _raise_value_error()
     assert not check_exception_chain(exc_info.value, KeyError)
 
 
 def test_simple_nested_chain_exception():
-    """Test simple nested chain of excepiton."""
+    """Test simple nested chain of exception."""
     with pytest.raises(KeyError) as exc_info:
         _raise_key_error_from_value_error()
     assert check_exception_chain(exc_info.value, ValueError)
 
 
 def test_list_nested_chain_exception():
-    """Test list nested chain of excepiton."""
+    """Test list nested chain of exception."""
     with pytest.raises(KeyError) as exc_info:
         _raise_key_error_from_value_error()
     assert check_exception_chain(exc_info.value, (ValueError, OSError))
 
 
 def test_list_nested_chain_exception_not():
-    """Test list nested chain of excepiton."""
+    """Test list nested chain of exception."""
     with pytest.raises(KeyError) as exc_info:
         _raise_key_error_from_value_error()
     assert not check_exception_chain(exc_info.value, (AssertionError, OSError))
 
 
 def test_simple_chain_exception_message():
-    """Test simple chain of excepiton."""
+    """Test simple chain of exception."""
     with pytest.raises(ValueError, match="^error$") as exc_info:
         _raise_value_error("error")
     assert get_message_from_exception_chain(exc_info.value) == "error"
 
 
 def test_simple_chain_exception_not_message():
-    """Test simple chain of excepiton."""
+    """Test simple chain of exception."""
     with pytest.raises(ValueError, match="^$") as exc_info:
         _raise_value_error()
     assert not get_message_from_exception_chain(exc_info.value)
 
 
 def test_simple_nested_chain_exception_message():
-    """Test simple nested chain of excepiton."""
+    """Test simple nested chain of exception."""
     with pytest.raises(KeyError) as exc_info:
         _raise_key_error_from_value_error("error")
     assert get_message_from_exception_chain(exc_info.value) == "error"

--- a/tests/utils/test_exception_helper.py
+++ b/tests/utils/test_exception_helper.py
@@ -1,87 +1,76 @@
 """Test exception helpers."""
 
+import pytest
+
 from supervisor.utils import check_exception_chain, get_message_from_exception_chain
+
+
+def _raise_value_error(message: str | None = None) -> None:
+    """Raise a ValueError, optionally with a message."""
+    if message is None:
+        raise ValueError()
+    raise ValueError(message)
+
+
+def _raise_key_error_from_value_error(value_message: str | None = None) -> None:
+    """Raise a KeyError chained from a ValueError."""
+    try:
+        _raise_value_error(value_message)
+    except ValueError as err:
+        raise KeyError() from err
 
 
 def test_simple_chain_exception():
     """Test simple chain of excepiton."""
-
-    try:
-        raise ValueError()
-    except ValueError as err:
-        assert check_exception_chain(err, ValueError)
+    with pytest.raises(ValueError, match="^$") as exc_info:
+        _raise_value_error()
+    assert check_exception_chain(exc_info.value, ValueError)
 
 
 def test_simple_chain_exception_not():
     """Test simple chain of excepiton."""
-
-    try:
-        raise ValueError()
-    except ValueError as err:
-        assert not check_exception_chain(err, KeyError)
+    with pytest.raises(ValueError, match="^$") as exc_info:
+        _raise_value_error()
+    assert not check_exception_chain(exc_info.value, KeyError)
 
 
 def test_simple_nested_chain_exception():
     """Test simple nested chain of excepiton."""
-
-    try:
-        try:
-            raise ValueError()
-        except ValueError as err:
-            raise KeyError() from err
-    except KeyError as err:
-        assert check_exception_chain(err, ValueError)
+    with pytest.raises(KeyError) as exc_info:
+        _raise_key_error_from_value_error()
+    assert check_exception_chain(exc_info.value, ValueError)
 
 
 def test_list_nested_chain_exception():
     """Test list nested chain of excepiton."""
-
-    try:
-        try:
-            raise ValueError()
-        except ValueError as err:
-            raise KeyError() from err
-    except KeyError as err:
-        assert check_exception_chain(err, (ValueError, OSError))
+    with pytest.raises(KeyError) as exc_info:
+        _raise_key_error_from_value_error()
+    assert check_exception_chain(exc_info.value, (ValueError, OSError))
 
 
 def test_list_nested_chain_exception_not():
     """Test list nested chain of excepiton."""
-
-    try:
-        try:
-            raise ValueError()
-        except ValueError as err:
-            raise KeyError() from err
-    except KeyError as err:
-        assert not check_exception_chain(err, (AssertionError, OSError))
+    with pytest.raises(KeyError) as exc_info:
+        _raise_key_error_from_value_error()
+    assert not check_exception_chain(exc_info.value, (AssertionError, OSError))
 
 
 def test_simple_chain_exception_message():
     """Test simple chain of excepiton."""
-
-    try:
-        raise ValueError("error")
-    except ValueError as err:
-        assert get_message_from_exception_chain(err) == "error"
+    with pytest.raises(ValueError, match="^error$") as exc_info:
+        _raise_value_error("error")
+    assert get_message_from_exception_chain(exc_info.value) == "error"
 
 
 def test_simple_chain_exception_not_message():
     """Test simple chain of excepiton."""
-
-    try:
-        raise ValueError()
-    except ValueError as err:
-        assert not get_message_from_exception_chain(err)
+    with pytest.raises(ValueError, match="^$") as exc_info:
+        _raise_value_error()
+    assert not get_message_from_exception_chain(exc_info.value)
 
 
 def test_simple_nested_chain_exception_message():
     """Test simple nested chain of excepiton."""
-
-    try:
-        try:
-            raise ValueError("error")
-        except ValueError as err:
-            raise KeyError() from err
-    except KeyError as err:
-        assert get_message_from_exception_chain(err) == "error"
+    with pytest.raises(KeyError) as exc_info:
+        _raise_key_error_from_value_error("error")
+    assert get_message_from_exception_chain(exc_info.value) == "error"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Enable the `PT` (flake8-pytest-style) rule set in ruff and fix the resulting violations across the test suite. The rules nudge tests toward idiomatic pytest usage and catch a few small footguns. No production code is touched and there are no behavioral changes to the tests themselves.

Concrete categories addressed:

- **PT006**: parametrize argument names are now tuples (`("a", "b")`) instead of a single comma-separated string (`"a,b"`).
- **PT022**: fixtures with no teardown use `return` instead of `yield`, so the absence of cleanup is obvious at a glance and the fixture isn't wrapped in unnecessary generator/finalizer machinery.
- **PT011**: `pytest.raises(ValueError)` blocks gained a `match=` argument so the expected error is anchored to a specific message rather than catching any `ValueError`.
- **PT012**: setup (patches, conditional branches) was hoisted out of `pytest.raises()` so only the call expected to raise remains inside the block.
- **PT013**: `from pytest import X` replaced with `import pytest` and module-qualified access.
- **PT015**: `try/except` + `assert False` patterns replaced with `pytest.raises(...)`.
- **PT017**: assertions on exceptions inside `except` blocks replaced with `pytest.raises(...) as exc_info` and assertions on `exc_info.value`.

Most of the diff is mechanical (PT006 and PT022 together account for the vast majority of the changed lines). The full test suite passes.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
