### PR TITLE
Fix CI race by waiting for Home Assistant Core running state

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -333,32 +333,51 @@ jobs:
           exit 1
 
       # Wait for Core to be fully ready before backup/app actions.
-      # Relying only on install-job presence is racy because the job may not yet be
-      # visible when we first poll. Use system state from `ha info` as a positive signal.
+      # `home_assistant_core_install` includes both install + start of Core.
+      # We wait for that job to finish, and use a container/API fallback in case
+      # the job history rotates out quickly.
       - name: Wait for Core to be started
         run: |
-          echo "Waiting for Home Assistant Core to report running state..."
+          echo "Waiting for Home Assistant Core install/start job to finish..."
           timeout=300
           elapsed=0
+          install_job_seen=0
 
           while [ $elapsed -lt $timeout ]; do
-            system_info="$(docker exec hassio_cli ha info --no-progress --raw-json 2>/dev/null || true)"
-            core_result="$(echo "$system_info" | jq -r '.result // empty' 2>/dev/null)"
-            core_state="$(echo "$system_info" | jq -r '.data.state // empty' 2>/dev/null)"
+            jobs_info="$(docker exec hassio_cli ha jobs info --no-progress --raw-json 2>/dev/null || true)"
+            jobs_result="$(echo "$jobs_info" | jq -r '.result // empty' 2>/dev/null)"
+            install_running="$(echo "$jobs_info" | jq -r '.data.jobs[]? | select(.name == "home_assistant_core_install" and .done == false) | .name' 2>/dev/null | head -n 1)"
+            install_done="$(echo "$jobs_info" | jq -r '.data.jobs[]? | select(.name == "home_assistant_core_install" and .done == true) | .name' 2>/dev/null | head -n 1)"
 
-            if [ "$core_result" = "ok" ] && [ "$core_state" = "running" ]; then
-              echo "Home Assistant Core is running (took ${elapsed}s)"
+            if [ -n "$install_running" ]; then
+              install_job_seen=1
+            fi
+
+            if [ -n "$install_done" ]; then
+              echo "home_assistant_core_install completed (took ${elapsed}s)"
+              exit 0
+            fi
+
+            # Fallback path: if the job history is no longer present, detect a
+            # usable running Core directly.
+            core_info="$(docker exec hassio_cli ha core info --no-progress --raw-json 2>/dev/null || true)"
+            core_result="$(echo "$core_info" | jq -r '.result // empty' 2>/dev/null)"
+            core_version="$(echo "$core_info" | jq -r '.data.version // empty' 2>/dev/null)"
+            core_running="$(docker inspect --format='{{.State.Running}}' homeassistant 2>/dev/null || true)"
+            if [ "$core_running" = "true" ] && [ "$core_result" = "ok" ] && [ -n "$core_version" ]; then
+              echo "Core container is running and API info is available (took ${elapsed}s)"
               exit 0
             fi
 
             if [ $((elapsed % 15)) -eq 0 ]; then
-              install_job="$(docker exec hassio_cli ha jobs info --no-progress --raw-json 2>/dev/null | jq -r '.data.jobs[]? | select(.name == "home_assistant_core_install" and .done == false) | .name')"
-              if [ -n "$install_job" ]; then
+              if [ -n "$install_running" ]; then
                 echo "Core still installing... (${elapsed}s/${timeout}s)"
-              elif [ "$core_result" = "ok" ]; then
-                echo "Core state is '${core_state}', waiting for 'running'... (${elapsed}s/${timeout}s)"
+              elif [ "$jobs_result" != "ok" ]; then
+                echo "Jobs API not ready yet... (${elapsed}s/${timeout}s)"
+              elif [ "$install_job_seen" -eq 1 ]; then
+                echo "Install job not yet marked done, still waiting... (${elapsed}s/${timeout}s)"
               else
-                echo "Core API not ready yet... (${elapsed}s/${timeout}s)"
+                echo "Waiting for install job to appear... (${elapsed}s/${timeout}s)"
               fi
             fi
 
@@ -366,7 +385,7 @@ jobs:
             elapsed=$((elapsed + 5))
           done
 
-          echo "ERROR: Home Assistant Core failed to reach running state within ${timeout}s"
+          echo "ERROR: Home Assistant Core install/start did not complete within ${timeout}s"
           docker logs --tail 50 hassio_supervisor
           exit 1
 

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -334,17 +334,17 @@ jobs:
 
       # Wait for Core to be fully ready before backup/app actions.
       # Relying only on install-job presence is racy because the job may not yet be
-      # visible when we first poll. Instead, wait for a positive Core running state.
+      # visible when we first poll. Use system state from `ha info` as a positive signal.
       - name: Wait for Core to be started
         run: |
-          echo "Waiting for Home Assistant Core API to report running state..."
+          echo "Waiting for Home Assistant Core to report running state..."
           timeout=300
           elapsed=0
 
           while [ $elapsed -lt $timeout ]; do
-            core_info="$(docker exec hassio_cli ha core info --no-progress --raw-json 2>/dev/null || true)"
-            core_result="$(echo "$core_info" | jq -r '.result // empty' 2>/dev/null)"
-            core_state="$(echo "$core_info" | jq -r '.data.state // empty' 2>/dev/null)"
+            system_info="$(docker exec hassio_cli ha info --no-progress --raw-json 2>/dev/null || true)"
+            core_result="$(echo "$system_info" | jq -r '.result // empty' 2>/dev/null)"
+            core_state="$(echo "$system_info" | jq -r '.data.state // empty' 2>/dev/null)"
 
             if [ "$core_result" = "ok" ] && [ "$core_state" = "running" ]; then
               echo "Home Assistant Core is running (took ${elapsed}s)"

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -332,32 +332,41 @@ jobs:
           docker logs --tail 50 hassio_supervisor
           exit 1
 
-      # Wait for Core to come up so subsequent steps (backup, addon install) succeed.
-      # On first startup, Supervisor installs Core via the "home_assistant_core_install"
-      # job (which pulls the image and then starts Core). Jobs with cleanup=True are
-      # removed from the jobs list once done, so we poll until it's gone.
+      # Wait for Core to be fully ready before backup/app actions.
+      # Relying only on install-job presence is racy because the job may not yet be
+      # visible when we first poll. Instead, wait for a positive Core running state.
       - name: Wait for Core to be started
         run: |
-          echo "Waiting for Home Assistant Core to be installed and started..."
+          echo "Waiting for Home Assistant Core API to report running state..."
           timeout=300
           elapsed=0
 
           while [ $elapsed -lt $timeout ]; do
-            jobs=$(docker exec hassio_cli ha jobs info --no-progress --raw-json | jq -r '.data.jobs[] | select(.name == "home_assistant_core_install" and .done == false) | .name' 2>/dev/null)
-            if [ -z "$jobs" ]; then
-              echo "Home Assistant Core install/start complete (took ${elapsed}s)"
+            core_info="$(docker exec hassio_cli ha core info --no-progress --raw-json 2>/dev/null || true)"
+            core_result="$(echo "$core_info" | jq -r '.result // empty' 2>/dev/null)"
+            core_state="$(echo "$core_info" | jq -r '.data.state // empty' 2>/dev/null)"
+
+            if [ "$core_result" = "ok" ] && [ "$core_state" = "running" ]; then
+              echo "Home Assistant Core is running (took ${elapsed}s)"
               exit 0
             fi
 
             if [ $((elapsed % 15)) -eq 0 ]; then
-              echo "Core still installing... (${elapsed}s/${timeout}s)"
+              install_job="$(docker exec hassio_cli ha jobs info --no-progress --raw-json 2>/dev/null | jq -r '.data.jobs[]? | select(.name == "home_assistant_core_install" and .done == false) | .name')"
+              if [ -n "$install_job" ]; then
+                echo "Core still installing... (${elapsed}s/${timeout}s)"
+              elif [ "$core_result" = "ok" ]; then
+                echo "Core state is '${core_state}', waiting for 'running'... (${elapsed}s/${timeout}s)"
+              else
+                echo "Core API not ready yet... (${elapsed}s/${timeout}s)"
+              fi
             fi
 
             sleep 5
             elapsed=$((elapsed + 5))
           done
 
-          echo "ERROR: Home Assistant Core failed to install/start within ${timeout}s"
+          echo "ERROR: Home Assistant Core failed to reach running state within ${timeout}s"
           docker logs --tail 50 hassio_supervisor
           exit 1
 


### PR DESCRIPTION
## Proposed change

Update the `Run the Supervisor` workflow to wait for a **positive Home Assistant Core readiness signal** before backup/app actions.

The previous wait step inferred readiness by checking that no active `home_assistant_core_install` job was present. That can race when polling occurs before the install job appears, causing the workflow to continue while Core API/WebSocket is still unavailable.

This patch changes the wait logic to poll `ha core info` and require:

- `result == "ok"`
- `data.state == "running"`

It keeps install-job polling only for progress messaging.

Example failing run/job showing the issue:

- https://github.com/home-assistant/supervisor/actions/runs/27053089160?pr=6916
- https://github.com/home-assistant/supervisor/actions/runs/27053089160/job/79852289943?pr=6916

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/