### PR TITLE
Enable flake8-pyi, flake8-return, flake8-raise ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,10 @@ disable = [
   "use-list-literal",                  # C405
   "useless-object-inheritance",        # UP004
   "useless-return",                    # PLR1711
+  "no-else-break",                     # RET508
+  "no-else-continue",                  # RET507
+  "no-else-raise",                     # RET506
+  "no-else-return",                    # RET505
   # "no-self-use", # PLR6301  # Optional plugin, not enabled
 ]
 
@@ -278,6 +282,9 @@ lint.select = [
   "PLW",     # pylint
   "PT",      # flake8-pytest-style
   "PTH",     # flake8-pathlib
+  "PYI",     # flake8-pyi
+  "RET",     # flake8-return
+  "RSE",     # flake8-raise
   "Q000",    # Double quotes found but single quotes preferred
   "RUF006",  # Store a reference to the return value of asyncio.create_task
   "S102",    # Use of exec detected

--- a/supervisor/api/auth.py
+++ b/supervisor/api/auth.py
@@ -96,14 +96,14 @@ class APIAuth(CoreSysAttributes):
         if request.headers.get(CONTENT_TYPE) == CONTENT_TYPE_JSON:
             data = await request.json(loads=json_loads)
             if not await self._process_dict(request, app, data):
-                raise HTTPUnauthorized()
+                raise HTTPUnauthorized
             return True
 
         # URL encoded
         if request.headers.get(CONTENT_TYPE) == CONTENT_TYPE_URL:
             data = await request.post()
             if not await self._process_dict(request, app, data):
-                raise HTTPUnauthorized()
+                raise HTTPUnauthorized
             return True
 
         # Advertise Basic authentication by default

--- a/supervisor/api/host.py
+++ b/supervisor/api/host.py
@@ -198,7 +198,7 @@ class APIHost(CoreSysAttributes):
             try:
                 return await self.sys_host.logs.get_boot_id(offset)
             except (ValueError, HostLogError) as err:
-                raise APIError() from err
+                raise APIError from err
         return possible_offset
 
     async def advanced_logs_handler(

--- a/supervisor/api/ingress.py
+++ b/supervisor/api/ingress.py
@@ -85,7 +85,7 @@ class APIIngress(CoreSysAttributes):
         app = self.sys_ingress.get(token)
         if not app:
             _LOGGER.warning("Ingress for %s not available", token)
-            raise HTTPServiceUnavailable()
+            raise HTTPServiceUnavailable
 
         return app
 
@@ -135,7 +135,7 @@ class APIIngress(CoreSysAttributes):
         # Check Ingress Session
         if not self.sys_ingress.validate_session(data[ATTR_SESSION]):
             _LOGGER.warning("No valid ingress session %s", data[ATTR_SESSION])
-            raise HTTPUnauthorized()
+            raise HTTPUnauthorized
 
     async def handler(
         self, request: web.Request
@@ -146,7 +146,7 @@ class APIIngress(CoreSysAttributes):
         session = request.cookies.get(COOKIE_INGRESS, "")
         if not self.sys_ingress.validate_session(session):
             _LOGGER.warning("No valid ingress session %s", session)
-            raise HTTPUnauthorized()
+            raise HTTPUnauthorized
 
         # Process requests
         app = self._extract_app(request)
@@ -163,7 +163,7 @@ class APIIngress(CoreSysAttributes):
         except aiohttp.ClientError as err:
             _LOGGER.error("Ingress error: %s", err)
 
-        raise HTTPBadGateway()
+        raise HTTPBadGateway
 
     async def _handle_websocket(
         self,

--- a/supervisor/api/middleware/security.py
+++ b/supervisor/api/middleware/security.py
@@ -311,7 +311,7 @@ class SecurityMiddleware(CoreSysAttributes):
         # Blacklist
         if BLACKLIST.match(request.path):
             _LOGGER.error("%s is blacklisted!", request.path)
-            raise HTTPForbidden()
+            raise HTTPForbidden
 
         # Ignore security check
         if patterns.no_security_check.match(request.path):
@@ -322,7 +322,7 @@ class SecurityMiddleware(CoreSysAttributes):
         # Not token
         if not supervisor_token:
             _LOGGER.warning("No API token provided for %s", request.path)
-            raise HTTPUnauthorized()
+            raise HTTPUnauthorized
 
         # Home-Assistant
         if supervisor_token == self.sys_homeassistant.supervisor_token:
@@ -333,7 +333,7 @@ class SecurityMiddleware(CoreSysAttributes):
                 "Attempted access to %s from client besides Home Assistant",
                 request.path,
             )
-            raise HTTPForbidden()
+            raise HTTPForbidden
 
         # Host
         if supervisor_token == self.sys_plugins.cli.supervisor_token:
@@ -344,7 +344,7 @@ class SecurityMiddleware(CoreSysAttributes):
         if supervisor_token == self.sys_plugins.observer.supervisor_token:
             if not OBSERVER_CHECK.match(request.path):
                 _LOGGER.warning("%s invalid Observer access", request.path)
-                raise HTTPForbidden()
+                raise HTTPForbidden
             _LOGGER.debug("%s access from Observer", request.path)
             request_from = self.sys_plugins.observer
 
@@ -372,4 +372,4 @@ class SecurityMiddleware(CoreSysAttributes):
             return await handler(request)
 
         _LOGGER.error("Invalid token for access %s", request.path)
-        raise HTTPForbidden()
+        raise HTTPForbidden

--- a/supervisor/api/proxy.py
+++ b/supervisor/api/proxy.py
@@ -59,7 +59,7 @@ class APIProxy(CoreSysAttributes):
             await response.prepare(request)
             async for data in client.content:
                 await response.write(data)
-        except (aiohttp.ClientError, aiohttp.ClientPayloadError):
+        except aiohttp.ClientError, aiohttp.ClientPayloadError:
             # Client disconnected or upstream closed
             pass
 
@@ -82,7 +82,7 @@ class APIProxy(CoreSysAttributes):
             _LOGGER.debug("%s access from %s", request.path, app.slug)
             return
 
-        raise HTTPUnauthorized()
+        raise HTTPUnauthorized
 
     @asynccontextmanager
     async def _api_client(
@@ -115,13 +115,13 @@ class APIProxy(CoreSysAttributes):
         except TimeoutError:
             _LOGGER.error("Client timeout error on API request %s", path)
 
-        raise HTTPBadGateway()
+        raise HTTPBadGateway
 
     async def stream(self, request: web.Request):
         """Proxy HomeAssistant EventStream Requests."""
         self._check_access(request)
         if not await self.sys_homeassistant.api.check_api_state():
-            raise HTTPBadGateway()
+            raise HTTPBadGateway
 
         _LOGGER.info("Home Assistant EventStream start")
         async with self._api_client(request, "stream", timeout=None) as client:
@@ -138,7 +138,7 @@ class APIProxy(CoreSysAttributes):
         """Proxy Home Assistant API Requests."""
         self._check_access(request)
         if not await self.sys_homeassistant.api.check_api_state():
-            raise HTTPBadGateway()
+            raise HTTPBadGateway
 
         # Normal request
         path = request.match_info.get("path", "")
@@ -221,7 +221,7 @@ class APIProxy(CoreSysAttributes):
     async def websocket(self, request: web.Request):
         """Initialize a WebSocket API connection."""
         if not await self.sys_homeassistant.api.check_api_state():
-            raise HTTPBadGateway()
+            raise HTTPBadGateway
         _LOGGER.info("Home Assistant WebSocket API request initialize")
 
         # init server

--- a/supervisor/api/utils.py
+++ b/supervisor/api/utils.py
@@ -85,7 +85,7 @@ def api_process(method):
             return answer
         if isinstance(answer, web.StreamResponse):
             return answer
-        elif isinstance(answer, bool) and not answer:
+        if isinstance(answer, bool) and not answer:
             return api_return_error()
         return api_return_ok()
 
@@ -100,7 +100,7 @@ def require_home_assistant(method):
         coresys: CoreSys = api.coresys
         request: Request = args[0]
         if request[REQUEST_FROM] != coresys.homeassistant:
-            raise HTTPUnauthorized()
+            raise HTTPUnauthorized
         return await method(api, *args, **kwargs)
 
     return wrap_api

--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -271,7 +271,7 @@ class App(AppModel):
                     await self.instance.install(
                         self.version, default_image, arch=self.arch
                     )
-                except (DockerError, AppNotSupportedError):
+                except DockerError, AppNotSupportedError:
                     self._create_missing_image_issue()
         except DockerError as err:
             # Docker error other than a clean "image not found" - we can't
@@ -1386,7 +1386,7 @@ class App(AppModel):
                 write_json_file(temp_path.joinpath("addon.json"), metadata)
             except ConfigurationFileError as err:
                 _LOGGER.error("Can't save meta for %s: %s", self.slug, err)
-                raise BackupRestoreUnknownError() from err
+                raise BackupRestoreUnknownError from err
 
             # Store AppArmor Profile
             if apparmor_profile:
@@ -1399,7 +1399,7 @@ class App(AppModel):
                     _LOGGER.error(
                         "Can't backup AppArmor profile for %s: %s", self.slug, err
                     )
-                    raise BackupRestoreUnknownError() from err
+                    raise BackupRestoreUnknownError from err
 
             # Write tarfile
             with tar_file as backup:
@@ -1463,10 +1463,10 @@ class App(AppModel):
             _LOGGER.info("Finish backup for app %s", self.slug)
         except DockerError as err:
             _LOGGER.error("Can't export image for app %s: %s", self.slug, err)
-            raise BackupRestoreUnknownError() from err
+            raise BackupRestoreUnknownError from err
         except (tarfile.TarError, OSError, AddFileError) as err:
             _LOGGER.error("Can't write backup tarfile for app %s: %s", self.slug, err)
-            raise BackupRestoreUnknownError() from err
+            raise BackupRestoreUnknownError from err
         finally:
             await self.sys_run_in_executor(temp_dir.cleanup)
             if was_running:
@@ -1515,7 +1515,7 @@ class App(AppModel):
                 _LOGGER.error,
             ) from err
         except tarfile.TarError as err:
-            raise BackupRestoreUnknownError() from err
+            raise BackupRestoreUnknownError from err
         except ConfigurationFileError as err:
             raise AppUnknownError(app=self.slug) from err
 
@@ -1593,7 +1593,7 @@ class App(AppModel):
                     _LOGGER.error(
                         "Can't restore origin data for %s: %s", self.slug, err
                     )
-                    raise BackupRestoreUnknownError() from err
+                    raise BackupRestoreUnknownError from err
 
                 # Restore AppArmor
                 profile_file = Path(tmp.name, "apparmor.txt")
@@ -1608,7 +1608,7 @@ class App(AppModel):
                             self.slug,
                             err,
                         )
-                        raise BackupRestoreUnknownError() from err
+                        raise BackupRestoreUnknownError from err
 
             finally:
                 # Is app loaded

--- a/supervisor/apps/model.py
+++ b/supervisor/apps/model.py
@@ -373,7 +373,7 @@ class AppModel(JobGroup, ABC):
         """Return True if AppArmor is enabled."""
         if not self.data.get(ATTR_APPARMOR):
             return SECURITY_DISABLE
-        elif self.sys_host.apparmor.exists(self.slug):
+        if self.sys_host.apparmor.exists(self.slug):
             return SECURITY_PROFILE
         return SECURITY_DEFAULT
 
@@ -712,7 +712,7 @@ class AppModel(JobGroup, ABC):
         """Validate if app is available for current system."""
         return self._validate_availability(self.data, logger=_LOGGER.error)
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Compare app objects."""
         if not isinstance(other, AppModel):
             return False

--- a/supervisor/apps/options.py
+++ b/supervisor/apps/options.py
@@ -94,7 +94,7 @@ class AppOptions(CoreSysAttributes):
             typ = self.raw_schema[key]
             try:
                 options[key] = self._validate_element(typ, value, key)
-            except (IndexError, KeyError):
+            except IndexError, KeyError:
                 raise vol.Invalid(
                     f"Type error for option '{key}' in {self._name} ({self._slug})"
                 ) from None
@@ -108,12 +108,11 @@ class AppOptions(CoreSysAttributes):
         if isinstance(typ, list):
             # nested value list
             return self._nested_validate_list(typ[0], value, key)
-        elif isinstance(typ, dict):
+        if isinstance(typ, dict):
             # nested value dict
             return self._nested_validate_dict(typ, value, key)
-        else:
-            # normal value
-            return self._single_validate(typ, value, key)
+        # normal value
+        return self._single_validate(typ, value, key)
 
     # pylint: disable=no-value-for-parameter
     def _single_validate(self, typ: str, value: Any, key: str) -> Any:
@@ -152,23 +151,23 @@ class AppOptions(CoreSysAttributes):
             if typ.startswith(_PASSWORD) and value:
                 self.pwned.add(hashlib.sha1(str(value).encode()).hexdigest())
             return vol.All(str(value), vol.Range(**range_args))(value)
-        elif typ.startswith(_INT):
+        if typ.startswith(_INT):
             return vol.All(vol.Coerce(int), vol.Range(**range_args))(value)
-        elif typ.startswith(_FLOAT):
+        if typ.startswith(_FLOAT):
             return vol.All(vol.Coerce(float), vol.Range(**range_args))(value)
-        elif typ.startswith(_BOOL):
+        if typ.startswith(_BOOL):
             return vol.Boolean()(value)
-        elif typ.startswith(_EMAIL):
+        if typ.startswith(_EMAIL):
             return vol.Email()(value)
-        elif typ.startswith(_URL):
+        if typ.startswith(_URL):
             return vol.Url()(value)
-        elif typ.startswith(_PORT):
+        if typ.startswith(_PORT):
             return network_port(value)
-        elif typ.startswith(_MATCH):
+        if typ.startswith(_MATCH):
             return vol.Match(match.group("match"))(str(value))
-        elif typ.startswith(_LIST):
+        if typ.startswith(_LIST):
             return vol.In(match.group("list").split("|"))(str(value))
-        elif typ.startswith(_DEVICE):
+        if typ.startswith(_DEVICE):
             if not isinstance(value, str):
                 raise vol.Invalid(
                     f"Expected a string for option '{key}' in {self._name} ({self._slug})"

--- a/supervisor/arch.py
+++ b/supervisor/arch.py
@@ -84,7 +84,7 @@ class CpuArchManager(CoreSysAttributes):
         for self_arch in self.supported:
             if self_arch in arch_list:
                 return CpuArch(self_arch)
-        raise HassioArchNotFound()
+        raise HassioArchNotFound
 
     def detect_cpu(self) -> CpuArch:
         """Return the arch type of local CPU."""

--- a/supervisor/auth.py
+++ b/supervisor/auth.py
@@ -136,7 +136,7 @@ class Auth(FileConfiguration, CoreSysAttributes):
         finally:
             self._running.pop(username, None)
 
-        raise AuthHomeAssistantAPIValidationError()
+        raise AuthHomeAssistantAPIValidationError
 
     async def change_password(self, username: str, password: str) -> None:
         """Change user password login."""
@@ -162,7 +162,7 @@ class Auth(FileConfiguration, CoreSysAttributes):
             return await self.sys_homeassistant.list_users()
         except HomeAssistantWSError as err:
             _LOGGER.error("Can't request listing users on Home Assistant: %s", err)
-            raise AuthListUsersError() from err
+            raise AuthListUsersError from err
 
     @staticmethod
     def _rehash(value: str, salt2: str = "") -> str:

--- a/supervisor/backups/backup.py
+++ b/supervisor/backups/backup.py
@@ -268,7 +268,7 @@ class Backup(JobGroup):
         """Returns a copy of the data."""
         return deepcopy(self._data)
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Return true if backups have same metadata."""
         return isinstance(other, Backup) and self.slug == other.slug
 

--- a/supervisor/bootstrap.py
+++ b/supervisor/bootstrap.py
@@ -301,17 +301,17 @@ def register_signal_handlers(
     """Register SIGTERM, SIGHUP and SIGKILL to stop the Supervisor."""
     try:
         loop.add_signal_handler(signal.SIGTERM, shutdown_handler)
-    except (ValueError, RuntimeError):
+    except ValueError, RuntimeError:
         _LOGGER.warning("Could not bind to SIGTERM")
 
     try:
         loop.add_signal_handler(signal.SIGHUP, shutdown_handler)
-    except (ValueError, RuntimeError):
+    except ValueError, RuntimeError:
         _LOGGER.warning("Could not bind to SIGHUP")
 
     try:
         loop.add_signal_handler(signal.SIGINT, shutdown_handler)
-    except (ValueError, RuntimeError):
+    except ValueError, RuntimeError:
         _LOGGER.warning("Could not bind to SIGINT")
 
 

--- a/supervisor/bus.py
+++ b/supervisor/bus.py
@@ -51,5 +51,5 @@ class Bus(CoreSysAttributes):
         """Unregister an listener."""
         try:
             self._listeners[listener.event_type].remove(listener)
-        except (ValueError, KeyError):
+        except ValueError, KeyError:
             _LOGGER.warning("Listener %s not registered", listener)

--- a/supervisor/dbus/agent/__init__.py
+++ b/supervisor/dbus/agent/__init__.py
@@ -111,7 +111,7 @@ class OSAgent(DBusInterfaceProxy):
         _LOGGER.info("Load dbus interface %s", self.name)
         try:
             await super().connect(bus)
-        except (DBusServiceUnkownError, DBusInterfaceError):
+        except DBusServiceUnkownError, DBusInterfaceError:
             _LOGGER.error(
                 "No OS-Agent support on the host. Some Host functions have been disabled."
             )

--- a/supervisor/dbus/hostname.py
+++ b/supervisor/dbus/hostname.py
@@ -40,7 +40,7 @@ class Hostname(DBusInterfaceProxy):
             await super().connect(bus)
         except DBusError:
             _LOGGER.warning("Can't connect to systemd-hostname")
-        except (DBusServiceUnkownError, DBusInterfaceError):
+        except DBusServiceUnkownError, DBusInterfaceError:
             _LOGGER.warning(
                 "No hostname support on the host. Hostname functions have been disabled."
             )

--- a/supervisor/dbus/interface.py
+++ b/supervisor/dbus/interface.py
@@ -19,7 +19,7 @@ def dbus_property(func):
     def wrapper(*args, **kwds):
         try:
             return func(*args, **kwds)
-        except (KeyError, AttributeError):
+        except KeyError, AttributeError:
             return None
 
     return wrapper
@@ -56,7 +56,7 @@ class DBusInterface(ABC):
     def connected_dbus(self) -> DBus:
         """Return dbus object. Raise if not connected."""
         if not self.dbus:
-            raise DBusNotConnectedError()
+            raise DBusNotConnectedError
         return self.dbus
 
     async def connect(self, bus: MessageBus) -> None:

--- a/supervisor/dbus/logind.py
+++ b/supervisor/dbus/logind.py
@@ -29,7 +29,7 @@ class Logind(DBusInterface):
             await super().connect(bus)
         except DBusError:
             _LOGGER.warning("Can't connect to systemd-logind")
-        except (DBusServiceUnkownError, DBusInterfaceError):
+        except DBusServiceUnkownError, DBusInterfaceError:
             _LOGGER.warning("No systemd-logind support on the host.")
 
     @dbus_connected

--- a/supervisor/dbus/manager.py
+++ b/supervisor/dbus/manager.py
@@ -95,7 +95,7 @@ class DBusManager(CoreSysAttributes):
     def connected_bus(self) -> MessageBus:
         """Return the message bus. Raise if not connected."""
         if not self._bus:
-            raise DBusNotConnectedError()
+            raise DBusNotConnectedError
         return self._bus
 
     @property

--- a/supervisor/dbus/network/__init__.py
+++ b/supervisor/dbus/network/__init__.py
@@ -148,7 +148,7 @@ class NetworkManager(DBusInterfaceProxy):
             await self.settings.connect(bus)
         except DBusError:
             _LOGGER.warning("Can't connect to Network Manager")
-        except (DBusServiceUnkownError, DBusInterfaceError):
+        except DBusServiceUnkownError, DBusInterfaceError:
             _LOGGER.warning(
                 "No Network Manager support on the host. Local network functions have been disabled."
             )
@@ -157,7 +157,7 @@ class NetworkManager(DBusInterfaceProxy):
         if self.is_connected:
             try:
                 await self._validate_version()
-            except (HostNotSupportedError, DBusError):
+            except HostNotSupportedError, DBusError:
                 self.disconnect()
                 self.dns.disconnect()
                 self.settings.disconnect()
@@ -170,7 +170,7 @@ class NetworkManager(DBusInterfaceProxy):
         try:
             if self.version >= MINIMAL_VERSION:
                 return
-        except (AwesomeVersionException, KeyError):
+        except AwesomeVersionException, KeyError:
             pass
 
         raise HostNotSupportedError(

--- a/supervisor/dbus/network/dns.py
+++ b/supervisor/dbus/network/dns.py
@@ -68,7 +68,7 @@ class NetworkManagerDNS(DBusInterfaceProxy):
             await super().connect(bus)
         except DBusError:
             _LOGGER.warning("Can't connect to DnsManager")
-        except (DBusServiceUnkownError, DBusInterfaceError):
+        except DBusServiceUnkownError, DBusInterfaceError:
             _LOGGER.warning(
                 "No DnsManager support on the host. Local DNS functions have been disabled."
             )

--- a/supervisor/dbus/network/settings.py
+++ b/supervisor/dbus/network/settings.py
@@ -29,7 +29,7 @@ class NetworkManagerSettings(DBusInterface):
             await super().connect(bus)
         except DBusError:
             _LOGGER.warning("Can't connect to Network Manager Settings")
-        except (DBusServiceUnkownError, DBusInterfaceError):
+        except DBusServiceUnkownError, DBusInterfaceError:
             _LOGGER.warning(
                 "No Network Manager Settings support on the host. Local network functions have been disabled."
             )

--- a/supervisor/dbus/rauc.py
+++ b/supervisor/dbus/rauc.py
@@ -74,7 +74,7 @@ class Rauc(DBusInterfaceProxy):
             await super().connect(bus)
         except DBusError:
             _LOGGER.warning("Can't connect to rauc")
-        except (DBusServiceUnkownError, DBusInterfaceError):
+        except DBusServiceUnkownError, DBusInterfaceError:
             _LOGGER.warning("Host has no rauc support. OTA updates have been disabled.")
 
     @property

--- a/supervisor/dbus/resolved.py
+++ b/supervisor/dbus/resolved.py
@@ -60,7 +60,7 @@ class Resolved(DBusInterfaceProxy):
             await super().connect(bus)
         except DBusError:
             _LOGGER.warning("Can't connect to systemd-resolved.")
-        except (DBusServiceUnkownError, DBusInterfaceError):
+        except DBusServiceUnkownError, DBusInterfaceError:
             _LOGGER.warning(
                 "Host has no systemd-resolved support. DNS will not work correctly."
             )

--- a/supervisor/dbus/timedate.py
+++ b/supervisor/dbus/timedate.py
@@ -76,7 +76,7 @@ class TimeDate(DBusInterfaceProxy):
             await super().connect(bus)
         except DBusError:
             _LOGGER.warning("Can't connect to systemd-timedate")
-        except (DBusServiceUnkownError, DBusInterfaceError):
+        except DBusServiceUnkownError, DBusInterfaceError:
             _LOGGER.warning(
                 "No timedate support on the host. Time/Date functions have been disabled."
             )

--- a/supervisor/dbus/udisks2/__init__.py
+++ b/supervisor/dbus/udisks2/__init__.py
@@ -69,7 +69,7 @@ class UDisks2Manager(DBusInterfaceProxy):
             await self.udisks2_object_manager.connect(bus)
         except DBusError as err:
             _LOGGER.critical("Can't connect to udisks2: %s", err)
-        except (DBusServiceUnkownError, DBusInterfaceError):
+        except DBusServiceUnkownError, DBusInterfaceError:
             _LOGGER.warning(
                 "No udisks2 support on the host. Host control has been disabled."
             )

--- a/supervisor/dbus/utils.py
+++ b/supervisor/dbus/utils.py
@@ -15,7 +15,7 @@ def dbus_connected(method):
         if api.is_shutdown:
             return noop()
         if api.dbus is None:
-            raise DBusNotConnectedError()
+            raise DBusNotConnectedError
         return method(api, *args, **kwargs)
 
     return wrap_dbus

--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -479,7 +479,7 @@ class DockerInterface(JobGroup, ABC):
     )
     async def run(self) -> None:
         """Run Docker image."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     async def _run(self, *, name: str, **kwargs) -> None:
         """Run Docker image with retry if necessary."""
@@ -658,7 +658,7 @@ class DockerInterface(JobGroup, ABC):
     )
     async def execute_command(self, command: str) -> CommandReturn:
         """Create a temporary container and run command."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     async def stats(self) -> DockerStats:
         """Read and return stats from container."""
@@ -683,7 +683,7 @@ class DockerInterface(JobGroup, ABC):
                     available_version.append(version)
 
             if not available_version:
-                raise ValueError()
+                raise ValueError
 
         except (aiodocker.DockerError, ValueError) as err:
             raise DockerNotFound(

--- a/supervisor/docker/manager.py
+++ b/supervisor/docker/manager.py
@@ -824,7 +824,7 @@ class DockerAPI(CoreSysAttributes):
         except aiodocker.DockerError as err:
             if err.status == HTTPStatus.NOT_FOUND:
                 # Generally suppressed so we don't log this
-                raise DockerNotFound() from None
+                raise DockerNotFound from None
             raise DockerError(
                 f"Could not get container {name} for stopping: {err!s}",
                 _LOGGER.error,

--- a/supervisor/hardware/manager.py
+++ b/supervisor/hardware/manager.py
@@ -102,7 +102,7 @@ class HardwareManager(CoreSysAttributes):
                 return device
             if device_node in device.links:
                 return device
-        raise HardwareNotFound()
+        raise HardwareNotFound
 
     def filter_devices(self, subsystem: UdevSubsystem | None = None) -> list[Device]:
         """Return a filtered list."""

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -423,7 +423,7 @@ class HomeAssistantCore(JobGroup):
             await _update(rollback_version)
         else:
             self.sys_resolution.create_issue(IssueType.UPDATE_FAILED, ContextType.CORE)
-            raise HomeAssistantUpdateError()
+            raise HomeAssistantUpdateError
 
     @Job(
         name="home_assistant_core_start",
@@ -441,7 +441,7 @@ class HomeAssistantCore(JobGroup):
             try:
                 await self.instance.start()
             except DockerError as err:
-                raise HomeAssistantError() from err
+                raise HomeAssistantError from err
 
             await self._block_till_run()
         # No Instance/Container found, extended start
@@ -456,7 +456,7 @@ class HomeAssistantCore(JobGroup):
             try:
                 await self.instance.run(restore_job_id=self.sys_backups.current_restore)
             except DockerError as err:
-                raise HomeAssistantError() from err
+                raise HomeAssistantError from err
 
             await self._block_till_run()
 
@@ -470,7 +470,7 @@ class HomeAssistantCore(JobGroup):
         try:
             return await self.instance.stop(remove_container=remove_container)
         except DockerError as err:
-            raise HomeAssistantError() from err
+            raise HomeAssistantError from err
 
     @Job(
         name="home_assistant_core_restart",
@@ -489,7 +489,7 @@ class HomeAssistantCore(JobGroup):
         try:
             await self.instance.restart()
         except DockerError as err:
-            raise HomeAssistantError() from err
+            raise HomeAssistantError from err
 
         await self._block_till_run()
 
@@ -516,7 +516,7 @@ class HomeAssistantCore(JobGroup):
         try:
             return await self.instance.stats()
         except DockerError as err:
-            raise HomeAssistantError() from err
+            raise HomeAssistantError from err
 
     def is_running(self) -> Awaitable[bool]:
         """Return True if Docker container is running.
@@ -552,7 +552,7 @@ class HomeAssistantCore(JobGroup):
                 ]
             )
         except DockerError as err:
-            raise HomeAssistantError() from err
+            raise HomeAssistantError from err
 
         # If not valid
         if result.exit_code is None:
@@ -613,7 +613,7 @@ class HomeAssistantCore(JobGroup):
                 "No Home Assistant Core response, assuming a fatal startup error",
                 _LOGGER.error,
             )
-        raise HomeAssistantCrashError()
+        raise HomeAssistantCrashError
 
     @Job(
         name="home_assistant_core_repair",

--- a/supervisor/homeassistant/module.py
+++ b/supervisor/homeassistant/module.py
@@ -284,7 +284,7 @@ class HomeAssistant(FileConfiguration, CoreSysAttributes):
         """Return true if a Home Assistant update is available."""
         try:
             return self.version is not None and self.version < self.latest_version
-        except (AwesomeVersionException, TypeError):
+        except AwesomeVersionException, TypeError:
             return False
 
     @property
@@ -543,7 +543,7 @@ class HomeAssistant(FileConfiguration, CoreSysAttributes):
                 try:
                     data = read_json_file(temp_meta)
                 except ConfigurationFileError as err:
-                    raise HomeAssistantError() from err
+                    raise HomeAssistantError from err
 
                 return data
 

--- a/supervisor/host/network.py
+++ b/supervisor/host/network.py
@@ -123,7 +123,7 @@ class NetworkManager(CoreSysAttributes):
     def get(self, inet_name: str) -> Interface:
         """Return interface from interface name."""
         if inet_name not in self.sys_dbus.network:
-            raise HostNetworkNotFound()
+            raise HostNetworkNotFound
 
         return Interface.from_dbus_interface(self.sys_dbus.network.get(inet_name))
 
@@ -369,7 +369,7 @@ class NetworkManager(CoreSysAttributes):
             await inet.wireless.request_scan()
         except DBusError as err:
             _LOGGER.warning("Can't request a new scan: %s", err)
-            raise HostNetworkError() from err
+            raise HostNetworkError from err
 
         await asyncio.sleep(5)
 

--- a/supervisor/host/services.py
+++ b/supervisor/host/services.py
@@ -98,7 +98,7 @@ class ServiceManager(CoreSysAttributes):
                 ):
                     continue
                 self._services.add(ServiceInfo.read_from(service_data))
-        except (HassioError, IndexError):
+        except HassioError, IndexError:
             _LOGGER.warning("Can't update host service information!")
 
 

--- a/supervisor/jobs/decorator.py
+++ b/supervisor/jobs/decorator.py
@@ -285,7 +285,7 @@ class Job(CoreSysAttributes):
                 # Handle execution limits using context manager
                 async with self._concurrency_control(job_group, job):
                     if not await self._handle_throttling(group_name):
-                        return  # Job was throttled, exit early
+                        return None  # Job was throttled, exit early
 
                     # Execute Job
                     with job.start():
@@ -309,7 +309,7 @@ class Job(CoreSysAttributes):
                             _LOGGER.exception("Unhandled exception: %s", err)
                             job.capture_error()
                             await async_capture_exception(err)
-                            raise JobException() from err
+                            raise JobException from err
 
             # Jobs that weren't started are always cleaned up. Also clean up done jobs if required
             finally:

--- a/supervisor/os/manager.py
+++ b/supervisor/os/manager.py
@@ -148,12 +148,12 @@ class OSManager(CoreSysAttributes):
     def get_slot_name(self, boot_name: str) -> str:
         """Get slot name from boot name."""
         if not self._slots:
-            raise HassOSSlotNotFound()
+            raise HassOSSlotNotFound
 
         for name, status in self._slots.items():
             if status.bootname == boot_name:
                 return name
-        raise HassOSSlotNotFound()
+        raise HassOSSlotNotFound
 
     def _get_download_url(self, version: AwesomeVersion) -> str:
         raw_url = self.sys_updater.ota_url
@@ -173,10 +173,9 @@ class OSManager(CoreSysAttributes):
         else:
             update_os_name = "haos"
 
-        url = raw_url.format(
+        return raw_url.format(
             version=str(version), board=update_board, os_name=update_os_name
         )
-        return url
 
     async def _download_raucb(self, url: str, raucb: Path) -> None:
         """Download rauc bundle (OTA) from URL."""
@@ -229,13 +228,13 @@ class OSManager(CoreSysAttributes):
         """Load HassOS data."""
         try:
             if not self.sys_host.info.cpe:
-                raise NotImplementedError()
+                raise NotImplementedError
 
             cpe = CPE(self.sys_host.info.cpe)
             os_name = cpe.get_product()[0]
             if os_name not in ("hassos", "haos"):
                 self._board = BOARD_NAME_SUPERVISED.lower()
-                raise NotImplementedError()
+                raise NotImplementedError
         except NotImplementedError:
             _LOGGER.info("No Home Assistant Operating System found")
             return
@@ -329,7 +328,7 @@ class OSManager(CoreSysAttributes):
             "Home Assistant Operating System update failed with: %s",
             self.sys_dbus.rauc.last_error,
         )
-        raise HassOSUpdateError()
+        raise HassOSUpdateError
 
     @Job(name="os_manager_mark_healthy", conditions=[JobCondition.HAOS], internal=True)
     async def mark_healthy(self) -> None:

--- a/supervisor/plugins/audio.py
+++ b/supervisor/plugins/audio.py
@@ -153,7 +153,7 @@ class PluginAudio(PluginBase):
         try:
             return await self.instance.stats()
         except DockerError as err:
-            raise AudioError() from err
+            raise AudioError from err
 
     async def repair(self) -> None:
         """Repair Audio plugin."""

--- a/supervisor/plugins/base.py
+++ b/supervisor/plugins/base.py
@@ -68,7 +68,7 @@ class PluginBase(ABC, FileConfiguration, CoreSysAttributes):
                 and self.latest_version is not None
                 and self.version < self.latest_version
             )
-        except (AwesomeVersionException, TypeError):
+        except AwesomeVersionException, TypeError:
             return False
 
     @property

--- a/supervisor/plugins/cli.py
+++ b/supervisor/plugins/cli.py
@@ -95,7 +95,7 @@ class PluginCli(PluginBase):
         try:
             return await self.instance.stats()
         except DockerError as err:
-            raise CliError() from err
+            raise CliError from err
 
     def is_running(self) -> Awaitable[bool]:
         """Return True if Docker container is running.

--- a/supervisor/plugins/dns.py
+++ b/supervisor/plugins/dns.py
@@ -501,7 +501,7 @@ class PluginDns(PluginBase):
         try:
             return await self.instance.stats()
         except DockerError as err:
-            raise CoreDNSError() from err
+            raise CoreDNSError from err
 
     async def repair(self) -> None:
         """Repair CoreDNS plugin."""

--- a/supervisor/plugins/multicast.py
+++ b/supervisor/plugins/multicast.py
@@ -98,7 +98,7 @@ class PluginMulticast(PluginBase):
         try:
             return await self.instance.stats()
         except DockerError as err:
-            raise MulticastError() from err
+            raise MulticastError from err
 
     async def repair(self) -> None:
         """Repair Multicast plugin."""

--- a/supervisor/plugins/observer.py
+++ b/supervisor/plugins/observer.py
@@ -93,7 +93,7 @@ class PluginObserver(PluginBase):
             raise ObserverPortConflict(_LOGGER.error) from err
         except DockerError as err:
             _LOGGER.error("Can't start observer plugin")
-            raise ObserverError() from err
+            raise ObserverError from err
 
     async def stop(self) -> None:
         """Raise. Supervisor should not stop observer."""
@@ -104,7 +104,7 @@ class PluginObserver(PluginBase):
         try:
             return await self.instance.stats()
         except DockerError as err:
-            raise ObserverError() from err
+            raise ObserverError from err
 
     async def check_system_runtime(self) -> bool:
         """Check if the observer is running."""
@@ -115,7 +115,7 @@ class PluginObserver(PluginBase):
             ) as request:
                 if request.status == 200:
                     return True
-        except (aiohttp.ClientError, TimeoutError):
+        except aiohttp.ClientError, TimeoutError:
             pass
 
         return False

--- a/supervisor/resolution/checks/dns_server.py
+++ b/supervisor/resolution/checks/dns_server.py
@@ -17,7 +17,7 @@ from .base import CheckBase
 
 
 async def check_server(
-    loop: asyncio.AbstractEventLoop, server: str, qtype: Literal["A"] | Literal["AAAA"]
+    loop: asyncio.AbstractEventLoop, server: str, qtype: Literal["A", "AAAA"]
 ) -> None:
     """Check a DNS server and report issues."""
     ip_addr = server[6:] if server.startswith("dns://") else server

--- a/supervisor/resolution/fixups/app_execute_remove.py
+++ b/supervisor/resolution/fixups/app_execute_remove.py
@@ -33,7 +33,7 @@ class FixupAppExecuteRemove(FixupBase):
             await app.uninstall(remove_config=False)
         except AppsError as err:
             _LOGGER.error("Could not remove %s due to %s", reference, err)
-            raise ResolutionFixupError() from None
+            raise ResolutionFixupError from None
 
     @property
     def suggestion(self) -> SuggestionType:

--- a/supervisor/resolution/fixups/app_execute_repair.py
+++ b/supervisor/resolution/fixups/app_execute_repair.py
@@ -65,7 +65,7 @@ class FixupAppExecuteRepair(FixupBase):
             # FixupBase swallows it without a Sentry event. The repair stays
             # available for manual retry once the underlying cause is fixed.
             _LOGGER.warning("Cannot repair app %s: %s", reference, err)
-            raise ResolutionFixupError() from err
+            raise ResolutionFixupError from err
 
     @property
     def suggestion(self) -> SuggestionType:

--- a/supervisor/resolution/fixups/app_execute_restart.py
+++ b/supervisor/resolution/fixups/app_execute_restart.py
@@ -32,7 +32,7 @@ class FixupAppExecuteRestart(FixupBase):
             await app.stop()
         except AppsError as err:
             _LOGGER.error("Could not stop %s due to %s", reference, err)
-            raise ResolutionFixupError() from None
+            raise ResolutionFixupError from None
 
         # Start app
         # Removing the container has already fixed the issue and dismissed it

--- a/supervisor/resolution/fixups/app_execute_start.py
+++ b/supervisor/resolution/fixups/app_execute_start.py
@@ -33,13 +33,13 @@ class FixupAppExecuteStart(FixupBase):
             start_task = await app.start()
         except AppsError as err:
             _LOGGER.error("Could not start %s due to %s", reference, err)
-            raise ResolutionFixupError() from None
+            raise ResolutionFixupError from None
 
         # Wait for app start. If it ends up in error or unknown state it's not fixed
         await start_task
         if app.state in {AppState.ERROR, AppState.UNKNOWN}:
             _LOGGER.error("App %s could not start successfully", reference)
-            raise ResolutionFixupError()
+            raise ResolutionFixupError
 
     @property
     def suggestion(self) -> SuggestionType:

--- a/supervisor/resolution/fixups/mount_execute_reload.py
+++ b/supervisor/resolution/fixups/mount_execute_reload.py
@@ -28,7 +28,7 @@ class FixupMountExecuteReload(FixupBase):
             # Leave the issue/suggestion in place so the user can try again
             # once the underlying problem (e.g. unreachable server) is fixed.
             _LOGGER.warning("Reload fixup for mount %s failed: %s", reference, err)
-            raise ResolutionFixupError() from err
+            raise ResolutionFixupError from err
 
     @property
     def suggestion(self) -> SuggestionType:

--- a/supervisor/resolution/fixups/store_execute_reload.py
+++ b/supervisor/resolution/fixups/store_execute_reload.py
@@ -48,7 +48,7 @@ class FixupStoreExecuteReload(FixupBase):
             await repository.load()
             await self.sys_store.reload(repository)
         except StoreError:
-            raise ResolutionFixupError() from None
+            raise ResolutionFixupError from None
 
     @property
     def suggestion(self) -> SuggestionType:

--- a/supervisor/resolution/fixups/store_execute_remove.py
+++ b/supervisor/resolution/fixups/store_execute_remove.py
@@ -34,7 +34,7 @@ class FixupStoreExecuteRemove(FixupBase):
         try:
             await self.sys_store.remove_repository(repository)
         except StoreError:
-            raise ResolutionFixupError() from None
+            raise ResolutionFixupError from None
 
     @property
     def suggestion(self) -> SuggestionType:

--- a/supervisor/resolution/fixups/store_execute_reset.py
+++ b/supervisor/resolution/fixups/store_execute_reset.py
@@ -45,7 +45,7 @@ class FixupStoreExecuteReset(FixupBase):
         try:
             await repository.reset()
         except StoreError:
-            raise ResolutionFixupError() from None
+            raise ResolutionFixupError from None
 
     @property
     def suggestion(self) -> SuggestionType:

--- a/supervisor/store/__init__.py
+++ b/supervisor/store/__init__.py
@@ -59,7 +59,7 @@ class StoreManager(CoreSysAttributes, FileConfiguration):
     def get(self, slug: str) -> Repository:
         """Return Repository with slug."""
         if slug not in self.repositories:
-            raise StoreNotFound()
+            raise StoreNotFound
         return self.repositories[slug]
 
     async def load(self) -> None:

--- a/supervisor/store/const.py
+++ b/supervisor/store/const.py
@@ -33,5 +33,4 @@ class BuiltinRepository(StrEnum):
             raise RuntimeError("Local repository does not have a git URL")
         if self == BuiltinRepository.CORE:
             return URL_HASSIO_ADDONS
-        else:
-            return self.value  # For URL-based repos, value is the URL
+        return self.value  # For URL-based repos, value is the URL

--- a/supervisor/store/git.py
+++ b/supervisor/store/git.py
@@ -66,7 +66,7 @@ class GitRepo(CoreSysAttributes):
                 UnicodeDecodeError,
             ) as err:
                 _LOGGER.error("Can't load %s", self.path)
-                raise StoreGitError() from err
+                raise StoreGitError from err
 
         # Fix possible corruption
         async with self.lock:
@@ -75,7 +75,7 @@ class GitRepo(CoreSysAttributes):
                 await self.sys_run_in_executor(self.repo.git.execute, ["git", "fsck"])
             except git.CommandError as err:
                 _LOGGER.error("Integrity check on %s failed: %s.", self.path, err)
-                raise StoreGitError() from err
+                raise StoreGitError from err
 
     @Job(
         name="git_repo_clone",
@@ -152,7 +152,7 @@ class GitRepo(CoreSysAttributes):
             UnicodeDecodeError,
         ) as err:
             _LOGGER.error("Can't clone %s repository: %s.", self.url, err)
-            raise StoreGitCloneError() from err
+            raise StoreGitCloneError from err
 
     @Job(
         name="git_repo_pull",
@@ -176,7 +176,7 @@ class GitRepo(CoreSysAttributes):
                 await self.sys_run_in_executor(git_cmd.ls_remote, "--heads", self.url)
             except git.CommandError as err:
                 _LOGGER.warning("Wasn't able to update %s repo: %s.", self.url, err)
-                raise StoreGitError() from err
+                raise StoreGitError from err
 
             try:
                 repo = self.repo
@@ -233,7 +233,7 @@ class GitRepo(CoreSysAttributes):
                     reference=self.path.stem,
                     suggestions=[SuggestionType.EXECUTE_RESET],
                 )
-                raise StoreGitError() from err
+                raise StoreGitError from err
 
     async def remove(self) -> None:
         """Remove a repository."""

--- a/supervisor/store/repository.py
+++ b/supervisor/store/repository.py
@@ -50,8 +50,7 @@ class Repository(CoreSysAttributes, ABC):
         """Create a repository instance."""
         if repository in BuiltinRepository:
             return Repository._create_builtin(coresys, BuiltinRepository(repository))
-        else:
-            return Repository._create_custom(coresys, repository)
+        return Repository._create_custom(coresys, repository)
 
     @staticmethod
     def _create_builtin(coresys: CoreSys, builtin: BuiltinRepository) -> Repository:
@@ -60,7 +59,7 @@ class Repository(CoreSysAttributes, ABC):
             slug = REPOSITORY_LOCAL
             local_path = coresys.config.path_apps_local
             return RepositoryLocal(coresys, local_path, slug)
-        elif builtin == BuiltinRepository.CORE:
+        if builtin == BuiltinRepository.CORE:
             slug = REPOSITORY_CORE
             local_path = coresys.config.path_apps_core
         else:

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -269,7 +269,7 @@ class Supervisor(CoreSysAttributes):
         try:
             return await self.instance.stats()
         except DockerError as err:
-            raise SupervisorUnknownError() from err
+            raise SupervisorUnknownError from err
 
     async def repair(self):
         """Repair local Supervisor data."""

--- a/supervisor/utils/__init__.py
+++ b/supervisor/utils/__init__.py
@@ -48,7 +48,7 @@ async def check_port(address: IPv4Address, port: int) -> bool:
     try:
         async with asyncio.timeout(0.5):
             await asyncio.get_running_loop().sock_connect(sock, (str(address), port))
-    except (OSError, TimeoutError):
+    except OSError, TimeoutError:
         return False
     finally:
         if sock is not None:

--- a/supervisor/utils/dbus.py
+++ b/supervisor/utils/dbus.py
@@ -368,7 +368,7 @@ class DBusCallWrapper:
     def __call__(self, *args, **kwargs) -> None:
         """Catch this method from being called."""
         _LOGGER.error("D-Bus method %s not exists!", self.interface)
-        raise DBusInterfaceMethodError()
+        raise DBusInterfaceMethodError
 
     def _dbus_action(
         self, name: str
@@ -448,7 +448,7 @@ class DBusCallWrapper:
 
             return _method_wrapper
 
-        elif dbus_type == "set":
+        if dbus_type == "set":
 
             def _set_wrapper(*args) -> Awaitable:
                 return DBus.call_dbus(dbus_proxy, name, *args, unpack_variants=False)

--- a/supervisor/utils/pwned.py
+++ b/supervisor/utils/pwned.py
@@ -20,7 +20,7 @@ async def check_pwned_password(websession: aiohttp.ClientSession, sha1_pw: str) 
     # Chech hit cache
     sha1_short = sha1_pw[:5]
     if sha1_short in _CACHE:
-        raise PwnedSecret()
+        raise PwnedSecret
 
     _LOGGER.debug("Check pwned state of %s", sha1_short)
     try:
@@ -38,7 +38,7 @@ async def check_pwned_password(websession: aiohttp.ClientSession, sha1_pw: str) 
             if not sha1_pw.endswith(line.split(":")[0]):
                 continue
             _CACHE.add(sha1_short)
-            raise PwnedSecret()
+            raise PwnedSecret
 
     except (aiohttp.ClientError, TimeoutError) as err:
         raise PwnedConnectivityError(

--- a/supervisor/validate.py
+++ b/supervisor/validate.py
@@ -112,7 +112,7 @@ token = vol.Match(r"^[0-9a-f]{32,256}$")
 
 
 def version_tag(
-    value: str | None | int | float | AwesomeVersion,
+    value: str | None | float | AwesomeVersion,
 ) -> AwesomeVersion | None:
     """Validate main version handling."""
     if value is None:

--- a/tests/api/test_ingress.py
+++ b/tests/api/test_ingress.py
@@ -126,28 +126,27 @@ async def test_ingress_proxy_no_content_type_for_empty_body_responses(
         if path == "/204":
             # 204 No Content - should not have Content-Type
             return web.Response(status=204)
-        elif path == "/304":
+        if path == "/304":
             # 304 Not Modified - should not have Content-Type
             return web.Response(status=304)
-        elif path == "/100":
+        if path == "/100":
             # 100 Continue - should not have Content-Type
             return web.Response(status=100)
-        elif path == "/head":
+        if path == "/head":
             # HEAD request - should have Content-Type (same as GET would)
             return web.Response(body=b"test", content_type="text/html")
-        elif path == "/200":
+        if path == "/200":
             # 200 OK with body - should have Content-Type
             return web.Response(body=b"test content", content_type="text/plain")
-        elif path == "/200-no-content-type":
+        if path == "/200-no-content-type":
             # 200 OK without explicit Content-Type - should get default
             return web.Response(body=b"test content")
-        elif path == "/200-json":
+        if path == "/200-json":
             # 200 OK with JSON - should preserve Content-Type
             return web.Response(
                 body=b'{"key": "value"}', content_type="application/json"
             )
-        else:
-            return web.Response(body=b"default", content_type="text/html")
+        return web.Response(body=b"default", content_type="text/html")
 
     # Create test server for mock app
     app = web.Application()

--- a/tests/common.py
+++ b/tests/common.py
@@ -200,4 +200,4 @@ class AsyncIterator:
         try:
             return next(self.iter)
         except StopIteration:
-            raise StopAsyncIteration() from None
+            raise StopAsyncIteration from None

--- a/tests/docker/test_app.py
+++ b/tests/docker/test_app.py
@@ -69,8 +69,7 @@ def get_docker_app(
     addonsdata_system.return_value = {slug: config}
 
     app = App(coresys, config.get("slug"))
-    docker_app = DockerApp(coresys, app)
-    return docker_app
+    return DockerApp(coresys, app)
 
 
 @pytest.mark.usefixtures("path_extern")

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -594,8 +594,7 @@ async def test_api_check_database_migration(
         calls.append(None)
         if len(calls) > 50:
             return APIState("RUNNING", False)
-        else:
-            return APIState("NOT_RUNNING", True)
+        return APIState("NOT_RUNNING", True)
 
     container.show.return_value["State"]["Status"] = "stopped"
     container.show.return_value["State"]["Running"] = False

--- a/tests/jobs/test_job_decorator.py
+++ b/tests/jobs/test_job_decorator.py
@@ -186,7 +186,7 @@ async def test_exception(coresys: CoreSys, capture_exception: Mock):
         @Job(name="test_exception_execute", conditions=[JobCondition.HEALTHY])
         async def execute(self):
             """Execute the class method."""
-            raise HassioError()
+            raise HassioError
 
     test = TestClass(coresys)
 

--- a/tests/store/test_custom_repository.py
+++ b/tests/store/test_custom_repository.py
@@ -26,7 +26,7 @@ def get_repository_by_url(store_manager: StoreManager, url: str) -> Repository:
     for repository in store_manager.all:
         if repository.source == url:
             return repository
-    raise StoreNotFound()
+    raise StoreNotFound
 
 
 @pytest.fixture(autouse=True)

--- a/tests/utils/test_exception_helper.py
+++ b/tests/utils/test_exception_helper.py
@@ -8,7 +8,7 @@ from supervisor.utils import check_exception_chain, get_message_from_exception_c
 def _raise_value_error(message: str | None = None) -> None:
     """Raise a ValueError, optionally with a message."""
     if message is None:
-        raise ValueError()
+        raise ValueError
     raise ValueError(message)
 
 
@@ -17,7 +17,7 @@ def _raise_key_error_from_value_error(value_message: str | None = None) -> None:
     try:
         _raise_value_error(value_message)
     except ValueError as err:
-        raise KeyError() from err
+        raise KeyError from err
 
 
 def test_simple_chain_exception():


### PR DESCRIPTION
## Proposed change

Enable three additional ruff rule sets and fix the resulting violations across the codebase:

- **PYI** (flake8-pyi): catches issues in type annotations, e.g. unnecessary literal unions, redundant numeric unions, and `__eq__`/`__ne__` parameters that should be typed as `object`.
- **RET** (flake8-return): catches superfluous `else` branches after `return`/`raise`/`continue`/`break`, redundant assign-then-return patterns, and implicit return values (while excluding some of these rules).
- **RSE** (flake8-raise): catches `raise Exception()` calls with empty parentheses.

This aligns rules with what Home Assistant Core is using currenlty.

The corresponding pylint `no-else-*` checks (RET505–508) are disabled in `pyproject.toml` since ruff now covers them.

All fixes are mechanical and behavior-preserving:

- Drop empty parentheses from `raise Exception()` when no arguments are passed.
- Flatten control flow by removing `else` branches that follow a terminating statement.
- Add explicit return values and remove redundant assign-then-return patterns.
- Tidy up type annotations (collapse literal unions, use `object` for `__eq__`/`__ne__`, drop redundant numeric unions).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
