### PR TITLE
Redact app options in info for unprivileged apps

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -625,7 +625,7 @@ class RestAPI(CoreSysAttributes):
                 """Route to store if info requested for not installed app."""
                 try:
                     addon: App = api_apps.get_app_for_request(request)
-                    return await api_apps.info_data(addon)
+                    return await api_apps.info_data(addon, request)
                 except APIAppNotInstalled:
                     # Route to store/{app}/info but add missing fields
                     return dict(

--- a/supervisor/api/apps.py
+++ b/supervisor/api/apps.py
@@ -95,6 +95,8 @@ from ..const import (
     ATTR_WATCHDOG,
     ATTR_WEBUI,
     REQUEST_FROM,
+    ROLE_ADMIN,
+    ROLE_MANAGER,
     AppBoot,
     AppBootConfig,
 )
@@ -221,8 +223,19 @@ class APIApps(CoreSysAttributes):
         """Reload all app data from store."""
         await asyncio.shield(self.sys_store.reload())
 
-    async def info_data(self, app: App) -> dict[str, Any]:
+    async def info_data(self, app: App, request: web.Request) -> dict[str, Any]:
         """Build and return app information dict (raises on invalid state)."""
+        # User options may contain secrets. Expose them only to trusted callers:
+        # Home Assistant Core (and other non-app internals), the app itself, or
+        # an app with the manager/admin role. Any other app reading a different
+        # app's info gets the options redacted.
+        request_from = request.get(REQUEST_FROM)
+        expose_options = (
+            not isinstance(request_from, App)
+            or request_from is app
+            or request_from.hassio_role in (ROLE_MANAGER, ROLE_ADMIN)
+        )
+
         return {
             ATTR_NAME: app.name,
             ATTR_SLUG: app.slug,
@@ -238,7 +251,7 @@ class APIApps(CoreSysAttributes):
             ATTR_RATING: rating_security(app),
             ATTR_BOOT_CONFIG: app.boot_config,
             ATTR_BOOT: app.boot,
-            ATTR_OPTIONS: app.options,
+            ATTR_OPTIONS: app.options if expose_options else {},
             ATTR_SCHEMA: app.schema_ui,
             ATTR_ARCH: app.supported_arch,
             ATTR_MACHINE: app.supported_machine,
@@ -303,7 +316,7 @@ class APIApps(CoreSysAttributes):
     async def info(self, request: web.Request) -> dict[str, Any]:
         """Return app information."""
         app: App = self.get_app_for_request(request)
-        return await self.info_data(app)
+        return await self.info_data(app, request)
 
     @api_process
     async def options(self, request: web.Request) -> None:

--- a/tests/api/test_apps.py
+++ b/tests/api/test_apps.py
@@ -57,6 +57,55 @@ async def test_apps_info(
     assert result["data"]["watchdog"] is False
 
 
+@pytest.mark.parametrize("api_client", ["local_example"], indirect=True)
+async def test_apps_info_options_redacted_for_other_app(
+    api_client: TestClient,
+    install_app_ssh: App,
+    install_app_example: App,
+):
+    """Test a default-role app cannot read another app's options via info."""
+    install_app_example.data["hassio_role"] = "default"
+
+    # Request originates from local_example, reading local_ssh's info
+    resp = await api_client.get(f"/addons/{TEST_ADDON_SLUG}/info")
+    result = await resp.json()
+    # Non-secret metadata is still exposed...
+    assert result["data"]["slug"] == TEST_ADDON_SLUG
+    # ...but user options (which may hold secrets) are redacted
+    assert install_app_ssh.options != {}
+    assert result["data"]["options"] == {}
+
+
+@pytest.mark.parametrize("api_client", ["local_example"], indirect=True)
+async def test_apps_info_options_exposed_to_manager(
+    api_client: TestClient,
+    install_app_ssh: App,
+    install_app_example: App,
+):
+    """Test a manager-role app can read another app's options via info."""
+    install_app_example.data["hassio_role"] = "manager"
+
+    # Request originates from local_example (manager), reading local_ssh's info
+    resp = await api_client.get(f"/addons/{TEST_ADDON_SLUG}/info")
+    result = await resp.json()
+    assert install_app_ssh.options != {}
+    assert result["data"]["options"] == install_app_ssh.options
+
+
+@pytest.mark.parametrize("api_client", [TEST_ADDON_SLUG], indirect=True)
+async def test_apps_info_options_visible_for_self(
+    api_client: TestClient,
+    install_app_ssh: App,
+):
+    """Test a default-role app can always read its own options via info."""
+    install_app_ssh.data["hassio_role"] = "default"
+
+    resp = await api_client.get("/addons/self/info")
+    result = await resp.json()
+    assert install_app_ssh.options != {}
+    assert result["data"]["options"] == install_app_ssh.options
+
+
 # DEPRECATED - Remove with legacy routing logic on 1/2023
 async def test_apps_info_not_installed(
     api_client: TestClient, coresys: CoreSys, test_repository: Repository


### PR DESCRIPTION
## Proposed change

The `/addons/{slug}/info` endpoint returned the target app's user `options`, which can contain secrets such as passwords and API keys. The security middleware grants every role (including the default role) access to any `/.+/info` path, so an installed app with `hassio_api: true` and the default role could read another app's options simply by requesting its info — even though the dedicated `/options/config` endpoint is already restricted to the app itself.

This redacts the `options` field in `info_data()` unless the caller is entitled to see it: Home Assistant Core (and other non-app internals), the app reading its own info, or an app with the `manager` or `admin` role. Other apps reading a different app's info now receive an empty options dict, while all non-secret metadata stays available for discovery. This mirrors the existing self-only restriction on the dedicated `/options/config` endpoint.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3186
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
