### PR TITLE
Fix `ha os import` in OS 18.0.rc1 and newer

### DIFF
--- a/supervisor/os/manager.py
+++ b/supervisor/os/manager.py
@@ -267,7 +267,14 @@ class OSManager(CoreSysAttributes):
         _LOGGER.info(
             "Synchronizing configuration from USB with Home Assistant Operating System."
         )
-        await self.sys_host.services.restart("hassos-config.service")
+        # hassos-config.service was renamed to haos-config.service in HAOS 18.0.
+        # The unit's Alias= is not reported by systemd's ListUnits, which
+        # ServiceManager.exists() relies on, so call the correct unit here.
+        if self.version is not None and self.version >= AwesomeVersion("18.0.rc1"):
+            service = "haos-config.service"
+        else:
+            service = "hassos-config.service"
+        await self.sys_host.services.restart(service)
 
     @Job(
         name="os_manager_update",

--- a/tests/os/test_manager.py
+++ b/tests/os/test_manager.py
@@ -261,3 +261,22 @@ async def test_load_slot_status_fresh_install(
     assert len(coresys.os.slots) == 6
     assert coresys.os.get_slot_name("A") == "kernel.0"
     assert coresys.os.get_slot_name("B") == "kernel.1"
+
+
+@pytest.mark.parametrize(
+    ("os_available", "expected_service"),
+    [
+        ("17.3", "hassos-config.service"),
+        ("18.0.rc1", "haos-config.service"),
+        ("18.0", "haos-config.service"),
+    ],
+    indirect=["os_available"],
+)
+async def test_config_sync_service_name(
+    coresys: CoreSys, os_available: None, expected_service: str
+) -> None:
+    """Test config_sync uses the correct service name per OS version."""
+    with patch.object(coresys.host.services, "restart", new=AsyncMock()) as restart:
+        await coresys.os.config_sync()
+
+    restart.assert_called_once_with(expected_service)


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The hassos-config service was renamed to haos-config in home-assistant/operating-system#4740. This change preserved the old name as an alias, however, Supervisor uses ListUnits that doesn't report the aliases and then thinks such unit doesn't exist. To fix that, simply call the unit by its primary name which now varies by the OS version.
## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #6942
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
