### PR TITLE
os: avoid blocking unlink() in OS update

### DIFF
--- a/supervisor/os/manager.py
+++ b/supervisor/os/manager.py
@@ -313,7 +313,7 @@ class OSManager(CoreSysAttributes):
             raise HassOSUpdateError("Rauc communication error", _LOGGER.error) from err
 
         finally:
-            int_ota.unlink()
+            await self.sys_run_in_executor(int_ota.unlink)
 
         # Update success
         if 0 in completed:


### PR DESCRIPTION
## Proposed change

`OSManager.update()` called `Path.unlink()` directly in its `finally` block to clean up the downloaded RAUC bundle in `/tmp`. blockbuster flagged the resulting `os.unlink` as a blocking call on the event loop. Move the unlink into the executor via `self.sys_run_in_executor(int_ota.unlink)`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
