### PR TITLE
Derive installed-app source location from the store

### DIFF
--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -35,6 +35,7 @@ from ..const import (
     ATTR_INGRESS_PANEL,
     ATTR_INGRESS_PORT,
     ATTR_INGRESS_TOKEN,
+    ATTR_LOCATION,
     ATTR_NETWORK,
     ATTR_OPTIONS,
     ATTR_PORTS,
@@ -270,9 +271,6 @@ class App(AppModel):
             await self.sys_hardware.helper.last_boot() != self.sys_config.last_boot
         )
 
-        if self.is_detached:
-            await super().refresh_path_cache()
-
         self._listeners.append(
             self.sys_bus.register_event(
                 BusEvent.DOCKER_CONTAINER_STATE_CHANGE, self.container_state_changed
@@ -387,30 +385,23 @@ class App(AppModel):
     @property
     def with_icon(self) -> bool:
         """Return True if an icon exists."""
-        if self.is_detached or not self.app_store:
-            return super().with_icon
-        return self.app_store.with_icon
+        # A detached app has no store source to read assets from.
+        return self.app_store is not None and self.app_store.with_icon
 
     @property
     def with_logo(self) -> bool:
         """Return True if a logo exists."""
-        if self.is_detached or not self.app_store:
-            return super().with_logo
-        return self.app_store.with_logo
+        return self.app_store is not None and self.app_store.with_logo
 
     @property
     def with_changelog(self) -> bool:
         """Return True if a changelog exists."""
-        if self.is_detached or not self.app_store:
-            return super().with_changelog
-        return self.app_store.with_changelog
+        return self.app_store is not None and self.app_store.with_changelog
 
     @property
     def with_documentation(self) -> bool:
         """Return True if a documentation exists."""
-        if self.is_detached or not self.app_store:
-            return super().with_documentation
-        return self.app_store.with_documentation
+        return self.app_store is not None and self.app_store.with_documentation
 
     @property
     def available(self) -> bool:
@@ -705,6 +696,25 @@ class App(AppModel):
     def latest_need_build(self) -> bool:
         """Return True if the latest version of the app needs a local build."""
         return ATTR_IMAGE not in self.data_store
+
+    @property
+    def path_location(self) -> Path:
+        """Return path to this app's source, resolved from the store.
+
+        The source location is owned by the store and recomputed on every store
+        reload, so it is derived here instead of being persisted (which used to
+        go stale, e.g. after the addons->apps path migration). It only exists
+        for a store-backed app: callers must ensure the app is attached (the
+        store is loaded before apps during setup, see Core.setup ordering) and
+        guard on is_detached. Reaching here while detached is a programming
+        error.
+        """
+        if self.is_detached:
+            raise RuntimeError(
+                f"App {self.slug} has no source location: not available in the "
+                "store (detached, or store accessed before it was loaded)"
+            )
+        return Path(self.data_store[ATTR_LOCATION])
 
     @property
     def path_data(self) -> Path:
@@ -1790,7 +1800,6 @@ class App(AppModel):
 
     async def refresh_path_cache(self) -> None:
         """Refresh cache of existing paths."""
-        if self.is_detached or not self.app_store:
-            await super().refresh_path_cache()
-        else:
+        # Asset paths live in the store source; a detached app has none.
+        if self.app_store:
             await self.app_store.refresh_path_cache()

--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -705,16 +705,15 @@ class App(AppModel):
         reload, so it is derived here instead of being persisted (which used to
         go stale, e.g. after the addons->apps path migration). It only exists
         for a store-backed app: callers must ensure the app is attached (the
-        store is loaded before apps during setup, see Core.setup ordering) and
-        guard on is_detached. Reaching here while detached is a programming
-        error.
+        store is loaded before apps during setup, see Core.setup ordering).
+        Reaching here without a store representation is a programming error.
         """
-        if self.is_detached:
+        if self.app_store is None:
             raise RuntimeError(
                 f"App {self.slug} has no source location: not available in the "
                 "store (detached, or store accessed before it was loaded)"
             )
-        return Path(self.data_store[ATTR_LOCATION])
+        return Path(self.app_store.data[ATTR_LOCATION])
 
     @property
     def path_data(self) -> Path:

--- a/supervisor/apps/model.py
+++ b/supervisor/apps/model.py
@@ -672,6 +672,9 @@ class AppModel(JobGroup, ABC):
 
     async def long_description(self) -> str | None:
         """Return README.md as long_description."""
+        # A detached app has no store source to read the README from.
+        if self.is_detached:
+            return None
 
         def read_readme() -> str | None:
             readme = Path(self.path_location, "README.md")

--- a/supervisor/apps/validate.py
+++ b/supervisor/apps/validate.py
@@ -57,7 +57,6 @@ from ..const import (
     ATTR_KERNEL_MODULES,
     ATTR_LABELS,
     ATTR_LEGACY,
-    ATTR_LOCATION,
     ATTR_MACHINE,
     ATTR_MAP,
     ATTR_NAME,
@@ -548,7 +547,9 @@ SCHEMA_APP_SYSTEM = vol.All(
     _migrate_app_config(),
     _SCHEMA_APP_CONFIG.extend(
         {
-            vol.Required(ATTR_LOCATION): str,
+            # The source location is owned by the store and resolved at runtime
+            # (see App.path_location); it is intentionally not persisted here.
+            # REMOVE_EXTRA drops any stale value left in older apps.json files.
             vol.Required(ATTR_REPOSITORY): str,
             vol.Required(ATTR_TRANSLATIONS, default=dict): {
                 str: SCHEMA_APP_TRANSLATIONS

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -18,7 +18,7 @@ from securetar import SecureTarArchive, SecureTarFile
 from supervisor.apps.app import App
 from supervisor.apps.const import AppBackupMode
 from supervisor.apps.model import AppModel
-from supervisor.const import ATTR_ADVANCED, AppBoot, AppState, BusEvent
+from supervisor.const import ATTR_ADVANCED, ATTR_LOCATION, AppBoot, AppState, BusEvent
 from supervisor.coresys import CoreSys
 from supervisor.docker.app import DockerApp
 from supervisor.docker.const import ContainerState
@@ -1344,3 +1344,33 @@ async def test_app_start_port_conflict_error(
         f"Cannot start container addon_local_ssh because port {port} is already in use"
         in caplog.text
     )
+
+
+async def test_path_location_derived_from_store(coresys: CoreSys, install_app_ssh: App):
+    """Test source location comes from the store, not the install snapshot."""
+    slug = install_app_ssh.slug
+    store_location = coresys.store.data.apps[slug][ATTR_LOCATION]
+
+    # location is no longer persisted; a stale value in the snapshot is ignored.
+    install_app_ssh.data[ATTR_LOCATION] = "/data/addons/git/stale/ssh"
+    assert install_app_ssh.path_location == Path(store_location)
+
+
+async def test_path_location_detached_raises(coresys: CoreSys, install_app_ssh: App):
+    """Test a detached app has no resolvable source location."""
+    slug = install_app_ssh.slug
+
+    # Simulate a removed/unloaded repository: drop the store representation.
+    coresys.store.data.apps.pop(slug)
+    coresys.apps.store.pop(slug, None)
+    assert install_app_ssh.is_detached
+
+    with pytest.raises(RuntimeError):
+        _ = install_app_ssh.path_location
+
+    # Asset accessors report absence instead of crashing.
+    assert install_app_ssh.with_icon is False
+    assert install_app_ssh.with_logo is False
+    assert install_app_ssh.with_changelog is False
+    assert install_app_ssh.with_documentation is False
+    assert await install_app_ssh.long_description() is None


### PR DESCRIPTION
## Proposed change

The source `location` of an installed app was persisted as an absolute string in `apps.json`, captured at install time. The `addons/{core,data,local,git}` → `apps/{...}` directory migration renamed those source directories but left the stored string pointing at the old `addons` path, so locally-built apps failed to build with a misleading "dockerfile is missing" error on install/update/rebuild (fixes #6917).

The location isn't really app state: it's the source directory discovered during the store scan and recomputed on every store reload. So this derives it from the store data (`App.path_location` → `data_store`) instead of persisting it, and drops `ATTR_LOCATION` from the system schema. `REMOVE_EXTRA` strips the stale value from existing `apps.json` files, so no migration step is needed and already-migrated instances are repaired as well.

`location` only exists for a store-backed app. The store is loaded before apps during setup (`Core.setup` ordering), so an installed, attached app can always resolve it; reaching `path_location` while detached is a programming error and now raises. Detached apps have no source, so their asset accessors (`with_icon`/`with_logo`/`with_changelog`/`with_documentation`, `long_description`) report absence instead of reading a path, and the path cache is no longer refreshed for them. Build, AppArmor install, and backup/restore never touch `path_location` on a detached app (build/update are blocked when detached; the AppArmor profile and the built image are captured from the host and restored from the backup), so those paths are unaffected.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #6917
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
