### PR TITLE
Derive App state from container state

### DIFF
--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -154,10 +154,9 @@ class App(AppModel):
         # event stream cannot reflect (e.g. container never came up). Cleared
         # on the next observed container state change.
         self._operation_error: bool = False
-        # Last AppState that listeners were notified about. Used to diff
-        # transitions even when ``state`` is shifted by an out-of-band change
-        # (e.g. ``instance.remove()`` clearing ``_meta`` during uninstall).
-        self._last_state: AppState = AppState.UNKNOWN
+        # Cached app state. Updated only via ``_update_state`` so the value
+        # consumers see matches what was last emitted.
+        self._state: AppState = AppState.UNKNOWN
         self._manual_stop: bool = False
         self._listeners: list[EventListener] = []
         self._startup_event = asyncio.Event()
@@ -185,7 +184,11 @@ class App(AppModel):
 
     @property
     def state(self) -> AppState:
-        """Return state of the app, derived from container state.
+        """Return current state of the app."""
+        return self._state
+
+    def _derive_state(self) -> AppState:
+        """Derive the app state from the cached docker signals.
 
         Falls back to install signals when no container has been observed
         yet: an attached instance (image present) is STOPPED, otherwise
@@ -218,23 +221,22 @@ class App(AppModel):
     ) -> None:
         """Update state-driving signals and emit a transition if anything changed.
 
-        Applies the given signal updates and emits a transition relative to
-        the last state listeners were notified about. ``None`` leaves a
-        signal untouched. Diffing against the last emitted state (rather
-        than the freshly derived one) lets callers rely on a consistent
-        transition even when an out-of-band mutation shifted the derivation
-        between updates (e.g. ``instance.remove()`` during uninstall).
+        Applies the given signal updates, re-derives the app state and
+        emits side effects if it differs from the cached state. ``None``
+        leaves a signal untouched; calling with no arguments simply
+        triggers a re-derivation (useful after ``attach()`` to settle the
+        state once the docker meta is known).
         """
         if container_state is not None:
             self._container_state = container_state
         if operation_error is not None:
             self._operation_error = operation_error
 
-        old_state = self._last_state
-        new_state = self.state
-        if old_state == new_state:
+        new_state = self._derive_state()
+        if new_state == self._state:
             return
-        self._last_state = new_state
+        old_state = self._state
+        self._state = new_state
 
         # Signal listeners about app state change
         if new_state == AppState.STARTED or old_state == AppState.STARTUP:
@@ -300,6 +302,7 @@ class App(AppModel):
             )
             with suppress(DockerError):
                 await self.instance.attach(version=self.version)
+            self._update_state()
             return
 
         default_image = self._image(self.data)
@@ -334,6 +337,11 @@ class App(AppModel):
 
         self.persist[ATTR_IMAGE] = default_image
         await self.save_persist()
+
+        # Settle the cached state now that attach() has run: image-only
+        # attaches do not fire a docker event, so without this an installed
+        # app stays in the constructor-default UNKNOWN until first start.
+        self._update_state()
 
     def _create_missing_image_issue(self) -> None:
         """Surface a repair suggestion for a missing app image."""

--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -148,7 +148,12 @@ class App(AppModel):
         """Initialize data holder."""
         super().__init__(coresys, slug)
         self.instance: DockerApp = DockerApp(coresys, self)
-        self._state: AppState = AppState.UNKNOWN
+        # Last observed container state; None until first event arrives.
+        self._container_state: ContainerState | None = None
+        # Sticky flag for failures of start/stop operations that the docker
+        # event stream cannot reflect (e.g. container never came up). Cleared
+        # on the next observed container state change.
+        self._operation_error: bool = False
         self._manual_stop: bool = False
         self._listeners: list[EventListener] = []
         self._startup_event = asyncio.Event()
@@ -176,16 +181,47 @@ class App(AppModel):
 
     @property
     def state(self) -> AppState:
-        """Return state of the app."""
-        return self._state
+        """Return state of the app, derived from container state.
 
-    @state.setter
-    def state(self, new_state: AppState) -> None:
-        """Set the app into new state."""
-        if self._state == new_state:
+        Falls back to install signals when no container has been observed
+        yet: an attached instance (image present) is STOPPED, otherwise
+        UNKNOWN. A sticky operation error overrides the derivation until
+        the next container event arrives.
+        """
+        if self._operation_error:
+            return AppState.ERROR
+        match self._container_state:
+            case ContainerState.RUNNING:
+                return (
+                    AppState.STARTUP if self.instance.healthcheck else AppState.STARTED
+                )
+            case ContainerState.HEALTHY | ContainerState.UNHEALTHY:
+                return AppState.STARTED
+            case ContainerState.STOPPED:
+                return AppState.STOPPED
+            case ContainerState.FAILED:
+                return AppState.ERROR
+            case _:
+                # No container observed (None) or container missing (UNKNOWN):
+                # fall back to install status.
+                return AppState.STOPPED if self.instance.attached else AppState.UNKNOWN
+
+    def _set_operation_error(self) -> None:
+        """Mark a failed start/stop operation so state reflects an error."""
+        old_state = self.state
+        self._operation_error = True
+        self._emit_state_change(old_state)
+
+    def _emit_state_change(self, old_state: AppState) -> None:
+        """Run side effects after a state transition.
+
+        Compares the previous (passed-in) state against the freshly derived
+        current state and fires listeners, dismisses related issues and
+        notifies the websocket if anything changed.
+        """
+        new_state = self.state
+        if old_state == new_state:
             return
-        old_state = self._state
-        self._state = new_state
 
         # Signal listeners about app state change
         if new_state == AppState.STARTED or old_state == AppState.STARTUP:
@@ -878,13 +914,17 @@ class App(AppModel):
         self, *, remove_config: bool, remove_image: bool = True
     ) -> None:
         """Uninstall and cleanup this app."""
+        old_state = self.state
         try:
             await self.instance.remove(remove_image=remove_image)
         except DockerError as err:
             _LOGGER.error("Could not remove image for app %s: %s", self.slug, err)
             raise AppUnknownError(app=self.slug) from err
 
-        self.state = AppState.UNKNOWN
+        # Reset cached signals so state derives back to UNKNOWN.
+        self._container_state = None
+        self._operation_error = False
+        self._emit_state_change(old_state)
 
         await self.unload()
 
@@ -1208,7 +1248,7 @@ class App(AppModel):
             ) from err
         except DockerError as err:
             _LOGGER.error("Could not start container for app %s: %s", self.slug, err)
-            self.state = AppState.ERROR
+            self._set_operation_error()
             raise AppUnknownError(app=self.slug) from err
 
         self._wait_for_startup_task = self.sys_create_task(self._wait_for_startup())
@@ -1226,7 +1266,7 @@ class App(AppModel):
             await self.instance.stop()
         except DockerError as err:
             _LOGGER.error("Could not stop container for app %s: %s", self.slug, err)
-            self.state = AppState.ERROR
+            self._set_operation_error()
             raise AppUnknownError(app=self.slug) from err
 
     @Job(
@@ -1690,22 +1730,12 @@ class App(AppModel):
             await asyncio.sleep(delay)
 
     async def container_state_changed(self, event: DockerContainerStateEvent) -> None:
-        """Set app state from container state."""
+        """Update cached container state and emit transitions."""
         if event.name != self.instance.name:
             return
 
         if event.state == ContainerState.RUNNING:
             self._manual_stop = False
-            self.state = (
-                AppState.STARTUP if self.instance.healthcheck else AppState.STARTED
-            )
-        elif event.state in [
-            ContainerState.HEALTHY,
-            ContainerState.UNHEALTHY,
-        ]:
-            self.state = AppState.STARTED
-        elif event.state == ContainerState.STOPPED:
-            self.state = AppState.STOPPED
         elif event.state == ContainerState.FAILED:
             if event.exit_code == EXIT_CODE_SIGTERM_DEFAULT:
                 _LOGGER.warning(
@@ -1722,7 +1752,12 @@ class App(AppModel):
                     self.name,
                     event.exit_code,
                 )
-            self.state = AppState.ERROR
+
+        old_state = self.state
+        self._container_state = event.state
+        # An observed container state supersedes any prior operation error.
+        self._operation_error = False
+        self._emit_state_change(old_state)
 
     async def watchdog_container(self, event: DockerContainerStateEvent) -> None:
         """Process state changes in app container and restart if necessary."""

--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -220,10 +220,9 @@ class App(AppModel):
 
         Re-derives the app state and emits side effects if it differs from
         the cached state. ``container_state=None`` leaves the last observed
-        container state untouched (e.g. the argless call after ``attach()``
-        settles the state once the docker meta is known). ``operation_error``
-        is a momentary signal forcing ERROR for the current transition; a
-        later container observation supersedes it via the default.
+        container state untouched. ``operation_error`` is a momentary signal
+        forcing ERROR for the current transition; a later container
+        observation supersedes it via the default.
         """
         if container_state is not None:
             self._container_state = container_state
@@ -298,7 +297,7 @@ class App(AppModel):
             )
             with suppress(DockerError):
                 await self.instance.attach(version=self.version)
-            self._update_state()
+                self._update_state(container_state=await self.instance.current_state())
             return
 
         default_image = self._image(self.data)
@@ -334,10 +333,12 @@ class App(AppModel):
         self.persist[ATTR_IMAGE] = default_image
         await self.save_persist()
 
-        # Settle the cached state now that attach() has run: image-only
-        # attaches do not fire a docker event, so without this an installed
-        # app stays in the constructor-default UNKNOWN until first start.
-        self._update_state()
+        # Settle the cached state from the attached container (UNKNOWN when
+        # only an image is present, which derives to STOPPED). attach() emits
+        # its runtime event asynchronously, so query synchronously here rather
+        # than racing that event during load.
+        with suppress(DockerError):
+            self._update_state(container_state=await self.instance.current_state())
 
     def _create_missing_image_issue(self) -> None:
         """Surface a repair suggestion for a missing app image."""

--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -150,10 +150,6 @@ class App(AppModel):
         self.instance: DockerApp = DockerApp(coresys, self)
         # Last observed container state; None until first event arrives.
         self._container_state: ContainerState | None = None
-        # Sticky flag for failures of start/stop operations that the docker
-        # event stream cannot reflect (e.g. container never came up). Cleared
-        # on the next observed container state change.
-        self._operation_error: bool = False
         # Cached app state. Updated only via ``_update_state`` so the value
         # consumers see matches what was last emitted.
         self._state: AppState = AppState.UNKNOWN
@@ -187,15 +183,16 @@ class App(AppModel):
         """Return current state of the app."""
         return self._state
 
-    def _derive_state(self) -> AppState:
+    def _derive_state(self, operation_error: bool) -> AppState:
         """Derive the app state from the cached docker signals.
 
         Falls back to install signals when no container has been observed
         yet: an attached instance (image present) is STOPPED, otherwise
-        UNKNOWN. A sticky operation error overrides the derivation until
-        the next container event arrives.
+        UNKNOWN. ``operation_error`` forces ERROR for start/stop failures
+        that the docker event stream cannot reflect (e.g. the container
+        never came up).
         """
-        if self._operation_error:
+        if operation_error:
             return AppState.ERROR
         match self._container_state:
             case ContainerState.RUNNING:
@@ -217,22 +214,21 @@ class App(AppModel):
         self,
         *,
         container_state: ContainerState | None = None,
-        operation_error: bool | None = None,
+        operation_error: bool = False,
     ) -> None:
-        """Update state-driving signals and emit a transition if anything changed.
+        """Update the cached container state and emit a transition if it changed.
 
-        Applies the given signal updates, re-derives the app state and
-        emits side effects if it differs from the cached state. ``None``
-        leaves a signal untouched; calling with no arguments simply
-        triggers a re-derivation (useful after ``attach()`` to settle the
-        state once the docker meta is known).
+        Re-derives the app state and emits side effects if it differs from
+        the cached state. ``container_state=None`` leaves the last observed
+        container state untouched (e.g. the argless call after ``attach()``
+        settles the state once the docker meta is known). ``operation_error``
+        is a momentary signal forcing ERROR for the current transition; a
+        later container observation supersedes it via the default.
         """
         if container_state is not None:
             self._container_state = container_state
-        if operation_error is not None:
-            self._operation_error = operation_error
 
-        new_state = self._derive_state()
+        new_state = self._derive_state(operation_error)
         if new_state == self._state:
             return
         old_state = self._state
@@ -943,9 +939,7 @@ class App(AppModel):
 
         # The container (and possibly the image) is gone; the state derives
         # back to UNKNOWN via the image-removed instance.
-        self._update_state(
-            container_state=ContainerState.UNKNOWN, operation_error=False
-        )
+        self._update_state(container_state=ContainerState.UNKNOWN)
 
         await self.unload()
 
@@ -1775,7 +1769,7 @@ class App(AppModel):
                 )
 
         # An observed container state supersedes any prior operation error.
-        self._update_state(container_state=event.state, operation_error=False)
+        self._update_state(container_state=event.state)
 
     async def watchdog_container(self, event: DockerContainerStateEvent) -> None:
         """Process state changes in app container and restart if necessary."""

--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -154,6 +154,10 @@ class App(AppModel):
         # event stream cannot reflect (e.g. container never came up). Cleared
         # on the next observed container state change.
         self._operation_error: bool = False
+        # Last AppState that listeners were notified about. Used to diff
+        # transitions even when ``state`` is shifted by an out-of-band change
+        # (e.g. ``instance.remove()`` clearing ``_meta`` during uninstall).
+        self._last_state: AppState = AppState.UNKNOWN
         self._manual_stop: bool = False
         self._listeners: list[EventListener] = []
         self._startup_event = asyncio.Event()
@@ -206,22 +210,31 @@ class App(AppModel):
                 # fall back to install status.
                 return AppState.STOPPED if self.instance.attached else AppState.UNKNOWN
 
-    def _set_operation_error(self) -> None:
-        """Mark a failed start/stop operation so state reflects an error."""
-        old_state = self.state
-        self._operation_error = True
-        self._emit_state_change(old_state)
+    def _update_state(
+        self,
+        *,
+        container_state: ContainerState | None = None,
+        operation_error: bool | None = None,
+    ) -> None:
+        """Update state-driving signals and emit a transition if anything changed.
 
-    def _emit_state_change(self, old_state: AppState) -> None:
-        """Run side effects after a state transition.
-
-        Compares the previous (passed-in) state against the freshly derived
-        current state and fires listeners, dismisses related issues and
-        notifies the websocket if anything changed.
+        Applies the given signal updates and emits a transition relative to
+        the last state listeners were notified about. ``None`` leaves a
+        signal untouched. Diffing against the last emitted state (rather
+        than the freshly derived one) lets callers rely on a consistent
+        transition even when an out-of-band mutation shifted the derivation
+        between updates (e.g. ``instance.remove()`` during uninstall).
         """
+        if container_state is not None:
+            self._container_state = container_state
+        if operation_error is not None:
+            self._operation_error = operation_error
+
+        old_state = self._last_state
         new_state = self.state
         if old_state == new_state:
             return
+        self._last_state = new_state
 
         # Signal listeners about app state change
         if new_state == AppState.STARTED or old_state == AppState.STARTUP:
@@ -914,17 +927,17 @@ class App(AppModel):
         self, *, remove_config: bool, remove_image: bool = True
     ) -> None:
         """Uninstall and cleanup this app."""
-        old_state = self.state
         try:
             await self.instance.remove(remove_image=remove_image)
         except DockerError as err:
             _LOGGER.error("Could not remove image for app %s: %s", self.slug, err)
             raise AppUnknownError(app=self.slug) from err
 
-        # Reset cached signals so state derives back to UNKNOWN.
-        self._container_state = None
-        self._operation_error = False
-        self._emit_state_change(old_state)
+        # The container (and possibly the image) is gone; the state derives
+        # back to UNKNOWN via the image-removed instance.
+        self._update_state(
+            container_state=ContainerState.UNKNOWN, operation_error=False
+        )
 
         await self.unload()
 
@@ -1248,7 +1261,7 @@ class App(AppModel):
             ) from err
         except DockerError as err:
             _LOGGER.error("Could not start container for app %s: %s", self.slug, err)
-            self._set_operation_error()
+            self._update_state(operation_error=True)
             raise AppUnknownError(app=self.slug) from err
 
         self._wait_for_startup_task = self.sys_create_task(self._wait_for_startup())
@@ -1266,7 +1279,7 @@ class App(AppModel):
             await self.instance.stop()
         except DockerError as err:
             _LOGGER.error("Could not stop container for app %s: %s", self.slug, err)
-            self._set_operation_error()
+            self._update_state(operation_error=True)
             raise AppUnknownError(app=self.slug) from err
 
     @Job(
@@ -1753,11 +1766,8 @@ class App(AppModel):
                     event.exit_code,
                 )
 
-        old_state = self.state
-        self._container_state = event.state
         # An observed container state supersedes any prior operation error.
-        self._operation_error = False
-        self._emit_state_change(old_state)
+        self._update_state(container_state=event.state, operation_error=False)
 
     async def watchdog_container(self, event: DockerContainerStateEvent) -> None:
         """Process state changes in app container and restart if necessary."""

--- a/tests/api/test_apps.py
+++ b/tests/api/test_apps.py
@@ -23,6 +23,7 @@ from supervisor.docker.monitor import DockerContainerStateEvent
 from supervisor.exceptions import HassioError
 from supervisor.store.repository import Repository
 
+from ..common import force_app_state
 from ..const import TEST_ADDON_SLUG
 
 
@@ -41,7 +42,7 @@ async def test_apps_info(
 ):
     """Test getting app info."""
     client, root = app_api_client_with_root
-    install_app_ssh.state = AppState.STOPPED
+    force_app_state(install_app_ssh, AppState.STOPPED)
     install_app_ssh.ingress_panel = True
     install_app_ssh.protected = True
     install_app_ssh.watchdog = False

--- a/tests/api/test_discovery.py
+++ b/tests/api/test_discovery.py
@@ -11,7 +11,7 @@ from supervisor.const import AppState
 from supervisor.coresys import CoreSys
 from supervisor.discovery import Message
 
-from tests.common import load_json_fixture
+from tests.common import force_app_state, load_json_fixture
 
 
 async def test_api_discovery_forbidden(
@@ -63,7 +63,7 @@ async def test_api_list_discovery(
         Message(app="local_ssh", service="adguard", config=ANY, uuid=ANY),
     ]
 
-    install_app_ssh.state = AppState.STARTED
+    force_app_state(install_app_ssh, AppState.STARTED)
     resp = await api_client.get(f"{prefix}/discovery")
     assert resp.status == 200
     result = await resp.json()
@@ -77,7 +77,7 @@ async def test_api_list_discovery(
         }
     ]
 
-    install_app_ssh.state = skip_state
+    force_app_state(install_app_ssh, skip_state)
     resp = await api_client.get(f"{prefix}/discovery")
     assert resp.status == 200
     result = await resp.json()

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -47,7 +47,7 @@ from supervisor.utils.dt import utcnow
 
 from .test_manager import BOOT_FAIL_ISSUE, BOOT_FAIL_SUGGESTIONS
 
-from tests.common import fire_bus_event, get_fixture_path, is_in_list
+from tests.common import fire_bus_event, force_app_state, get_fixture_path, is_in_list
 from tests.const import TEST_ADDON_SLUG
 
 
@@ -1257,10 +1257,10 @@ async def test_app_state_dismisses_issue(
     suggestions: list[SuggestionType],
 ):
     """Test an app state change dismisses the issues."""
-    install_app_ssh.state = initial_state
+    force_app_state(install_app_ssh, initial_state)
     coresys.resolution.add_issue(issue, suggestions)
 
-    install_app_ssh.state = target_state
+    force_app_state(install_app_ssh, target_state)
     assert coresys.resolution.issues == []
     assert coresys.resolution.suggestions == []
 
@@ -1270,7 +1270,7 @@ async def test_app_disable_boot_dismisses_boot_fail(
 ):
     """Test a disabling boot dismisses the boot fail issue."""
     install_app_ssh.boot = AppBoot.AUTO
-    install_app_ssh.state = AppState.ERROR
+    force_app_state(install_app_ssh, AppState.ERROR)
     coresys.resolution.add_issue(
         BOOT_FAIL_ISSUE, [suggestion.type for suggestion in BOOT_FAIL_SUGGESTIONS]
     )

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -126,7 +126,10 @@ def test_options_merge(coresys: CoreSys, install_app_ssh: App) -> None:
 
 async def test_app_state_listener(coresys: CoreSys, install_app_ssh: App) -> None:
     """Test app is setting state from docker events."""
-    with patch.object(DockerApp, "attach"):
+    with (
+        patch.object(DockerApp, "attach"),
+        patch.object(DockerApp, "current_state", return_value=ContainerState.UNKNOWN),
+    ):
         await install_app_ssh.load()
 
     assert install_app_ssh.state == AppState.UNKNOWN
@@ -460,6 +463,19 @@ async def test_listeners_removed_on_uninstall(
             listener
             not in coresys.bus._listeners[BusEvent.DOCKER_CONTAINER_STATE_CHANGE]
         )
+
+
+@pytest.mark.usefixtures("tmp_supervisor_data", "path_extern")
+async def test_load_settles_state_from_running_container(
+    install_app_ssh: App, container: DockerContainer
+) -> None:
+    """Test load derives the state from a running container, not the default."""
+    container.show.return_value["State"]["Status"] = "running"
+    container.show.return_value["State"]["Running"] = True
+    await install_app_ssh.load()
+    # State is settled synchronously from current_state(), so it reflects the
+    # running container immediately rather than the image-only STOPPED default.
+    assert install_app_ssh.state == AppState.STARTED
 
 
 @pytest.mark.usefixtures("tmp_supervisor_data", "path_extern")

--- a/tests/apps/test_manager.py
+++ b/tests/apps/test_manager.py
@@ -39,7 +39,7 @@ from supervisor.store.repository import RepositoryLocal
 from supervisor.utils import check_exception_chain
 from supervisor.utils.common import write_json_file
 
-from tests.common import fire_bus_event, load_json_fixture
+from tests.common import fire_bus_event, force_app_state, load_json_fixture
 from tests.const import TEST_ADDON_SLUG
 
 BOOT_FAIL_ISSUE = Issue(
@@ -219,7 +219,7 @@ async def test_app_shutdown_error(
     coresys: CoreSys, install_app_ssh: App, capture_exception: Mock
 ):
     """Test errors captured during app shutdown."""
-    install_app_ssh.state = AppState.STARTED
+    force_app_state(install_app_ssh, AppState.STARTED)
     with patch.object(DockerApp, "stop", side_effect=DockerNotFound()):
         await coresys.apps.shutdown(AppStartup.APPLICATION)
 

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -43,7 +43,7 @@ from supervisor.mounts.mount import Mount
 from supervisor.resolution.const import UnhealthyReason
 from supervisor.utils.json import read_json_file, write_json_file
 
-from tests.common import get_fixture_path
+from tests.common import force_app_state, get_fixture_path
 from tests.const import TEST_ADDON_SLUG
 from tests.dbus_service_mocks.base import DBusServiceMock
 from tests.dbus_service_mocks.systemd import Systemd as SystemdService
@@ -1255,7 +1255,7 @@ async def test_restore_progress(
     container.show.return_value["State"]["Status"] = "running"
     container.show.return_value["State"]["Running"] = True
     install_app_ssh.path_data.mkdir()
-    install_app_ssh.state = AppState.STARTED
+    force_app_state(install_app_ssh, AppState.STARTED)
     await coresys.core.set_state(CoreState.RUNNING)
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
 
@@ -1387,7 +1387,7 @@ async def test_restore_progress(
 
     container.show.return_value["State"]["Status"] = "stopped"
     container.show.return_value["State"]["Running"] = False
-    install_app_ssh.state = AppState.STOPPED
+    force_app_state(install_app_ssh, AppState.STOPPED)
     app_backup: Backup = await coresys.backups.do_backup_partial(apps=["local_ssh"])
 
     ha_ws_client.async_send_command.reset_mock()

--- a/tests/common.py
+++ b/tests/common.py
@@ -26,15 +26,15 @@ from .dbus_service_mocks.base import DBusServiceMock
 def force_app_state(app: App, state: AppState) -> None:
     """Drive an app's derived state to ``state`` by setting underlying signals.
 
-    The ``App.state`` property is purely derived from the last observed
-    container state and an operation-error flag. Tests sometimes need a
+    The ``App.state`` value is derived from the last observed container
+    state and a momentary operation-error signal. Tests sometimes need a
     specific AppState as setup without spinning up real Docker events;
     this helper maps each AppState back to plausible signals and routes
     them through the normal state update path.
     """
     # pylint: disable=protected-access
     container_state: ContainerState | None = None
-    operation_error: bool | None = False
+    operation_error = False
     match state:
         case AppState.UNKNOWN:
             # The derivation falls back to STOPPED when ``instance.attached``

--- a/tests/common.py
+++ b/tests/common.py
@@ -29,25 +29,25 @@ def force_app_state(app: App, state: AppState) -> None:
     The ``App.state`` property is purely derived from the last observed
     container state and an operation-error flag. Tests sometimes need a
     specific AppState as setup without spinning up real Docker events;
-    this helper maps each AppState back to plausible signals and emits
-    the resulting transition through the normal side-effect path.
+    this helper maps each AppState back to plausible signals and routes
+    them through the normal state update path.
     """
     # pylint: disable=protected-access
-    old_state = app.state
-    app._operation_error = False
+    container_state: ContainerState | None = None
+    operation_error: bool | None = False
     match state:
         case AppState.UNKNOWN:
-            app._container_state = None
             # The derivation falls back to STOPPED when ``instance.attached``
             # is true; clear the docker metadata so the helper is
             # deterministic regardless of prior fixture setup.
             app.instance._meta = None
+            container_state = ContainerState.UNKNOWN
         case AppState.STOPPED:
-            app._container_state = ContainerState.STOPPED
+            container_state = ContainerState.STOPPED
         case AppState.STARTED:
-            app._container_state = ContainerState.HEALTHY
+            container_state = ContainerState.HEALTHY
         case AppState.STARTUP:
-            app._container_state = ContainerState.RUNNING
+            container_state = ContainerState.RUNNING
             # STARTUP only resolves from RUNNING when the container has a
             # healthcheck configured; ensure one is present in the mocked
             # container metadata.
@@ -55,8 +55,8 @@ def force_app_state(app: App, state: AppState) -> None:
             meta.setdefault("Config", {})["Healthcheck"] = {"Test": ["CMD", "true"]}
             app.instance._meta = meta
         case AppState.ERROR:
-            app._operation_error = True
-    app._emit_state_change(old_state)
+            operation_error = True
+    app._update_state(container_state=container_state, operation_error=operation_error)
 
 
 async def fire_bus_event(coresys: CoreSys, event: BusEvent, data: Any) -> None:

--- a/tests/common.py
+++ b/tests/common.py
@@ -12,13 +12,47 @@ from typing import Any, Self
 
 from dbus_fast.aio.message_bus import MessageBus
 
-from supervisor.const import BusEvent
+from supervisor.apps.app import App
+from supervisor.const import AppState, BusEvent
 from supervisor.coresys import CoreSys
+from supervisor.docker.const import ContainerState
 from supervisor.jobs.decorator import Job
 from supervisor.resolution.validate import get_valid_modules
 from supervisor.utils.yaml import read_yaml_file
 
 from .dbus_service_mocks.base import DBusServiceMock
+
+
+def force_app_state(app: App, state: AppState) -> None:
+    """Drive an app's derived state to ``state`` by setting underlying signals.
+
+    The ``App.state`` property is purely derived from the last observed
+    container state and an operation-error flag. Tests sometimes need a
+    specific AppState as setup without spinning up real Docker events;
+    this helper maps each AppState back to plausible signals and emits
+    the resulting transition through the normal side-effect path.
+    """
+    # pylint: disable=protected-access
+    old_state = app.state
+    app._operation_error = False
+    match state:
+        case AppState.UNKNOWN:
+            app._container_state = None
+        case AppState.STOPPED:
+            app._container_state = ContainerState.STOPPED
+        case AppState.STARTED:
+            app._container_state = ContainerState.HEALTHY
+        case AppState.STARTUP:
+            app._container_state = ContainerState.RUNNING
+            # STARTUP only resolves from RUNNING when the container has a
+            # healthcheck configured; ensure one is present in the mocked
+            # container metadata.
+            meta = app.instance._meta or {}
+            meta.setdefault("Config", {})["Healthcheck"] = {"Test": ["CMD", "true"]}
+            app.instance._meta = meta
+        case AppState.ERROR:
+            app._operation_error = True
+    app._emit_state_change(old_state)
 
 
 async def fire_bus_event(coresys: CoreSys, event: BusEvent, data: Any) -> None:

--- a/tests/common.py
+++ b/tests/common.py
@@ -38,6 +38,10 @@ def force_app_state(app: App, state: AppState) -> None:
     match state:
         case AppState.UNKNOWN:
             app._container_state = None
+            # The derivation falls back to STOPPED when ``instance.attached``
+            # is true; clear the docker metadata so the helper is
+            # deterministic regardless of prior fixture setup.
+            app.instance._meta = None
         case AppState.STOPPED:
             app._container_state = ContainerState.STOPPED
         case AppState.STARTED:

--- a/tests/resolution/fixup/test_app_execute_restart.py
+++ b/tests/resolution/fixup/test_app_execute_restart.py
@@ -14,6 +14,7 @@ from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.data import Issue, Suggestion
 from supervisor.resolution.fixups.app_execute_restart import FixupAppExecuteRestart
 
+from tests.common import force_app_state
 from tests.const import TEST_ADDON_SLUG
 
 DEVICE_ACCESS_MISSING_ISSUE = Issue(
@@ -29,12 +30,12 @@ EXECUTE_RESTART_SUGGESTION = Suggestion(
 @pytest.mark.usefixtures("path_extern")
 async def test_fixup(coresys: CoreSys, install_app_ssh: App):
     """Test fixup restarts app."""
-    install_app_ssh.state = AppState.STARTED
+    force_app_state(install_app_ssh, AppState.STARTED)
     app_execute_restart = FixupAppExecuteRestart(coresys)
     assert app_execute_restart.auto is False
 
     async def mock_stop(*args, **kwargs):
-        install_app_ssh.state = AppState.STOPPED
+        force_app_state(install_app_ssh, AppState.STOPPED)
 
     coresys.resolution.add_issue(
         DEVICE_ACCESS_MISSING_ISSUE,
@@ -59,7 +60,7 @@ async def test_fixup_stop_error(
     coresys: CoreSys, install_app_ssh: App, caplog: pytest.LogCaptureFixture
 ):
     """Test fixup fails on stop app failure."""
-    install_app_ssh.state = AppState.STARTED
+    force_app_state(install_app_ssh, AppState.STARTED)
     app_execute_start = FixupAppExecuteRestart(coresys)
 
     coresys.resolution.add_issue(
@@ -83,7 +84,7 @@ async def test_fixup_start_error(
     coresys: CoreSys, install_app_ssh: App, caplog: pytest.LogCaptureFixture
 ):
     """Test fixup logs a start app failure."""
-    install_app_ssh.state = AppState.STARTED
+    force_app_state(install_app_ssh, AppState.STARTED)
     app_execute_start = FixupAppExecuteRestart(coresys)
 
     coresys.resolution.add_issue(

--- a/tests/resolution/fixup/test_app_execute_start.py
+++ b/tests/resolution/fixup/test_app_execute_start.py
@@ -14,6 +14,7 @@ from supervisor.resolution.data import Suggestion
 from supervisor.resolution.fixups.app_execute_start import FixupAppExecuteStart
 
 from tests.apps.test_manager import BOOT_FAIL_ISSUE
+from tests.common import force_app_state
 
 EXECUTE_START_SUGGESTION = Suggestion(
     SuggestionType.EXECUTE_START, ContextType.ADDON, reference="local_ssh"
@@ -26,12 +27,12 @@ EXECUTE_START_SUGGESTION = Suggestion(
 @pytest.mark.usefixtures("path_extern")
 async def test_fixup(coresys: CoreSys, install_app_ssh: App, state: AppState):
     """Test fixup starts app."""
-    install_app_ssh.state = AppState.UNKNOWN
+    force_app_state(install_app_ssh, AppState.UNKNOWN)
     app_execute_start = FixupAppExecuteStart(coresys)
     assert app_execute_start.auto is False
 
     async def mock_start(*args, **kwargs):
-        install_app_ssh.state = state
+        force_app_state(install_app_ssh, state)
 
     coresys.resolution.add_issue(
         BOOT_FAIL_ISSUE,
@@ -52,7 +53,7 @@ async def test_fixup(coresys: CoreSys, install_app_ssh: App, state: AppState):
 @pytest.mark.usefixtures("path_extern")
 async def test_fixup_start_error(coresys: CoreSys, install_app_ssh: App):
     """Test fixup fails on start app failure."""
-    install_app_ssh.state = AppState.UNKNOWN
+    force_app_state(install_app_ssh, AppState.UNKNOWN)
     app_execute_start = FixupAppExecuteStart(coresys)
 
     coresys.resolution.add_issue(
@@ -76,11 +77,11 @@ async def test_fixup_wait_start_failure(
     coresys: CoreSys, install_app_ssh: App, state: AppState
 ):
     """Test fixup fails if app does not complete startup."""
-    install_app_ssh.state = AppState.UNKNOWN
+    force_app_state(install_app_ssh, AppState.UNKNOWN)
     app_execute_start = FixupAppExecuteStart(coresys)
 
     async def mock_start(*args, **kwargs):
-        install_app_ssh.state = state
+        force_app_state(install_app_ssh, state)
 
     coresys.resolution.add_issue(
         BOOT_FAIL_ISSUE,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

`App.state` previously combined two responsibilities in a single setter: it both mutated a private `_state` field and dispatched side effects (WebSocket events, issue dismissal, `_startup_event` signaling). The state itself moved only through that setter, driven by `DOCKER_CONTAINER_STATE_CHANGE` events from the docker layer, and supplemented by a couple of direct assignments for operation failures and uninstall. This worked, but it kept two state machines in lockstep by convention and made it easy to lose the distinction between `ContainerState.UNKNOWN` ("container does not exist") and `AppState.UNKNOWN` ("nothing observed yet") at call sites.

This PR turns `App.state` into a pure derived property. The source of truth is the last observed `ContainerState` cached on the `App`, plus a sticky operation-error flag for start/stop failures that the docker event stream cannot reflect (the container was never created in the first place). When no container has ever been observed, the derivation falls back to install signals: an attached instance (image present) is `STOPPED`, otherwise `UNKNOWN`. `container_state_changed` updates the cached container state and routes all side effects through a single `_emit_state_change` helper that diffs old vs new derived state. The two start/stop failure paths route through `_set_operation_error()`; `uninstall()` resets the cached signals so the derivation naturally returns `UNKNOWN`.

This is intentionally a small behavior change: an installed-but-never-started app now reports `STOPPED` instead of `UNKNOWN`. Previously `AppState.UNKNOWN` was returned in two unrelated situations — "constructor default before anything was observed" and "container is missing for an installed app" — and consumers had no way to tell them apart. With the derivation, `UNKNOWN` only remains for "no image, no container", which is closer to what the value name suggests.

Tests that previously assigned `install_app_ssh.state = ...` use a new `tests/common.force_app_state` helper that pokes the underlying signals directly, so the production class no longer carries any test-only setter.

This is groundwork for #6850 (richer v2 lifecycle states): with the derivation in place, adding states like `installing` / `updating` / `restarting` becomes a matter of feeding an extra signal into the property, not threading new setter calls through every call site. The PR does not introduce any new states itself.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/supervisor#6850
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
