### PR TITLE
Handle Docker status-check failures in Home Assistant API paths

### DIFF
--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -35,6 +35,7 @@ from ..exceptions import (
     DockerNotFound,
     DockerRegistryAuthError,
     DockerRegistryRateLimitExceeded,
+    DockerTimeoutError,
     GithubContainerRegistryRateLimitExceeded,
 )
 from ..jobs.const import JOB_GROUP_DOCKER_INTERFACE, JobConcurrency
@@ -410,6 +411,10 @@ class DockerInterface(JobGroup, ABC):
         try:
             container = await self.sys_docker.containers.get(self.name)
             return await container.show()
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout occurred while getting container information for {self.name}: {err!s}"
+            ) from err
         except aiodocker.DockerError as err:
             if err.status == HTTPStatus.NOT_FOUND:
                 return None

--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -413,7 +413,7 @@ class DockerInterface(JobGroup, ABC):
             return await container.show()
         except TimeoutError as err:
             raise DockerTimeoutError(
-                f"Timeout occurred while getting container information for {self.name}: {err!s}"
+                f"Timeout occurred while getting container information for {self.name}"
             ) from err
         except aiodocker.DockerError as err:
             if err.status == HTTPStatus.NOT_FOUND:

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -1049,6 +1049,10 @@ class DockerError(HassioError):
     """Docker API/Transport errors."""
 
 
+class DockerTimeoutError(DockerError):
+    """Docker operation timed out."""
+
+
 class DockerBuildError(DockerError):
     """Docker error during build."""
 

--- a/supervisor/homeassistant/api.py
+++ b/supervisor/homeassistant/api.py
@@ -17,7 +17,7 @@ from ..const import SOCKET_CORE
 from ..coresys import CoreSys, CoreSysAttributes
 from ..docker.const import ENV_CORE_API_SOCKET, ContainerState
 from ..docker.monitor import DockerContainerStateEvent
-from ..exceptions import HomeAssistantAPIError, HomeAssistantAuthError
+from ..exceptions import DockerError, HomeAssistantAPIError, HomeAssistantAuthError
 from ..utils import version_is_new_enough
 from .const import LANDINGPAGE
 from .websocket import WSClient
@@ -190,6 +190,19 @@ class HomeAssistantAPI(CoreSysAttributes):
                     seconds=tokens["expires_in"]
                 )
 
+    async def _ensure_core_running(self) -> None:
+        """Ensure Core container is running before communicating with it."""
+        try:
+            if not await self.sys_homeassistant.core.instance.is_running():
+                raise HomeAssistantAPIError(
+                    "Core container is not running", _LOGGER.debug
+                )
+        except DockerError as err:
+            _LOGGER.debug("Error checking if Core container is running: %s", err)
+            raise HomeAssistantAPIError(
+                "Unable to determine if Core container is running"
+            ) from err
+
     async def connect_websocket(self) -> WSClient:
         """Connect a WebSocket to Core, handling auth as appropriate.
 
@@ -201,8 +214,7 @@ class HomeAssistantAPI(CoreSysAttributes):
             HomeAssistantAPIError: On connection or auth failure.
 
         """
-        if not await self.sys_homeassistant.core.instance.is_running():
-            raise HomeAssistantAPIError("Core container is not running", _LOGGER.debug)
+        await self._ensure_core_running()
 
         if self.use_unix_socket:
             return await WSClient.connect(self.session, self.ws_url)
@@ -265,8 +277,7 @@ class HomeAssistantAPI(CoreSysAttributes):
                 network errors, timeouts, or connection failures
 
         """
-        if not await self.sys_homeassistant.core.instance.is_running():
-            raise HomeAssistantAPIError("Core container is not running", _LOGGER.debug)
+        await self._ensure_core_running()
 
         url = f"{self.api_url}/{path}"
         headers = headers or {}

--- a/tests/docker/test_interface.py
+++ b/tests/docker/test_interface.py
@@ -25,6 +25,7 @@ from supervisor.exceptions import (
     DockerNotFound,
     DockerRegistryAuthError,
     DockerRegistryRateLimitExceeded,
+    DockerTimeoutError,
     GithubContainerRegistryRateLimitExceeded,
 )
 from supervisor.homeassistant.const import WSEvent, WSType
@@ -231,6 +232,14 @@ async def test_current_state_failures(coresys: CoreSys):
         500, {"message": "fail"}
     )
     with pytest.raises(DockerAPIError):
+        await coresys.homeassistant.core.instance.current_state()
+
+
+async def test_current_state_timeout(coresys: CoreSys):
+    """Test timeout while reading container state raises DockerTimeoutError."""
+    coresys.docker.containers.get.side_effect = TimeoutError("timed out")
+
+    with pytest.raises(DockerTimeoutError, match="Timeout occurred"):
         await coresys.homeassistant.core.instance.current_state()
 
 

--- a/tests/homeassistant/test_api.py
+++ b/tests/homeassistant/test_api.py
@@ -9,7 +9,7 @@ import pytest
 from supervisor.coresys import CoreSys
 from supervisor.docker.const import ContainerState
 from supervisor.docker.monitor import DockerContainerStateEvent
-from supervisor.exceptions import HomeAssistantAPIError
+from supervisor.exceptions import DockerError, HomeAssistantAPIError
 from supervisor.homeassistant.api import APIState, HomeAssistantAPI
 from supervisor.homeassistant.const import LANDINGPAGE
 
@@ -297,6 +297,19 @@ async def test_make_request_not_running(coresys: CoreSys):
             pass
 
 
+async def test_make_request_running_check_docker_error(coresys: CoreSys):
+    """Test make_request wraps Docker errors from running check."""
+    coresys.homeassistant.core.instance.is_running = AsyncMock(
+        side_effect=DockerError("docker failure")
+    )
+
+    with pytest.raises(
+        HomeAssistantAPIError, match="Unable to determine if Core container is running"
+    ):
+        async with coresys.homeassistant.api.make_request("get", "api/test"):
+            pass
+
+
 @pytest.mark.usefixtures("websession")
 async def test_make_request_tcp_with_token_fetch(coresys: CoreSys):
     """Test make_request fetches token via /auth/token and makes the request."""
@@ -360,6 +373,18 @@ async def test_connect_websocket_unix(coresys: CoreSys):
 
     assert result is mock_ws_client
     mock_connect.assert_called_once()
+
+
+async def test_connect_websocket_running_check_docker_error(coresys: CoreSys):
+    """Test connect_websocket wraps Docker errors from running check."""
+    coresys.homeassistant.core.instance.is_running = AsyncMock(
+        side_effect=DockerError("docker failure")
+    )
+
+    with pytest.raises(
+        HomeAssistantAPIError, match="Unable to determine if Core container is running"
+    ):
+        await coresys.homeassistant.api.connect_websocket()
 
 
 @pytest.mark.usefixtures("websession")


### PR DESCRIPTION
## Proposed change

This PR fixes unhandled Docker status-check failures that can bubble out of Home Assistant API communication paths.

Changes included:
- Add a dedicated `DockerTimeoutError` that inherits from `DockerError`.
- Raise `DockerTimeoutError` from `_get_container` when `TimeoutError` occurs while querying Docker container metadata.
- Standardize Core-running preflight checks in `HomeAssistantAPI` via a shared helper.
- Use that helper in both `make_request` and `connect_websocket`.
- Wrap `DockerError` from the running check as `HomeAssistantAPIError` to preserve existing fail-fast behavior and API contract.
- Add tests for timeout wrapping and DockerError wrapping paths.

The change to `_get_container` also addresses the separately linked sentry issue below about `App.start`. It will no longer bubble `asyncio.TimeoutError` as an unhandled exception and instead report a `DockerTimeoutError` that is handled the same as other errors communicating with docker in that codepath.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
    - `make_request` codepath: https://home-assistant-io.sentry.io/issues/7241686140/events/e71e265dfe75468a9aaa7e4d852e30ba/, https://home-assistant-io.sentry.io/issues/7449775230/events/c6b273edaac442db8d6ba54d78d80bad/
    - `App.start` -> `is_running` codepath: https://home-assistant-io.sentry.io/issues/7241686140/events/8ecf59a6809c4b8c989872b265128102/ 
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

Sentry impact context:
- ~165k reports in the latest release between the two events
- ~350k reports total in the past week
- `App.start` issue has ~1.5k reports in the past week, most from latest release

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/