### PR TITLE
Make Core.shutdown idempotent and safe to call concurrently

### DIFF
--- a/supervisor/__main__.py
+++ b/supervisor/__main__.py
@@ -70,7 +70,6 @@ if __name__ == "__main__":
 
     # Create startup task that can be cancelled gracefully
     startup_task = loop.create_task(coresys.core.start())
-    shutdown_tasks: list[asyncio.Task] = []
 
     async def host_is_shutting_down() -> bool:
         """Return True if systemd is shutting the host down.
@@ -103,10 +102,7 @@ if __name__ == "__main__":
             _LOGGER.warning("Supervisor startup interrupted by shutdown signal")
             startup_task.cancel()
 
-        if shutdown_tasks and not shutdown_tasks[0].done():
-            return
-
-        shutdown_tasks[:] = [coresys.create_task(stop_supervisor())]
+        coresys.create_task(stop_supervisor())
 
     bootstrap.register_signal_handlers(loop, shutdown_handler)
 

--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -864,7 +864,7 @@ class BackupManager(FileConfiguration, JobGroup):
 
         try:
             # Stop Home-Assistant / Apps
-            await self.sys_core.shutdown(remove_homeassistant_container=True)
+            await self.sys_core.teardown_services(remove_homeassistant_container=True)
 
             success = await self._do_restore(
                 backup,

--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -43,6 +43,7 @@ class Core(CoreSysAttributes):
         self.coresys: CoreSys = coresys
         self._state: CoreState = CoreState.INITIALIZE
         self.exit_code: int = 0
+        self._shutdown_event: asyncio.Event = asyncio.Event()
 
     @property
     def state(self) -> CoreState:
@@ -364,28 +365,57 @@ class Core(CoreSysAttributes):
         self.sys_loop.stop()
 
     async def shutdown(self, *, remove_homeassistant_container: bool = False) -> None:
-        """Shutdown all running containers in correct order."""
+        """Shutdown all running containers in correct order.
+
+        Reentrant: if a shutdown is already in progress, additional callers
+        await completion of the in-flight shutdown instead of starting a
+        second one.
+        """
+        # Nothing coherent to gracefully shut down before startup completes;
+        # the caller (e.g. signal handler) is expected to follow up with stop().
+        if self.state in STARTING_STATES:
+            _LOGGER.warning(
+                "Ignoring shutdown request, Supervisor has not finished starting"
+            )
+            return
+
+        # Supervisor is already tearing itself down, no point running shutdown
+        if self.state in (CoreState.STOPPING, CoreState.CLOSE):
+            _LOGGER.warning("Ignoring shutdown request, Supervisor is already stopping")
+            return
+
+        # Another shutdown is in progress, wait for it to complete
+        if self.state == CoreState.SHUTDOWN:
+            await self._shutdown_event.wait()
+            return
+
+        # Reset event for this shutdown cycle (supports repeated use, e.g. backup restore)
+        self._shutdown_event.clear()
+
         # don't process scheduler anymore
         if self.state == CoreState.RUNNING:
             await self.set_state(CoreState.SHUTDOWN)
 
-        # Shutdown Application Apps, using Home Assistant API
-        await self.sys_apps.shutdown(AppStartup.APPLICATION)
+        try:
+            # Shutdown Application Apps, using Home Assistant API
+            await self.sys_apps.shutdown(AppStartup.APPLICATION)
 
-        # Close Home Assistant
-        with suppress(HassioError):
-            await self.sys_homeassistant.core.stop(
-                remove_container=remove_homeassistant_container
-            )
+            # Close Home Assistant
+            with suppress(HassioError):
+                await self.sys_homeassistant.core.stop(
+                    remove_container=remove_homeassistant_container
+                )
 
-        # Shutdown System Apps
-        await self.sys_apps.shutdown(AppStartup.SERVICES)
-        await self.sys_apps.shutdown(AppStartup.SYSTEM)
-        await self.sys_apps.shutdown(AppStartup.INITIALIZE)
+            # Shutdown System Apps
+            await self.sys_apps.shutdown(AppStartup.SERVICES)
+            await self.sys_apps.shutdown(AppStartup.SYSTEM)
+            await self.sys_apps.shutdown(AppStartup.INITIALIZE)
 
-        # Shutdown all Plugins
-        if self.state in (CoreState.STOPPING, CoreState.SHUTDOWN):
-            await self.sys_plugins.shutdown()
+            # Shutdown all Plugins
+            if self.state in (CoreState.STOPPING, CoreState.SHUTDOWN):
+                await self.sys_plugins.shutdown()
+        finally:
+            self._shutdown_event.set()
 
     async def _update_last_boot(self) -> None:
         """Update last boot time."""

--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -364,15 +364,39 @@ class Core(CoreSysAttributes):
         _LOGGER.info("Supervisor is down - %d", self.exit_code)
         self.sys_loop.stop()
 
-    async def shutdown(self, *, remove_homeassistant_container: bool = False) -> None:
-        """Shutdown all running containers in correct order.
+    async def teardown_services(
+        self, *, remove_homeassistant_container: bool = False
+    ) -> None:
+        """Stop all add-ons and Home Assistant Core in correct order.
 
-        Reentrant: if a shutdown is already in progress, additional callers
-        await completion of the in-flight shutdown instead of starting a
-        second one.
+        Does not change Core state and does not stop plugins. Used during
+        backup restore (state stays FREEZE, plugins keep running) and as
+        the inner step of shutdown().
         """
-        # Nothing coherent to gracefully shut down before startup completes;
-        # the caller (e.g. signal handler) is expected to follow up with stop().
+        # Stop application add-ons (using Home Assistant API)
+        await self.sys_apps.shutdown(AppStartup.APPLICATION)
+
+        # Close Home Assistant Core
+        with suppress(HassioError):
+            await self.sys_homeassistant.core.stop(
+                remove_container=remove_homeassistant_container
+            )
+
+        # Stop system add-ons
+        await self.sys_apps.shutdown(AppStartup.SERVICES)
+        await self.sys_apps.shutdown(AppStartup.SYSTEM)
+        await self.sys_apps.shutdown(AppStartup.INITIALIZE)
+
+    async def shutdown(self) -> None:
+        """Shut down managed services and plugins.
+
+        Real shutdown ceremony invoked from the SIGTERM signal handler
+        and the host reboot/power-off API. Reentrant: concurrent callers
+        observe state == SHUTDOWN and await the in-flight shutdown rather
+        than re-running the sequence.
+        """
+        # Nothing coherent to shut down before startup completes; the caller
+        # (e.g. signal handler) is expected to follow up with stop().
         if self.state in STARTING_STATES:
             _LOGGER.warning(
                 "Ignoring shutdown request, Supervisor has not finished starting"
@@ -389,31 +413,10 @@ class Core(CoreSysAttributes):
             await self._shutdown_event.wait()
             return
 
-        # Reset event for this shutdown cycle (supports repeated use, e.g. backup restore)
-        self._shutdown_event.clear()
-
-        # don't process scheduler anymore
-        if self.state == CoreState.RUNNING:
-            await self.set_state(CoreState.SHUTDOWN)
-
+        await self.set_state(CoreState.SHUTDOWN)
         try:
-            # Shutdown Application Apps, using Home Assistant API
-            await self.sys_apps.shutdown(AppStartup.APPLICATION)
-
-            # Close Home Assistant
-            with suppress(HassioError):
-                await self.sys_homeassistant.core.stop(
-                    remove_container=remove_homeassistant_container
-                )
-
-            # Shutdown System Apps
-            await self.sys_apps.shutdown(AppStartup.SERVICES)
-            await self.sys_apps.shutdown(AppStartup.SYSTEM)
-            await self.sys_apps.shutdown(AppStartup.INITIALIZE)
-
-            # Shutdown all Plugins
-            if self.state in (CoreState.STOPPING, CoreState.SHUTDOWN):
-                await self.sys_plugins.shutdown()
+            await self.teardown_services()
+            await self.sys_plugins.shutdown()
         finally:
             self._shutdown_event.set()
 

--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -413,8 +413,12 @@ class Core(CoreSysAttributes):
             await self._shutdown_event.wait()
             return
 
-        await self.set_state(CoreState.SHUTDOWN)
         try:
+            # Wrap state transition inside try so waiters are released even if
+            # set_state() is cancelled mid-write: Core._state has already been
+            # updated to SHUTDOWN by then (see set_state()), so concurrent
+            # callers would otherwise block on _shutdown_event forever.
+            await self.set_state(CoreState.SHUTDOWN)
             await self.teardown_services()
             await self.sys_plugins.shutdown()
         finally:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -269,29 +269,34 @@ async def test_shutdown_reentrant_waits(coresys: CoreSys):
     assert coresys.core._shutdown_event.is_set()
 
 
-async def test_shutdown_event_reset_between_cycles(coresys: CoreSys):
-    """Repeated shutdown cycles (e.g. backup restore) work because the event is reset."""
+async def test_shutdown_transitions_state(coresys: CoreSys):
+    """Shutdown moves Core into SHUTDOWN state so HA Core/WS observers react."""
     await coresys.core.set_state(CoreState.RUNNING)
-
     await coresys.core.shutdown()
-    assert coresys.core._shutdown_event.is_set()
+    assert coresys.core.state == CoreState.SHUTDOWN
 
-    # Simulate restore returning to RUNNING and shutting down again
+
+async def test_teardown_services_does_not_change_state(coresys: CoreSys):
+    """Teardown leaves Core state alone so callers (e.g. backup restore) control it."""
+    await coresys.core.set_state(CoreState.FREEZE)
+    await coresys.core.teardown_services()
+    assert coresys.core.state == CoreState.FREEZE
+
+
+async def test_teardown_services_does_not_stop_plugins(coresys: CoreSys):
+    """Plugins must keep running across teardown so restore can talk to them."""
+    await coresys.core.set_state(CoreState.FREEZE)
+    with patch.object(coresys.plugins, "shutdown") as mock_plugins_shutdown:
+        await coresys.core.teardown_services()
+    mock_plugins_shutdown.assert_not_called()
+
+
+async def test_shutdown_stops_plugins(coresys: CoreSys):
+    """Real shutdown stops plugins as the final step."""
     await coresys.core.set_state(CoreState.RUNNING)
-
-    second_entered = False
-    original_shutdown = coresys.apps.shutdown
-
-    async def track_app_shutdown(startup):
-        nonlocal second_entered
-        second_entered = True
-        return await original_shutdown(startup)
-
-    with patch.object(coresys.apps, "shutdown", side_effect=track_app_shutdown):
+    with patch.object(coresys.plugins, "shutdown") as mock_plugins_shutdown:
         await coresys.core.shutdown()
-
-    assert second_entered
-    assert coresys.core._shutdown_event.is_set()
+    mock_plugins_shutdown.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=W0212
 import asyncio
+from contextlib import suppress
 import datetime
 import errno
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
@@ -266,6 +267,37 @@ async def test_shutdown_reentrant_waits(coresys: CoreSys):
     # AppStartup has 4 levels (APPLICATION/SERVICES/SYSTEM/INITIALIZE); a single
     # shutdown call iterates them. A re-entered shutdown would double the count.
     assert call_count == 4
+    assert coresys.core._shutdown_event.is_set()
+
+
+async def test_shutdown_releases_event_when_set_state_cancelled(coresys: CoreSys):
+    """Cancellation mid set_state() must still release waiters.
+
+    set_state() updates Core._state before awaiting the run-state file write.
+    If cancellation hits during that await, in-memory state is already
+    SHUTDOWN. Without the try/finally around set_state(), _shutdown_event
+    would never be set and concurrent callers would deadlock on wait().
+    """
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    cancel_during_write = asyncio.Event()
+
+    async def cancel_during_set_state(*_args, **_kwargs):
+        cancel_during_write.set()
+        await asyncio.sleep(3600)  # wait long enough to be cancelled
+
+    with patch.object(
+        coresys.core, "_write_run_state", side_effect=cancel_during_set_state
+    ):
+        task = asyncio.create_task(coresys.core.shutdown())
+        await cancel_during_write.wait()
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    # In-memory state moved to SHUTDOWN before the cancellation point
+    assert coresys.core.state == CoreState.SHUTDOWN
+    # finally must have run so any future caller does not deadlock
     assert coresys.core._shutdown_event.is_set()
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -233,3 +233,98 @@ async def test_setup_unhandled_exception_captured(
     capture_mock.assert_called_once()
     assert "Fatal error happening on load Task" in caplog.text
     assert UnhealthyReason.SETUP in coresys.resolution.unhealthy
+
+
+async def test_shutdown_reentrant_waits(coresys: CoreSys):
+    """Concurrent shutdown() calls await the in-flight shutdown rather than re-running."""
+    call_count = 0
+    shutdown_started = asyncio.Event()
+    proceed = asyncio.Event()
+
+    original_shutdown = coresys.apps.shutdown
+
+    async def slow_app_shutdown(startup):
+        nonlocal call_count
+        call_count += 1
+        shutdown_started.set()
+        await proceed.wait()
+        return await original_shutdown(startup)
+
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    with patch.object(coresys.apps, "shutdown", side_effect=slow_app_shutdown):
+        task1 = asyncio.create_task(coresys.core.shutdown())
+        await shutdown_started.wait()
+
+        # Second call should wait, not start a new shutdown
+        task2 = asyncio.create_task(coresys.core.shutdown())
+        await asyncio.sleep(0.05)
+
+        proceed.set()
+        await asyncio.gather(task1, task2)
+
+    # AppStartup has 4 levels (APPLICATION/SERVICES/SYSTEM/INITIALIZE); a single
+    # shutdown call iterates them. A re-entered shutdown would double the count.
+    assert call_count == 4
+    assert coresys.core._shutdown_event.is_set()
+
+
+async def test_shutdown_event_reset_between_cycles(coresys: CoreSys):
+    """Repeated shutdown cycles (e.g. backup restore) work because the event is reset."""
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    await coresys.core.shutdown()
+    assert coresys.core._shutdown_event.is_set()
+
+    # Simulate restore returning to RUNNING and shutting down again
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    second_entered = False
+    original_shutdown = coresys.apps.shutdown
+
+    async def track_app_shutdown(startup):
+        nonlocal second_entered
+        second_entered = True
+        return await original_shutdown(startup)
+
+    with patch.object(coresys.apps, "shutdown", side_effect=track_app_shutdown):
+        await coresys.core.shutdown()
+
+    assert second_entered
+    assert coresys.core._shutdown_event.is_set()
+
+
+@pytest.mark.parametrize(
+    "state", [CoreState.STOPPING, CoreState.CLOSE], ids=["stopping", "close"]
+)
+async def test_shutdown_ignored_during_stop(
+    coresys: CoreSys, caplog: pytest.LogCaptureFixture, state: CoreState
+):
+    """Shutdown is ignored when Supervisor is already stopping."""
+    await coresys.core.set_state(state)
+
+    with patch.object(coresys.apps, "shutdown") as mock_app_shutdown:
+        await coresys.core.shutdown()
+
+    mock_app_shutdown.assert_not_called()
+    assert "Ignoring shutdown request, Supervisor is already stopping" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "state",
+    [CoreState.INITIALIZE, CoreState.STARTUP, CoreState.SETUP],
+    ids=["initialize", "startup", "setup"],
+)
+async def test_shutdown_skipped_during_startup(
+    coresys: CoreSys, caplog: pytest.LogCaptureFixture, state: CoreState
+):
+    """Shutdown returns early when Supervisor has not finished starting yet."""
+    await coresys.core.set_state(state)
+
+    with patch.object(coresys.apps, "shutdown") as mock_app_shutdown:
+        await coresys.core.shutdown()
+
+    mock_app_shutdown.assert_not_called()
+    assert (
+        "Ignoring shutdown request, Supervisor has not finished starting" in caplog.text
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

After #6887, `Core.shutdown()` runs from the SIGTERM signal handler during host shutdown in addition to the existing call sites (`host.control.reboot()`/`shutdown()`, backup restore). To avoid spawning a second `stop_supervisor()` task when a repeat SIGTERM arrives, `__main__.py` debounced the signal handler by stashing the in-flight task in a single-element list and bailing out on subsequent invocations. That workaround only covers the SIGTERM-vs-SIGTERM race; two API-initiated reboots, or a reboot API call racing with SIGTERM, would still re-enter the shutdown sequence.

This PR moves the idempotency into `Core.shutdown()` itself, where every caller benefits:

- A second call while a shutdown is in progress awaits the in-flight shutdown via an `asyncio.Event` rather than re-running the sequence.
- Calls while state is `STOPPING`/`CLOSE` return early — Supervisor is already going away, the work is moot.
- Calls while state is in `STARTING_STATES` (`INITIALIZE`/`STARTUP`/`SETUP`) return early too. There is nothing coherent to gracefully stop before startup completes, and on the SIGTERM-during-startup path the caller cancels `startup_task` first, so waiting for it to complete would deadlock (the `finally` in `Core.start()` cannot reach `set_state(RUNNING)` once awaits raise `CancelledError`).
- The sequence is wrapped in `try`/`finally` so the completion event is set even when an inner step raises.

With idempotency in `Core`, the closure-with-list workaround in `__main__.py` collapses to a plain `coresys.create_task(stop_supervisor())`: repeat SIGTERMs spawn extra tasks but each just observes the in-flight shutdown and waits.

Inspired by (a subset of) #6631.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6887
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
