### PR TITLE
Repair stale installed-app locations after addons->apps rename

### DIFF
--- a/supervisor/apps/manager.py
+++ b/supervisor/apps/manager.py
@@ -4,12 +4,20 @@ import asyncio
 from collections.abc import Awaitable
 from contextlib import suppress
 import logging
-from typing import Self, Union
+from pathlib import Path
+from typing import Any, Self, Union
 
 from attr import evolve
 from securetar import SecureTarFile
 
-from ..const import FILE_HASSIO_ADDONS, FILE_HASSIO_APPS, AppBoot, AppStartup, AppState
+from ..const import (
+    ATTR_LOCATION,
+    FILE_HASSIO_ADDONS,
+    FILE_HASSIO_APPS,
+    AppBoot,
+    AppStartup,
+    AppState,
+)
 from ..coresys import CoreSys, CoreSysAttributes
 from ..exceptions import (
     AppAlreadyInstalledError,
@@ -47,6 +55,24 @@ def _migrate_addons_json() -> None:
             "Migrating %s to %s", FILE_HASSIO_ADDONS.name, FILE_HASSIO_APPS.name
         )
         FILE_HASSIO_ADDONS.rename(FILE_HASSIO_APPS)
+
+
+def _migrate_app_locations(system: dict[str, Any], supervisor_path: Path) -> bool:
+    """Rewrite stored app locations from legacy addons paths to apps paths.
+
+    The directory migration renamed addons/{core,data,local,git} to apps/{...}
+    but the absolute location persisted per installed app was left pointing at
+    the old addons path, which breaks local builds. Returns True if changed.
+    """
+    legacy_prefix = f"{supervisor_path / 'addons'}/"
+    new_prefix = f"{supervisor_path / 'apps'}/"
+    changed = False
+    for app in system.values():
+        location = app.get(ATTR_LOCATION)
+        if location and location.startswith(legacy_prefix):
+            app[ATTR_LOCATION] = f"{new_prefix}{location[len(legacy_prefix) :]}"
+            changed = True
+    return changed
 
 
 class AppManager(CoreSysAttributes):
@@ -98,6 +124,12 @@ class AppManager(CoreSysAttributes):
         """Load config in executor."""
         await self.sys_run_in_executor(_migrate_addons_json)
         await self.data.read_data()
+
+        if _migrate_app_locations(self.data.system, self.sys_config.path_supervisor):
+            _LOGGER.info(
+                "Repairing stale app source locations in %s", FILE_HASSIO_APPS.name
+            )
+            await self.data.save_data()
         return self
 
     async def load(self) -> None:

--- a/tests/apps/test_manager.py
+++ b/tests/apps/test_manager.py
@@ -11,9 +11,17 @@ from awesomeversion import AwesomeVersion
 import pytest
 
 from supervisor.apps.app import App
+from supervisor.apps.manager import _migrate_app_locations
 from supervisor.arch import CpuArchManager
 from supervisor.config import CoreConfig
-from supervisor.const import ATTR_INGRESS, AppBoot, AppStartup, AppState, BusEvent
+from supervisor.const import (
+    ATTR_INGRESS,
+    ATTR_LOCATION,
+    AppBoot,
+    AppStartup,
+    AppState,
+    BusEvent,
+)
 from supervisor.coresys import CoreSys
 from supervisor.docker.app import DockerApp
 from supervisor.docker.const import ContainerState
@@ -671,3 +679,67 @@ async def test_shared_image_kept_on_update(
         await coresys.apps.update("local_example_image")
         docker.images.delete.assert_called_once_with("image_old", force=True)
         assert install_app_example_image.version == "1.3.0"
+
+
+def test_migrate_app_locations():
+    """Test stale legacy addon locations are rewritten to apps paths."""
+    supervisor_path = Path("/data")
+    system = {
+        "0f1cc410_puppet": {ATTR_LOCATION: "/data/addons/git/0f1cc410/puppet"},
+        "local_example": {ATTR_LOCATION: "/data/addons/local/example"},
+        "already_migrated": {ATTR_LOCATION: "/data/apps/git/0f1cc410/other"},
+        "image_based": {},
+    }
+
+    assert _migrate_app_locations(system, supervisor_path) is True
+    assert system["0f1cc410_puppet"][ATTR_LOCATION] == "/data/apps/git/0f1cc410/puppet"
+    assert system["local_example"][ATTR_LOCATION] == "/data/apps/local/example"
+    # Already-migrated and image-based (no location) apps are left untouched
+    assert system["already_migrated"][ATTR_LOCATION] == "/data/apps/git/0f1cc410/other"
+    assert system["image_based"] == {}
+
+    # Idempotent: second run leaves everything untouched
+    assert _migrate_app_locations(system, supervisor_path) is False
+
+
+async def test_load_config_repairs_already_migrated_locations(
+    coresys: CoreSys, install_app_ssh: App, tmp_path: Path
+):
+    """Test stale locations are repaired when apps.json was migrated earlier."""
+    apps_file = tmp_path / "apps.json"
+    slug = install_app_ssh.slug
+
+    # Simulate an instance whose directories/file were renamed on an earlier
+    # boot but whose stored location still points at the legacy addons path.
+    coresys.apps.data.system[slug][ATTR_LOCATION] = "/data/addons/local/ssh"
+    coresys.apps.data._file = apps_file
+    await coresys.run_in_executor(write_json_file, apps_file, coresys.apps.data._data)
+
+    coresys.apps.data.save_data.reset_mock()
+    with (
+        patch("supervisor.apps.manager.FILE_HASSIO_ADDONS", tmp_path / "addons.json"),
+        patch("supervisor.apps.manager.FILE_HASSIO_APPS", apps_file),
+    ):
+        await coresys.apps.load_config()
+
+    # Stale location is rewritten in memory and the change is persisted
+    assert coresys.apps.data.system[slug][ATTR_LOCATION] == "/data/apps/local/ssh"
+    coresys.apps.data.save_data.assert_called_once()
+
+
+async def test_load_config_skips_repair_for_clean_locations(
+    coresys: CoreSys, install_app_ssh: App, tmp_path: Path
+):
+    """Test no save happens when no stale locations need repairing."""
+    apps_file = tmp_path / "apps.json"
+    coresys.apps.data._file = apps_file
+    await coresys.run_in_executor(write_json_file, apps_file, coresys.apps.data._data)
+
+    coresys.apps.data.save_data.reset_mock()
+    with (
+        patch("supervisor.apps.manager.FILE_HASSIO_ADDONS", tmp_path / "addons.json"),
+        patch("supervisor.apps.manager.FILE_HASSIO_APPS", apps_file),
+    ):
+        await coresys.apps.load_config()
+
+    coresys.apps.data.save_data.assert_not_called()


### PR DESCRIPTION
## Proposed change

The `addons/{core,data,local,git}` → `apps/{...}` directory migration renamed the directories and `addons.json` → `apps.json`, but left the absolute source `location` persisted per installed app pointing at the old `addons` path. `App.path_location` reads that stored string directly, so for locally-built add-ons the build validity check resolves a now-nonexistent directory and the build fails with a misleading "dockerfile is missing" error on install, update, or rebuild.

This rewrites stale `location` values from the legacy `addons` prefix to the `apps` prefix when loading app config. The rewrite runs on every load and is idempotent, so it also repairs instances that migrated their directories on an earlier boot (before this fix existed), where no migration event is left to hook into. The rename and the location rewrite are each individually atomic (`Path.rename` and the atomicwrites-backed `save_data`), so they compose without ever persisting a partially migrated file.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #6917
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
