### PR TITLE
Drop obsolete UNIX_SOCKET_CORE_API feature flag

### DIFF
--- a/supervisor/const.py
+++ b/supervisor/const.py
@@ -566,7 +566,6 @@ class FeatureFlag(StrEnum):
     """Development features that can be toggled."""
 
     SUPERVISOR_V2_API = "supervisor_v2_api"
-    UNIX_SOCKET_CORE_API = "unix_socket_core_api"
 
 
 @dataclass

--- a/supervisor/homeassistant/api.py
+++ b/supervisor/homeassistant/api.py
@@ -13,7 +13,7 @@ from aiohttp import hdrs
 from awesomeversion import AwesomeVersion
 from multidict import MultiMapping
 
-from ..const import SOCKET_CORE, FeatureFlag
+from ..const import SOCKET_CORE
 from ..coresys import CoreSys, CoreSysAttributes
 from ..docker.const import ENV_CORE_API_SOCKET, ContainerState
 from ..docker.monitor import DockerContainerStateEvent
@@ -27,7 +27,6 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 CORE_UNIX_SOCKET_MIN_VERSION: AwesomeVersion = AwesomeVersion(
     "2026.4.0.dev202603250907"
 )
-CORE_UNIX_SOCKET_DEFAULT_VERSION: AwesomeVersion = AwesomeVersion("2026.5.1")
 GET_CORE_STATE_MIN_VERSION: AwesomeVersion = AwesomeVersion("2023.8.0.dev20230720")
 
 
@@ -57,26 +56,16 @@ class HomeAssistantAPI(CoreSysAttributes):
     def supports_unix_socket(self) -> bool:
         """Return True if the installed Core version supports Unix socket communication.
 
-        Enabled by default for Core >= CORE_UNIX_SOCKET_DEFAULT_VERSION; for
-        older versions down to CORE_UNIX_SOCKET_MIN_VERSION it is gated behind
-        the UNIX_SOCKET_CORE_API feature flag.
+        Enabled by default for Core >= CORE_UNIX_SOCKET_MIN_VERSION.
 
         Used to decide whether to configure the env var when starting Core.
         """
-        if (
-            self.sys_homeassistant.version is None
-            or self.sys_homeassistant.version == LANDINGPAGE
-            or not version_is_new_enough(
+        return (
+            self.sys_homeassistant.version is not None
+            and self.sys_homeassistant.version != LANDINGPAGE
+            and version_is_new_enough(
                 self.sys_homeassistant.version, CORE_UNIX_SOCKET_MIN_VERSION
             )
-        ):
-            return False
-        if version_is_new_enough(
-            self.sys_homeassistant.version, CORE_UNIX_SOCKET_DEFAULT_VERSION
-        ):
-            return True
-        return self.sys_config.feature_flags.get(
-            FeatureFlag.UNIX_SOCKET_CORE_API, False
         )
 
     @property

--- a/tests/docker/test_homeassistant.py
+++ b/tests/docker/test_homeassistant.py
@@ -7,7 +7,6 @@ from aiodocker.containers import DockerContainer
 from awesomeversion import AwesomeVersion
 import pytest
 
-from supervisor.const import FeatureFlag
 from supervisor.coresys import CoreSys
 from supervisor.docker.const import (
     MOUNT_CORE_RUN,
@@ -152,7 +151,6 @@ async def test_homeassistant_start_with_unix_socket(
 ):
     """Test starting homeassistant with unix socket env var for supported version."""
     coresys.homeassistant.version = AwesomeVersion("2026.4.0")
-    coresys.config.set_feature_flag(FeatureFlag.UNIX_SOCKET_CORE_API, True)
 
     with (
         patch.object(DockerAPI, "run", return_value=container.show.return_value) as run,

--- a/tests/homeassistant/test_api.py
+++ b/tests/homeassistant/test_api.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from awesomeversion import AwesomeVersion
 import pytest
 
-from supervisor.const import FeatureFlag
 from supervisor.coresys import CoreSys
 from supervisor.docker.const import ContainerState
 from supervisor.docker.monitor import DockerContainerStateEvent
@@ -101,23 +100,18 @@ async def test_get_config_api_error(coresys: CoreSys):
 
 
 @pytest.mark.parametrize(
-    ("version", "flag_enabled", "expected"),
+    ("version", "expected"),
     [
-        ("2026.4.0", True, True),
-        ("2026.4.0", False, False),
-        ("2026.5.1", True, True),
-        ("2026.5.1", False, True),
-        ("2026.6.0", False, True),
-        ("2024.1.0", True, False),
-        (LANDINGPAGE, True, False),
+        ("2026.4.0", True),
+        ("2026.5.1", True),
+        ("2026.6.0", True),
+        ("2024.1.0", False),
+        (LANDINGPAGE, False),
     ],
 )
-async def test_supports_unix_socket(
-    coresys: CoreSys, version: str, flag_enabled: bool, expected: bool
-):
-    """Test supports_unix_socket based on Core version and feature flag."""
+async def test_supports_unix_socket(coresys: CoreSys, version: str, expected: bool):
+    """Test supports_unix_socket based on Core version."""
     coresys.homeassistant.version = AwesomeVersion(version)
-    coresys.config.set_feature_flag(FeatureFlag.UNIX_SOCKET_CORE_API, flag_enabled)
     assert coresys.homeassistant.api.supports_unix_socket is expected
 
 
@@ -134,7 +128,6 @@ async def test_use_unix_socket(
 ):
     """Test use_unix_socket based on version and container env."""
     coresys.homeassistant.version = AwesomeVersion(version)
-    coresys.config.set_feature_flag(FeatureFlag.UNIX_SOCKET_CORE_API, True)
     # pylint: disable-next=protected-access
     coresys.homeassistant.core.instance._meta = {"Config": {"Env": env}}
     assert coresys.homeassistant.api.use_unix_socket is expected


### PR DESCRIPTION
## Proposed change

Unix socket communication between Supervisor and Home Assistant Core was initially gated behind the `UNIX_SOCKET_CORE_API` feature flag (opt-in, disabled by default). It was later enabled by default for Core 2026.5.1+, while older supported versions down to `CORE_UNIX_SOCKET_MIN_VERSION` still required the flag. Now that the transport has settled and is enabled by default, the flag no longer serves a purpose.

This drops the `UNIX_SOCKET_CORE_API` feature flag and the `CORE_UNIX_SOCKET_DEFAULT_VERSION` split, collapsing `supports_unix_socket` back to a single check: the Unix socket is used for any non-landingpage Core version at or above `CORE_UNIX_SOCKET_MIN_VERSION`.

An alternative would have been to keep the flag but flip its default to enabled, allowing a "force off" escape hatch. There seems to be no need for that though — we have not observed any issues with the Unix socket transport since it was enabled by default, so the simpler path is to just drop the flag entirely.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
