### PR TITLE
fix(docker): restore add-on device access after USB re-enumeration

### DIFF
--- a/supervisor/apps/model.py
+++ b/supervisor/apps/model.py
@@ -359,6 +359,11 @@ class AppModel(JobGroup, ABC):
         return [Path(node) for node in self.data.get(ATTR_DEVICES, [])]
 
     @property
+    def option_device_paths(self) -> set[Path]:
+        """Return raw device paths configured in options without full validation."""
+        return self.schema.extract_device_paths(self.options)
+
+    @property
     def environment(self) -> dict[str, str] | None:
         """Return environment of app."""
         return self.data.get(ATTR_ENVIRONMENT)

--- a/supervisor/apps/options.py
+++ b/supervisor/apps/options.py
@@ -196,6 +196,37 @@ class AppOptions(CoreSysAttributes):
             f"Fatal error for option '{key}' with type '{typ}' in {self._name} ({self._slug})"
         ) from None
 
+    def extract_device_paths(self, options: dict[str, Any]) -> set[Path]:
+        """Return raw device paths from options without full validation."""
+        paths: set[Path] = set()
+        self._collect_device_paths(self.raw_schema, options, paths)
+        return paths
+
+    def _collect_device_paths(
+        self, schema: dict[str, Any], options: dict[str, Any], paths: set[Path]
+    ) -> None:
+        """Recursively collect raw device paths configured in options."""
+        for key, typ in schema.items():
+            if key not in options:
+                continue
+            value = options[key]
+            if isinstance(typ, list) and len(typ) == 1:
+                inner = typ[0]
+                if isinstance(inner, str) and inner.startswith(_DEVICE):
+                    for item in value if isinstance(value, list) else []:
+                        if item:
+                            paths.add(Path(str(item)))
+                elif isinstance(inner, dict):
+                    for item in value if isinstance(value, list) else []:
+                        if isinstance(item, dict):
+                            self._collect_device_paths(inner, item, paths)
+            elif isinstance(typ, dict):
+                if isinstance(value, dict):
+                    self._collect_device_paths(typ, value, paths)
+            elif isinstance(typ, str) and typ.startswith(_DEVICE):
+                if value:
+                    paths.add(Path(str(value)))
+
     def _nested_validate_list(self, typ: Any, data_list: Any, key: str) -> list[Any]:
         """Validate nested items."""
         options = []

--- a/supervisor/docker/app.py
+++ b/supervisor/docker/app.py
@@ -618,8 +618,9 @@ class DockerApp(DockerInterface):
             _LOGGER.warning("Can't update DNS for %s", self.name)
             await async_capture_exception(err)
 
-        # Hardware Access
-        if self.app.static_devices:
+        # Hardware Access — register listener for both manifest static_devices and
+        # options-based devices (e.g. Z-Wave JS `device:` option).
+        if self.app.static_devices or self.app.devices:
             self._hw_listener = self.sys_bus.register_event(
                 BusEvent.HARDWARE_NEW_DEVICE, self._hardware_events
             )
@@ -887,9 +888,12 @@ class DockerApp(DockerInterface):
     )
     async def _hardware_events(self, device: Device) -> None:
         """Process Hardware events for adjust device access."""
-        if not any(
-            device_path in (device.path, device.sysfs)
-            for device_path in self.app.static_devices
+        if (
+            not any(
+                device_path in (device.path, device.sysfs)
+                for device_path in self.app.static_devices
+            )
+            and device not in self.app.devices
         ):
             return
 

--- a/supervisor/docker/app.py
+++ b/supervisor/docker/app.py
@@ -620,7 +620,7 @@ class DockerApp(DockerInterface):
 
         # Hardware Access — register listener for both manifest static_devices and
         # options-based devices (e.g. Z-Wave JS `device:` option).
-        if self.app.static_devices or self.app.devices:
+        if self.app.static_devices or self.app.option_device_paths:
             self._hw_listener = self.sys_bus.register_event(
                 BusEvent.HARDWARE_NEW_DEVICE, self._hardware_events
             )
@@ -888,13 +888,8 @@ class DockerApp(DockerInterface):
     )
     async def _hardware_events(self, device: Device) -> None:
         """Process Hardware events for adjust device access."""
-        if (
-            not any(
-                device_path in (device.path, device.sysfs)
-                for device_path in self.app.static_devices
-            )
-            and device not in self.app.devices
-        ):
+        allowed_paths = set(self.app.static_devices) | self.app.option_device_paths
+        if not allowed_paths & {device.path, device.sysfs, *device.links}:
             return
 
         try:

--- a/supervisor/docker/app.py
+++ b/supervisor/docker/app.py
@@ -892,6 +892,15 @@ class DockerApp(DockerInterface):
         if not allowed_paths & {device.path, device.sysfs, *device.links}:
             return
 
+        # Check hardware access policy before granting cgroup access
+        if not self.sys_hardware.policy.allowed_for_access(device):
+            _LOGGER.error(
+                "App %s tried to access blocked device %s via hardware event!",
+                self.app.name,
+                device.name,
+            )
+            return
+
         try:
             docker_container = await self.sys_docker.containers.get(self.name)
         except aiodocker.DockerError as err:

--- a/tests/apps/test_options.py
+++ b/tests/apps/test_options.py
@@ -351,6 +351,69 @@ def test_device_schema_wrong_type(coresys):
         )({"name": "Pascal", "input": 12345})
 
 
+def test_extract_device_paths(coresys):
+    """Test extract_device_paths collects configured device paths.
+
+    It must walk every schema shape (flat, optional, filtered, list, nested
+    dict and list of dicts) and return the raw configured paths without
+    resolving them against live hardware, while skipping non-device options,
+    unset keys and empty values.
+    """
+    options = AppOptions(
+        coresys,
+        {
+            "single": "device",
+            "optional": "device?",
+            "filtered": "device(subsystem=tty)",
+            "many": ["device"],
+            "group": {"inner": "device", "name": "str"},
+            "repeated": [{"dev": "device", "label": "str"}],
+            "plain": "str",
+            "empty": "device?",
+            "missing": "device",
+        },
+        MOCK_ADDON_NAME,
+        MOCK_ADDON_SLUG,
+    )
+
+    assert options.extract_device_paths(
+        {
+            "single": "/dev/ttyUSB0",
+            "optional": "/dev/serial/by-id/usb-aaa",
+            "filtered": "/dev/ttyACM0",
+            "many": ["/dev/bus/usb/001/002", "/dev/bus/usb/001/003"],
+            "group": {"inner": "/dev/gpiochip0", "name": "x"},
+            "repeated": [
+                {"dev": "/dev/video0", "label": "cam0"},
+                {"dev": "/dev/video1", "label": "cam1"},
+            ],
+            "plain": "not a device",
+            "empty": "",
+            # "missing" is intentionally absent from the options
+        }
+    ) == {
+        Path("/dev/ttyUSB0"),
+        Path("/dev/serial/by-id/usb-aaa"),
+        Path("/dev/ttyACM0"),
+        Path("/dev/bus/usb/001/002"),
+        Path("/dev/bus/usb/001/003"),
+        Path("/dev/gpiochip0"),
+        Path("/dev/video0"),
+        Path("/dev/video1"),
+    }
+
+    # No device options configured returns an empty set
+    assert (
+        AppOptions(
+            coresys,
+            {"name": "str", "port": "port"},
+            MOCK_ADDON_NAME,
+            MOCK_ADDON_SLUG,
+        ).extract_device_paths({"name": "Pascal", "port": 8080})
+        == set()
+    )
+
+
 def test_simple_schema_password(coresys):
     """Test with simple schema password pwned."""
     validate = AppOptions(

--- a/tests/docker/test_app.py
+++ b/tests/docker/test_app.py
@@ -28,6 +28,7 @@ from supervisor.docker.const import (
 from supervisor.docker.manager import DockerAPI
 from supervisor.exceptions import CoreDNSError, DockerNotFound
 from supervisor.hardware.data import Device
+from supervisor.host.const import HostFeature
 from supervisor.os.manager import OSManager
 from supervisor.plugins.dns import PluginDns
 from supervisor.resolution.const import ContextType, IssueType, SuggestionType
@@ -432,6 +433,11 @@ async def test_app_new_device(
         patch.object(App, "write_options"),
         patch.object(OSManager, "available", new=PropertyMock(return_value=is_os)),
         patch.object(
+            type(coresys.host),
+            "features",
+            new=PropertyMock(return_value=[HostFeature.OS_AGENT]),
+        ),
+        patch.object(
             CGroup, "add_devices_allowed", new_callable=AsyncMock
         ) as add_devices,
     ):
@@ -459,6 +465,11 @@ async def test_app_new_device_no_haos(
     with (
         patch.object(App, "write_options"),
         patch.object(OSManager, "available", new=PropertyMock(return_value=False)),
+        patch.object(
+            type(coresys.host),
+            "features",
+            new=PropertyMock(return_value=[HostFeature.OS_AGENT]),
+        ),
         patch.object(
             CGroup, "add_devices_allowed", new_callable=AsyncMock
         ) as add_devices,
@@ -619,6 +630,11 @@ async def test_app_options_device_hw_listener(
         # called exactly once — from the hardware event via the options listener.
         patch.object(OSManager, "available", new=PropertyMock(return_value=False)),
         patch.object(
+            type(coresys.host),
+            "features",
+            new=PropertyMock(return_value=[HostFeature.OS_AGENT]),
+        ),
+        patch.object(
             CGroup, "add_devices_allowed", new_callable=AsyncMock
         ) as add_devices,
     ):
@@ -656,6 +672,11 @@ async def test_app_options_device_policy_check(
     with (
         patch.object(App, "write_options"),
         patch.object(OSManager, "available", new=PropertyMock(return_value=True)),
+        patch.object(
+            type(coresys.host),
+            "features",
+            new=PropertyMock(return_value=[HostFeature.OS_AGENT]),
+        ),
         # Mock policy to block this device
         patch.object(
             coresys.hardware.policy,

--- a/tests/docker/test_app.py
+++ b/tests/docker/test_app.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, PropertyMock, patch
 
 import aiodocker
+import attr
 import pytest
 
 from supervisor.apps import validate as vd
@@ -380,7 +381,7 @@ TEST_DEV_PATH = "/dev/ttyAMA0"
 TEST_SYSFS_PATH = "/sys/devices/platform/soc/ffe09000.usb/ff500000.usb/xhci-hcd.0.auto/usb1/1-1/1-1.1/1-1.1:1.0/tty/ttyACM0"
 TEST_HW_DEVICE = Device(
     name="ttyACM0",
-    path=Path("/dev/ttyAMA0"),
+    path=Path("/dev/ttyACM0"),
     sysfs=Path(
         "/sys/devices/platform/soc/ffe09000.usb/ff500000.usb/xhci-hcd.0.auto/usb1/1-1/1-1.1/1-1.1:1.0/tty/ttyACM0"
     ),
@@ -395,7 +396,7 @@ TEST_HW_DEVICE = Device(
         Path("/dev/serial/by-path/platform-xhci-hcd.0.auto-usb-0:1.1:1.0"),
         Path("/dev/serial/by-path/platform-xhci-hcd.0.auto-usbv2-0:1.1:1.0"),
     ],
-    attributes={},
+    attributes={"MAJOR": "166", "MINOR": "0"},
     children=[],
 )
 
@@ -442,7 +443,7 @@ async def test_app_new_device(
             TEST_HW_DEVICE,
         )
 
-        add_devices.assert_called_once_with(123, "c 0:0 rwm")
+        add_devices.assert_called_once_with(123, "c 166:0 rwm")
 
 
 @pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
@@ -599,11 +600,17 @@ async def test_app_options_device_hw_listener(
     container.id = 123
     docker._info = replace(docker.info, cgroup="1")  # pylint: disable=protected-access
 
-    # Re-enumerated device: same by-id symlink, different kernel node (ttyACM1).
-    reenumerated_device = replace(
+    # Re-enumerated device: same by-id symlink, different kernel node and minor number.
+    # When a USB device is unplugged and plugged back in, the kernel may assign a new
+    # device node (ttyACM0 → ttyACM1) with a different minor number.
+    reenumerated_device = attr.evolve(
         TEST_HW_DEVICE,
         name="ttyACM1",
         path=Path("/dev/ttyACM1"),
+        sysfs=Path(
+            "/sys/devices/platform/soc/ffe09000.usb/ff500000.usb/xhci-hcd.0.auto/usb1/1-1/1-1.1/1-1.1:1.0/tty/ttyACM1"
+        ),
+        attributes={"MAJOR": "166", "MINOR": "1"},  # minor number changed from 0 to 1
     )
 
     with (
@@ -618,4 +625,49 @@ async def test_app_options_device_hw_listener(
         await install_app_ssh.start()
         await fire_bus_event(coresys, BusEvent.HARDWARE_NEW_DEVICE, reenumerated_device)
 
-        add_devices.assert_called_once_with(123, "c 0:0 rwm")
+        # Verify cgroup permission was granted for the re-enumerated device with new minor number
+        add_devices.assert_called_once_with(123, "c 166:1 rwm")
+
+
+@pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
+async def test_app_options_device_policy_check(
+    coresys: CoreSys,
+    install_app_ssh: App,
+    container: MagicMock,
+    docker: DockerAPI,
+):
+    """Test hardware policy blocks device access even for options-based devices.
+
+    Scenario: an add-on has a device option configured, but the device is blocked
+    by hardware policy (e.g., used by system). The hardware event handler must
+    respect the policy and not grant cgroup access.
+    """
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    install_app_ssh.data["devices"] = []
+
+    # Configure a device-type option
+    by_id_path = TEST_HW_DEVICE.links[0]
+    install_app_ssh.data["schema"] = {"device": "device"}
+    install_app_ssh.persist["options"] = {"device": str(by_id_path)}
+
+    container.id = 123
+    docker._info = replace(docker.info, cgroup="1")  # pylint: disable=protected-access
+
+    with (
+        patch.object(App, "write_options"),
+        patch.object(OSManager, "available", new=PropertyMock(return_value=True)),
+        # Mock policy to block this device
+        patch.object(
+            coresys.hardware.policy,
+            "allowed_for_access",
+            return_value=False,
+        ),
+        patch.object(
+            CGroup, "add_devices_allowed", new_callable=AsyncMock
+        ) as add_devices,
+    ):
+        await install_app_ssh.start()
+        await fire_bus_event(coresys, BusEvent.HARDWARE_NEW_DEVICE, TEST_HW_DEVICE)
+
+        # Verify cgroup permission was NOT granted due to policy block
+        add_devices.assert_not_called()

--- a/tests/docker/test_app.py
+++ b/tests/docker/test_app.py
@@ -378,7 +378,7 @@ async def test_app_stop_delete_host_error(
         capture_exception.assert_called_once_with(err)
 
 
-TEST_DEV_PATH = "/dev/ttyAMA0"
+TEST_DEV_PATH = "/dev/ttyACM0"
 TEST_SYSFS_PATH = "/sys/devices/platform/soc/ffe09000.usb/ff500000.usb/xhci-hcd.0.auto/usb1/1-1/1-1.1/1-1.1:1.0/tty/ttyACM0"
 TEST_HW_DEVICE = Device(
     name="ttyACM0",

--- a/tests/docker/test_app.py
+++ b/tests/docker/test_app.py
@@ -683,6 +683,15 @@ async def test_app_options_device_policy_check(
             "features",
             new=PropertyMock(return_value=[HostFeature.OS_AGENT]),
         ),
+        # Make the event device match. option_device_paths reads the merged
+        # options, which the test's persist override doesn't populate, so without
+        # this mock the match guard returns early and the policy check below is
+        # never reached (the assertion would then pass for the wrong reason).
+        patch.object(
+            type(install_app_ssh),
+            "option_device_paths",
+            new=PropertyMock(return_value={by_id_path}),
+        ),
         # Mock policy to block this device
         patch.object(
             coresys.hardware.policy,

--- a/tests/docker/test_app.py
+++ b/tests/docker/test_app.py
@@ -572,3 +572,40 @@ async def test_ulimits_integration(coresys: CoreSys, install_app_ssh: App):
     assert core_limit is not None
     assert core_limit.soft == 0
     assert core_limit.hard == 0
+
+
+@pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
+async def test_app_options_device_hw_listener(
+    coresys: CoreSys,
+    install_app_ssh: App,
+    container: MagicMock,
+    docker: DockerAPI,
+):
+    """Test hw_listener is registered and fires for options-based devices.
+
+    Before the fix, _hw_listener was only registered when addon.static_devices
+    was non-empty. Add-ons like Z-Wave JS that configure the device via the
+    options schema (addon.devices) never had a listener, so cgroup permissions
+    were never updated after a USB re-enumeration.
+    """
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    install_app_ssh.data["devices"] = []  # no static devices
+    container.id = 123
+    docker._info = replace(docker.info, cgroup="1")  # pylint: disable=protected-access
+
+    with (
+        patch.object(App, "write_options"),
+        # HAOS not available: proactive cgroup call is skipped, so add_devices is
+        # called exactly once — from the hardware event via the options listener.
+        patch.object(OSManager, "available", new=PropertyMock(return_value=False)),
+        patch.object(
+            App, "devices", new_callable=PropertyMock, return_value={TEST_HW_DEVICE}
+        ),
+        patch.object(
+            CGroup, "add_devices_allowed", new_callable=AsyncMock
+        ) as add_devices,
+    ):
+        await install_app_ssh.start()
+        await fire_bus_event(coresys, BusEvent.HARDWARE_NEW_DEVICE, TEST_HW_DEVICE)
+
+        add_devices.assert_called_once_with(123, "c 0:0 rwm")

--- a/tests/docker/test_app.py
+++ b/tests/docker/test_app.py
@@ -581,17 +581,30 @@ async def test_app_options_device_hw_listener(
     container: MagicMock,
     docker: DockerAPI,
 ):
-    """Test hw_listener is registered and fires for options-based devices.
+    """Test hw_listener fires for a by-id option device after re-enumeration.
 
-    Before the fix, _hw_listener was only registered when addon.static_devices
-    was non-empty. Add-ons like Z-Wave JS that configure the device via the
-    options schema (addon.devices) never had a listener, so cgroup permissions
-    were never updated after a USB re-enumeration.
+    Scenario: the user picks a by-id path (stable symlink) in the add-on options.
+    On USB re-enumeration the kernel assigns a new device node (minor number
+    changes, e.g. ttyACM0 → ttyACM1) but the by-id symlink remains the same.
+    The hardware event must still be processed and cgroup permissions updated.
     """
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     install_app_ssh.data["devices"] = []  # no static devices
+
+    # Configure a device-type option with the by-id path from TEST_HW_DEVICE.
+    by_id_path = TEST_HW_DEVICE.links[0]
+    install_app_ssh.data["schema"] = {"device": "device"}
+    install_app_ssh.persist["options"] = {"device": str(by_id_path)}
+
     container.id = 123
     docker._info = replace(docker.info, cgroup="1")  # pylint: disable=protected-access
+
+    # Re-enumerated device: same by-id symlink, different kernel node (ttyACM1).
+    reenumerated_device = replace(
+        TEST_HW_DEVICE,
+        name="ttyACM1",
+        path=Path("/dev/ttyACM1"),
+    )
 
     with (
         patch.object(App, "write_options"),
@@ -599,13 +612,10 @@ async def test_app_options_device_hw_listener(
         # called exactly once — from the hardware event via the options listener.
         patch.object(OSManager, "available", new=PropertyMock(return_value=False)),
         patch.object(
-            App, "devices", new_callable=PropertyMock, return_value={TEST_HW_DEVICE}
-        ),
-        patch.object(
             CGroup, "add_devices_allowed", new_callable=AsyncMock
         ) as add_devices,
     ):
         await install_app_ssh.start()
-        await fire_bus_event(coresys, BusEvent.HARDWARE_NEW_DEVICE, TEST_HW_DEVICE)
+        await fire_bus_event(coresys, BusEvent.HARDWARE_NEW_DEVICE, reenumerated_device)
 
         add_devices.assert_called_once_with(123, "c 0:0 rwm")

--- a/tests/docker/test_app.py
+++ b/tests/docker/test_app.py
@@ -634,6 +634,12 @@ async def test_app_options_device_hw_listener(
             "features",
             new=PropertyMock(return_value=[HostFeature.OS_AGENT]),
         ),
+        # Mock option_device_paths to ensure it returns the by-id path
+        patch.object(
+            type(install_app_ssh),
+            "option_device_paths",
+            new=PropertyMock(return_value={by_id_path}),
+        ),
         patch.object(
             CGroup, "add_devices_allowed", new_callable=AsyncMock
         ) as add_devices,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Add-ons that get their serial device from the options schema (e.g. Z-Wave JS
`device:`) lose access whenever the device re-enumerates to a different minor
number (e.g. `ttyACM0` → `ttyACM1` after a HAOS reboot). The add-on then
crash-loops on `EACCES` until the user restarts it.

**Key prerequisite:** the user must have selected the device via a
`/dev/serial/by-id/…` symlink (the stable path shown in the add-on UI). On
re-enumeration the kernel assigns a new device node and a new major:minor pair,
but the by-id symlink stays the same. Supervisor must therefore match the
incoming hardware event via that stable by-id link and re-grant cgroup access
with the device's current major:minor.

Two independent bugs in `DockerApp` caused this:

1. **Listener never registered for options-based devices.** `_hw_listener` was
   only wired up when `addon.static_devices` (the manifest's `devices:` list)
   was non-empty. Add-ons that expose a device only via the options schema
   never registered the listener, so `add_devices_allowed` was never called
   when the device reappeared at a new minor.

2. **Options-based devices never matched in `_hardware_events`.** The handler
   compared the incoming `Device` only against `static_devices` (and only
   against `.path`/`.sysfs`, not `.links`). Devices configured via the options
   schema were never matched, so access was never re-granted even if the
   listener had been registered.

### Fix

Introduce `AppOptions.extract_device_paths` and `AppModel.option_device_paths`:
a cheap property that walks the raw schema and options to return the configured
device path strings as `set[Path]`, **without** running full options validation
(no hardware lookup, no pwnd hashing).

In `_hardware_events`, replace the old two-condition guard with a single
set-intersection:

```python
allowed_paths = set(self.app.static_devices) | self.app.option_device_paths
if not allowed_paths & {device.path, device.sysfs, *device.links}:
    return
```

This is strictly better:
- No per-event full validation.
- Matches by-id symlinks (via `device.links`) for both static and
  options-based devices.
- Uses the incoming device's current major:minor for the cgroup rule, which is
  the whole point of re-enumeration handling.

### Reproduction

1. Install Z-Wave JS, point its `device:` option at a `/dev/serial/by-id/…`
   symlink.
2. Replug the USB stick (or reboot HAOS) so it re-enumerates to a different
   minor.
3. Before fix: add-on crash-loops on `EACCES` reading the device.
   After fix: Supervisor re-grants cgroup access and the add-on recovers.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/