### PR TITLE
Read store repository app folders in parallel

### DIFF
--- a/supervisor/store/data.py
+++ b/supervisor/store/data.py
@@ -1,5 +1,6 @@
 """Init file for Supervisor app data."""
 
+import asyncio
 from dataclasses import dataclass
 import errno
 import logging
@@ -111,22 +112,10 @@ class StoreData(CoreSysAttributes):
 
     async def update(self) -> None:
         """Read data from app repository."""
-        # read core repository
-        apps = await self._read_apps_folder(
-            self.sys_config.path_apps_core, REPOSITORY_CORE
-        )
-
-        # read local repository
-        apps.update(
-            await self._read_apps_folder(
-                self.sys_config.path_apps_local, REPOSITORY_LOCAL
-            )
-        )
-
         # add built-in repositories information
         repositories = await self.sys_run_in_executor(self._get_builtin_repositories)
 
-        # read custom git repositories
+        # discover custom git repositories
         def _read_git_repositories() -> list[ProcessedRepository]:
             return [
                 repo
@@ -135,9 +124,25 @@ class StoreData(CoreSysAttributes):
                 and (repo := _read_git_repository(repository_element))
             ]
 
-        for repo in await self.sys_run_in_executor(_read_git_repositories):
+        git_repositories = await self.sys_run_in_executor(_read_git_repositories)
+        for repo in git_repositories:
             repositories[repo.slug] = repo.config
-            apps.update(await self._read_apps_folder(repo.path, repo.slug))
+
+        # Read all repository app folders in parallel; they are independent and
+        # each produces apps under its own repository-prefixed slug.
+        folders = [
+            (self.sys_config.path_apps_core, REPOSITORY_CORE),
+            (self.sys_config.path_apps_local, REPOSITORY_LOCAL),
+            *((repo.path, repo.slug) for repo in git_repositories),
+        ]
+        folder_apps = await asyncio.gather(
+            *(self._read_apps_folder(path, slug) for path, slug in folders)
+        )
+
+        # Merge in folder order to preserve the previous precedence
+        apps: dict[str, dict[str, Any]] = {}
+        for result in folder_apps:
+            apps.update(result)
 
         self.repositories = repositories
         self.apps = apps


### PR DESCRIPTION
## Proposed change

`StoreData.update()` reads each repository's app folder in sequence: the core repository, the local repository, then every custom git repository one after another. Each read does a recursive `**/config.*` glob and parses every add-on config for that repository, so the total time grows with the number of repositories. This runs on every store reload (startup, adding/removing a repository, and the periodic reload), and is more expensive with large or network-backed repositories.

The repositories are independent and each produces apps under its own repository-prefixed slug (`{repository}_{slug}`), so this reads all app folders concurrently with `asyncio.gather` instead of awaiting them one by one. The results are merged in the original order (core, local, then git repositories), so behavior is unchanged; only the wall-clock time drops toward the slowest single repository instead of the sum of all of them.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
