### PR TITLE
Allow slashes in add-on repository branch names

### DIFF
--- a/supervisor/validate.py
+++ b/supervisor/validate.py
@@ -59,7 +59,7 @@ from .docker.utils import get_registry_from_image
 from .utils.validate import validate_timezone
 
 # Move to store.validate when addons_repository config removed
-RE_REPOSITORY = re.compile(r"^(?P<url>[^#]+)(?:#(?P<branch>[\w\-.]+))?$")
+RE_REPOSITORY = re.compile(r"^(?P<url>[^#]+)(?:#(?P<branch>[\w\-./]+))?$")
 RE_REGISTRY = re.compile(r"^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$")
 
 # pylint: disable=no-value-for-parameter

--- a/tests/store/test_validate.py
+++ b/tests/store/test_validate.py
@@ -11,6 +11,8 @@ from supervisor.store.validate import repositories
     [
         (["core", "local"], True),
         (["https://github.com/hassio-addons/repository"], True),
+        (["https://github.com/hassio-addons/repository#beta"], True),
+        (["https://github.com/hassio-addons/repository#feature/hot-new-stuff"], True),
         (["not_a_url"], False),
         (["https://fail.com/duplicate", "https://fail.com/duplicate"], False),
     ],


### PR DESCRIPTION
## Proposed change

Add-on repositories can pin a specific branch using the `url#branch` syntax. The branch part of the repository regex (`RE_REPOSITORY`) only accepted word characters, hyphens, and dots, so a branch name containing a slash like `feature/hot-new-stuff` failed to match and the repository was rejected as an invalid format.

Git branch names commonly use prefixes such as `feature/` or `fix/`, so this allows slashes in the captured branch name. The `url` group already stops at the first `#`, so widening the branch character class is the complete fix. Both consumers of the regex (the repository validator and `GitRepo`) benefit.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #6535
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
