### PR TITLE
blockbuster: allow os.sendfile from asyncio selector loop

### DIFF
--- a/supervisor/utils/blockbuster.py
+++ b/supervisor/utils/blockbuster.py
@@ -27,6 +27,17 @@ class BlockBusterManager:
         _LOGGER.info("Activating BlockBuster blocking I/O detection")
         if cls._instance is None:
             cls._instance = BlockBuster()
+            # aiohttp's FileResponse reaches os.sendfile via
+            # asyncio/unix_events.py:_sock_sendfile_native_impl on a
+            # non-blocking socket. Blockbuster only whitelists the
+            # base_events.sendfile entry point, so allow this caller too.
+            # Fixed upstream by https://github.com/cbornet/blockbuster/pull/58
+            # (issue https://github.com/cbornet/blockbuster/issues/57) — drop
+            # this workaround once blockbuster is bumped to a version that
+            # includes the fix.
+            cls._instance.functions["os.sendfile"].can_block_in(
+                "asyncio/unix_events.py", "_sock_sendfile_native_impl"
+            )
         cls._instance.activate()
 
     @classmethod


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Serving aiohttp FileResponse triggers BlockBuster's os.sendfile guard because the actual syscall happens in asyncio/unix_events.py's _sock_sendfile_native_impl rather than the base_events.sendfile entry point that blockbuster whitelists. The socket is non-blocking and EAGAIN is handled by re-registering a writer, so the call is safe.

Extend the os.sendfile allowlist with the selector-loop caller as a local workaround. Fixed upstream by
https://github.com/cbornet/blockbuster/pull/58 (issue https://github.com/cbornet/blockbuster/issues/57); we can remove this work around once blockbuster is bumped to a version that includes the fix.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
