### PR TITLE
watchdog: include container exit code in restart log message

### DIFF
--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -1637,7 +1637,7 @@ class App(AppModel):
         attempts = 0
         while await self.instance.current_state() == state:
             if not self.in_progress:
-                if state == ContainerState.FAILED and exit_code is not None:
+                if state == ContainerState.FAILED:
                     _LOGGER.warning(
                         "Watchdog found app %s exited with code %d, restarting...",
                         self.name,

--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -1630,16 +1630,25 @@ class App(AppModel):
         on_condition=AppsJobError,
         throttle=JobThrottle.GROUP_RATE_LIMIT,
     )
-    async def _restart_after_problem(self, state: ContainerState):
+    async def _restart_after_problem(
+        self, state: ContainerState, exit_code: int | None = None
+    ):
         """Restart unhealthy or failed app."""
         attempts = 0
         while await self.instance.current_state() == state:
             if not self.in_progress:
-                _LOGGER.warning(
-                    "Watchdog found app %s is %s, restarting...",
-                    self.name,
-                    state,
-                )
+                if state == ContainerState.FAILED and exit_code is not None:
+                    _LOGGER.warning(
+                        "Watchdog found app %s exited with code %d, restarting...",
+                        self.name,
+                        exit_code,
+                    )
+                else:
+                    _LOGGER.warning(
+                        "Watchdog found app %s is %s, restarting...",
+                        self.name,
+                        state,
+                    )
                 try:
                     if state == ContainerState.FAILED:
                         # Ensure failed container is removed before attempting reanimation
@@ -1729,7 +1738,7 @@ class App(AppModel):
             ContainerState.STOPPED,
             ContainerState.UNHEALTHY,
         ]:
-            await self._restart_after_problem(event.state)
+            await self._restart_after_problem(event.state, event.exit_code)
 
     async def refresh_path_cache(self) -> None:
         """Refresh cache of existing paths."""

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -665,7 +665,7 @@ class HomeAssistantCore(JobGroup):
         while await self.instance.current_state() == state:
             # Don't interrupt a task in progress or if rollback is handling it
             if not (self.in_progress or self.error_state):
-                if state == ContainerState.FAILED and exit_code is not None:
+                if state == ContainerState.FAILED:
                     _LOGGER.warning(
                         "Watchdog found Home Assistant exited with code %d, "
                         "restarting...",

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -639,7 +639,7 @@ class HomeAssistantCore(JobGroup):
             return
 
         if event.state in [ContainerState.FAILED, ContainerState.UNHEALTHY]:
-            await self._restart_after_problem(event.state)
+            await self._restart_after_problem(event.state, event.exit_code)
 
     async def _supervisor_state_changed(self, state: CoreState) -> None:
         """Handle supervisor state changes to disable watchdog during shutdown."""
@@ -657,15 +657,24 @@ class HomeAssistantCore(JobGroup):
         throttle_max_calls=WATCHDOG_THROTTLE_MAX_CALLS,
         throttle=JobThrottle.RATE_LIMIT,
     )
-    async def _restart_after_problem(self, state: ContainerState):
+    async def _restart_after_problem(
+        self, state: ContainerState, exit_code: int | None = None
+    ):
         """Restart unhealthy or failed Home Assistant."""
         attempts = 0
         while await self.instance.current_state() == state:
             # Don't interrupt a task in progress or if rollback is handling it
             if not (self.in_progress or self.error_state):
-                _LOGGER.warning(
-                    "Watchdog found Home Assistant %s, restarting...", state
-                )
+                if state == ContainerState.FAILED and exit_code is not None:
+                    _LOGGER.warning(
+                        "Watchdog found Home Assistant exited with code %d, "
+                        "restarting...",
+                        exit_code,
+                    )
+                else:
+                    _LOGGER.warning(
+                        "Watchdog found Home Assistant %s, restarting...", state
+                    )
                 if state == ContainerState.FAILED and attempts == 0:
                     try:
                         await self.start()

--- a/supervisor/plugins/audio.py
+++ b/supervisor/plugins/audio.py
@@ -201,6 +201,8 @@ class PluginAudio(PluginBase):
         on_condition=AudioJobError,
         throttle=JobThrottle.RATE_LIMIT,
     )
-    async def _restart_after_problem(self, state: ContainerState):
+    async def _restart_after_problem(
+        self, state: ContainerState, exit_code: int | None = None
+    ):
         """Restart unhealthy or failed plugin."""
-        return await super()._restart_after_problem(state)
+        return await super()._restart_after_problem(state, exit_code)

--- a/supervisor/plugins/base.py
+++ b/supervisor/plugins/base.py
@@ -111,7 +111,7 @@ class PluginBase(ABC, FileConfiguration, CoreSysAttributes):
         attempts = 0
         while await self.instance.current_state() == state:
             if not self.in_progress:
-                if state == ContainerState.FAILED and exit_code is not None:
+                if state == ContainerState.FAILED:
                     _LOGGER.warning(
                         "Watchdog found %s plugin exited with code %d, restarting...",
                         self.slug,

--- a/supervisor/plugins/base.py
+++ b/supervisor/plugins/base.py
@@ -102,18 +102,27 @@ class PluginBase(ABC, FileConfiguration, CoreSysAttributes):
             return
 
         if event.state in {ContainerState.FAILED, ContainerState.UNHEALTHY}:
-            await self._restart_after_problem(event.state)
+            await self._restart_after_problem(event.state, event.exit_code)
 
-    async def _restart_after_problem(self, state: ContainerState):
+    async def _restart_after_problem(
+        self, state: ContainerState, exit_code: int | None = None
+    ):
         """Restart unhealthy or failed plugin."""
         attempts = 0
         while await self.instance.current_state() == state:
             if not self.in_progress:
-                _LOGGER.warning(
-                    "Watchdog found %s plugin %s, restarting...",
-                    self.slug,
-                    state,
-                )
+                if state == ContainerState.FAILED and exit_code is not None:
+                    _LOGGER.warning(
+                        "Watchdog found %s plugin exited with code %d, restarting...",
+                        self.slug,
+                        exit_code,
+                    )
+                else:
+                    _LOGGER.warning(
+                        "Watchdog found %s plugin %s, restarting...",
+                        self.slug,
+                        state,
+                    )
                 try:
                     await self.rebuild()
                 except PluginError as err:

--- a/supervisor/plugins/cli.py
+++ b/supervisor/plugins/cli.py
@@ -123,6 +123,8 @@ class PluginCli(PluginBase):
         on_condition=CliJobError,
         throttle=JobThrottle.RATE_LIMIT,
     )
-    async def _restart_after_problem(self, state: ContainerState):
+    async def _restart_after_problem(
+        self, state: ContainerState, exit_code: int | None = None
+    ):
         """Restart unhealthy or failed plugin."""
-        return await super()._restart_after_problem(state)
+        return await super()._restart_after_problem(state, exit_code)

--- a/supervisor/plugins/dns.py
+++ b/supervisor/plugins/dns.py
@@ -355,9 +355,11 @@ class PluginDns(PluginBase):
         on_condition=CoreDNSJobError,
         throttle=JobThrottle.RATE_LIMIT,
     )
-    async def _restart_after_problem(self, state: ContainerState):
+    async def _restart_after_problem(
+        self, state: ContainerState, exit_code: int | None = None
+    ):
         """Restart unhealthy or failed plugin."""
-        return await super()._restart_after_problem(state)
+        return await super()._restart_after_problem(state, exit_code)
 
     async def loop_detection(self) -> None:
         """Check if there was a loop found."""

--- a/supervisor/plugins/multicast.py
+++ b/supervisor/plugins/multicast.py
@@ -119,6 +119,8 @@ class PluginMulticast(PluginBase):
         on_condition=MulticastJobError,
         throttle=JobThrottle.RATE_LIMIT,
     )
-    async def _restart_after_problem(self, state: ContainerState):
+    async def _restart_after_problem(
+        self, state: ContainerState, exit_code: int | None = None
+    ):
         """Restart unhealthy or failed plugin."""
-        return await super()._restart_after_problem(state)
+        return await super()._restart_after_problem(state, exit_code)

--- a/supervisor/plugins/observer.py
+++ b/supervisor/plugins/observer.py
@@ -139,6 +139,8 @@ class PluginObserver(PluginBase):
         on_condition=ObserverJobError,
         throttle=JobThrottle.RATE_LIMIT,
     )
-    async def _restart_after_problem(self, state: ContainerState):
+    async def _restart_after_problem(
+        self, state: ContainerState, exit_code: int | None = None
+    ):
         """Restart unhealthy or failed plugin."""
-        return await super()._restart_after_problem(state)
+        return await super()._restart_after_problem(state, exit_code)

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -235,7 +235,10 @@ async def test_app_watchdog(coresys: CoreSys, install_app_ssh: App) -> None:
         current_state.return_value = ContainerState.FAILED
         with patch.object(DockerApp, "stop") as stop:
             await _fire_test_event(
-                coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.FAILED
+                coresys,
+                f"addon_{TEST_ADDON_SLUG}",
+                ContainerState.FAILED,
+                exit_code=1,
             )
             stop.assert_called_once_with(remove_container=True)
             restart.assert_not_called()
@@ -246,7 +249,10 @@ async def test_app_watchdog(coresys: CoreSys, install_app_ssh: App) -> None:
         # Do not process event if container state has changed since fired
         current_state.return_value = ContainerState.HEALTHY
         await _fire_test_event(
-            coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.FAILED
+            coresys,
+            f"addon_{TEST_ADDON_SLUG}",
+            ContainerState.FAILED,
+            exit_code=1,
         )
         restart.assert_not_called()
         start.assert_not_called()
@@ -282,7 +288,10 @@ async def test_watchdog_port_conflict_does_not_retry(
     ):
         caplog.clear()
         await _fire_test_event(
-            coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.FAILED
+            coresys,
+            f"addon_{TEST_ADDON_SLUG}",
+            ContainerState.FAILED,
+            exit_code=1,
         )
 
         start.assert_called_once()

--- a/tests/homeassistant/test_home_assistant_watchdog.py
+++ b/tests/homeassistant/test_home_assistant_watchdog.py
@@ -60,6 +60,7 @@ async def test_home_assistant_watchdog(coresys: CoreSys) -> None:
                 state=ContainerState.FAILED,
                 id="abc123",
                 time=1,
+                exit_code=1,
             ),
         )
         restart.assert_not_called()
@@ -76,6 +77,7 @@ async def test_home_assistant_watchdog(coresys: CoreSys) -> None:
                 state=ContainerState.FAILED,
                 id="abc123",
                 time=1,
+                exit_code=1,
             ),
         )
         restart.assert_not_called()
@@ -143,6 +145,7 @@ async def test_home_assistant_watchdog_rebuild_on_failure(coresys: CoreSys) -> N
                 state=ContainerState.FAILED,
                 id="abc123",
                 time=1,
+                exit_code=1,
             ),
         )
         start.assert_called_once()
@@ -217,6 +220,7 @@ async def test_home_assistant_watchdog_unregisters_on_shutdown(
                 state=ContainerState.FAILED,
                 id="abc123",
                 time=1,
+                exit_code=1,
             ),
         )
         start.assert_called_once()

--- a/tests/plugins/test_dns.py
+++ b/tests/plugins/test_dns.py
@@ -175,6 +175,7 @@ async def test_loop_detection_on_failure(coresys: CoreSys, container: DockerCont
                 state=ContainerState.FAILED,
                 id="abc123",
                 time=1,
+                exit_code=1,
             ),
         )
         await asyncio.sleep(0)
@@ -191,6 +192,7 @@ async def test_loop_detection_on_failure(coresys: CoreSys, container: DockerCont
                 state=ContainerState.FAILED,
                 id="abc123",
                 time=1,
+                exit_code=1,
             ),
         )
         await asyncio.sleep(0)

--- a/tests/plugins/test_plugin_base.py
+++ b/tests/plugins/test_plugin_base.py
@@ -98,6 +98,7 @@ async def test_plugin_watchdog(coresys: CoreSys, plugin: PluginBase) -> None:
                 state=ContainerState.FAILED,
                 id="abc123",
                 time=1,
+                exit_code=1,
             ),
         )
         rebuild.assert_called_once()
@@ -129,6 +130,7 @@ async def test_plugin_watchdog(coresys: CoreSys, plugin: PluginBase) -> None:
                 state=ContainerState.FAILED,
                 id="abc123",
                 time=1,
+                exit_code=1,
             ),
         )
         rebuild.assert_not_called()
@@ -185,6 +187,7 @@ async def test_plugin_watchdog_max_failed_attempts(
                 state=ContainerState.FAILED,
                 id="abc123",
                 time=1,
+                exit_code=1,
             )
         )
         assert start.call_count == 5


### PR DESCRIPTION
## Proposed change

Issue #6868 illustrates how the current watchdog log message is misleading. A user saw a tight loop of `Watchdog found app phpMyAdmin is failed, restarting...` and concluded the watchdog itself was the problem, asking whether its window could be widened. Nothing in the message hints that the container is exiting on its own, nor what exit code it returned.

PR #6848 already plumbed the container exit code through `DockerContainerStateEvent` and added a separate log line in `container_state_changed` when an app exits non-zero. This PR builds on that by forwarding `event.exit_code` into `_restart_after_problem` for apps, Home Assistant Core, and plugins, and uses it in the watchdog warning when the state is `FAILED`. The fallback message is kept for `STOPPED` and `UNHEALTHY` where an exit code is not meaningful.

After this change the example above reads `Watchdog found app phpMyAdmin exited with code 1, restarting...`, making it immediately clear that the container itself is dying and giving the user a code to grep for in the add-on logs.

The plugin subclasses (`audio`, `cli`, `dns`, `multicast`, `observer`) each override `_restart_after_problem` only to attach their plugin-specific `@Job` decorator; their signatures were updated to accept and forward the new optional `exit_code` argument to the base implementation.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6868
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
