### PR TITLE
store API: drop unnecessary asyncio.gather over non-awaiting coroutines

### DIFF
--- a/supervisor/api/store.py
+++ b/supervisor/api/store.py
@@ -192,15 +192,11 @@ class APIStore(CoreSysAttributes):
         }
 
     async def _all_store_apps_info(self) -> list[dict[str, Any]]:
-        """Return gathered info for all apps in the store."""
-        return list(
-            await asyncio.gather(
-                *[
-                    self._generate_app_information(self.sys_apps.store[app])
-                    for app in self.sys_apps.store
-                ]
-            )
-        )
+        """Return info for all apps in the store."""
+        return [
+            await self._generate_app_information(self.sys_apps.store[app])
+            for app in self.sys_apps.store
+        ]
 
     @api_process
     async def reload(self, request: web.Request) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Drop `asyncio.gather` in `APIStore._all_store_apps_info` and replace it with a plain async list comprehension.

Investigating sporadic `asyncio` slow-callback warnings during `ha store list`, py-spy flamegraphs showed roughly 70% of the on-CPU time in that call going into `traceback.extract_stack()` and `linecache.checkcache()` — triggered by N task creations inside the `gather`. In the non-extended path, `_generate_app_information` never `await`s, so each gathered coroutine runs straight through in a single Task step. `gather` therefore provides zero concurrency here and only adds N task creations plus scheduling cycles. Under `loop.set_debug(True)` (supervisor dev mode) each `create_task` captures its creation stack via `extract_stack()`, which is what produced the observed ~5x slowdown and the slow-callback warnings. 

Outside debug mode the overhead is negligible, but the `gather` is still misleading: it implies parallelism that doesn't exist.

The list comprehension preserves behavior exactly: the non-extended path was already serial, and the extended path's `await app.long_description()` still serializes the same way `gather` would have once it observed that suspension.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
