### PR TITLE
docker: log when stored registry credentials are used for a pull

### DIFF
--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -228,10 +228,11 @@ class DockerInterface(JobGroup, ABC):
             if registry in (DOCKER_HUB, DOCKER_HUB_LEGACY):
                 qualified_image = f"{DOCKER_HUB}/{image}"
 
-            _LOGGER.debug(
-                "Logging in to %s as %s",
+            _LOGGER.info(
+                "Using stored registry credentials for %s (user: %s) to pull %s",
                 registry,
                 stored[ATTR_USERNAME],
+                image,
             )
 
         return credentials, qualified_image

--- a/supervisor/docker/manifest.py
+++ b/supervisor/docker/manifest.py
@@ -172,7 +172,12 @@ class RegistryManifestFetcher:
             username, password = credentials
             if username and password:
                 auth = aiohttp.BasicAuth(username, password)
-                _LOGGER.debug("Using credentials for %s", registry)
+                _LOGGER.info(
+                    "Using stored registry credentials for %s (user: %s) to fetch manifest for %s",
+                    registry,
+                    username,
+                    repository,
+                )
 
         try:
             async with self._session.get(token_url, auth=auth) as resp:


### PR DESCRIPTION
## Proposed change

Promote the "stored registry credentials are being used" log lines from DEBUG to INFO, in both the image pull path (`DockerInterface._get_credentials`) and the manifest fetcher (`RegistryManifestFetcher._get_auth_token`). The messages now also include the image (or repository) being accessed.

Background: stored registry credentials are applied globally to any pull whose image matches the configured registry hostname. This is fine while the credentials are valid, but our public images on `ghcr.io` (Core, Supervisor, plugins) can normally be pulled anonymously - so as soon as the stored credentials become invalid (token expired or revoked), every `ghcr.io` pull starts failing with 401/403 even though anonymous access would still work. The user has typically forgotten the credentials were ever added (often during a private add-on install), and the supervisor logs previously gave no hint that credentials were in play. See home-assistant/core#170281, where exactly this happened: an expired GitHub token blocked Core updates with a misleading `denied: denied` error.

With this change, a failing pull that used stored credentials leaves a visible breadcrumb in the logs pointing at the likely cause:

```
INFO  Using stored registry credentials for ghcr.io (user: …) to fetch manifest for home-assistant/green-homeassistant
WARN  Failed to fetch manifest for ghcr.io/home-assistant/green-homeassistant:2026.5.1 - 401
```

Usernames are not secret and are already routinely shared in support logs, so logging them at INFO is acceptable. Credentials are only used when registries are configured, so this does not add meaningful log noise for the typical installation.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/core#170281
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
