### PR TITLE
Precompute bind mount paths in folder backup filter

### DIFF
--- a/supervisor/backups/backup.py
+++ b/supervisor/backups/backup.py
@@ -766,18 +766,18 @@ class Backup(JobGroup):
             # Take backup
             _LOGGER.info("Backing up folder %s", name)
 
+            # Bind mounts are constant during the backup, so resolve the set of
+            # paths to skip once instead of per file.
+            excluded_paths = {
+                bound.bind_mount.local_where for bound in self.sys_mounts.bound_mounts
+            }
+
             def is_excluded_by_filter(item_arcpath: PurePath) -> bool:
                 """Filter out bind mounts in folders being backed up."""
                 full_path = origin_dir / item_arcpath.relative_to(".")
 
-                for bound in self.sys_mounts.bound_mounts:
-                    if full_path != bound.bind_mount.local_where:
-                        continue
-                    _LOGGER.debug(
-                        "Ignoring %s because of %s",
-                        full_path,
-                        bound.bind_mount.local_where.as_posix(),
-                    )
+                if full_path in excluded_paths:
+                    _LOGGER.debug("Ignoring %s because of bind mount", full_path)
                     return True
 
                 return False


### PR DESCRIPTION
## Proposed change

The per-file exclusion filter in folder backups (`Backup._folder_save`) looped over `self.sys_mounts.bound_mounts` for every file in the folder. That property rebuilds a list from a dict on each access, so backing up a folder with many files meant rebuilding the list and scanning it linearly once per file.

Bind mounts don't change during a backup, so this resolves the set of paths to skip once up front and turns the per-file check into a single set membership test. Behavior is unchanged: `local_where` is always a `Path`, so the set comparison matches the old `!=` logic exactly. The only visible difference is the debug log line no longer echoes the mount's own path, which was the same value as the file path in the match case anyway.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
