### PR TITLE
Enable flake8-pathlib (PTH) ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,6 +277,7 @@ lint.select = [
   "PLR",     # pylint
   "PLW",     # pylint
   "PT",      # flake8-pytest-style
+  "PTH",     # flake8-pathlib
   "Q000",    # Double quotes found but single quotes preferred
   "RUF006",  # Store a reference to the return value of asyncio.create_task
   "S102",    # Use of exec detected

--- a/supervisor/utils/yaml.py
+++ b/supervisor/utils/yaml.py
@@ -22,7 +22,7 @@ def read_yaml_file(path: Path) -> dict:
     Must be run in executor.
     """
     try:
-        with open(path, encoding="utf-8") as yaml_file:
+        with path.open(encoding="utf-8") as yaml_file:
             return load(yaml_file, Loader=SafeLoader) or {}
 
     except (YAMLError, AttributeError, OSError, UnicodeDecodeError) as err:

--- a/tests/backups/test_backup.py
+++ b/tests/backups/test_backup.py
@@ -1,7 +1,6 @@
 """Test backups."""
 
 from contextlib import AbstractContextManager, nullcontext as does_not_raise
-from os import listdir
 from pathlib import Path
 from shutil import copy
 import tarfile
@@ -33,13 +32,13 @@ async def test_new_backup_stays_in_folder(coresys: CoreSys, tmp_path: Path):
     """Test making a new backup operates entirely within folder where backup will be stored."""
     backup = Backup(coresys, tmp_path / "my_backup.tar", "test", None)
     backup.new("test", "2023-07-21T21:05:00.000000+00:00", BackupType.FULL)
-    assert not listdir(tmp_path)
+    assert not list(tmp_path.iterdir())
 
     async with backup.create():
-        assert len(listdir(tmp_path)) == 1
+        assert len(list(tmp_path.iterdir())) == 1
         assert backup.tarfile.exists()
 
-    assert len(listdir(tmp_path)) == 1
+    assert len(list(tmp_path.iterdir())) == 1
     assert backup.tarfile.exists()
 
 
@@ -47,7 +46,7 @@ async def test_new_backup_permission_error(coresys: CoreSys, tmp_path: Path):
     """Test if a permission error is correctly handled when a new backup is created."""
     backup = Backup(coresys, tmp_path / "my_backup.tar", "test", None)
     backup.new("test", "2023-07-21T21:05:00.000000+00:00", BackupType.FULL)
-    assert not listdir(tmp_path)
+    assert not list(tmp_path.iterdir())
 
     with (
         patch(
@@ -59,7 +58,7 @@ async def test_new_backup_permission_error(coresys: CoreSys, tmp_path: Path):
         async with backup.create():
             pass
 
-    assert not listdir(tmp_path)
+    assert not list(tmp_path.iterdir())
     assert not backup.tarfile.exists()
 
 

--- a/tests/hardware/test_disk.py
+++ b/tests/hardware/test_disk.py
@@ -2,7 +2,6 @@
 
 # pylint: disable=protected-access
 import errno
-import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -315,22 +314,23 @@ def test_get_dir_structure_sizes_ebadmsg_error(coresys, tmp_path):
     subdir.mkdir()
     (subdir / "file2.txt").write_text("content2")
 
-    # Mock is_dir, is_symlink, and stat methods to handle the EBADMSG error correctly
+    # Capture the real Path methods before they get patched below so the mocks
+    # can delegate to them without recursing into themselves.
+    real_is_dir = Path.is_dir
+    real_is_symlink = Path.is_symlink
+    real_stat = Path.stat
 
     def mock_is_dir(self):
-        # Use the real is_dir for all paths
-        return os.path.isdir(self)
+        return real_is_dir(self)
 
     def mock_is_symlink(self):
-        # Use the real is_symlink for all paths
-        return os.path.islink(self)
+        return real_is_symlink(self)
 
     def mock_stat_ebadmsg(self, follow_symlinks=True):
         # Raise EBADMSG for any child of test_dir to ensure consistent behavior
         if self.parent == test_dir:
             raise OSError(errno.EBADMSG, "Bad message")
-        # For other paths, use the real os.stat
-        return os.stat(self, follow_symlinks=follow_symlinks)
+        return real_stat(self, follow_symlinks=follow_symlinks)
 
     with (
         patch.object(Path, "is_dir", mock_is_dir),

--- a/tests/homeassistant/test_module.py
+++ b/tests/homeassistant/test_module.py
@@ -27,8 +27,8 @@ async def test_load(
     coresys: CoreSys, tmp_supervisor_data: Path, ha_ws_client: AsyncMock
 ):
     """Test homeassistant module load."""
-    with open(
-        tmp_supervisor_data / "homeassistant" / "secrets.yaml", "w", encoding="utf-8"
+    with (tmp_supervisor_data / "homeassistant" / "secrets.yaml").open(
+        "w", encoding="utf-8"
     ) as secrets:
         secrets.write("hello: world\n")
 

--- a/tests/mounts/test_mount.py
+++ b/tests/mounts/test_mount.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import errno
-import os
 from pathlib import Path
 import stat
 from typing import Any
@@ -712,7 +711,7 @@ async def test_mount_local_where_invalid(
         await mount.mount()
 
     # Cannot mount on top of a non-empty directory
-    os.remove(mount_path)
+    mount_path.unlink()
     mount_path.mkdir()
     (mount_path / "test").touch()
 

--- a/tests/resolution/fixup/test_store_execute_reset.py
+++ b/tests/resolution/fixup/test_store_execute_reset.py
@@ -2,7 +2,6 @@
 
 # pylint: disable=import-error,protected-access
 import errno
-from os import listdir
 from pathlib import Path
 from unittest.mock import PropertyMock, patch
 
@@ -82,7 +81,7 @@ async def test_fixup(coresys: CoreSys):
     assert not corrupt_marker.exists()
     assert len(coresys.resolution.suggestions) == 0
     assert len(coresys.resolution.issues) == 0
-    assert len(listdir(coresys.config.path_tmp)) == 0
+    assert len(list(coresys.config.path_tmp.iterdir())) == 0
 
 
 @pytest.mark.usefixtures("supervisor_internet")
@@ -111,7 +110,7 @@ async def test_fixup_clone_fail(coresys: CoreSys):
     assert corrupt_marker.exists()
     assert len(coresys.resolution.suggestions) == 1
     assert len(coresys.resolution.issues) == 1
-    assert len(listdir(coresys.config.path_tmp)) == 0
+    assert len(list(coresys.config.path_tmp.iterdir())) == 0
 
 
 @pytest.mark.parametrize(
@@ -143,7 +142,7 @@ async def test_fixup_move_fail(coresys: CoreSys, error_num: int, unhealthy: bool
 
     assert len(coresys.resolution.suggestions) == 1
     assert len(coresys.resolution.issues) == 1
-    assert len(listdir(coresys.config.path_tmp)) == 0
+    assert len(list(coresys.config.path_tmp.iterdir())) == 0
     assert (
         UnhealthyReason.OSERROR_BAD_MESSAGE in coresys.resolution.unhealthy
     ) is unhealthy

--- a/tests/store/test_translation_load.py
+++ b/tests/store/test_translation_load.py
@@ -1,7 +1,6 @@
 """Test loading add-translation."""
 
 # pylint: disable=import-error,protected-access
-import os
 from pathlib import Path
 
 import pytest
@@ -13,7 +12,7 @@ from supervisor.utils.common import write_json_or_yaml_file
 
 def test_loading_traslations(coresys: CoreSys, tmp_path: Path):
     """Test loading add-translation."""
-    os.makedirs(tmp_path / "translations")
+    (tmp_path / "translations").mkdir(parents=True)
     # no transaltions
     assert _read_app_translations(tmp_path) == {}
 
@@ -69,7 +68,7 @@ def test_translation_file_failure(
     coresys: CoreSys, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ):
     """Test translations load if one fails."""
-    os.makedirs(tmp_path / "translations")
+    (tmp_path / "translations").mkdir(parents=True)
     write_json_or_yaml_file(
         tmp_path / "translations" / "en.json",
         {"configuration": {"test": {"name": "test", "test": "test"}}},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Turn on the PTH rule set in ruff and convert the remaining call sites that triggered violations:

- `supervisor/utils/yaml.py` and `tests/homeassistant/test_module.py` use `Path.open()` instead of the builtin `open()`.
- `tests/backups/test_backup.py` and `tests/resolution/fixup/test_store_execute_reset.py` use `Path.iterdir()` instead of `os.listdir()`.
- `tests/mounts/test_mount.py` uses `Path.unlink()` instead of `os.remove()`.
- `tests/store/test_translation_load.py` uses `Path.mkdir(parents=True)` instead of `os.makedirs()`.
- `tests/hardware/test_disk.py` captures the unpatched `Path.is_dir`, `Path.is_symlink` and `Path.stat` before the `patch.object(Path, ...)` block so the mocks can delegate to the real implementations without reaching for `os.path.isdir`/`os.path.islink`/`os.stat`.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
