### PR TITLE
apps: avoid blocking is_file() check in restore

### DIFF
--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -1551,7 +1551,7 @@ class App(AppModel):
                     _LOGGER.info("Restore/Install of image for app %s", self.slug)
 
                     image_file = Path(tmp.name, "image.tar")
-                    if image_file.is_file():
+                    if await self.sys_run_in_executor(image_file.is_file):
                         with suppress(DockerError):
                             await self.instance.import_image(image_file)
                     else:

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -1644,6 +1644,36 @@ async def test_restore_new_app(coresys: CoreSys, install_app_example: App):
 
 
 @pytest.mark.usefixtures("supervisor_internet", "tmp_supervisor_data", "path_extern")
+async def test_restore_app_image_missing(coresys: CoreSys, install_app_example: App):
+    """Test restore when local image is missing installs from registry.
+
+    Exercises the ``not instance.exists()`` branch in ``App.restore()`` which
+    checks the extracted bundle for an ``image.tar`` to import. This path is
+    skipped by other restore tests because the mocked Docker image inspect
+    always reports the image as present.
+    """
+    await coresys.core.set_state(CoreState.RUNNING)
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+
+    backup: Backup = await coresys.backups.do_backup_partial(apps=["local_example"])
+    await coresys.apps.uninstall("local_example")
+    assert "local_example" not in coresys.apps.local
+
+    with (
+        patch.object(AppModel, "_validate_availability"),
+        patch.object(DockerApp, "attach"),
+        patch.object(DockerApp, "exists", new=AsyncMock(return_value=False)),
+        patch.object(DockerApp, "install", new=AsyncMock()) as install_mock,
+        patch.object(DockerApp, "cleanup", new=AsyncMock()),
+        patch.object(DockerApp, "import_image", new=AsyncMock()) as import_mock,
+    ):
+        assert await coresys.backups.do_restore_partial(backup, apps=["local_example"])
+
+    import_mock.assert_called_once()
+    install_mock.assert_not_called()
+
+
+@pytest.mark.usefixtures("supervisor_internet", "tmp_supervisor_data", "path_extern")
 async def test_restore_preserves_data_config(
     coresys: CoreSys, install_app_example: App
 ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

While restoring an app from a backup, `App.restore()` called `Path.is_file()` directly on the event loop to check whether the bundle contained an `image.tar`. Under blockbuster-based blocking-call detection this surfaced as an unhandled `BlockingError: Blocking call to os.stat`, originating from `os.path.isfile`.

Wrap the check in `self.sys_run_in_executor(...)` so the stat happens off the main thread. This matches the pattern already used for the same kind of check in `supervisor/api/backups.py`.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
