### PR TITLE
Treat mount errors as API errors instead of unexpected failures

### DIFF
--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -1412,8 +1412,14 @@ class SecurityJobError(SecurityError, JobException):
 # Mount
 
 
-class MountError(HassioError):
-    """Raise on an error related to mounting/unmounting."""
+class MountError(APIError):
+    """Raise on an error related to mounting/unmounting.
+
+    Mount failures generally reflect user configuration or host conditions
+    (unreachable server, wrong credentials, ...) rather than a Supervisor bug.
+    Modeling them as APIError keeps them out of the unexpected-error path that
+    logs a traceback and reports to Sentry.
+    """
 
 
 class MountActivationError(MountError):
@@ -1424,7 +1430,7 @@ class MountInvalidError(MountError):
     """Raise on invalid mount attempt."""
 
 
-class MountNotFound(MountError):
+class MountNotFound(MountError, APINotFound):
     """Raise on mount not found."""
 
 

--- a/tests/api/test_mounts.py
+++ b/tests/api/test_mounts.py
@@ -127,20 +127,24 @@ async def test_api_create_dbus_error_mount_not_added(
     )
     systemd_service.response_start_transient_unit = DBusError(ErrorType.FAILED, "fail")
 
-    resp = await api_client.post(
-        f"{prefix}/mounts",
-        json={
-            "name": "backup_test",
-            "type": "cifs",
-            "usage": "backup",
-            "server": "backup.local",
-            "share": "backups",
-        },
-    )
-    assert resp.status == 400
-    result = await resp.json()
-    assert result["result"] == "error"
-    assert result["message"] == "Could not mount backup_test due to: fail"
+    # Mount failures reflect host/config conditions, not Supervisor bugs, so they
+    # must be reported as client-side errors without capturing to Sentry.
+    with patch("supervisor.api.utils.async_capture_exception") as capture_exception:
+        resp = await api_client.post(
+            f"{prefix}/mounts",
+            json={
+                "name": "backup_test",
+                "type": "cifs",
+                "usage": "backup",
+                "server": "backup.local",
+                "share": "backups",
+            },
+        )
+        assert resp.status == 400
+        result = await resp.json()
+        assert result["result"] == "error"
+        assert result["message"] == "Could not mount backup_test due to: fail"
+        capture_exception.assert_not_called()
 
     resp = await api_client.get(f"{prefix}/mounts")
     result = await resp.json()
@@ -154,23 +158,25 @@ async def test_api_create_dbus_error_mount_not_added(
     systemd_service.response_start_transient_unit = "/org/freedesktop/systemd1/job/7623"
     systemd_unit_service.active_state = ["failed", "failed", "inactive"]
 
-    resp = await api_client.post(
-        f"{prefix}/mounts",
-        json={
-            "name": "backup_test",
-            "type": "cifs",
-            "usage": "backup",
-            "server": "backup.local",
-            "share": "backups",
-        },
-    )
-    assert resp.status == 400
-    result = await resp.json()
-    assert result["result"] == "error"
-    assert (
-        result["message"]
-        == "Mounting backup_test did not succeed. Check host logs for errors from mount or systemd unit mnt-data-supervisor-mounts-backup_test.mount for details."
-    )
+    with patch("supervisor.api.utils.async_capture_exception") as capture_exception:
+        resp = await api_client.post(
+            f"{prefix}/mounts",
+            json={
+                "name": "backup_test",
+                "type": "cifs",
+                "usage": "backup",
+                "server": "backup.local",
+                "share": "backups",
+            },
+        )
+        assert resp.status == 400
+        result = await resp.json()
+        assert result["result"] == "error"
+        assert (
+            result["message"]
+            == "Mounting backup_test did not succeed. Check host logs for errors from mount or systemd unit mnt-data-supervisor-mounts-backup_test.mount for details."
+        )
+        capture_exception.assert_not_called()
 
     resp = await api_client.get(f"{prefix}/mounts")
     result = await resp.json()


### PR DESCRIPTION
## Proposed change

Mount failures generally reflect user configuration or host conditions (unreachable server, wrong credentials, network down, ...) rather than a Supervisor bug. As a plain `HassioError`, `MountError` reached the generic error branch of `api_process`, which logged a full traceback as an "Unexpected error during API call" and captured the exception to Sentry. The mount reload path already encoded the opposite intent, explicitly skipping Sentry for `MountError`.

This makes `MountError` an `APIError` so mount failures are surfaced to the caller as client-side errors with their explicit message, without a redundant traceback or Sentry noise. This matches the existing handling of `JobException` (#6739). The informative error logged at the raise site (e.g. "Mounting m1 did not succeed...") is unaffected.

`MountNotFound` additionally inherits from `APINotFound` so it returns a 404 instead of a 400, while remaining a `MountError` so the existing `isinstance(err, MountError)` Sentry-skip check keeps working.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
