### PR TITLE
Surface Home Assistant update failures as translatable API errors

### DIFF
--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -171,8 +171,39 @@ class HomeAssistantError(HassioError):
     """Home Assistant exception."""
 
 
-class HomeAssistantUpdateError(HomeAssistantError):
+class HomeAssistantUpdateError(HomeAssistantError, APIError):
     """Error on update of a Home Assistant."""
+
+    error_key = "homeassistant_update_error"
+    message_template = "Updating Home Assistant failed"
+
+
+class HomeAssistantUpdateImageError(HomeAssistantUpdateError):
+    """Raise when the Home Assistant image cannot be downloaded during update."""
+
+    error_key = "homeassistant_update_image_error"
+    message_template = "Downloading Home Assistant version {version} failed"
+
+    def __init__(
+        self, logger: Callable[..., None] | None = None, *, version: str
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"version": version}
+        super().__init__(None, logger)
+
+
+class HomeAssistantUpdateAlreadyInstalledError(HomeAssistantUpdateError):
+    """Raise when the requested Home Assistant version is already installed."""
+
+    error_key = "homeassistant_update_already_installed_error"
+    message_template = "Home Assistant version {version} is already installed"
+
+    def __init__(
+        self, logger: Callable[..., None] | None = None, *, version: str
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"version": version}
+        super().__init__(None, logger)
 
 
 class HomeAssistantCrashError(HomeAssistantError):

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -28,7 +28,9 @@ from ..exceptions import (
     HomeAssistantError,
     HomeAssistantJobError,
     HomeAssistantStartupTimeout,
+    HomeAssistantUpdateAlreadyInstalledError,
     HomeAssistantUpdateError,
+    HomeAssistantUpdateImageError,
     JobException,
     SupervisorUpdateError,
 )
@@ -325,8 +327,8 @@ class HomeAssistantCore(JobGroup):
         exists = await self.instance.exists()
 
         if exists and to_version == self.instance.version:
-            raise HomeAssistantUpdateError(
-                f"Version {to_version!s} is already installed", _LOGGER.warning
+            raise HomeAssistantUpdateAlreadyInstalledError(
+                _LOGGER.warning, version=str(to_version)
             )
 
         # If being run in the background, notify caller that validation has completed
@@ -341,18 +343,20 @@ class HomeAssistantCore(JobGroup):
             )
 
         # process an update
-        async def _update(to_version: AwesomeVersion) -> None:
-            """Run Home Assistant update."""
+        async def _install_image(to_version: AwesomeVersion) -> None:
+            """Pull the Home Assistant image for the given version."""
             _LOGGER.info("Updating Home Assistant to version %s", to_version)
             try:
                 await self.instance.update(
                     to_version, image=self.sys_updater.image_homeassistant
                 )
             except DockerError as err:
-                raise HomeAssistantUpdateError(
-                    "Updating Home Assistant image failed", _LOGGER.warning
+                raise HomeAssistantUpdateImageError(
+                    _LOGGER.warning, version=str(to_version)
                 ) from err
 
+        async def _start_update(to_version: AwesomeVersion) -> None:
+            """Record the new version, (re)start Core and persist the change."""
             self.sys_homeassistant.version = self.instance.version or to_version
             self.sys_homeassistant.set_image(self.sys_updater.image_homeassistant)
 
@@ -363,9 +367,17 @@ class HomeAssistantCore(JobGroup):
             # Successfull - last step
             await self.sys_homeassistant.save_data()
 
-        # Update Home Assistant
-        with suppress(HomeAssistantError):
-            await _update(to_version)
+        # A failed image install (e.g. the version does not exist) leaves the
+        # running Core untouched, so bubble it out rather than masking it with
+        # the health check below.
+        await _install_image(to_version)
+
+        # The image is in place; a start failure here defers to the health
+        # check below to decide on a rollback.
+        try:
+            await _start_update(to_version)
+        except HomeAssistantError as err:
+            _LOGGER.debug("Error starting Home Assistant after update: %s", err)
 
         # If Core wasn't running on entry, the caller is responsible for
         # starting it (e.g. backup restore, which stops and removes Core
@@ -420,7 +432,8 @@ class HomeAssistantCore(JobGroup):
                 _LOGGER.info(
                     "A backup of the logfile is stored in /config/home-assistant-rollback.log"
                 )
-            await _update(rollback_version)
+            await _install_image(rollback_version)
+            await _start_update(rollback_version)
         else:
             self.sys_resolution.create_issue(IssueType.UPDATE_FAILED, ContextType.CORE)
             raise HomeAssistantUpdateError

--- a/tests/api/test_homeassistant.py
+++ b/tests/api/test_homeassistant.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from pathlib import Path
-from unittest.mock import AsyncMock, PropertyMock, patch
+from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 from aiodocker.containers import DockerContainer
 from aiohttp.test_utils import TestClient
@@ -14,7 +14,7 @@ from supervisor.const import DNS_SUFFIX, CoreState
 from supervisor.coresys import CoreSys
 from supervisor.docker.homeassistant import DockerHomeAssistant
 from supervisor.docker.interface import DockerInterface
-from supervisor.exceptions import HomeAssistantError
+from supervisor.exceptions import DockerError, HomeAssistantError
 from supervisor.homeassistant.api import APIState, HomeAssistantAPI
 from supervisor.homeassistant.const import WSEvent
 import supervisor.homeassistant.core as ha_core
@@ -292,7 +292,8 @@ async def test_background_home_assistant_update_fails_fast(
 
     assert resp.status == 400
     body = await resp.json()
-    assert body["message"] == "Version 2025.8.3 is already installed"
+    assert body["message"] == "Home Assistant version 2025.8.3 is already installed"
+    assert body["error_key"] == "homeassistant_update_already_installed_error"
 
 
 @pytest.mark.usefixtures("tmp_supervisor_data")
@@ -662,6 +663,61 @@ async def test_update_get_config_error_triggers_rollback(
         Issue(IssueType.UPDATE_ROLLBACK, ContextType.CORE) in coresys.resolution.issues
     )
     mock_cleanup.assert_not_called()
+
+
+async def test_update_image_install_failure_surfaces_error(
+    core_api_client_with_root: tuple[TestClient, str],
+    coresys: CoreSys,
+    capture_exception: Mock,
+    caplog: pytest.LogCaptureFixture,
+    tmp_supervisor_data: Path,
+):
+    """Test that a failed image install surfaces a clean translated error.
+
+    When the target version does not exist the image pull fails before the
+    running Core is touched. The post-update health check would otherwise pass
+    against the still-healthy old version and mask the failure. The error is
+    modeled as a client-facing APIError so it does not reach Sentry.
+    """
+    api_client, root = core_api_client_with_root
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    coresys.homeassistant.version = AwesomeVersion("2025.8.0")
+
+    with (
+        patch.object(
+            DockerInterface, "update", side_effect=DockerError("404 not found")
+        ),
+        patch.object(DockerInterface, "is_running", AsyncMock(return_value=True)),
+        patch.object(
+            DockerHomeAssistant,
+            "version",
+            new=PropertyMock(return_value=AwesomeVersion("2025.8.0")),
+        ),
+        patch.object(HomeAssistantAPI, "get_config") as mock_get_config,
+        patch.object(ha_core, "verify_frontend", AsyncMock(return_value=True)),
+        patch.object(DockerInterface, "cleanup") as mock_cleanup,
+    ):
+        resp = await api_client.post(f"{root}/update", json={"version": "2025.8.3"})
+
+    # The update reports a clean client error with a translatable key.
+    assert resp.status == 400
+    body = await resp.json()
+    assert body["result"] == "error"
+    assert body["error_key"] == "homeassistant_update_image_error"
+    assert "2025.8.3" in body["message"]
+    # A client error must not be captured as an unexpected error in Sentry.
+    capture_exception.assert_not_called()
+    assert "Unexpected error during API call" not in caplog.text
+    # No health check or rollback should run since the old Core is untouched.
+    mock_get_config.assert_not_called()
+    assert "HomeAssistant update failed -> rollback!" not in caplog.text
+    mock_cleanup.assert_not_called()
+    # Version is unchanged and no rollback issue is created.
+    assert coresys.homeassistant.version == AwesomeVersion("2025.8.0")
+    assert (
+        Issue(IssueType.UPDATE_ROLLBACK, ContextType.CORE)
+        not in coresys.resolution.issues
+    )
 
 
 async def test_update_skips_health_check_when_core_not_running(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updating Core to a non-existent version (e.g. a mistyped beta tag) reported success on the CLI: the image pull failed with a 404, but update() swallowed the error via "with suppress(HomeAssistantError)" and then ran its post-update health check against the still-running old Core, which passed.

Split the update routine into image install and start phases. A failed image install leaves the running Core untouched, so there is nothing to health-check or roll back; let it bubble out instead of masking it. Only failures after the image is in place (e.g. the new container starting unhealthy) fall through to the health check and rollback logic, where the error is now captured at debug level rather than silently suppressed.

Model the update errors as client-facing APIError subclasses carrying an error_key so the frontend can translate them and they no longer reach Sentry as unexpected errors:

- HomeAssistantUpdateError: generic update failure
- HomeAssistantUpdateImageError: image download failed (includes the version)
- HomeAssistantUpdateAlreadyInstalledError: requested version already installed

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
