### PR TITLE
tests: cover OS update success path to catch blocking I/O

### DIFF
--- a/tests/os/test_manager.py
+++ b/tests/os/test_manager.py
@@ -1,5 +1,6 @@
 """Test Home Assistant OS functionality."""
 
+from pathlib import Path
 from unittest.mock import AsyncMock, PropertyMock, patch
 
 from awesomeversion import AwesomeVersion
@@ -99,6 +100,42 @@ async def test_update_fails_if_unhealthy(
         pytest.raises(HassOSJobError),
     ):
         await coresys.os.update()
+
+
+async def test_update_success_cleans_up_bundle(
+    coresys: CoreSys,
+    tmp_supervisor_data: Path,
+    path_extern: None,
+    supervisor_internet: AsyncMock,
+) -> None:
+    """Test successful OS update installs via RAUC and removes the downloaded bundle."""
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    coresys.os._available = True
+    coresys.os._board = "generic-x86-64"
+    coresys.os._os_name = "haos"
+    coresys.os._version = AwesomeVersion("12.0")
+    coresys.updater._data = {
+        "ota": (
+            "https://github.com/home-assistant/operating-system/releases/download/"
+            "{version}/{os_name}_{board}-{version}.raucb"
+        ),
+        "hassos_unrestricted": AwesomeVersion("13.0"),
+    }
+
+    async def fake_download(url: str, raucb: Path) -> None:
+        raucb.touch()
+
+    reboot_mock = AsyncMock()
+
+    with (
+        patch.object(coresys.os, "_download_raucb", side_effect=fake_download),
+        patch.object(coresys.host.control, "reboot", reboot_mock),
+    ):
+        await coresys.os.update()
+
+    bundle = coresys.config.path_tmp / "hassos-13.0.raucb"
+    assert not bundle.exists()
 
 
 async def test_board_name_supervised(coresys: CoreSys) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Add a happy-path test for `OSManager.update()` that exercises the full download → RAUC install → cleanup flow. The existing two `update()` tests only assert that precondition checks raise (`out-of-date supervisor`, `unhealthy`), so they bail out before ever reaching the download and the `finally: int_ota.unlink()` cleanup. That gap is why the blocking `Path.unlink()` regression fixed in #6863 wasn't caught by CI and only surfaced on a real device.

The new test stubs `_download_raucb` to create the bundle file, lets the existing RAUC dbus mock emit a successful `Completed` signal, mocks the post-install reboot, and asserts the downloaded bundle has been removed. Verified by temporarily reverting the executor wrapping from #6863: blockbuster then reports `Blocking call to os.unlink` from `supervisor/os/manager.py`, confirming the test would have caught the regression.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: follow-up to #6863 (os: avoid blocking unlink() in OS update)
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
