### PR TITLE
Report progress during initial Core install

### DIFF
--- a/supervisor/docker/homeassistant.py
+++ b/supervisor/docker/homeassistant.py
@@ -36,7 +36,7 @@ from .interface import CommandReturn, DockerInterface
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 _VERIFY_TRUST: AwesomeVersion = AwesomeVersion("2021.5.0")
-_HASS_DOCKER_NAME: str = "homeassistant"
+HASS_DOCKER_NAME: str = "homeassistant"
 ENV_S6_GRACETIME = re.compile(r"^S6_SERVICES_GRACETIME=([0-9]+)$")
 ENV_RESTORE_JOB_ID = "SUPERVISOR_RESTORE_JOB_ID"
 
@@ -59,7 +59,7 @@ class DockerHomeAssistant(DockerInterface):
     @property
     def name(self) -> str:
         """Return name of Docker container."""
-        return _HASS_DOCKER_NAME
+        return HASS_DOCKER_NAME
 
     @property
     def timeout(self) -> int:

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -19,7 +19,7 @@ from ..bus import EventListener
 from ..const import ATTR_HOMEASSISTANT, BusEvent, CoreState
 from ..coresys import CoreSys
 from ..docker.const import ContainerState
-from ..docker.homeassistant import DockerHomeAssistant
+from ..docker.homeassistant import HASS_DOCKER_NAME, DockerHomeAssistant
 from ..docker.monitor import DockerContainerStateEvent
 from ..docker.stats import DockerStats
 from ..exceptions import (
@@ -190,9 +190,15 @@ class HomeAssistantCore(JobGroup):
         # We assume for now the docker image pull is 100% of this task. But from
         # a user perspective that isn't true. Other steps that take time which
         # is not accounted for in progress include: image cleanup and Home
-        # Assistant start.
+        # Assistant start. The reference is scoped to the Home Assistant
+        # container so a Supervisor self-update done first (which also pulls an
+        # image via docker_interface_install) does not count towards this job.
         child_job_syncs=[
-            ChildJobSyncFilter("docker_interface_install", progress_allocation=1.0)
+            ChildJobSyncFilter(
+                "docker_interface_install",
+                reference=HASS_DOCKER_NAME,
+                progress_allocation=1.0,
+            )
         ],
     )
     async def install(self) -> None:
@@ -307,7 +313,11 @@ class HomeAssistantCore(JobGroup):
         # is not accounted for in progress include: partial backup, image
         # cleanup, and Home Assistant restart
         child_job_syncs=[
-            ChildJobSyncFilter("docker_interface_install", progress_allocation=1.0)
+            ChildJobSyncFilter(
+                "docker_interface_install",
+                reference=HASS_DOCKER_NAME,
+                progress_allocation=1.0,
+            )
         ],
     )
     async def update(

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -187,6 +187,13 @@ class HomeAssistantCore(JobGroup):
         name="home_assistant_core_install",
         on_condition=HomeAssistantJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
+        # We assume for now the docker image pull is 100% of this task. But from
+        # a user perspective that isn't true. Other steps that take time which
+        # is not accounted for in progress include: image cleanup and Home
+        # Assistant start.
+        child_job_syncs=[
+            ChildJobSyncFilter("docker_interface_install", progress_allocation=1.0)
+        ],
     )
     async def install(self) -> None:
         """Install Home Assistant Core."""

--- a/supervisor/jobs/__init__.py
+++ b/supervisor/jobs/__init__.py
@@ -141,6 +141,20 @@ class SupervisorJob:
     extra: dict[str, Any] | None = None
     child_job_syncs: list[ChildJobSyncFilter] | None = None
     parent_job_syncs: list[ParentJobSync] = field(init=False, factory=list)
+    _child_sync_baselines: dict[ChildJobSyncFilter, float] = field(
+        init=False, factory=dict
+    )
+
+    def register_child_sync(self, sync: ChildJobSyncFilter) -> float:
+        """Return the progress baseline a child sync owns on this job.
+
+        The first child to match a sync captures this job's current progress as
+        the baseline of the sync's allocation band. Children matching the same
+        sync afterwards (e.g. a docker image pull retried after a failure) reuse
+        that baseline so they restart the band instead of stacking progress on
+        top of the previous attempt.
+        """
+        return self._child_sync_baselines.setdefault(sync, self.progress)
 
     def as_dict(self) -> dict[str, Any]:
         """Return dictionary representation."""
@@ -335,11 +349,8 @@ class JobManager(FileConfiguration, CoreSysAttributes):
                 if not curr_parent.child_job_syncs:
                     continue
 
-                # HACK: If parent trigger the same child job, we just skip this second
-                # sync. Maybe it would be better to have this reflected in the job stage
-                # and reset progress to 0 instead? There is no support for such stage
-                # information on Core update entities today though.
-                if curr_parent.done is True or curr_parent.progress >= 100:
+                # A finished parent can no longer take progress updates
+                if curr_parent.done is True:
                     _LOGGER.debug(
                         "Skipping parent job sync for done parent job %s",
                         curr_parent.name,
@@ -349,15 +360,28 @@ class JobManager(FileConfiguration, CoreSysAttributes):
                 # Break after first match at each parent as it doesn't make sense
                 # to match twice. But it could match multiple parents
                 for sync in curr_parent.child_job_syncs:
-                    if sync.matches(job):
-                        job.parent_job_syncs.append(
-                            ParentJobSync(
-                                curr_parent.uuid,
-                                starting_progress=curr_parent.progress,
-                                progress_allocation=sync.progress_allocation,
-                            )
-                        )
+                    if not sync.matches(job):
+                        continue
+
+                    # Reset the parent to the baseline this sync owns so a
+                    # re-triggered child (e.g. an image pull retried after a
+                    # failure) restarts its allocation band instead of stacking
+                    # on top of the previous attempt's progress.
+                    baseline = curr_parent.register_child_sync(sync)
+                    if baseline >= 100:
                         break
+                    # Guard avoids triggering a redundant on change when unchanged
+                    # pylint: disable-next=R1730
+                    if curr_parent.progress > baseline:  # noqa: PLR1730
+                        curr_parent.progress = baseline
+                    job.parent_job_syncs.append(
+                        ParentJobSync(
+                            curr_parent.uuid,
+                            starting_progress=baseline,
+                            progress_allocation=sync.progress_allocation,
+                        )
+                    )
+                    break
 
         self._jobs[job.uuid] = job
         return job

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -3,7 +3,7 @@
 import asyncio
 from datetime import datetime, timedelta
 from http import HTTPStatus
-from unittest.mock import ANY, MagicMock, Mock, PropertyMock, call, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, Mock, PropertyMock, call, patch
 
 import aiodocker
 from aiodocker.containers import DockerContainer
@@ -25,13 +25,14 @@ from supervisor.exceptions import (
     SupervisorUpdateError,
 )
 from supervisor.homeassistant.api import APIState
+from supervisor.homeassistant.const import WSEvent
 from supervisor.homeassistant.core import HomeAssistantCore
 from supervisor.homeassistant.module import HomeAssistant
 from supervisor.resolution.const import ContextType, IssueType
 from supervisor.resolution.data import Issue
 from supervisor.updater import Updater
 
-from tests.common import AsyncIterator
+from tests.common import AsyncIterator, load_json_fixture
 
 
 async def test_update_fails_if_out_of_date(coresys: CoreSys):
@@ -367,6 +368,66 @@ async def test_install_logs_progress_periodically(
         await coresys.homeassistant.core.install()
 
     assert expected_log in caplog.text
+
+
+async def test_install_exposes_core_install_job_with_progress(
+    coresys: CoreSys, ha_ws_client: AsyncMock
+):
+    """Test initial Core install exposes a progress-reporting job for the landing page.
+
+    During the initial Core install the landing page frontend polls
+    ``/jobs/info`` and looks for a root job named ``home_assistant_core_install``
+    to render a download progress bar, reading the job's ``progress`` field
+    directly (see home-assistant/frontend#52359). This test guards that contract:
+    Supervisor must expose a non-internal ``home_assistant_core_install`` job
+    whose progress is driven by the underlying docker image pull (via
+    ``child_job_syncs``), so it reports intermediate progress rather than jumping
+    straight from 0 to 100.
+    """
+    coresys.security.force = True
+
+    logs = load_json_fixture("docker_pull_image_log_containerd_snapshot.json")
+    coresys.docker.images.pull.return_value = AsyncIterator(logs)
+
+    with (
+        patch.object(HomeAssistantCore, "start"),
+        patch.object(DockerHomeAssistant, "cleanup"),
+        patch.object(
+            Updater,
+            "image_homeassistant",
+            new=PropertyMock(return_value="homeassistant"),
+        ),
+        patch.object(
+            Updater, "version_homeassistant", new=PropertyMock(return_value="2022.7.3")
+        ),
+        patch.object(
+            DockerInterface, "arch", new=PropertyMock(return_value=CpuArch.AMD64)
+        ),
+    ):
+        await coresys.homeassistant.core.install()
+
+    await asyncio.sleep(0)
+
+    # The job events the landing page would observe via /jobs/info for the
+    # install job. Receiving events at all proves the job is non-internal.
+    install_events = [
+        msg["data"]["data"]
+        for c in ha_ws_client.async_send_command.call_args_list
+        if (msg := c.args[0])["data"].get("event") == WSEvent.JOB
+        and msg["data"]["data"]["name"] == "home_assistant_core_install"
+    ]
+
+    assert install_events
+    # The landing page matches it as a root job (jobs[0]); it must not be nested.
+    assert all(event["parent_id"] is None for event in install_events)
+
+    # Progress is driven by the docker pull: starts at 0, reports intermediate
+    # values, and completes at 100 - not a bare 0 -> 100 jump.
+    progress = [event["progress"] for event in install_events]
+    assert progress[0] == 0
+    assert any(0 < value < 100 for value in progress)
+    assert progress[-1] == 100
+    assert install_events[-1]["done"] is True
 
 
 @pytest.mark.parametrize(

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -430,6 +430,138 @@ async def test_install_exposes_core_install_job_with_progress(
     assert install_events[-1]["done"] is True
 
 
+def _core_install_progress(ha_ws_client: AsyncMock) -> list[float]:
+    """Return the progress values reported for the Core install job over the WS."""
+    return [
+        msg["data"]["data"]["progress"]
+        for c in ha_ws_client.async_send_command.call_args_list
+        if (msg := c.args[0])["data"].get("event") == WSEvent.JOB
+        and msg["data"]["data"]["name"] == "home_assistant_core_install"
+    ]
+
+
+async def test_install_progress_excludes_supervisor_self_update(
+    coresys: CoreSys, ha_ws_client: AsyncMock
+):
+    """Test a Supervisor self-update pull does not count towards Core install progress.
+
+    When Supervisor needs updating first, that runs its own docker image pull
+    (a ``docker_interface_install`` job carrying the Supervisor container
+    reference). The Core install job's ``child_job_syncs`` is scoped to the Home
+    Assistant container, so the Supervisor pull must not move the Core install
+    progress.
+    """
+    coresys.security.force = True
+
+    logs = load_json_fixture("docker_pull_image_log_containerd_snapshot.json")
+    coresys.docker.images.pull.return_value = AsyncIterator(logs)
+
+    progress_after_self_update: list[float] = []
+
+    async def fake_supervisor_update(*args, **kwargs) -> None:
+        """Emulate a Supervisor self-update pulling its own image."""
+        child = coresys.jobs.new_job(
+            "docker_interface_install", reference="hassio_supervisor"
+        )
+        with child.start():
+            child.progress = 100
+        progress_after_self_update.append(coresys.jobs.current.progress)
+
+    with (
+        patch.object(HomeAssistantCore, "start"),
+        patch.object(DockerHomeAssistant, "cleanup"),
+        patch.object(
+            Updater,
+            "image_homeassistant",
+            new=PropertyMock(return_value="homeassistant"),
+        ),
+        patch.object(
+            Updater, "version_homeassistant", new=PropertyMock(return_value="2022.7.3")
+        ),
+        patch.object(
+            DockerInterface, "arch", new=PropertyMock(return_value=CpuArch.AMD64)
+        ),
+        patch.object(
+            type(coresys.supervisor),
+            "need_update",
+            new=PropertyMock(return_value=True),
+        ),
+        patch.object(
+            type(coresys.updater), "auto_update", new=PropertyMock(return_value=True)
+        ),
+        patch.object(coresys.supervisor, "update", new=fake_supervisor_update),
+    ):
+        await coresys.homeassistant.core.install()
+
+    await asyncio.sleep(0)
+
+    # The Supervisor self-update pull reached 100% but must not have moved the
+    # Core install job (it would be 100 here if the sync were not scoped).
+    assert progress_after_self_update == [0]
+    # The Core image pull afterwards still drives the job to completion.
+    assert _core_install_progress(ha_ws_client)[-1] == 100
+
+
+async def test_install_resets_progress_on_retry(
+    coresys: CoreSys, ha_ws_client: AsyncMock
+):
+    """Test a failed install attempt resets progress instead of overshooting.
+
+    The Core image pull runs in a retry loop. Docker resumes already-downloaded
+    layers, so a retry's fresh pull reports them immediately and would otherwise
+    push the synced progress straight to 100% if it stacked on top of the failed
+    attempt. The sync resets to the baseline on a re-triggered child, so the bar
+    restarts rather than overshooting.
+    """
+    coresys.security.force = True
+
+    partial_then_error = [
+        {
+            "status": "Pulling from home-assistant/odroid-n2-homeassistant",
+            "id": "1.2.3",
+        },
+        {"status": "Pulling fs layer", "progressDetail": {}, "id": "1578b14a573c"},
+        {
+            "status": "Downloading",
+            "progressDetail": {"current": 500, "total": 1000},
+            "id": "1578b14a573c",
+        },
+        {"errorDetail": {"message": "failure"}, "error": "failure"},
+    ]
+    full = load_json_fixture("docker_pull_image_log_containerd_snapshot.json")
+    coresys.docker.images.pull.side_effect = [
+        AsyncIterator(partial_then_error),
+        AsyncIterator(full),
+    ]
+
+    with (
+        patch.object(HomeAssistantCore, "start"),
+        patch.object(DockerHomeAssistant, "cleanup"),
+        patch.object(
+            Updater,
+            "image_homeassistant",
+            new=PropertyMock(return_value="homeassistant"),
+        ),
+        patch.object(
+            Updater, "version_homeassistant", new=PropertyMock(return_value="2022.7.3")
+        ),
+        patch.object(
+            DockerInterface, "arch", new=PropertyMock(return_value=CpuArch.AMD64)
+        ),
+        patch("supervisor.homeassistant.core.asyncio.sleep"),
+    ):
+        await coresys.homeassistant.core.install()
+
+    await asyncio.sleep(0)
+
+    progress = _core_install_progress(ha_ws_client)
+    first_nonzero = next(i for i, value in enumerate(progress) if value > 0)
+    # The first attempt moved the bar, then the retry reset it back to 0 before
+    # climbing to completion (rather than continuing from the failed progress).
+    assert 0 in progress[first_nonzero:]
+    assert progress[-1] == 100
+
+
 @pytest.mark.parametrize(
     ("container_exc", "image_exc", "delete_calls"),
     [


### PR DESCRIPTION
## Proposed change

On a fresh system, the initial Home Assistant Core install (`home_assistant_core_install`) reported no intermediate progress: its job jumped from 0% straight to 100% once the install finished. The download/extract progress is tracked on the internal `docker_interface_install` job, but `home_assistant_core_install` declared no `child_job_syncs`, so that progress never propagated up to the user-visible install job.

This mirrors what `home_assistant_core_update` already does and syncs the docker pull progress up to the install job, allocating it the full progress range. As with the update path, this treats the image pull as 100% of the task even though image cleanup and Home Assistant start are not accounted for, which is acceptable since the pull dominates the install time.

This is the Supervisor-side change for the landing page progress indicator added in home-assistant/frontend#52359, which surfaces this progress to the user during the initial Core install.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
