### PR TITLE
Use a set for backup app slug lookups when removing delta apps

### DIFF
--- a/supervisor/backups/backup.py
+++ b/supervisor/backups/backup.py
@@ -728,8 +728,10 @@ class Backup(JobGroup):
     async def remove_delta_apps(self) -> bool:
         """Remove apps which are not in this backup."""
         success = True
+        # Resolve the backup's app slugs once for fast membership checks
+        backup_app_slugs = set(self.app_list)
         for app in self.sys_apps.installed:
-            if app.slug in self.app_list:
+            if app.slug in backup_app_slugs:
                 continue
 
             # Remove App because it's not a part of the new env


### PR DESCRIPTION
## Proposed change

`Backup.remove_delta_apps` checks each installed app against the backup's app list to decide what to uninstall. It tested membership against the `app_list` property, which rebuilds a list on every access, so the check rebuilt and linearly scanned that list once per installed app.

Resolve the slugs into a set once before the loop and use that for constant-time membership checks. Behavior is unchanged; it's a small clarity/efficiency cleanup on the restore path.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
