### PR TITLE
Warn when skipping persistent timezone on OS older than 16.2

### DIFF
--- a/supervisor/host/control.py
+++ b/supervisor/host/control.py
@@ -126,9 +126,7 @@ class SystemControl(CoreSysAttributes):
             await self.sys_dbus.timedate.set_timezone(timezone)
             await self.sys_dbus.timedate.update()
         else:
-            # pylint: disable=fixme
-            # TODO: we can change this to a warning once 16.2 is out
-            _LOGGER.info(
-                "Skipping persistent timezone setting, OS %s < 16.2",
+            _LOGGER.warning(
+                "Skipping persistent timezone setting, OS %s is older than 16.2",
                 self.sys_os.version,
             )


### PR DESCRIPTION
## Proposed change

Persisting the host timezone via D-Bus requires Home Assistant OS 16.2 or newer, since `/etc/localtime` is not writable on older versions. While 16.2 was still unreleased, the skip on older versions was logged at info level because running an older OS was the expected case, and the code carried a `TODO` to raise it to a warning once 16.2 shipped. Home Assistant OS 16.2 has since been released (it is in fact the release that propagates the configured timezone to the host), so an OS that still cannot persist the timezone is now outdated. This change raises the skip message to a warning to make the limitation visible to the user, and removes the now-resolved `TODO` along with its `# pylint: disable=fixme` suppression.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
