### PR TITLE
Only force a versioned Supervisor update in DEV mode

### DIFF
--- a/supervisor/api/supervisor.py
+++ b/supervisor/api/supervisor.py
@@ -227,16 +227,18 @@ class APISupervisor(CoreSysAttributes):
     async def update(self, request: web.Request) -> None:
         """Update Supervisor OS."""
         body = await api_validate(SCHEMA_VERSION, request)
+        version = body.get(ATTR_VERSION)
 
-        # This option is useless outside of DEV
-        if not self.sys_dev and not self.sys_supervisor.need_update:
+        # Updating to a specific version is only possible in DEV. Without an
+        # explicit version an update is only triggered when one is actually
+        # available (in DEV need_update is always False, so a versionless
+        # request is a no-op).
+        if version is None and not self.sys_supervisor.need_update:
             raise APIError(
                 f"No supervisor update available - {self.sys_supervisor.version!s}"
             )
 
-        if self.sys_dev:
-            version = body.get(ATTR_VERSION, self.sys_updater.version_supervisor)
-        else:
+        if not self.sys_dev:
             version = self.sys_updater.version_supervisor
 
         await asyncio.shield(self.sys_supervisor.update(version))

--- a/tests/api/test_supervisor.py
+++ b/tests/api/test_supervisor.py
@@ -450,6 +450,51 @@ async def test_api_progress_updates_supervisor_update(
     ]
 
 
+@pytest.mark.parametrize("dev", [True, False])
+async def test_api_supervisor_update_no_update_available(
+    api_client_with_prefix: tuple[TestClient, str],
+    dev: bool,
+):
+    """Test versionless update is a no-op when no update is available.
+
+    Home Assistant Core triggers a versionless Supervisor update during
+    onboarding. Without an available update (always the case in DEV) this
+    must report no update rather than installing the latest published version.
+    """
+    api_client, prefix = api_client_with_prefix
+
+    with (
+        patch.object(CoreSys, "dev", new=PropertyMock(return_value=dev)),
+        patch.object(Supervisor, "need_update", new=PropertyMock(return_value=False)),
+        patch.object(Supervisor, "update") as update,
+    ):
+        resp = await api_client.post(f"{prefix}/supervisor/update")
+
+    assert resp.status == 400
+    result = await resp.json()
+    assert "No supervisor update available" in result["message"]
+    update.assert_not_called()
+
+
+async def test_api_supervisor_update_dev_explicit_version(
+    api_client_with_prefix: tuple[TestClient, str],
+):
+    """Test an explicit version can be forced in DEV without an update available."""
+    api_client, prefix = api_client_with_prefix
+
+    with (
+        patch.object(CoreSys, "dev", new=PropertyMock(return_value=True)),
+        patch.object(Supervisor, "need_update", new=PropertyMock(return_value=False)),
+        patch.object(Supervisor, "update") as update,
+    ):
+        resp = await api_client.post(
+            f"{prefix}/supervisor/update", json={"version": "2025.08.3"}
+        )
+
+    assert resp.status == 200
+    update.assert_called_once_with(AwesomeVersion("2025.08.3"))
+
+
 async def test_api_supervisor_stats(
     api_client_with_prefix: tuple[TestClient, str], container: DockerContainer
 ):


### PR DESCRIPTION
## Proposed change

Home Assistant Core now triggers a versionless Supervisor update during onboarding (see home-assistant/core#171129) to ensure Supervisor is current before it continues setup. Core treats a "no update available" response as the signal to proceed.

In DEV mode (environment `SUPERVISOR_DEV=1` which we use in CI) the `/supervisor/update` endpoint bypassed the `need_update` check entirely and resolved a versionless request to the latest published version. So Core's onboarding call made a freshly-built DEV Supervisor install the latest published build and restart itself. This breaks the `run_supervisor` CI job: the Supervisor API disappears mid-test and subsequent steps fail with `connection refused`. The Supervisor log shows the trigger directly: `Update Supervisor to version 2026.06.0.dev0106` followed by `Shutting down scheduled tasks`.

This change ties the DEV bypass to an explicit version instead of to DEV mode in general. Specifying a version is still DEV-only, but a versionless request now always respects `need_update`. Since `need_update` is always `False` in DEV, Core's onboarding call becomes a no-op there and returns "no update available", matching production behavior. As a side effect this also closes a narrow real-world bug where a DEV Supervisor would force a side/downgrade to the published version on every fresh onboarding.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/171129
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
