### PR TITLE
Don't offer a rebuild repair for a detached app

### DIFF
--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -306,7 +306,16 @@ class App(AppModel):
             await self.instance.check_image(self.version, default_image, self.arch)
         except DockerNotFound:
             _LOGGER.info("No %s app Docker image %s found", self.slug, self.image)
-            if self.need_build:
+            if self.need_build and self.is_detached:
+                # Image is gone and there is no store source to rebuild from.
+                # A rebuild repair would be futile; the detached-app check
+                # surfaces a remove suggestion instead.
+                _LOGGER.warning(
+                    "App %s is missing its image and is detached from its store; "
+                    "it cannot be rebuilt and should be removed",
+                    self.slug,
+                )
+            elif self.need_build:
                 # Don't run a local build during setup. Surface a repair so
                 # the resolution autofix loop can handle it off the critical
                 # path.

--- a/supervisor/resolution/fixups/app_execute_repair.py
+++ b/supervisor/resolution/fixups/app_execute_repair.py
@@ -49,6 +49,16 @@ class FixupAppExecuteRepair(FixupBase):
             )
             return
 
+        if app.is_detached and app.need_build:
+            # No store source to rebuild from; the repair cannot succeed. The
+            # detached-app check surfaces a remove suggestion instead.
+            _LOGGER.warning(
+                "Cannot repair app %s as it is detached from its store and "
+                "needs a local build, dismissing suggestion",
+                reference,
+            )
+            return
+
         _LOGGER.info("Installing image for app %s", reference)
         self.attempts += 1
         try:

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -1176,6 +1176,35 @@ async def test_app_loads_missing_image_build(coresys: CoreSys, install_app_ssh: 
     assert any(s.type == SuggestionType.EXECUTE_REPAIR for s in suggestions)
 
 
+async def test_app_loads_missing_image_build_detached(
+    coresys: CoreSys, install_app_ssh: App
+):
+    """Test detached build app does not surface a (futile) rebuild repair."""
+    slug = install_app_ssh.slug
+    # Detach: drop the store representation so there is no source to build from.
+    coresys.store.data.apps.pop(slug)
+    coresys.apps.store.pop(slug, None)
+    assert install_app_ssh.is_detached
+    assert install_app_ssh.need_build
+
+    coresys.docker.images.inspect.side_effect = aiodocker.DockerError(
+        HTTPStatus.NOT_FOUND, {"message": "missing"}
+    )
+
+    with patch.object(
+        coresys.docker,
+        "run_command",
+        return_value=CommandReturn(0, ["Build successful"]),
+    ) as mock_run_command:
+        await install_app_ssh.load()
+
+    # No build attempted and no rebuild repair raised; removal is offered by
+    # the detached-app check instead.
+    mock_run_command.assert_not_called()
+    issue = Issue(IssueType.MISSING_IMAGE, ContextType.ADDON, reference=slug)
+    assert issue not in coresys.resolution.issues
+
+
 @pytest.mark.usefixtures("mock_amd64_arch_supported")
 async def test_app_loads_missing_image_pull(coresys: CoreSys, install_app_ssh: App):
     """Test pullable app installs the missing image during load."""

--- a/tests/resolution/fixup/test_app_execute_repair.py
+++ b/tests/resolution/fixup/test_app_execute_repair.py
@@ -40,6 +40,35 @@ async def test_fixup(docker: DockerAPI, coresys: CoreSys, install_app_ssh: App):
     assert not coresys.resolution.suggestions
 
 
+async def test_fixup_detached_build_app_skips(
+    docker: DockerAPI, coresys: CoreSys, install_app_ssh: App
+):
+    """Test fixup skips a detached app that needs a local build (no source)."""
+    docker.images.inspect.side_effect = aiodocker.DockerError(
+        HTTPStatus.NOT_FOUND, {"message": "missing"}
+    )
+    # Detach: no store source to build from, and no image to pull.
+    coresys.store.data.apps.pop("local_ssh")
+    coresys.apps.store.pop("local_ssh", None)
+    assert install_app_ssh.is_detached
+    assert install_app_ssh.need_build
+
+    app_execute_repair = FixupAppExecuteRepair(coresys)
+    coresys.resolution.create_issue(
+        IssueType.MISSING_IMAGE,
+        ContextType.ADDON,
+        reference="local_ssh",
+        suggestions=[SuggestionType.EXECUTE_REPAIR],
+    )
+    with patch.object(DockerInterface, "install") as install:
+        await app_execute_repair()
+        install.assert_not_called()
+
+    # Dismissed gracefully without attempting a build or raising.
+    assert not coresys.resolution.issues
+    assert not coresys.resolution.suggestions
+
+
 async def test_fixup_max_auto_attempts(
     docker: DockerAPI, coresys: CoreSys, install_app_ssh: App
 ):


### PR DESCRIPTION
## Proposed change

Fixes a corner case where the resolution autofix loop crashes with an unhandled exception while trying to repair a detached, locally-built app.

The scenario: a locally-built app whose container image went missing for some external reason *and* which is also detached from its store (e.g. its local source folder was removed). There is no normal Supervisor command that produces this combination — `rebuild` removes the image before rebuilding, but it is rejected for detached apps, so it cannot leave a detached app without an image. The image loss here came from outside Supervisor's normal flow.

Such an app cannot be rebuilt: there is no source. But `App.load` still surfaced a `MISSING_IMAGE` repair with an `EXECUTE_REPAIR` suggestion for it, and the autofix loop then tried to rebuild it. That dead-ends in `App.path_location`, which raises for a detached app, crashing the autofix with an unhandled exception:

```
INFO (MainThread) [supervisor.resolution.fixup] Starting system autofix at state running
INFO (MainThread) [supervisor.resolution.fixups.app_execute_repair] Installing image for app local_deconz
ERROR (MainThread) [supervisor.jobs] Unhandled exception: App local_deconz has no source location: not available in the store (detached, or store accessed before it was loaded)
  ...
  File "supervisor/apps/build.py", line 89, in _read_build_config
    app.path_location, "build", FILE_SUFFIX_CONFIGURATION
  File "supervisor/apps/app.py", line 712, in path_location
    raise RuntimeError(...)
```

This PR:

- Doesn't create the rebuild repair in `App.load` when the app is detached. The detached-app check already surfaces a `DETACHED_ADDON_REMOVED` issue with an `EXECUTE_REMOVE` suggestion for these apps (the built-in `local` repository is always loaded), so the user is offered removal instead of a repair that can never succeed.
- Guards the repair fixup itself against a detached build app. With the `App.load` change this is only reachable via a race (the repair is created while the app is attached, then the app detaches before/between autofix runs); it now skips gracefully rather than throwing, mirroring the `is_detached` guards already in `AppManager.update`/`rebuild`.

Image-based detached apps are unaffected — they can still be re-pulled.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
