### PR TITLE
Use zip() instead of range(len()) for paired iteration

### DIFF
--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -975,7 +975,9 @@ class BackupManager(FileConfiguration, JobGroup):
         is_running: list[bool] = await asyncio.gather(
             *[app.is_running() for app in installed]
         )
-        running_apps = [app for app, running in zip(installed, is_running, strict=True) if running]
+        running_apps = [
+            app for app, running in zip(installed, is_running, strict=True) if running
+        ]
 
         # Create thaw task first to ensure we eventually undo freezes even if the below fails
         self._thaw_task = asyncio.shield(

--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -969,7 +969,7 @@ class BackupManager(FileConfiguration, JobGroup):
         is_running: list[bool] = await asyncio.gather(
             *[app.is_running() for app in installed]
         )
-        running_apps = [app for app, running in zip(installed, is_running) if running]
+        running_apps = [app for app, running in zip(installed, is_running, strict=True) if running]
 
         # Create thaw task first to ensure we eventually undo freezes even if the below fails
         self._thaw_task = asyncio.shield(

--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -969,9 +969,7 @@ class BackupManager(FileConfiguration, JobGroup):
         is_running: list[bool] = await asyncio.gather(
             *[app.is_running() for app in installed]
         )
-        running_apps = [
-            installed[ind] for ind in range(len(installed)) if is_running[ind]
-        ]
+        running_apps = [app for app, running in zip(installed, is_running) if running]
 
         # Create thaw task first to ensure we eventually undo freezes even if the below fails
         self._thaw_task = asyncio.shield(

--- a/supervisor/jobs/decorator.py
+++ b/supervisor/jobs/decorator.py
@@ -470,7 +470,9 @@ class Job(CoreSysAttributes):
             )
 
             if update_failures := [
-                out_of_date[i].slug for i in range(len(errors)) if errors[i] is not None
+                plugin.slug
+                for plugin, error in zip(out_of_date, errors)
+                if error is not None
             ]:
                 raise JobConditionException(
                     f"'{method_name}' blocked from execution, was unable to update plugin(s) {', '.join(update_failures)} and all plugins must be up to date first"

--- a/supervisor/mounts/manager.py
+++ b/supervisor/mounts/manager.py
@@ -160,7 +160,9 @@ class MountManager(FileConfiguration, CoreSysAttributes):
         )
 
         # Try to reload failed mounts and report issues if failure persists
-        failures = [mounts[i] for i in range(len(mounts)) if results[i] is not True]
+        failures = [
+            mount for mount, result in zip(mounts, results) if result is not True
+        ]
         await self._mount_errors_to_issues(
             failures, [self.reload_mount(mount.name) for mount in failures]
         )


### PR DESCRIPTION
## Proposed change

Three list comprehensions paired a list with its `asyncio.gather()` results by index using `range(len(...))`. This iterates the pairs directly with `zip()` instead, which reads cleaner and drops the manual indexing:

- `supervisor/mounts/manager.py` (failed-mount collection)
- `supervisor/backups/manager.py` (running-apps filter)
- `supervisor/jobs/decorator.py` (plugin update-failure slugs)

`asyncio.gather()` returns results in the same order and length as its input list, so each pair lines up and the behavior is unchanged. Pure readability cleanup, no functional change.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
