### PR TITLE
Detect landingpage by io.hass.type label instead of version

### DIFF
--- a/supervisor/docker/homeassistant.py
+++ b/supervisor/docker/homeassistant.py
@@ -6,10 +6,10 @@ import re
 
 from awesomeversion import AwesomeVersion
 
-from ..const import LABEL_MACHINE
+from ..const import LABEL_MACHINE, LABEL_TYPE
 from ..exceptions import DockerJobError
 from ..hardware.const import PolicyGroup
-from ..homeassistant.const import LANDINGPAGE
+from ..homeassistant.const import LANDINGPAGE, LANDINGPAGE_TYPE
 from ..jobs.const import JobConcurrency
 from ..jobs.decorator import Job
 from .const import (
@@ -43,6 +43,18 @@ ENV_RESTORE_JOB_ID = "SUPERVISOR_RESTORE_JOB_ID"
 
 class DockerHomeAssistant(DockerInterface):
     """Docker Supervisor wrapper for Home Assistant."""
+
+    @property
+    def version(self) -> AwesomeVersion | None:
+        """Return version of Home Assistant Docker image.
+
+        Landingpage images always resolve to LANDINGPAGE, regardless of the
+        version stamped into the io.hass.version label. The io.hass.type label
+        is the authoritative signal for "this is a landingpage".
+        """
+        if self.meta_labels.get(LABEL_TYPE) == LANDINGPAGE_TYPE:
+            return LANDINGPAGE
+        return super().version
 
     @property
     def machine(self) -> str | None:

--- a/supervisor/homeassistant/const.py
+++ b/supervisor/homeassistant/const.py
@@ -12,6 +12,7 @@ ATTR_ERROR = "error"
 ATTR_OVERRIDE_IMAGE = "override_image"
 ATTR_SUCCESS = "success"
 LANDINGPAGE: AwesomeVersion = AwesomeVersion("landingpage")
+LANDINGPAGE_TYPE = "landingpage"
 WATCHDOG_RETRY_SECONDS = 10
 WATCHDOG_MAX_ATTEMPTS = 5
 WATCHDOG_THROTTLE_PERIOD = timedelta(minutes=30)

--- a/tests/docker/test_homeassistant.py
+++ b/tests/docker/test_homeassistant.py
@@ -227,6 +227,36 @@ async def test_landingpage_start(coresys: CoreSys, container: DockerContainer):
         assert "volumes" not in run.call_args.kwargs
 
 
+async def test_version_landingpage_from_type_label(
+    coresys: CoreSys, container: DockerContainer
+):
+    """Test landingpage image resolves to LANDINGPAGE despite a real version label."""
+    container.show.return_value["Config"] = {
+        "Labels": {
+            "io.hass.type": "landingpage",
+            "io.hass.version": "2026.06.3",
+        }
+    }
+    await coresys.homeassistant.core.instance.attach(AwesomeVersion("2026.06.3"))
+
+    assert coresys.homeassistant.core.instance.version == LANDINGPAGE
+
+
+async def test_version_core_from_version_label(
+    coresys: CoreSys, container: DockerContainer
+):
+    """Test non-landingpage image resolves to the io.hass.version label value."""
+    container.show.return_value["Config"] = {
+        "Labels": {
+            "io.hass.type": "homeassistant",
+            "io.hass.version": "2026.06.3",
+        }
+    }
+    await coresys.homeassistant.core.instance.attach(AwesomeVersion("2026.06.3"))
+
+    assert coresys.homeassistant.core.instance.version == AwesomeVersion("2026.06.3")
+
+
 async def test_timeout(coresys: CoreSys, container: DockerContainer):
     """Test timeout for set from S6_SERVICES_GRACETIME."""
     assert coresys.homeassistant.core.instance.timeout == 260

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -25,7 +25,7 @@ from supervisor.exceptions import (
     SupervisorUpdateError,
 )
 from supervisor.homeassistant.api import APIState
-from supervisor.homeassistant.const import WSEvent
+from supervisor.homeassistant.const import LANDINGPAGE, WSEvent
 from supervisor.homeassistant.core import HomeAssistantCore
 from supervisor.homeassistant.module import HomeAssistant
 from supervisor.resolution.const import ContextType, IssueType
@@ -851,6 +851,33 @@ async def test_core_loads_wrong_image_for_machine(
     assert (
         coresys.homeassistant.image == "ghcr.io/home-assistant/qemux86-64-homeassistant"
     )
+
+
+@pytest.mark.usefixtures("path_extern")
+async def test_load_preinstalled_landingpage_keeps_version(
+    coresys: CoreSys, container: DockerContainer
+):
+    """Test load keeps LANDINGPAGE when the landingpage image has a real version label.
+
+    Regression test: the landingpage image stamps a real Core version into its
+    io.hass.version label while keeping io.hass.type=landingpage. On a Supervisor
+    restart the persisted version (LANDINGPAGE) must not be overwritten with that
+    real version, otherwise the landingpage is mistaken for an installed Core and
+    Core never gets installed.
+    """
+    coresys.homeassistant.version = LANDINGPAGE
+    coresys.homeassistant.override_image = True
+    container.show.return_value["Config"] = {
+        "Labels": {
+            "io.hass.type": "landingpage",
+            "io.hass.version": "2026.06.3",
+        }
+    }
+
+    with patch.object(DockerHomeAssistant, "is_running", return_value=True):
+        await coresys.homeassistant.core.load()
+
+    assert coresys.homeassistant.version == LANDINGPAGE
 
 
 async def test_core_load_allows_image_override(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The landingpage image now stamps a real Core version into its io.hass.version label rather than the sentinel "landingpage" string. Supervisor decided whether Core was still just a landingpage by comparing that version against the LANDINGPAGE constant, so with the new label it mistook the landingpage for an installed Core. Restarting the Supervisor mid-install then stranded the system on the landingpage until the next OS reboot, with no install job scheduled and the watchdog hot-looping on the missing Core auth API.

Override the version resolution for the Home Assistant container so a landingpage image (io.hass.type == "landingpage") always reports LANDINGPAGE, keeping every existing version check working unchanged while leaving io.hass.version free to carry the real version.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #6934
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
