### PR TITLE
Offer reset for corrupt store repositories on load

### DIFF
--- a/supervisor/resolution/fixups/store_execute_reset.py
+++ b/supervisor/resolution/fixups/store_execute_reset.py
@@ -51,9 +51,7 @@ class FixupStoreExecuteReset(FixupBase):
             # problem is upstream and retrying won't help. Drop the reset
             # suggestion to stop the hourly auto-retry, while leaving the
             # issue (and its remove suggestion) so the user stays informed.
-            for suggestion in self.all_suggestions:
-                if suggestion.reference == reference:
-                    self.sys_resolution.dismiss_suggestion(suggestion)
+            self.sys_resolution.dismiss_suggestion(suggestion)
             raise ResolutionFixupError from None
         except StoreError:
             raise ResolutionFixupError from None

--- a/supervisor/resolution/fixups/store_execute_reset.py
+++ b/supervisor/resolution/fixups/store_execute_reset.py
@@ -7,6 +7,7 @@ from ...exceptions import (
     ResolutionFixupError,
     ResolutionFixupJobError,
     StoreError,
+    StoreInvalidAppRepo,
     StoreNotFound,
 )
 from ...jobs.const import JobCondition
@@ -45,6 +46,15 @@ class FixupStoreExecuteReset(FixupBase):
 
         try:
             await repository.reset()
+        except StoreInvalidAppRepo:
+            # The repository re-cloned fine but still isn't valid, so the
+            # problem is upstream and retrying won't help. Drop the reset
+            # suggestion to stop the hourly auto-retry, while leaving the
+            # issue (and its remove suggestion) so the user stays informed.
+            for suggestion in self.all_suggestions:
+                if suggestion.reference == reference:
+                    self.sys_resolution.dismiss_suggestion(suggestion)
+            raise ResolutionFixupError from None
         except StoreError:
             raise ResolutionFixupError from None
 

--- a/supervisor/store/__init__.py
+++ b/supervisor/store/__init__.py
@@ -199,7 +199,13 @@ class StoreManager(CoreSysAttributes, FileConfiguration):
                         IssueType.CORRUPT_REPOSITORY,
                         ContextType.STORE,
                         reference=repository.slug,
-                        suggestions=[SuggestionType.EXECUTE_REMOVE],
+                        # A repository that validated before and now doesn't is
+                        # most likely a corrupt local copy. Offer a reset to
+                        # re-clone and self-heal, keeping removal as a fallback.
+                        suggestions=[
+                            SuggestionType.EXECUTE_RESET,
+                            SuggestionType.EXECUTE_REMOVE,
+                        ],
                     )
                 else:
                     await repository.remove()

--- a/supervisor/store/repository.py
+++ b/supervisor/store/repository.py
@@ -215,7 +215,7 @@ class RepositoryGit(Repository, ABC):
         # failure instead of silently considering it fixed.
         if not await self.validate():
             raise StoreInvalidAppRepo(
-                f"Repository {self.slug} is still not a valid add-on repository "
+                f"Repository {self.slug} is still not a valid app repository "
                 "after reset",
                 logger=_LOGGER.error,
             )

--- a/supervisor/store/repository.py
+++ b/supervisor/store/repository.py
@@ -21,6 +21,7 @@ from ..exceptions import (
     ConfigurationFileError,
     StoreError,
     StoreGitError,
+    StoreInvalidAppRepo,
     StoreRepositoryLocalCannotReset,
     StoreRepositoryUnknownError,
 )
@@ -213,10 +214,11 @@ class RepositoryGit(Repository, ABC):
         # example the repository configuration was removed), so report the
         # failure instead of silently considering it fixed.
         if not await self.validate():
-            _LOGGER.error(
-                "Reset of repository %s did not yield a valid repo", self.slug
+            raise StoreInvalidAppRepo(
+                f"Repository {self.slug} is still not a valid add-on repository "
+                "after reset",
+                logger=_LOGGER.error,
             )
-            raise StoreRepositoryUnknownError(repo=self.slug)
 
 
 class RepositoryLocal(RepositoryBuiltin):

--- a/supervisor/store/repository.py
+++ b/supervisor/store/repository.py
@@ -208,6 +208,16 @@ class RepositoryGit(Repository, ABC):
             _LOGGER.error("Can't reset repository %s: %s", self.slug, err)
             raise StoreRepositoryUnknownError(repo=self.slug) from err
 
+        # A reset only recovers a corrupt local copy. If the freshly cloned
+        # repository still doesn't validate, the problem is upstream (for
+        # example the repository configuration was removed), so report the
+        # failure instead of silently considering it fixed.
+        if not await self.validate():
+            _LOGGER.error(
+                "Reset of repository %s did not yield a valid repo", self.slug
+            )
+            raise StoreRepositoryUnknownError(repo=self.slug)
+
 
 class RepositoryLocal(RepositoryBuiltin):
     """A local app repository."""

--- a/tests/resolution/fixup/test_store_execute_reset.py
+++ b/tests/resolution/fixup/test_store_execute_reset.py
@@ -87,11 +87,17 @@ async def test_fixup(coresys: CoreSys):
 
 @pytest.mark.usefixtures("supervisor_internet")
 async def test_fixup_still_invalid_after_reset(coresys: CoreSys):
-    """Test issue is kept when the repository is still invalid after reset."""
+    """Test reset suggestion is dropped but issue kept when repo stays invalid."""
     store_execute_reset = FixupStoreExecuteReset(coresys)
     test_repo = coresys.config.path_apps_git / "94cfad5a"
 
     add_store_reset_suggestion(coresys)
+    # A remove suggestion is offered alongside reset for corrupt repositories
+    coresys.resolution.add_suggestion(
+        Suggestion(
+            SuggestionType.EXECUTE_REMOVE, ContextType.STORE, reference="94cfad5a"
+        )
+    )
     test_repo.mkdir(parents=True)
 
     async def mock_clone(obj: GitRepo, path: Path | None = None):
@@ -111,8 +117,13 @@ async def test_fixup_still_invalid_after_reset(coresys: CoreSys):
     ):
         await store_execute_reset()
 
-    # The reset did not actually fix the repository, so the issue must remain
-    assert len(coresys.resolution.suggestions) == 1
+    # Retrying the reset won't help, so its suggestion is dropped to stop the
+    # hourly auto-retry. The issue and the remove suggestion must remain.
+    suggestion_types = {
+        suggestion.type for suggestion in coresys.resolution.suggestions
+    }
+    assert SuggestionType.EXECUTE_RESET not in suggestion_types
+    assert SuggestionType.EXECUTE_REMOVE in suggestion_types
     assert len(coresys.resolution.issues) == 1
     assert len(list(coresys.config.path_tmp.iterdir())) == 0
 

--- a/tests/resolution/fixup/test_store_execute_reset.py
+++ b/tests/resolution/fixup/test_store_execute_reset.py
@@ -19,7 +19,7 @@ from supervisor.resolution.const import (
 from supervisor.resolution.data import Issue, Suggestion
 from supervisor.resolution.fixups.store_execute_reset import FixupStoreExecuteReset
 from supervisor.store.git import GitRepo
-from supervisor.store.repository import Repository
+from supervisor.store.repository import Repository, RepositoryGit
 
 
 @pytest.fixture(name="mock_addons_git", autouse=True)
@@ -72,6 +72,7 @@ async def test_fixup(coresys: CoreSys):
     with (
         patch.object(GitRepo, "load"),
         patch.object(GitRepo, "_clone", new=mock_clone),
+        patch.object(RepositoryGit, "validate", return_value=True),
         patch("shutil.disk_usage", return_value=(42, 42, 2 * (1024.0**3))),
     ):
         await store_execute_reset()
@@ -81,6 +82,38 @@ async def test_fixup(coresys: CoreSys):
     assert not corrupt_marker.exists()
     assert len(coresys.resolution.suggestions) == 0
     assert len(coresys.resolution.issues) == 0
+    assert len(list(coresys.config.path_tmp.iterdir())) == 0
+
+
+@pytest.mark.usefixtures("supervisor_internet")
+async def test_fixup_still_invalid_after_reset(coresys: CoreSys):
+    """Test issue is kept when the repository is still invalid after reset."""
+    store_execute_reset = FixupStoreExecuteReset(coresys)
+    test_repo = coresys.config.path_apps_git / "94cfad5a"
+
+    add_store_reset_suggestion(coresys)
+    test_repo.mkdir(parents=True)
+
+    async def mock_clone(obj: GitRepo, path: Path | None = None):
+        """Mock of clone method."""
+        path = path or obj.path
+        await coresys.run_in_executor((path / ".git").mkdir)
+
+    coresys.store.repositories["94cfad5a"] = Repository.create(
+        coresys, "https://github.com/home-assistant/addons-example"
+    )
+    with (
+        patch.object(GitRepo, "load"),
+        patch.object(GitRepo, "_clone", new=mock_clone),
+        # Repository re-clones fine but its content is still not valid
+        patch.object(RepositoryGit, "validate", return_value=False),
+        patch("shutil.disk_usage", return_value=(42, 42, 2 * (1024.0**3))),
+    ):
+        await store_execute_reset()
+
+    # The reset did not actually fix the repository, so the issue must remain
+    assert len(coresys.resolution.suggestions) == 1
+    assert len(coresys.resolution.issues) == 1
     assert len(list(coresys.config.path_tmp.iterdir())) == 0
 
 

--- a/tests/store/test_custom_repository.py
+++ b/tests/store/test_custom_repository.py
@@ -126,12 +126,15 @@ async def test_add_invalid_repository_file(
             set(current) | {"http://example.com"}, issue_on_error=True
         )
 
-        assert not await get_repository_by_url(
-            store_manager, "http://example.com"
-        ).validate()
+        repository = get_repository_by_url(store_manager, "http://example.com")
+        assert not await repository.validate()
 
     assert "http://example.com" in coresys.store.repository_urls
-    assert {suggestion.type for suggestion in coresys.resolution.suggestions} == {
+    assert {
+        suggestion.type
+        for suggestion in coresys.resolution.suggestions
+        if suggestion.reference == repository.slug
+    } == {
         SuggestionType.EXECUTE_RESET,
         SuggestionType.EXECUTE_REMOVE,
     }

--- a/tests/store/test_custom_repository.py
+++ b/tests/store/test_custom_repository.py
@@ -131,7 +131,10 @@ async def test_add_invalid_repository_file(
         ).validate()
 
     assert "http://example.com" in coresys.store.repository_urls
-    assert coresys.resolution.suggestions[-1].type == SuggestionType.EXECUTE_REMOVE
+    assert {suggestion.type for suggestion in coresys.resolution.suggestions} == {
+        SuggestionType.EXECUTE_RESET,
+        SuggestionType.EXECUTE_REMOVE,
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change

When a saved git store repository loads but fails validation (for example because the local clone lost its `repository.json`/`.yaml` configuration file), the only suggestion Supervisor offered was to remove the repository. Removal is refused when an installed add-on still uses that repository, so the user ends up stuck with a corrupt local copy and no way to recover it.

This adds an `EXECUTE_RESET` suggestion alongside `EXECUTE_REMOVE` for that case. The reset fixup re-clones the repository and runs automatically, so a corrupt local copy self-heals, while removal stays available as a manual fallback. This mirrors how the `pull()` corruption path already behaves.

The branch is only reached for repositories that validated successfully before (first-time adds use a path that raises instead of creating an issue), so a now-invalid copy is most likely local corruption that re-cloning fixes.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #6635
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
