### PR TITLE
Enable blocking I/O detection in integration tests

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -280,6 +280,7 @@ jobs:
       - name: Create the Supervisor
         run: |
           mkdir -p /tmp/supervisor/data
+          echo '{"detect_blocking_io": true}' > /tmp/supervisor/data/config.json
           docker create --name hassio_supervisor \
             --privileged \
             --security-opt seccomp=unconfined \

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -191,7 +191,7 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
           container-registry-password: ${{ secrets.GITHUB_TOKEN }}
-          cosign-base-identity: "https://github.com/home-assistant/docker-base/.*"
+          cosign-base-identity: 'https://github.com/home-assistant/docker-base/.*'
           cosign-base-verify: ghcr.io/home-assistant/base-python:3.14-alpine3.22
           image: ${{ matrix.image }}
           image-tags: |
@@ -280,7 +280,6 @@ jobs:
       - name: Create the Supervisor
         run: |
           mkdir -p /tmp/supervisor/data
-          echo '{"detect_blocking_io": true}' > /tmp/supervisor/data/config.json
           docker create --name hassio_supervisor \
             --privileged \
             --security-opt seccomp=unconfined \
@@ -308,7 +307,7 @@ jobs:
             sleep 1
           done
           echo "Waiting for Supervisor API at http://${SUPERVISOR}/supervisor/ping"
-          timeout=30
+          timeout=300
           elapsed=0
 
           while [ $elapsed -lt $timeout ]; do

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -191,7 +191,7 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
           container-registry-password: ${{ secrets.GITHUB_TOKEN }}
-          cosign-base-identity: 'https://github.com/home-assistant/docker-base/.*'
+          cosign-base-identity: "https://github.com/home-assistant/docker-base/.*"
           cosign-base-verify: ghcr.io/home-assistant/base-python:3.14-alpine3.22
           image: ${{ matrix.image }}
           image-tags: |
@@ -308,7 +308,7 @@ jobs:
             sleep 1
           done
           echo "Waiting for Supervisor API at http://${SUPERVISOR}/supervisor/ping"
-          timeout=300
+          timeout=30
           elapsed=0
 
           while [ $elapsed -lt $timeout ]; do

--- a/supervisor/bootstrap.py
+++ b/supervisor/bootstrap.py
@@ -61,6 +61,7 @@ async def initialize_coresys() -> CoreSys:
         _LOGGER.warning("Environment variable 'SUPERVISOR_DEV' is set")
         coresys.config.logging = LogLevel.DEBUG
         coresys.config.debug = True
+        coresys.config.detect_blocking_io = True
     else:
         coresys.config.modify_log_level()
 

--- a/supervisor/bootstrap.py
+++ b/supervisor/bootstrap.py
@@ -3,7 +3,6 @@
 # ruff: noqa: T100
 import asyncio
 from collections.abc import Callable
-from importlib import import_module
 import logging
 import os
 import signal
@@ -320,11 +319,15 @@ async def supervisor_debugger(coresys: CoreSys) -> None:
     if not coresys.config.debug:
         return
 
-    debugpy = await coresys.run_in_executor(import_module, "debugpy")
+    def setup_debugger() -> None:
+        # pylint: disable-next=import-outside-toplevel
+        import debugpy  # noqa: PLC0415
 
-    _LOGGER.info("Initializing Supervisor debugger")
+        _LOGGER.info("Initializing Supervisor debugger")
 
-    debugpy.listen(("0.0.0.0", 33333))
-    if coresys.config.debug_block:
-        _LOGGER.info("Wait until debugger is attached")
-        debugpy.wait_for_client()
+        debugpy.listen(("0.0.0.0", 33333))
+        if coresys.config.debug_block:
+            _LOGGER.info("Wait until debugger is attached")
+            debugpy.wait_for_client()
+
+    await coresys.run_in_executor(setup_debugger)


### PR DESCRIPTION
## Proposed change

The `run_supervisor` CI job runs integration tests against a live Supervisor instance to catch issues unit tests miss. We already use [blockbuster](https://github.com/PerchunPak/blockbuster) to detect blocking I/O in unit tests, but the integration tests have not had this enabled.

This adds a single line before Supervisor starts to write a `config.json` with `detect_blocking_io: true` into the data directory, so Supervisor activates blocking I/O detection at startup for all integration test runs.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/