### PR TITLE
Migrate addon/addons config paths and schema names to app/apps

### DIFF
--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -109,7 +109,7 @@ from .const import (
 from .model import AppModel, Data
 from .options import AppOptions
 from .utils import remove_data
-from .validate import SCHEMA_ADDON_BACKUP
+from .validate import SCHEMA_APP_BACKUP
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -1522,7 +1522,7 @@ class App(AppModel):
         try:
             # Validate
             try:
-                data = SCHEMA_ADDON_BACKUP(data)
+                data = SCHEMA_APP_BACKUP(data)
             except vol.Invalid as err:
                 raise AppBackupMetadataInvalidError(
                     _LOGGER.error,

--- a/supervisor/apps/data.py
+++ b/supervisor/apps/data.py
@@ -15,7 +15,7 @@ from ..coresys import CoreSys, CoreSysAttributes
 from ..store.app import AppStore
 from ..utils.common import FileConfiguration
 from .app import App
-from .validate import SCHEMA_ADDONS_FILE
+from .validate import SCHEMA_APPS_FILE
 
 Config = dict[str, Any]
 
@@ -25,7 +25,7 @@ class AppsData(FileConfiguration, CoreSysAttributes):
 
     def __init__(self, coresys: CoreSys):
         """Initialize data holder."""
-        super().__init__(FILE_HASSIO_APPS, SCHEMA_ADDONS_FILE)
+        super().__init__(FILE_HASSIO_APPS, SCHEMA_APPS_FILE)
         self.coresys: CoreSys = coresys
 
     @property

--- a/supervisor/apps/data.py
+++ b/supervisor/apps/data.py
@@ -9,7 +9,7 @@ from ..const import (
     ATTR_SYSTEM,
     ATTR_USER,
     ATTR_VERSION,
-    FILE_HASSIO_ADDONS,
+    FILE_HASSIO_APPS,
 )
 from ..coresys import CoreSys, CoreSysAttributes
 from ..store.app import AppStore
@@ -25,7 +25,7 @@ class AppsData(FileConfiguration, CoreSysAttributes):
 
     def __init__(self, coresys: CoreSys):
         """Initialize data holder."""
-        super().__init__(FILE_HASSIO_ADDONS, SCHEMA_ADDONS_FILE)
+        super().__init__(FILE_HASSIO_APPS, SCHEMA_ADDONS_FILE)
         self.coresys: CoreSys = coresys
 
     @property

--- a/supervisor/apps/manager.py
+++ b/supervisor/apps/manager.py
@@ -9,7 +9,7 @@ from typing import Self, Union
 from attr import evolve
 from securetar import SecureTarFile
 
-from ..const import AppBoot, AppStartup, AppState
+from ..const import FILE_HASSIO_ADDONS, FILE_HASSIO_APPS, AppBoot, AppStartup, AppState
 from ..coresys import CoreSys, CoreSysAttributes
 from ..exceptions import (
     AppAlreadyInstalledError,
@@ -38,6 +38,15 @@ from .data import AppsData
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 AnyApp = Union[App, AppStore]
+
+
+def _migrate_addons_json() -> None:
+    """Rename legacy addons.json to apps.json if needed."""
+    if FILE_HASSIO_ADDONS.is_file() and not FILE_HASSIO_APPS.exists():
+        _LOGGER.info(
+            "Migrating %s to %s", FILE_HASSIO_ADDONS.name, FILE_HASSIO_APPS.name
+        )
+        FILE_HASSIO_ADDONS.rename(FILE_HASSIO_APPS)
 
 
 class AppManager(CoreSysAttributes):
@@ -87,6 +96,7 @@ class AppManager(CoreSysAttributes):
 
     async def load_config(self) -> Self:
         """Load config in executor."""
+        await self.sys_run_in_executor(_migrate_addons_json)
         await self.data.read_data()
         return self
 

--- a/supervisor/apps/validate.py
+++ b/supervisor/apps/validate.py
@@ -378,7 +378,7 @@ def _migrate_app_config(protocol=False):
 
 
 # pylint: disable=no-value-for-parameter
-_SCHEMA_ADDON_CONFIG = vol.Schema(
+_SCHEMA_APP_CONFIG = vol.Schema(
     {
         vol.Required(ATTR_NAME): str,
         vol.Required(ATTR_VERSION): version_tag,
@@ -483,8 +483,8 @@ _SCHEMA_ADDON_CONFIG = vol.Schema(
     extra=vol.REMOVE_EXTRA,
 )
 
-SCHEMA_ADDON_CONFIG = vol.All(
-    _migrate_app_config(True), _warn_app_config, _SCHEMA_ADDON_CONFIG
+SCHEMA_APP_CONFIG = vol.All(
+    _migrate_app_config(True), _warn_app_config, _SCHEMA_APP_CONFIG
 )
 
 
@@ -512,7 +512,7 @@ SCHEMA_TRANSLATION_CONFIGURATION = vol.Schema(
 )
 
 
-SCHEMA_ADDON_TRANSLATIONS = vol.Schema(
+SCHEMA_APP_TRANSLATIONS = vol.Schema(
     {
         vol.Optional(ATTR_CONFIGURATION): {str: SCHEMA_TRANSLATION_CONFIGURATION},
         vol.Optional(ATTR_NETWORK): {str: str},
@@ -522,7 +522,7 @@ SCHEMA_ADDON_TRANSLATIONS = vol.Schema(
 
 
 # pylint: disable=no-value-for-parameter
-SCHEMA_ADDON_USER = vol.Schema(
+SCHEMA_APP_USER = vol.Schema(
     {
         vol.Required(ATTR_VERSION): version_tag,
         vol.Optional(ATTR_IMAGE): docker_image,
@@ -544,33 +544,33 @@ SCHEMA_ADDON_USER = vol.Schema(
     extra=vol.REMOVE_EXTRA,
 )
 
-SCHEMA_ADDON_SYSTEM = vol.All(
+SCHEMA_APP_SYSTEM = vol.All(
     _migrate_app_config(),
-    _SCHEMA_ADDON_CONFIG.extend(
+    _SCHEMA_APP_CONFIG.extend(
         {
             vol.Required(ATTR_LOCATION): str,
             vol.Required(ATTR_REPOSITORY): str,
             vol.Required(ATTR_TRANSLATIONS, default=dict): {
-                str: SCHEMA_ADDON_TRANSLATIONS
+                str: SCHEMA_APP_TRANSLATIONS
             },
         }
     ),
 )
 
 
-SCHEMA_ADDONS_FILE = vol.Schema(
+SCHEMA_APPS_FILE = vol.Schema(
     {
-        vol.Optional(ATTR_USER, default=dict): {str: SCHEMA_ADDON_USER},
-        vol.Optional(ATTR_SYSTEM, default=dict): {str: SCHEMA_ADDON_SYSTEM},
+        vol.Optional(ATTR_USER, default=dict): {str: SCHEMA_APP_USER},
+        vol.Optional(ATTR_SYSTEM, default=dict): {str: SCHEMA_APP_SYSTEM},
     },
     extra=vol.REMOVE_EXTRA,
 )
 
 
-SCHEMA_ADDON_BACKUP = vol.Schema(
+SCHEMA_APP_BACKUP = vol.Schema(
     {
-        vol.Required(ATTR_USER): SCHEMA_ADDON_USER,
-        vol.Required(ATTR_SYSTEM): SCHEMA_ADDON_SYSTEM,
+        vol.Required(ATTR_USER): SCHEMA_APP_USER,
+        vol.Required(ATTR_SYSTEM): SCHEMA_APP_SYSTEM,
         vol.Required(ATTR_STATE): vol.Coerce(AppState),
         vol.Required(ATTR_VERSION): version_tag,
     },

--- a/supervisor/bootstrap.py
+++ b/supervisor/bootstrap.py
@@ -144,6 +144,17 @@ def _migrate_legacy_paths(coresys: CoreSys) -> None:
             _LOGGER.info("Migrating %s to %s", old, new)
             old.rename(new)
 
+    # Opportunistic remove of the now-empty legacy addons directory.
+    # rmdir only succeeds if empty, so leftover files keep it around.
+    legacy_addons = supervisor / "addons"
+    try:
+        legacy_addons.rmdir()
+    except OSError:
+        _LOGGER.debug(
+            "Legacy addons directory '%s' not empty, leaving in place",
+            legacy_addons.as_posix(),
+        )
+
 
 def initialize_system(coresys: CoreSys) -> None:
     """Set up the default configuration and create folders."""

--- a/supervisor/bootstrap.py
+++ b/supervisor/bootstrap.py
@@ -102,7 +102,12 @@ async def initialize_coresys() -> CoreSys:
         init_sentry(coresys)
 
     # bootstrap config
-    initialize_system(coresys)
+    def _bootstrap_config() -> None:
+        """Bootstrap config."""
+        _migrate_legacy_paths(coresys)
+        initialize_system(coresys)
+
+    await coresys.run_in_executor(_bootstrap_config)
 
     if coresys.dev:
         coresys.updater.channel = UpdateChannel.DEV
@@ -111,6 +116,33 @@ async def initialize_coresys() -> CoreSys:
     logging.Formatter.converter = lambda *args: coresys.now().timetuple()
 
     return coresys
+
+
+def _migrate_legacy_paths(coresys: CoreSys) -> None:
+    """Rename legacy addon directories and config file to new app paths."""
+    config = coresys.config
+    supervisor = config.path_supervisor
+
+    # Migrate addons/{core,data,local,git} -> apps/{core,data,local,git}
+    apps_dir = supervisor / "apps"
+    migrations = [
+        (supervisor / "addons" / "core", config.path_apps_core),
+        (supervisor / "addons" / "data", config.path_apps_data),
+        (supervisor / "addons" / "local", config.path_apps_local),
+        (supervisor / "addons" / "git", config.path_apps_git),
+        (supervisor / "addon_configs", config.path_app_configs),
+    ]
+    needs_apps_dir = any(
+        old.is_dir() and not new.exists()
+        for old, new in migrations[:4]  # only the apps/ sub-dirs
+    )
+    if needs_apps_dir and not apps_dir.is_dir():
+        apps_dir.mkdir(parents=True)
+
+    for old, new in migrations:
+        if old.is_dir() and not new.exists():
+            _LOGGER.info("Migrating %s to %s", old, new)
+            old.rename(new)
 
 
 def initialize_system(coresys: CoreSys) -> None:

--- a/supervisor/config.py
+++ b/supervisor/config.py
@@ -38,10 +38,10 @@ HOMEASSISTANT_CONFIG = PurePath("homeassistant")
 
 HASSIO_SSL = PurePath("ssl")
 
-ADDONS_CORE = PurePath("addons/core")
-ADDONS_LOCAL = PurePath("addons/local")
-ADDONS_GIT = PurePath("addons/git")
-ADDONS_DATA = PurePath("addons/data")
+APPS_CORE = PurePath("apps/core")
+APPS_DATA = PurePath("apps/data")
+APPS_LOCAL = PurePath("apps/local")
+APPS_GIT = PurePath("apps/git")
 
 BACKUP_DATA = PurePath("backup")
 SHARE_DATA = PurePath("share")
@@ -54,7 +54,7 @@ MEDIA_DATA = PurePath("media")
 MOUNTS_FOLDER = PurePath("mounts")
 MOUNTS_CREDENTIALS = PurePath(".mounts_credentials")
 EMERGENCY_DATA = PurePath("emergency")
-ADDON_CONFIGS = PurePath("addon_configs")
+APP_CONFIGS = PurePath("app_configs")
 CORE_BACKUP_DATA = PurePath("core/backup")
 CID_FILES = PurePath("cid_files")
 
@@ -256,42 +256,42 @@ class CoreConfig(FileConfiguration):
     @property
     def path_apps_core(self) -> Path:
         """Return git path for core Apps."""
-        return self.path_supervisor / ADDONS_CORE
+        return self.path_supervisor / APPS_CORE
 
     @property
     def path_apps_git(self) -> Path:
         """Return path for Git App."""
-        return self.path_supervisor / ADDONS_GIT
+        return self.path_supervisor / APPS_GIT
 
     @property
     def path_apps_local(self) -> Path:
         """Return path for custom Apps."""
-        return self.path_supervisor / ADDONS_LOCAL
+        return self.path_supervisor / APPS_LOCAL
 
     @property
     def path_extern_apps_local(self) -> PurePath:
         """Return path for custom Apps."""
-        return PurePath(self.path_extern_supervisor, ADDONS_LOCAL)
+        return PurePath(self.path_extern_supervisor, APPS_LOCAL)
 
     @property
     def path_apps_data(self) -> Path:
         """Return root App data folder."""
-        return self.path_supervisor / ADDONS_DATA
+        return self.path_supervisor / APPS_DATA
 
     @property
     def path_extern_apps_data(self) -> PurePath:
         """Return root app data folder external for Docker."""
-        return PurePath(self.path_extern_supervisor, ADDONS_DATA)
+        return PurePath(self.path_extern_supervisor, APPS_DATA)
 
     @property
     def path_app_configs(self) -> Path:
         """Return root App configs folder."""
-        return self.path_supervisor / ADDON_CONFIGS
+        return self.path_supervisor / APP_CONFIGS
 
     @property
     def path_extern_app_configs(self) -> PurePath:
         """Return root App configs folder external for Docker."""
-        return PurePath(self.path_extern_supervisor, ADDON_CONFIGS)
+        return PurePath(self.path_extern_supervisor, APP_CONFIGS)
 
     @property
     def path_audio(self) -> Path:

--- a/supervisor/const.py
+++ b/supervisor/const.py
@@ -27,6 +27,7 @@ URL_HASSIO_VERSION = "https://version.home-assistant.io/{channel}.json"
 SUPERVISOR_DATA = Path("/data")
 
 FILE_HASSIO_ADDONS = Path(SUPERVISOR_DATA, "addons.json")
+FILE_HASSIO_APPS = Path(SUPERVISOR_DATA, "apps.json")
 FILE_HASSIO_AUTH = Path(SUPERVISOR_DATA, "auth.json")
 FILE_HASSIO_BACKUPS = Path(SUPERVISOR_DATA, "backups.json")
 FILE_HASSIO_BOARD = Path(SUPERVISOR_DATA, "board.json")

--- a/supervisor/store/data.py
+++ b/supervisor/store/data.py
@@ -9,7 +9,7 @@ from typing import Any
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
-from ..apps.validate import SCHEMA_ADDON_CONFIG, SCHEMA_ADDON_TRANSLATIONS
+from ..apps.validate import SCHEMA_APP_CONFIG, SCHEMA_APP_TRANSLATIONS
 from ..const import (
     ATTR_LOCATION,
     ATTR_REPOSITORY,
@@ -59,7 +59,7 @@ def _read_app_translations(app_path: Path) -> dict:
 
     for translation in translation_files:
         try:
-            translations[translation.stem] = SCHEMA_ADDON_TRANSLATIONS(
+            translations[translation.stem] = SCHEMA_APP_TRANSLATIONS(
                 read_json_or_yaml_file(translation)
             )
 
@@ -197,7 +197,7 @@ class StoreData(CoreSysAttributes):
 
                 # validate
                 try:
-                    app = SCHEMA_ADDON_CONFIG(app)
+                    app = SCHEMA_APP_CONFIG(app)
                 except vol.Invalid as ex:
                     _LOGGER.warning(
                         "Can't read %s: %s", app_config, humanize_error(app, ex)

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -320,7 +320,7 @@ async def test_api_detached_app_changelog(
     Currently the frontend expects a valid body even in the error case. Make sure that is
     what the API returns.
     """
-    (apps_dir := tmp_supervisor_data / "addons" / "local").mkdir()
+    (apps_dir := tmp_supervisor_data / "apps" / "local").mkdir(parents=True)
     with patch.object(
         CoreConfig, "path_apps_local", new=PropertyMock(return_value=apps_dir)
     ):
@@ -343,7 +343,7 @@ async def test_api_detached_app_changelog_v2(
 ):
     """Test /store/apps/{app}/changelog for a detached app for both v1 and v2 store paths."""
     client, root = store_app_api_client_with_root
-    (apps_dir := tmp_supervisor_data / "addons" / "local").mkdir()
+    (apps_dir := tmp_supervisor_data / "apps" / "local").mkdir(parents=True)
     with patch.object(
         CoreConfig, "path_apps_local", new=PropertyMock(return_value=apps_dir)
     ):
@@ -401,7 +401,7 @@ async def test_api_detached_app_documentation(
     Currently the frontend expects a valid body even in the error case. Make sure that is
     what the API returns.
     """
-    (apps_dir := tmp_supervisor_data / "addons" / "local").mkdir()
+    (apps_dir := tmp_supervisor_data / "apps" / "local").mkdir(parents=True)
     with patch.object(
         CoreConfig, "path_apps_local", new=PropertyMock(return_value=apps_dir)
     ):
@@ -424,7 +424,7 @@ async def test_api_detached_app_documentation_v2(
 ):
     """Test /store/apps/{app}/documentation for a detached app for both v1 and v2 store paths."""
     client, root = store_app_api_client_with_root
-    (apps_dir := tmp_supervisor_data / "addons" / "local").mkdir()
+    (apps_dir := tmp_supervisor_data / "apps" / "local").mkdir(parents=True)
     with patch.object(
         CoreConfig, "path_apps_local", new=PropertyMock(return_value=apps_dir)
     ):

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -870,7 +870,7 @@ async def test_local_example_install(coresys: CoreSys, tmp_supervisor_data: Path
     """Test install of an app."""
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     assert not (
-        data_dir := tmp_supervisor_data / "addons" / "data" / "local_example"
+        data_dir := tmp_supervisor_data / "apps" / "data" / "local_example"
     ).exists()
 
     with patch.object(DockerApp, "install") as install:
@@ -946,7 +946,7 @@ async def test_local_example_start(tmp_supervisor_data: Path, install_app_exampl
     assert install_app_example.state == AppState.STOPPED
 
     assert not (
-        app_config_dir := tmp_supervisor_data / "addon_configs" / "local_example"
+        app_config_dir := tmp_supervisor_data / "app_configs" / "local_example"
     ).exists()
 
     await install_app_example.start()

--- a/tests/apps/test_config.py
+++ b/tests/apps/test_config.py
@@ -13,7 +13,7 @@ def test_basic_config():
     """Validate basic config and check the default values."""
     config = load_json_fixture("basic-app-config.json")
 
-    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
 
     assert valid_config["name"] == "Test Add-on"
     assert valid_config["image"] == "test/{arch}-my-custom-addon"
@@ -36,13 +36,13 @@ def test_migration_startup():
 
     config["startup"] = "before"
 
-    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
 
     assert valid_config["startup"] == "services"
 
     config["startup"] = "after"
 
-    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
 
     assert valid_config["startup"] == "application"
 
@@ -53,7 +53,7 @@ def test_migration_auto_uart():
 
     config["auto_uart"] = True
 
-    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
 
     assert valid_config["uart"]
     assert "auto_uart" not in valid_config
@@ -65,7 +65,7 @@ def test_migration_devices():
 
     config["devices"] = ["test:test:rw", "bla"]
 
-    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
 
     assert valid_config["devices"] == ["test", "bla"]
 
@@ -76,7 +76,7 @@ def test_migration_tmpfs():
 
     config["tmpfs"] = "test:test:rw"
 
-    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
 
     assert valid_config["tmpfs"]
 
@@ -90,7 +90,7 @@ def test_migration_backup():
     config["snapshot_post"] = "post_command"
     config["snapshot_exclude"] = ["excludeed"]
 
-    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
 
     assert valid_config.get("snapshot") is None
     assert valid_config.get("snapshot_pre") is None
@@ -109,17 +109,17 @@ def test_invalid_repository():
 
     config["image"] = "-invalid-something"
     with pytest.raises(vol.Invalid):
-        vd.SCHEMA_ADDON_CONFIG(config)
+        vd.SCHEMA_APP_CONFIG(config)
 
     config["image"] = "ghcr.io/home-assistant/no-valid-repo:no-tag-allow"
     with pytest.raises(vol.Invalid):
-        vd.SCHEMA_ADDON_CONFIG(config)
+        vd.SCHEMA_APP_CONFIG(config)
 
     config["image"] = (
         "registry.gitlab.com/company/add-ons/test-example/text-example:no-tag-allow"
     )
     with pytest.raises(vol.Invalid):
-        vd.SCHEMA_ADDON_CONFIG(config)
+        vd.SCHEMA_APP_CONFIG(config)
 
 
 def test_valid_repository():
@@ -128,7 +128,7 @@ def test_valid_repository():
 
     custom_registry = "registry.gitlab.com/company/add-ons/core/test-example"
     config["image"] = custom_registry
-    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
     assert valid_config["image"] == custom_registry
 
 
@@ -137,7 +137,7 @@ def test_valid_map():
     config = load_json_fixture("basic-app-config.json")
 
     config["map"] = ["backup:rw", "ssl:ro", "config"]
-    vd.SCHEMA_ADDON_CONFIG(config)
+    vd.SCHEMA_APP_CONFIG(config)
 
 
 def test_malformed_map_entries():
@@ -146,17 +146,17 @@ def test_malformed_map_entries():
 
     # Test case 1: Empty dict in map (should be skipped with warning)
     config["map"] = [{}]
-    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
     assert valid_config["map"] == []
 
     # Test case 2: Dict missing required 'type' field (should be skipped with warning)
     config["map"] = [{"read_only": False, "path": "/custom"}]
-    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
     assert valid_config["map"] == []
 
     # Test case 3: Invalid string format that doesn't match regex
     config["map"] = ["invalid_format", "not:a:valid:mapping", "share:invalid_mode"]
-    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
     assert valid_config["map"] == []
 
     # Test case 4: Mix of valid and invalid entries (invalid should be filtered out)
@@ -167,7 +167,7 @@ def test_malformed_map_entries():
         {"type": "config", "read_only": True},  # Valid dict format
         {"read_only": False},  # Invalid - missing type
     ]
-    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
     # Should only keep the valid entries
     assert len(valid_config["map"]) == 2
     assert any(entry["type"] == "share" for entry in valid_config["map"])
@@ -176,7 +176,7 @@ def test_malformed_map_entries():
     # Test case 5: The specific case from the UplandJacob repo (malformed YAML format)
     # This simulates what YAML "- addon_config: rw" creates
     config["map"] = [{"addon_config": "rw"}]  # Wrong structure, missing 'type' key
-    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
     assert valid_config["map"] == []
 
 
@@ -192,7 +192,7 @@ def test_valid_legacy_arch_values_for_migration():
     config = load_json_fixture("basic-app-config.json")
     config["arch"] = ["armv7", "amd64"]
 
-    assert vd.SCHEMA_ADDON_CONFIG(config)
+    assert vd.SCHEMA_APP_CONFIG(config)
 
 
 def test_valid_legacy_build_from_keys_for_migration():
@@ -208,7 +208,7 @@ def test_warn_legacy_arch_values(caplog: pytest.LogCaptureFixture):
     config = load_json_fixture("basic-app-config.json")
     config["arch"] = ["armv7", "amd64"]
 
-    vd.SCHEMA_ADDON_CONFIG(config)
+    vd.SCHEMA_APP_CONFIG(config)
 
     assert "App config 'arch' uses deprecated values" in caplog.text
 
@@ -218,7 +218,7 @@ def test_warn_legacy_machine_values(caplog: pytest.LogCaptureFixture):
     config = load_json_fixture("basic-app-config.json")
     config["machine"] = ["qemux86"]
 
-    vd.SCHEMA_ADDON_CONFIG(config)
+    vd.SCHEMA_APP_CONFIG(config)
 
     assert "App config 'machine' uses deprecated values" in caplog.text
 
@@ -228,7 +228,7 @@ def test_warn_advanced_deprecated(caplog: pytest.LogCaptureFixture):
     config = load_json_fixture("basic-app-config.json")
     config["advanced"] = True
 
-    vd.SCHEMA_ADDON_CONFIG(config)
+    vd.SCHEMA_APP_CONFIG(config)
 
     assert "uses deprecated 'advanced' field in config" in caplog.text
 
@@ -268,7 +268,7 @@ def test_valid_machine():
         "generic-x86-64",
     ]
 
-    assert vd.SCHEMA_ADDON_CONFIG(config)
+    assert vd.SCHEMA_APP_CONFIG(config)
 
     config["machine"] = [
         "!intel-nuc",
@@ -294,7 +294,7 @@ def test_valid_machine():
         "!generic-x86-64",
     ]
 
-    assert vd.SCHEMA_ADDON_CONFIG(config)
+    assert vd.SCHEMA_APP_CONFIG(config)
 
     config["machine"] = [
         "odroid-n2",
@@ -310,7 +310,7 @@ def test_valid_machine():
         "!tinker",
     ]
 
-    assert vd.SCHEMA_ADDON_CONFIG(config)
+    assert vd.SCHEMA_APP_CONFIG(config)
 
 
 def test_invalid_machine():
@@ -325,7 +325,7 @@ def test_invalid_machine():
     ]
 
     with pytest.raises(vol.Invalid):
-        assert vd.SCHEMA_ADDON_CONFIG(config)
+        assert vd.SCHEMA_APP_CONFIG(config)
 
     config["machine"] = [
         "intel-nuc",
@@ -333,7 +333,7 @@ def test_invalid_machine():
     ]
 
     with pytest.raises(vol.Invalid):
-        assert vd.SCHEMA_ADDON_CONFIG(config)
+        assert vd.SCHEMA_APP_CONFIG(config)
 
 
 def test_watchdog_url():
@@ -346,7 +346,7 @@ def test_watchdog_url():
         "https://[HOST]:[PORT:80]/",
     ):
         config["watchdog"] = test_options
-        assert vd.SCHEMA_ADDON_CONFIG(config)
+        assert vd.SCHEMA_APP_CONFIG(config)
 
 
 def test_valid_slug():
@@ -355,31 +355,31 @@ def test_valid_slug():
 
     # All examples pulled from https://analytics.home-assistant.io/apps.json
     config["slug"] = "uptime-kuma"
-    assert vd.SCHEMA_ADDON_CONFIG(config)
+    assert vd.SCHEMA_APP_CONFIG(config)
 
     config["slug"] = "hassio_google_drive_backup"
-    assert vd.SCHEMA_ADDON_CONFIG(config)
+    assert vd.SCHEMA_APP_CONFIG(config)
 
     config["slug"] = "paradox_alarm_interface_3.x"
-    assert vd.SCHEMA_ADDON_CONFIG(config)
+    assert vd.SCHEMA_APP_CONFIG(config)
 
     config["slug"] = "Lupusec2Mqtt"
-    assert vd.SCHEMA_ADDON_CONFIG(config)
+    assert vd.SCHEMA_APP_CONFIG(config)
 
     # No whitespace
     config["slug"] = "my addon"
     with pytest.raises(vol.Invalid):
-        assert vd.SCHEMA_ADDON_CONFIG(config)
+        assert vd.SCHEMA_APP_CONFIG(config)
 
     # No url control chars (or other non-word ascii characters)
     config["slug"] = "a/b_&_c\\d_@ddon$:_test=#2?"
     with pytest.raises(vol.Invalid):
-        assert vd.SCHEMA_ADDON_CONFIG(config)
+        assert vd.SCHEMA_APP_CONFIG(config)
 
     # No unicode
     config["slug"] = "complemento telefónico"
     with pytest.raises(vol.Invalid):
-        assert vd.SCHEMA_ADDON_CONFIG(config)
+        assert vd.SCHEMA_APP_CONFIG(config)
 
 
 def test_valid_schema():
@@ -422,7 +422,7 @@ def test_valid_schema():
         "float_max": "float(,10)",
         "float_minmax": "float(5,10)",
     }
-    assert vd.SCHEMA_ADDON_CONFIG(config)
+    assert vd.SCHEMA_APP_CONFIG(config)
 
     # Different valid ways of nesting dicts and lists
     config["schema"] = {
@@ -459,21 +459,21 @@ def test_valid_schema():
             },
         },
     }
-    assert vd.SCHEMA_ADDON_CONFIG(config)
+    assert vd.SCHEMA_APP_CONFIG(config)
 
     # List nested within dict within list
     config["schema"] = {"field": [{"subfield": ["str"]}]}
-    assert vd.SCHEMA_ADDON_CONFIG(config)
+    assert vd.SCHEMA_APP_CONFIG(config)
 
     # No lists directly nested within each other
     config["schema"] = {"field": [["str"]]}
     with pytest.raises(vol.Invalid):
-        assert vd.SCHEMA_ADDON_CONFIG(config)
+        assert vd.SCHEMA_APP_CONFIG(config)
 
     # Field types must be valid
     config["schema"] = {"field": "invalid"}
     with pytest.raises(vol.Invalid):
-        assert vd.SCHEMA_ADDON_CONFIG(config)
+        assert vd.SCHEMA_APP_CONFIG(config)
 
 
 def test_ulimits_simple_format():
@@ -482,7 +482,7 @@ def test_ulimits_simple_format():
 
     config["ulimits"] = {"nofile": 65535, "nproc": 32768, "memlock": 134217728}
 
-    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
     assert valid_config["ulimits"]["nofile"] == 65535
     assert valid_config["ulimits"]["nproc"] == 32768
     assert valid_config["ulimits"]["memlock"] == 134217728
@@ -498,7 +498,7 @@ def test_ulimits_detailed_format():
         "memlock": {"soft": 67108864, "hard": 134217728},
     }
 
-    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
     assert valid_config["ulimits"]["nofile"]["soft"] == 20000
     assert valid_config["ulimits"]["nofile"]["hard"] == 40000
     assert valid_config["ulimits"]["nproc"] == 32768
@@ -510,7 +510,7 @@ def test_ulimits_empty_dict():
     """Test ulimits with empty dict (default)."""
     config = load_json_fixture("basic-app-config.json")
 
-    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
     assert valid_config["ulimits"] == {}
 
 
@@ -521,33 +521,33 @@ def test_ulimits_invalid_values():
     # Invalid string values
     config["ulimits"] = {"nofile": "invalid"}
     with pytest.raises(vol.Invalid):
-        vd.SCHEMA_ADDON_CONFIG(config)
+        vd.SCHEMA_APP_CONFIG(config)
 
     # Invalid detailed format
     config["ulimits"] = {"nofile": {"invalid_key": 1000}}
     with pytest.raises(vol.Invalid):
-        vd.SCHEMA_ADDON_CONFIG(config)
+        vd.SCHEMA_APP_CONFIG(config)
 
     # Missing hard value in detailed format
     config["ulimits"] = {"nofile": {"soft": 1000}}
     with pytest.raises(vol.Invalid):
-        vd.SCHEMA_ADDON_CONFIG(config)
+        vd.SCHEMA_APP_CONFIG(config)
 
     # Missing soft value in detailed format
     config["ulimits"] = {"nofile": {"hard": 1000}}
     with pytest.raises(vol.Invalid):
-        vd.SCHEMA_ADDON_CONFIG(config)
+        vd.SCHEMA_APP_CONFIG(config)
 
     # Empty dict in detailed format
     config["ulimits"] = {"nofile": {}}
     with pytest.raises(vol.Invalid):
-        vd.SCHEMA_ADDON_CONFIG(config)
+        vd.SCHEMA_APP_CONFIG(config)
 
 
 def test_non_dict_config_raises_invalid():
     """Test that a non-dict config raises vol.Invalid, not AttributeError."""
     with pytest.raises(vol.Invalid):
-        vd.SCHEMA_ADDON_CONFIG("not a dict")
+        vd.SCHEMA_APP_CONFIG("not a dict")
 
     with pytest.raises(vol.Invalid):
-        vd.SCHEMA_ADDON_CONFIG(["list", "not", "dict"])
+        vd.SCHEMA_APP_CONFIG(["list", "not", "dict"])

--- a/tests/apps/test_manager.py
+++ b/tests/apps/test_manager.py
@@ -410,7 +410,7 @@ async def test_repository_file_missing(
     with patch.object(
         CoreConfig,
         "path_apps_git",
-        new=PropertyMock(return_value=tmp_supervisor_data / "addons" / "git"),
+        new=PropertyMock(return_value=tmp_supervisor_data / "apps" / "git"),
     ):
         repo_dir = coresys.config.path_apps_git / "test"
         repo_dir.mkdir(parents=True)
@@ -427,7 +427,7 @@ async def test_repository_file_error(
     with patch.object(
         CoreConfig,
         "path_apps_git",
-        new=PropertyMock(return_value=tmp_supervisor_data / "addons" / "git"),
+        new=PropertyMock(return_value=tmp_supervisor_data / "apps" / "git"),
     ):
         repo_dir = coresys.config.path_apps_git / "test"
         repo_dir.mkdir(parents=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -548,13 +548,11 @@ async def coresys(
     coresys_obj.host.network._connectivity = True
 
     # Fix Paths
-    su_config.ADDONS_CORE = Path(
-        Path(__file__).parent.joinpath("fixtures"), "apps/core"
-    )
-    su_config.ADDONS_LOCAL = Path(
+    su_config.APPS_CORE = Path(Path(__file__).parent.joinpath("fixtures"), "apps/core")
+    su_config.APPS_LOCAL = Path(
         Path(__file__).parent.joinpath("fixtures"), "apps/local"
     )
-    su_config.ADDONS_GIT = Path(Path(__file__).parent.joinpath("fixtures"), "apps/git")
+    su_config.APPS_GIT = Path(Path(__file__).parent.joinpath("fixtures"), "apps/git")
     su_config.APPARMOR_DATA = Path(
         Path(__file__).parent.joinpath("fixtures"), "apparmor"
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ from securetar import SecureTarArchive
 from supervisor import config as su_config
 from supervisor.api import RestAPI
 from supervisor.apps.app import App
-from supervisor.apps.validate import SCHEMA_ADDON_SYSTEM
+from supervisor.apps.validate import SCHEMA_APP_SYSTEM
 from supervisor.backups.backup import Backup
 from supervisor.backups.const import BackupType
 from supervisor.backups.validate import ALL_FOLDERS
@@ -753,7 +753,7 @@ def store_app(coresys: CoreSys, tmp_path, test_repository):
     app_obj = AppStore(coresys, "test_store_addon")
 
     coresys.apps.store[app_obj.slug] = app_obj
-    coresys.store.data.apps[app_obj.slug] = SCHEMA_ADDON_SYSTEM(
+    coresys.store.data.apps[app_obj.slug] = SCHEMA_APP_SYSTEM(
         load_json_fixture("app.json")
     )
     coresys.store.data.apps[app_obj.slug]["location"] = tmp_path

--- a/tests/docker/test_app.py
+++ b/tests/docker/test_app.py
@@ -64,7 +64,7 @@ def get_docker_app(
     config = (
         load_json_fixture(config_file) if isinstance(config_file, str) else config_file
     )
-    config = vd.SCHEMA_ADDON_CONFIG(config)
+    config = vd.SCHEMA_APP_CONFIG(config)
     slug = config.get("slug")
     addonsdata_system.return_value = {slug: config}
 

--- a/tests/resolution/check/test_check_detached_app_removed.py
+++ b/tests/resolution/check/test_check_detached_app_removed.py
@@ -27,7 +27,7 @@ async def test_check(coresys: CoreSys, install_app_ssh: App, tmp_supervisor_data
     assert len(coresys.resolution.issues) == 0
     assert len(coresys.resolution.suggestions) == 0
 
-    (apps_dir := tmp_supervisor_data / "addons" / "local").mkdir()
+    (apps_dir := tmp_supervisor_data / "apps" / "local").mkdir(parents=True)
     with patch.object(
         CoreConfig, "path_apps_local", new=PropertyMock(return_value=apps_dir)
     ):
@@ -58,7 +58,7 @@ async def test_approve(
         is False
     )
 
-    (apps_dir := tmp_supervisor_data / "addons" / "local").mkdir()
+    (apps_dir := tmp_supervisor_data / "apps" / "local").mkdir(parents=True)
     with patch.object(
         CoreConfig, "path_apps_local", new=PropertyMock(return_value=apps_dir)
     ):

--- a/tests/resolution/fixup/test_store_execute_reset.py
+++ b/tests/resolution/fixup/test_store_execute_reset.py
@@ -28,7 +28,7 @@ async def fixture_mock_apps_git(tmp_supervisor_data: Path) -> None:
     with patch.object(
         CoreConfig,
         "path_apps_git",
-        new=PropertyMock(return_value=tmp_supervisor_data / "addons" / "git"),
+        new=PropertyMock(return_value=tmp_supervisor_data / "apps" / "git"),
     ):
         yield
 


### PR DESCRIPTION
## Proposed change

Rename legacy `addons`-prefixed config file paths, directory paths, and schema constants to use the `apps` naming convention, consistent with the broader addons→apps rename.

**File/directory path changes (with backwards-compatible migration):**
- `addons.json` → `apps.json` (constant `FILE_HASSIO_APPS`)
- `addons/core` → `apps/core`
- `addons/data` → `apps/data`
- `addons/local` → `apps/local`
- `addons/git` → `apps/git`
- `addon_configs` → `app_configs`

On startup, Supervisor checks for the legacy paths and renames them if the new paths don't already exist:
- `addons.json` migration runs in `AppManager.load_config` (executor)
- Directory migrations run in `bootstrap` before `initialize_system` (executor)

**Schema constant renames in `supervisor/apps/validate.py`:**
- `SCHEMA_ADDONS_FILE` → `SCHEMA_APPS_FILE`
- `SCHEMA_ADDON_CONFIG` → `SCHEMA_APP_CONFIG`
- `SCHEMA_ADDON_TRANSLATIONS` → `SCHEMA_APP_TRANSLATIONS`
- `SCHEMA_ADDON_USER` → `SCHEMA_APP_USER`
- `SCHEMA_ADDON_SYSTEM` → `SCHEMA_APP_SYSTEM`
- `SCHEMA_ADDON_BACKUP` → `SCHEMA_APP_BACKUP`

All references in supervisor and tests updated accordingly.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #6745

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/