### PR TITLE
List backup locations in parallel on reload

### DIFF
--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -295,10 +295,16 @@ class BackupManager(FileConfiguration, JobGroup):
             if location == DEFAULT
             else {location_name: self.backup_locations[location_name]}
         )
+        # List the backup files of all locations in parallel; a slow or
+        # network-backed location should not hold up the others.
+        location_items = list(locations.items())
+        location_files = await asyncio.gather(
+            *(self._list_backup_files(path) for _, path in location_items)
+        )
         tasks = [
             self.sys_create_task(_load_backup(_location, tar_file))
-            for _location, path in locations.items()
-            for tar_file in await self._list_backup_files(path)
+            for (_location, _), tar_files in zip(location_items, location_files)
+            for tar_file in tar_files
         ]
 
         _LOGGER.info("Found %d backup files", len(tasks))


### PR DESCRIPTION
## Proposed change

`BackupManager.reload()` listed the backup files of each location one after another: it awaited a location's directory check and `*.tar` glob before starting the next one. With several locations configured (local, cloud backup, and one or more network mounts), a slow or network-backed location held up listing all the others. This runs at startup (via `load()`) and on every backup-list refresh.

This lists the backup files of all locations concurrently with `asyncio.gather` instead. Each listing already handles its own `OSError` (returning an empty list), and the results are paired back with their location in order, so the behavior is unchanged; only the wall-clock time drops toward the slowest single location instead of the sum.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
