### PR TITLE
Increase s6 service stop timeout for graceful shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ ARG BUILD_FROM=ghcr.io/home-assistant/base-python:3.14-alpine3.22-2026.05.0
 FROM ${BUILD_FROM} AS supervisor-base
 
 ENV \
-    S6_SERVICES_GRACETIME=10000 \
+    S6_SERVICES_GRACETIME=415000 \
+    S6_KILL_GRACETIME=3000 \
     SUPERVISOR_API=http://localhost \
     CRYPTOGRAPHY_OPENSSL_NO_LEGACY=1 \
     UV_SYSTEM_PYTHON=true


### PR DESCRIPTION
## Proposed change

The s6 supervision tree only waited `S6_SERVICES_GRACETIME` (10s) for the Supervisor service in `/etc/services.d` to stop before giving up and tearing down the rest of the tree. This cut graceful shutdown short well before the container's own stop timeout, killing Supervisor mid-shutdown when an orderly shutdown legitimately needed more time (e.g. stopping add-ons and Home Assistant Core).

This builds on the graceful shutdown coordination introduced in https://github.com/home-assistant/supervisor/pull/6887. Now that the OS grants the Supervisor container significantly more time to shut down (see https://github.com/home-assistant/operating-system/pull/4736), raise `S6_SERVICES_GRACETIME` to 415s so a long-running graceful shutdown can actually complete within the s6 supervision tree.

`S6_KILL_GRACETIME` is also set explicitly to its default of 3000ms. It only governs the final SIGTERM-to-SIGKILL grace at the very end of the shutdown procedure, so the default value is fine, but stating it keeps both shutdown timers documented together in one place.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/supervisor/pull/6887, https://github.com/home-assistant/operating-system/pull/4736
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
