### PR TITLE
Coordinate graceful shutdown with Home Assistant OS

### DIFF
--- a/supervisor/__main__.py
+++ b/supervisor/__main__.py
@@ -13,6 +13,8 @@ zlib_fast.enable()
 
 # pylint: disable=wrong-import-position
 from supervisor import bootstrap  # noqa: E402
+from supervisor.dbus.const import SystemState  # noqa: E402
+from supervisor.exceptions import HassioError  # noqa: E402
 from supervisor.utils.blockbuster import BlockBusterManager  # noqa: E402
 from supervisor.utils.logging import activate_log_queue_handler  # noqa: E402
 
@@ -68,6 +70,32 @@ if __name__ == "__main__":
 
     # Create startup task that can be cancelled gracefully
     startup_task = loop.create_task(coresys.core.start())
+    shutdown_tasks: list[asyncio.Task] = []
+
+    async def host_is_shutting_down() -> bool:
+        """Return True if systemd is shutting the host down.
+
+        This relies only on the Systemd manager state, which is exposed by
+        every Systemd version, so it works regardless of the running HAOS
+        release (no dependency on OS-side units being present).
+        """
+        if not coresys.dbus.systemd.is_connected:
+            return False
+
+        try:
+            return await coresys.dbus.systemd.get_system_state() == SystemState.STOPPING
+        except HassioError as err:
+            _LOGGER.warning("Could not read systemd manager state: %s", err)
+            return False
+
+    async def stop_supervisor() -> None:
+        """Stop Supervisor, including managed services during host shutdown."""
+        try:
+            if await host_is_shutting_down():
+                _LOGGER.info("Host shutdown detected, shutting down managed services")
+                await coresys.core.shutdown()
+        finally:
+            await coresys.core.stop()
 
     def shutdown_handler() -> None:
         """Handle shutdown signals gracefully during startup."""
@@ -75,7 +103,10 @@ if __name__ == "__main__":
             _LOGGER.warning("Supervisor startup interrupted by shutdown signal")
             startup_task.cancel()
 
-        coresys.create_task(coresys.core.stop())
+        if shutdown_tasks and not shutdown_tasks[0].done():
+            return
+
+        shutdown_tasks[:] = [coresys.create_task(stop_supervisor())]
 
     bootstrap.register_signal_handlers(loop, shutdown_handler)
 

--- a/supervisor/dbus/const.py
+++ b/supervisor/dbus/const.py
@@ -428,6 +428,17 @@ class StartUnitMode(StrEnum):
     ISOLATE = "isolate"
 
 
+class SystemState(DBusStrEnum):
+    """State of the systemd manager."""
+
+    INITIALIZING = "initializing"
+    STARTING = "starting"
+    RUNNING = "running"
+    DEGRADED = "degraded"
+    MAINTENANCE = "maintenance"
+    STOPPING = "stopping"
+
+
 class UnitActiveState(DBusStrEnum):
     """Active state of a systemd unit."""
 

--- a/supervisor/dbus/systemd.py
+++ b/supervisor/dbus/systemd.py
@@ -32,6 +32,7 @@ from .const import (
     DBUS_SIGNAL_PROPERTIES_CHANGED,
     StartUnitMode,
     StopUnitMode,
+    SystemState,
     UnitActiveState,
 )
 from .interface import DBusInterface, DBusInterfaceProxy, dbus_property
@@ -233,6 +234,11 @@ class Systemd(DBusInterfaceProxy):
     ) -> list[tuple[str, str, str, str, str, str, str, int, str, str]]:
         """Return a list of available systemd services."""
         return await self.connected_dbus.Manager.call("list_units")
+
+    @dbus_connected
+    async def get_system_state(self) -> SystemState:
+        """Return the systemd manager state."""
+        return SystemState(await self.connected_dbus.Manager.get("system_state"))
 
     @dbus_connected
     async def start_transient_unit(

--- a/supervisor/host/control.py
+++ b/supervisor/host/control.py
@@ -15,6 +15,12 @@ from ..exceptions import (
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
+# First HAOS release whose hassos-supervisor.service has a stop timeout long
+# enough for the SIGTERM handler to run the managed shutdown while the host is
+# tearing down. On older releases Supervisor stops Core, apps and plugins
+# in-process before requesting the reboot/power off instead.
+HAOS_GRACEFUL_SHUTDOWN_MIN_VERSION = AwesomeVersion("18.0.dev20260527")
+
 
 class SystemControl(CoreSysAttributes):
     """Handle host power controls."""
@@ -38,6 +44,21 @@ class SystemControl(CoreSysAttributes):
             f"No {flag!s} D-Bus connection available", _LOGGER.error
         )
 
+    def _os_coordinates_graceful_shutdown(self) -> bool:
+        """Return True if the OS gives Supervisor time to shut down on teardown.
+
+        Newer HAOS releases give hassos-supervisor.service a long stop timeout,
+        so the SIGTERM handler can run the managed shutdown while the host is
+        tearing down (see __main__.py). On older releases (or when not running
+        HAOS) the timeout is too short, so Core, apps and plugins must be
+        stopped in-process before the reboot/power off is requested.
+        """
+        return (
+            self.coresys.os.available
+            and self.sys_os.version is not None
+            and self.sys_os.version >= HAOS_GRACEFUL_SHUTDOWN_MIN_VERSION
+        )
+
     async def reboot(self) -> None:
         """Reboot host system."""
         self._check_dbus(HostFeature.REBOOT)
@@ -48,7 +69,8 @@ class SystemControl(CoreSysAttributes):
         )
 
         try:
-            await self.sys_core.shutdown()
+            if not self._os_coordinates_graceful_shutdown():
+                await self.sys_core.shutdown()
         finally:
             if use_logind:
                 await self.sys_dbus.logind.reboot()
@@ -65,7 +87,8 @@ class SystemControl(CoreSysAttributes):
         )
 
         try:
-            await self.sys_core.shutdown()
+            if not self._os_coordinates_graceful_shutdown():
+                await self.sys_core.shutdown()
         finally:
             if use_logind:
                 await self.sys_dbus.logind.power_off()

--- a/tests/dbus/test_systemd.py
+++ b/tests/dbus/test_systemd.py
@@ -5,7 +5,12 @@ from dbus_fast import DBusError, Variant
 from dbus_fast.aio.message_bus import MessageBus
 import pytest
 
-from supervisor.dbus.const import StartUnitMode, StopUnitMode, UnitActiveState
+from supervisor.dbus.const import (
+    StartUnitMode,
+    StopUnitMode,
+    SystemState,
+    UnitActiveState,
+)
 from supervisor.dbus.systemd import Systemd
 from supervisor.exceptions import DBusNotConnectedError, DBusSystemdNoSuchUnit
 
@@ -30,6 +35,7 @@ async def test_dbus_systemd_info(dbus_session_bus: MessageBus):
 
     assert systemd.boot_timestamp == 1632236713344227
     assert systemd.startup_time == 45.304696
+    assert await systemd.get_system_state() == SystemState.RUNNING
 
 
 async def test_subscribe_on_connect(

--- a/tests/dbus_service_mocks/systemd.py
+++ b/tests/dbus_service_mocks/systemd.py
@@ -28,6 +28,7 @@ class Systemd(DBusServiceMock):
     reboot_watchdog_usec = 600000000
     kexec_watchdog_usec = 0
     service_watchdogs = True
+    system_state = "running"
     virtualization = ""
     response_get_unit: (
         dict[str, list[str | DBusError]] | list[str | DBusError] | str | DBusError
@@ -401,7 +402,7 @@ class Systemd(DBusServiceMock):
     @dbus_property(access=PropertyAccess.READ)
     def SystemState(self) -> "s":
         """Get SystemState."""
-        return "running"
+        return self.system_state
 
     @dbus_property(access=PropertyAccess.READ)
     def ExitCode(self) -> "y":

--- a/tests/host/test_control.py
+++ b/tests/host/test_control.py
@@ -1,5 +1,7 @@
 """Test host control."""
 
+from unittest.mock import patch
+
 from dbus_fast import DBusError, ErrorType
 import pytest
 
@@ -8,6 +10,7 @@ from supervisor.exceptions import HostInvalidHostnameError
 
 from tests.dbus_service_mocks.base import DBusServiceMock
 from tests.dbus_service_mocks.hostname import Hostname as HostnameService
+from tests.dbus_service_mocks.logind import Logind as LogindService
 from tests.dbus_service_mocks.timedate import TimeDate as TimeDateService
 
 
@@ -73,3 +76,49 @@ async def test_set_timezone_unsupported(
 
     await coresys.host.control.set_timezone("Europe/Prague")
     assert timedate_service.SetTimezone.calls == []
+
+
+@pytest.mark.parametrize(
+    ("os_available", "in_process_shutdown"),
+    [("18.0", False), ("17.3", True)],
+    indirect=["os_available"],
+    ids=["new-os", "old-os"],
+)
+async def test_reboot_graceful_shutdown_gating(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+    os_available: str,
+    in_process_shutdown: bool,
+):
+    """reboot() stops Core in-process only on OS too old for coordinated shutdown."""
+    logind_service: LogindService = all_dbus_services["logind"]
+    logind_service.Reboot.calls.clear()
+
+    with patch.object(coresys.core, "shutdown") as core_shutdown:
+        await coresys.host.control.reboot()
+
+    assert core_shutdown.called is in_process_shutdown
+    assert len(logind_service.Reboot.calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("os_available", "in_process_shutdown"),
+    [("18.0", False), ("17.3", True)],
+    indirect=["os_available"],
+    ids=["new-os", "old-os"],
+)
+async def test_shutdown_graceful_shutdown_gating(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+    os_available: str,
+    in_process_shutdown: bool,
+):
+    """shutdown() stops Core in-process only on OS too old for coordinated shutdown."""
+    logind_service: LogindService = all_dbus_services["logind"]
+    logind_service.PowerOff.calls.clear()
+
+    with patch.object(coresys.core, "shutdown") as core_shutdown:
+        await coresys.host.control.shutdown()
+
+    assert core_shutdown.called is in_process_shutdown
+    assert len(logind_service.PowerOff.calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

On newer HAOS (home-assistant/operating-system#4736), hassos-supervisor.service gets a long stop timeout (420 s docker stop + 450 s TimeoutStopSec) so Supervisor can handle the SIGTERM during host teardown and gracefully stop Core, apps and plugins via its existing shutdown handler. On older releases the timeout is too short, so reboot()/shutdown() keep stopping Core in-process before requesting the reboot/power off.

For host shutdowns not initiated by Supervisor (ACPI, power button, systemctl reboot), the SIGTERM handler now checks the systemd manager state. When it is "stopping", Supervisor runs Core.shutdown() to stop managed services gracefully; on a plain Supervisor restart the state is "running", so only Supervisor stops as before. The manager state is exposed by every systemd version, so this works regardless of the OS release.

Closes home-assistant/operating-system#4642

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/operating-system#4642
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
