### PR TITLE
Refine Docker timeout handling and add regression tests

### DIFF
--- a/supervisor/docker/app.py
+++ b/supervisor/docker/app.py
@@ -34,6 +34,7 @@ from ..exceptions import (
     DockerError,
     DockerJobError,
     DockerNotFound,
+    DockerTimeoutError,
     HardwareNotFound,
 )
 from ..hardware.const import PolicyGroup
@@ -695,6 +696,11 @@ class DockerApp(DockerInterface):
         try:
             container = await self.sys_docker.containers.get(builder_name)
             await container.delete(force=True, v=True)
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                "Timeout cleaning up existing builder container",
+                _LOGGER.error,
+            ) from err
         except aiodocker.DockerError as err:
             if err.status != HTTPStatus.NOT_FOUND:
                 raise DockerBuildError(
@@ -762,6 +768,10 @@ class DockerApp(DockerInterface):
         try:
             # Update meta data
             self._meta = await self.sys_docker.images.inspect(app_image_tag)
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout getting image metadata for {app_image_tag} after build"
+            ) from err
         except aiodocker.DockerError as err:
             raise DockerBuildError(
                 f"Can't get image metadata for {app_image_tag} after build: {err!s}"
@@ -835,6 +845,10 @@ class DockerApp(DockerInterface):
             # Load needed docker objects
             container = await self.sys_docker.containers.get(self.name)
             socket = container.attach(stdin=True)
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout attaching to {self.name} stdin", _LOGGER.error
+            ) from err
         except aiodocker.DockerError as err:
             raise DockerError(
                 f"Can't attach to {self.name} stdin: {err!s}", _LOGGER.error
@@ -903,6 +917,11 @@ class DockerApp(DockerInterface):
 
         try:
             docker_container = await self.sys_docker.containers.get(self.name)
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout processing Hardware Event on {self.name}",
+                _LOGGER.error,
+            ) from err
         except aiodocker.DockerError as err:
             if err.status == HTTPStatus.NOT_FOUND:
                 if self._hw_listener:

--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -401,7 +401,7 @@ class DockerInterface(JobGroup, ABC):
 
     async def exists(self) -> bool:
         """Return True if Docker image exists in local repository."""
-        with suppress(aiodocker.DockerError):
+        with suppress(aiodocker.DockerError, TimeoutError):
             await self.sys_docker.images.inspect(f"{self.image}:{self.version!s}")
             return True
         return False
@@ -442,7 +442,7 @@ class DockerInterface(JobGroup, ABC):
         self, version: AwesomeVersion, *, skip_state_event_if_down: bool = False
     ) -> None:
         """Attach to running Docker container."""
-        with suppress(aiodocker.DockerError):
+        with suppress(aiodocker.DockerError, TimeoutError):
             docker_container = await self.sys_docker.containers.get(self.name)
             self._meta = await docker_container.show()
             self.sys_docker.monitor.watch_container(self._meta)
@@ -465,6 +465,10 @@ class DockerInterface(JobGroup, ABC):
                 self._meta = await self.sys_docker.images.inspect(
                     f"{self.image}:{version!s}"
                 )
+            except TimeoutError as err:
+                raise DockerTimeoutError(
+                    f"Timeout occurred while inspecting image {self.image}:{version!s}"
+                ) from err
             except aiodocker.DockerError as err:
                 if err.status != HTTPStatus.NOT_FOUND:
                     raise DockerAPIError(

--- a/supervisor/docker/manager.py
+++ b/supervisor/docker/manager.py
@@ -697,7 +697,8 @@ class DockerAPI(CoreSysAttributes):
                 ) from err
             _LOGGER.info("Pulling image %s:%s", image, tag)
             try:
-                await self.images.pull(image, tag=tag, timeout=None)
+                # Timeout is disabled for pull operations by default, matching docker-py behavior.
+                await self.images.pull(image, tag=tag)
             except aiodocker.DockerError as pull_err:
                 raise DockerError(
                     f"Can't pull image {image}:{tag}: {pull_err}", _LOGGER.error
@@ -749,10 +750,9 @@ class DockerAPI(CoreSysAttributes):
         raises only if the get fails afterwards. Additionally it fires progress reports for the pull
         on the bus so listeners can use that to update status for users.
         """
-        # Use timeout=None to disable timeout for pull operations, matching docker-py behavior.
-        # aiodocker converts None to ClientTimeout(total=None) which disables the timeout.
+        # Timeout is disabled for pull operations by default, matching docker-py behavior.
         async for e in self.images.pull(
-            repository, tag=tag, platform=platform, auth=auth, stream=True, timeout=None
+            repository, tag=tag, platform=platform, auth=auth, stream=True
         ):
             entry = PullLogEntry.from_pull_log_dict(job_id, e)
             if entry.error:

--- a/supervisor/docker/manager.py
+++ b/supervisor/docker/manager.py
@@ -43,6 +43,7 @@ from ..exceptions import (
     DockerNoSpaceOnDevice,
     DockerNotFound,
     DockerRegistryRateLimitExceeded,
+    DockerTimeoutError,
 )
 from ..utils.common import FileConfiguration
 from ..validate import SCHEMA_DOCKER_CONFIG
@@ -288,7 +289,12 @@ class DockerAPI(CoreSysAttributes):
 
     async def post_init(self) -> Self:
         """Post init actions that must be done in event loop."""
-        self._info = await DockerInfo.new(await self.docker.system.info())
+        try:
+            self._info = await DockerInfo.new(await self.docker.system.info())
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                "Timeout while getting Docker information", _LOGGER.error
+            ) from err
         await self.config.read_data()
         self._network = await DockerNetwork(self.docker).post_init(
             self.config.enable_ipv6, self.config.mtu
@@ -457,6 +463,68 @@ class DockerAPI(CoreSysAttributes):
 
         return config
 
+    async def _setup_container_network(
+        self,
+        container: DockerContainer,
+        *,
+        name: str | None,
+        hostname: str | None,
+        network_mode: str | None,
+        networking_config: dict[str, Any] | None,
+        ipv4: IPv4Address | None,
+    ) -> None:
+        """Set up networking for container before start."""
+        if networking_config or network_mode not in ("host", None):
+            return
+
+        # Attach network
+        if not network_mode:
+            alias = [hostname] if hostname else None
+            try:
+                await self.network.attach_container(
+                    container.id, name, alias=alias, ipv4=ipv4
+                )
+            except DockerError:
+                _LOGGER.warning(
+                    "Can't attach %s to hassio-network!", name or container.id
+                )
+            else:
+                with suppress(DockerError):
+                    await self.network.detach_default_bridge(container.id, name)
+            return
+
+        try:
+            host_network = await self.docker.networks.get(DOCKER_NETWORK_HOST)
+            host_network_meta = await host_network.show()
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                "Timeout getting host network information from Docker",
+                _LOGGER.error,
+            ) from err
+        except aiodocker.DockerError as err:
+            raise DockerError(
+                f"Can't get host network information from Docker: {err!s}",
+                _LOGGER.error,
+            ) from err
+
+        # Check if container is register on host
+        # https://github.com/moby/moby/issues/23302
+        if name and name in (
+            val.get("Name") for val in host_network_meta.get("Containers", {}).values()
+        ):
+            try:
+                await host_network.disconnect({"Container": name, "Force": True})
+            except TimeoutError as err:
+                raise DockerTimeoutError(
+                    f"Timeout disconnecting container {name} from host network",
+                    _LOGGER.error,
+                ) from err
+            except aiodocker.DockerError as err:
+                if err.status != HTTPStatus.NOT_FOUND:
+                    raise DockerError(
+                        f"Can't disconnect container {name} from host network: {err!s}"
+                    ) from err
+
     async def _run(
         self,
         image: str,
@@ -526,6 +594,10 @@ class DockerAPI(CoreSysAttributes):
         )
         try:
             container = await self.containers.create(config, name=name)
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout creating container from {image}:{tag}", _LOGGER.error
+            ) from err
         except aiodocker.DockerError as err:
             if err.status == HTTPStatus.NOT_FOUND:
                 raise DockerNotFound(
@@ -545,50 +617,22 @@ class DockerAPI(CoreSysAttributes):
             await self.sys_run_in_executor(setup_cidfile, cidfile_path)
 
         # Setup network for host and default modes
-        if not networking_config and network_mode in ("host", None):
-            # Attach network
-            if not network_mode:
-                alias = [hostname] if hostname else None
-                try:
-                    await self.network.attach_container(
-                        container.id, name, alias=alias, ipv4=ipv4
-                    )
-                except DockerError:
-                    _LOGGER.warning(
-                        "Can't attach %s to hassio-network!", name or container.id
-                    )
-                else:
-                    with suppress(DockerError):
-                        await self.network.detach_default_bridge(container.id, name)
-            else:
-                try:
-                    host_network = await self.docker.networks.get(DOCKER_NETWORK_HOST)
-                    host_network_meta = await host_network.show()
-                except aiodocker.DockerError as err:
-                    raise DockerError(
-                        f"Can't get host network information from Docker: {err!s}",
-                        _LOGGER.error,
-                    ) from err
-
-                # Check if container is register on host
-                # https://github.com/moby/moby/issues/23302
-                if name and name in (
-                    val.get("Name")
-                    for val in host_network_meta.get("Containers", {}).values()
-                ):
-                    try:
-                        await host_network.disconnect(
-                            {"Container": name, "Force": True}
-                        )
-                    except aiodocker.DockerError as err:
-                        if err.status != HTTPStatus.NOT_FOUND:
-                            raise DockerError(
-                                f"Can't disconnect container {name} from host network: {err!s}"
-                            ) from err
+        await self._setup_container_network(
+            container,
+            name=name,
+            hostname=hostname,
+            network_mode=network_mode,
+            networking_config=networking_config,
+            ipv4=ipv4,
+        )
 
         # Run container
         try:
             await container.start()
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout starting {name or container.id}", _LOGGER.error
+            ) from err
         except aiodocker.DockerError as err:
             if err.status == HTTPStatus.INTERNAL_SERVER_ERROR and (
                 match := RE_PORT_CONFLICT_ERROR.match(err.message)
@@ -615,6 +659,10 @@ class DockerAPI(CoreSysAttributes):
         # Get container metadata after the container is started
         try:
             container_attrs = await container.show()
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout inspecting started container {name}", _LOGGER.error
+            ) from err
         except aiodocker.DockerError as err:
             raise DockerAPIError(
                 f"Can't inspect started container {name}: {err}", _LOGGER.error
@@ -638,6 +686,10 @@ class DockerAPI(CoreSysAttributes):
         # Ensure image exists, pull if not found
         try:
             await self.images.inspect(f"{image}:{tag}")
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout inspecting image {image}:{tag}", _LOGGER.error
+            ) from err
         except aiodocker.DockerError as err:
             if err.status != HTTPStatus.NOT_FOUND:
                 raise DockerError(
@@ -645,7 +697,7 @@ class DockerAPI(CoreSysAttributes):
                 ) from err
             _LOGGER.info("Pulling image %s:%s", image, tag)
             try:
-                await self.images.pull(image, tag=tag)
+                await self.images.pull(image, tag=tag, timeout=None)
             except aiodocker.DockerError as pull_err:
                 raise DockerError(
                     f"Can't pull image {image}:{tag}: {pull_err}", _LOGGER.error
@@ -662,12 +714,16 @@ class DockerAPI(CoreSysAttributes):
                 skip_cidfile=True,
                 **kwargs,
             )
+        except DockerError as err:
+            # _run() already logs the root cause when creating DockerError-derived exceptions.
+            # Re-raise here with command context without duplicating error-level logging.
+            raise DockerError(f"Can't execute command: {err}") from err
 
+        try:
             # wait until command is done
             result = await container.wait()
             log = await container.log(stdout=stdout, stderr=stderr, follow=False)
-
-        except (DockerError, aiodocker.DockerError) as err:
+        except aiodocker.DockerError as err:
             raise DockerError(f"Can't execute command: {err}", _LOGGER.error) from err
 
         finally:
@@ -715,6 +771,8 @@ class DockerAPI(CoreSysAttributes):
         try:
             output = await self.docker.containers.prune()
             _LOGGER.debug("Containers prune: %s", output)
+        except TimeoutError:
+            _LOGGER.warning("Error for containers prune: timed out")
         except aiodocker.DockerError as err:
             _LOGGER.warning("Error for containers prune: %s", err)
 
@@ -722,6 +780,8 @@ class DockerAPI(CoreSysAttributes):
         try:
             output = await self.images.prune(filters={"dangling": "false"})
             _LOGGER.debug("Images prune: %s", output)
+        except TimeoutError:
+            _LOGGER.warning("Error for images prune: timed out")
         except aiodocker.DockerError as err:
             _LOGGER.warning("Error for images prune: %s", err)
 
@@ -729,6 +789,8 @@ class DockerAPI(CoreSysAttributes):
         try:
             output = await self.images.prune_builds()
             _LOGGER.debug("Builds prune: %s", output)
+        except TimeoutError:
+            _LOGGER.warning("Error for builds prune: timed out")
         except aiodocker.DockerError as err:
             _LOGGER.warning("Error for builds prune: %s", err)
 
@@ -736,6 +798,8 @@ class DockerAPI(CoreSysAttributes):
         try:
             output = await self.docker.volumes.prune()
             _LOGGER.debug("Volumes prune: %s", output)
+        except TimeoutError:
+            _LOGGER.warning("Error for volumes prune: timed out")
         except aiodocker.DockerError as err:
             _LOGGER.warning("Error for volumes prune: %s", err)
 
@@ -743,6 +807,8 @@ class DockerAPI(CoreSysAttributes):
         try:
             output = await self.docker.networks.prune()
             _LOGGER.debug("Networks prune: %s", output)
+        except TimeoutError:
+            _LOGGER.warning("Error for networks prune: timed out")
         except aiodocker.DockerError as err:
             _LOGGER.warning("Error for networks prune: %s", err)
 
@@ -763,13 +829,24 @@ class DockerAPI(CoreSysAttributes):
 
         Fix: https://github.com/moby/moby/issues/23302
         """
-        network = await self.docker.networks.get(network_name)
-        network_meta = await network.show()
+        try:
+            network = await self.docker.networks.get(network_name)
+            network_meta = await network.show()
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout loading network metadata for {network_name}",
+                _LOGGER.warning,
+            ) from err
 
         for cid, data in network_meta.get("Containers", {}).items():
             try:
                 await self.containers.get(cid)
                 continue
+            except TimeoutError as err:
+                raise DockerTimeoutError(
+                    f"Timeout checking container {cid} on {network_name}",
+                    _LOGGER.warning,
+                ) from err
             except aiodocker.DockerError as err:
                 if err.status != HTTPStatus.NOT_FOUND:
                     _LOGGER.warning(
@@ -783,7 +860,7 @@ class DockerAPI(CoreSysAttributes):
                 _LOGGER.debug(
                     "Docker network %s is corrupt on container: %s", network_name, cid
                 )
-                with suppress(aiodocker.DockerError):
+                with suppress(aiodocker.DockerError, TimeoutError):
                     await network.disconnect(
                         {"Container": data.get("Name", cid), "Force": True}
                     )
@@ -796,6 +873,11 @@ class DockerAPI(CoreSysAttributes):
             docker_container = await self.containers.get(name)
             container_metadata = await docker_container.show()
             docker_image = await self.images.inspect(f"{image}:{version}")
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout getting container {name} or image {image}:{version} to check state",
+                _LOGGER.error,
+            ) from err
         except aiodocker.DockerError as err:
             if err.status == HTTPStatus.NOT_FOUND:
                 return False
@@ -820,6 +902,11 @@ class DockerAPI(CoreSysAttributes):
         try:
             docker_container = await self.containers.get(name)
             container_metadata = await docker_container.show()
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout getting container {name} for stopping",
+                _LOGGER.error,
+            ) from err
         except aiodocker.DockerError as err:
             if err.status == HTTPStatus.NOT_FOUND:
                 # Generally suppressed so we don't log this
@@ -847,6 +934,10 @@ class DockerAPI(CoreSysAttributes):
         """Start Docker container."""
         try:
             docker_container = await self.containers.get(name)
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout getting {name} for starting up", _LOGGER.error
+            ) from err
         except aiodocker.DockerError as err:
             if err.status == HTTPStatus.NOT_FOUND:
                 raise DockerNotFound(
@@ -859,6 +950,8 @@ class DockerAPI(CoreSysAttributes):
         _LOGGER.info("Starting %s", name)
         try:
             await docker_container.start()
+        except TimeoutError as err:
+            raise DockerTimeoutError(f"Timeout starting {name}", _LOGGER.error) from err
         except aiodocker.DockerError as err:
             raise DockerError(f"Can't start {name}: {err}", _LOGGER.error) from err
 
@@ -866,6 +959,11 @@ class DockerAPI(CoreSysAttributes):
         """Restart docker container."""
         try:
             container = await self.containers.get(name)
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout getting container {name} for restarting",
+                _LOGGER.error,
+            ) from err
         except aiodocker.DockerError as err:
             if err.status == HTTPStatus.NOT_FOUND:
                 raise DockerNotFound(
@@ -885,6 +983,10 @@ class DockerAPI(CoreSysAttributes):
         """Return Docker logs of container."""
         try:
             container = await self.containers.get(name)
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout getting container {name} for logs", _LOGGER.warning
+            ) from err
         except aiodocker.DockerError as err:
             if err.status == HTTPStatus.NOT_FOUND:
                 raise DockerNotFound(
@@ -908,6 +1010,10 @@ class DockerAPI(CoreSysAttributes):
         try:
             docker_container = await self.containers.get(name)
             container_metadata = await docker_container.show()
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout inspecting container '{name}'", _LOGGER.error
+            ) from err
         except aiodocker.DockerError as err:
             if err.status == HTTPStatus.NOT_FOUND:
                 raise DockerNotFound(
@@ -936,6 +1042,10 @@ class DockerAPI(CoreSysAttributes):
         """Execute a command inside Docker container."""
         try:
             docker_container = await self.containers.get(name)
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout getting container {name} to run command"
+            ) from err
         except aiodocker.DockerError as err:
             if err.status == HTTPStatus.NOT_FOUND:
                 raise DockerNotFound(
@@ -975,6 +1085,10 @@ class DockerAPI(CoreSysAttributes):
             raise DockerError(
                 f"Can't run command in container {name}: {err!s}"
             ) from err
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout running command in container {name}", _LOGGER.error
+            ) from err
 
         _LOGGER.debug(
             "Exec command '%s' in %s exited with %d", command, name, exit_code
@@ -990,6 +1104,10 @@ class DockerAPI(CoreSysAttributes):
                 _LOGGER.info("Removing image %s with latest", image)
                 try:
                     await self.images.delete(f"{image}:latest", force=True)
+                except TimeoutError as err:
+                    raise DockerTimeoutError(
+                        f"Timeout removing image {image}:latest", _LOGGER.warning
+                    ) from err
                 except aiodocker.DockerError as err:
                     if err.status != HTTPStatus.NOT_FOUND:
                         raise
@@ -997,6 +1115,11 @@ class DockerAPI(CoreSysAttributes):
             _LOGGER.info("Removing image %s with %s", image, version)
             try:
                 await self.images.delete(f"{image}:{version!s}", force=True)
+            except TimeoutError as err:
+                raise DockerTimeoutError(
+                    f"Timeout removing image {image}:{version!s}",
+                    _LOGGER.warning,
+                ) from err
             except aiodocker.DockerError as err:
                 if err.status != HTTPStatus.NOT_FOUND:
                     raise
@@ -1050,6 +1173,10 @@ class DockerAPI(CoreSysAttributes):
 
         try:
             return await self.images.inspect(docker_image_list[0])
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                "Timeout inspecting imported image", _LOGGER.error
+            ) from err
         except aiodocker.DockerError as err:
             raise DockerError(
                 f"Could not inspect imported image due to: {err!s}", _LOGGER.error
@@ -1098,6 +1225,11 @@ class DockerAPI(CoreSysAttributes):
         try:
             try:
                 image_attr = await self.images.inspect(image)
+            except TimeoutError as err:
+                raise DockerTimeoutError(
+                    f"Timeout getting {current_image} for cleanup",
+                    _LOGGER.warning,
+                ) from err
             except aiodocker.DockerError as err:
                 if err.status == HTTPStatus.NOT_FOUND:
                     raise DockerNotFound(
@@ -1136,6 +1268,10 @@ class DockerAPI(CoreSysAttributes):
         )
         try:
             images_list = await self.images.list(filters={"reference": image_names})
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                "Timeout listing images for cleanup", _LOGGER.warning
+            ) from err
         except aiodocker.DockerError as err:
             raise DockerError(
                 f"Corrupt docker overlayfs found: {err}", _LOGGER.warning
@@ -1145,6 +1281,6 @@ class DockerAPI(CoreSysAttributes):
             if docker_image["Id"] in keep:
                 continue
 
-            with suppress(aiodocker.DockerError):
+            with suppress(aiodocker.DockerError, TimeoutError):
                 _LOGGER.info("Cleanup images: %s", docker_image["RepoTags"])
                 await self.images.delete(docker_image["Id"], force=True)

--- a/supervisor/docker/network.py
+++ b/supervisor/docker/network.py
@@ -21,7 +21,7 @@ from ..const import (
     OBSERVER_DOCKER_NAME,
     SUPERVISOR_DOCKER_NAME,
 )
-from ..exceptions import DockerError, DockerNotFound
+from ..exceptions import DockerError, DockerNotFound, DockerTimeoutError
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -64,6 +64,10 @@ class DockerNetwork:
         """Post init actions that must be done in event loop."""
         try:
             self._network = network = await self.docker.networks.get(DOCKER_NETWORK)
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                "Timeout getting network from Docker", _LOGGER.error
+            ) from err
         except aiodocker.DockerError as err:
             # If network was not found, create it instead. Can skip further checks since it's new
             if err.status == HTTPStatus.NOT_FOUND:
@@ -115,6 +119,13 @@ class DockerNetwork:
         for c_id, meta in containers.items():
             try:
                 await network.disconnect({"Container": c_id, "Force": True})
+            except TimeoutError:
+                _LOGGER.warning(
+                    "Cannot apply Supervisor network changes because container %s "
+                    "could not be disconnected. Reboot your system to apply change.",
+                    meta.get("Name"),
+                )
+                return self
             except aiodocker.DockerError:
                 _LOGGER.warning(
                     "Cannot apply Supervisor network changes because container %s "
@@ -126,6 +137,12 @@ class DockerNetwork:
         # Remove the network
         try:
             await network.delete()
+        except TimeoutError:
+            _LOGGER.warning(
+                "Cannot apply Supervisor network changes because Supervisor network "
+                "could not be removed and recreated. Reboot your system to apply change."
+            )
+            return self
         except aiodocker.DockerError:
             _LOGGER.warning(
                 "Cannot apply Supervisor network changes because Supervisor network "
@@ -208,6 +225,10 @@ class DockerNetwork:
 
         try:
             self._network = await self.docker.networks.create(network_params)
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                "Timeout creating Supervisor network", _LOGGER.error
+            ) from err
         except aiodocker.DockerError as err:
             raise DockerError(
                 f"Can't create Supervisor network: {err}", _LOGGER.error
@@ -253,6 +274,10 @@ class DockerNetwork:
         """Get and cache metadata for supervisor network."""
         try:
             self._network_meta = await self.network.show()
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                "Timeout getting network metadata from Docker", _LOGGER.error
+            ) from err
         except aiodocker.DockerError as err:
             raise DockerError(
                 f"Could not get network metadata from Docker: {err!s}", _LOGGER.error
@@ -288,6 +313,11 @@ class DockerNetwork:
                     "EndpointConfig": endpoint_config,
                 }
             )
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout connecting {name or container_id} to Supervisor network",
+                _LOGGER.error,
+            ) from err
         except aiodocker.DockerError as err:
             raise DockerError(
                 f"Can't connect {name or container_id} to Supervisor network: {err}",
@@ -300,6 +330,8 @@ class DockerNetwork:
         """Attach container to Supervisor network."""
         try:
             container = await self.docker.containers.get(name)
+        except TimeoutError as err:
+            raise DockerTimeoutError(f"Timeout finding {name}") from err
         except aiodocker.DockerError as err:
             if err.status == HTTPStatus.NOT_FOUND:
                 raise DockerNotFound(f"Can't find {name}") from err
@@ -315,6 +347,11 @@ class DockerNetwork:
         try:
             default_network = await self.docker.networks.get(DOCKER_NETWORK_DRIVER)
             await default_network.disconnect({"Container": container_id})
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout disconnecting {name or container_id} from default network",
+                _LOGGER.warning,
+            ) from err
         except aiodocker.DockerError as err:
             if err.status == HTTPStatus.NOT_FOUND:
                 return
@@ -330,6 +367,11 @@ class DockerNetwork:
         """
         try:
             await self.network.disconnect({"Container": name, "Force": True})
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout disconnecting {name} from Supervisor network",
+                _LOGGER.warning,
+            ) from err
         except aiodocker.DockerError as err:
             raise DockerError(
                 f"Can't disconnect {name} from Supervisor network: {err}",

--- a/supervisor/docker/supervisor.py
+++ b/supervisor/docker/supervisor.py
@@ -8,7 +8,7 @@ import os
 import aiodocker
 from awesomeversion.awesomeversion import AwesomeVersion
 
-from ..exceptions import DockerError
+from ..exceptions import DockerError, DockerTimeoutError
 from ..jobs.const import JobConcurrency
 from ..jobs.decorator import Job
 from .const import PropagationMode
@@ -52,6 +52,10 @@ class DockerSupervisor(DockerInterface):
         try:
             docker_container = await self.sys_docker.containers.get(self.name)
             self._meta = await docker_container.show()
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                "Timeout getting supervisor container metadata"
+            ) from err
         except aiodocker.DockerError as err:
             raise DockerError(
                 f"Could not get supervisor container metadata: {err!s}"
@@ -82,6 +86,11 @@ class DockerSupervisor(DockerInterface):
         try:
             docker_container = await self.sys_docker.containers.get(self.name)
             container_metadata = await docker_container.show()
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                "Timeout getting Supervisor container for retag",
+                _LOGGER.error,
+            ) from err
         except aiodocker.DockerError as err:
             raise DockerError(
                 f"Could not get Supervisor container for retag: {err}", _LOGGER.error
@@ -102,6 +111,10 @@ class DockerSupervisor(DockerInterface):
                 ),
                 self.sys_docker.images.tag(metadata_image, self.image, tag="latest"),
             )
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                "Timeout retagging Supervisor version", _LOGGER.error
+            ) from err
         except aiodocker.DockerError as err:
             raise DockerError(
                 f"Can't retag Supervisor version: {err}", _LOGGER.error
@@ -116,6 +129,10 @@ class DockerSupervisor(DockerInterface):
         try:
             docker_container = await self.sys_docker.containers.get(self.name)
             container_metadata = await docker_container.show()
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                "Timeout getting container to fix start tag", _LOGGER.error
+            ) from err
         except aiodocker.DockerError as err:
             raise DockerError(
                 f"Can't get container to fix start tag: {err}", _LOGGER.error
@@ -134,6 +151,11 @@ class DockerSupervisor(DockerInterface):
                 self.sys_docker.images.inspect(metadata_image),
                 self.sys_docker.images.inspect(f"{image}:{version!s}"),
             )
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                "Timeout getting image metadata to fix start tag",
+                _LOGGER.error,
+            ) from err
         except aiodocker.DockerError as err:
             raise DockerError(
                 f"Can't get image metadata to fix start tag: {err}", _LOGGER.error
@@ -161,5 +183,7 @@ class DockerSupervisor(DockerInterface):
                     ),
                 )
 
+        except TimeoutError as err:
+            raise DockerTimeoutError("Timeout fixing start tag", _LOGGER.error) from err
         except aiodocker.DockerError as err:
             raise DockerError(f"Can't fix start tag: {err}", _LOGGER.error) from err

--- a/supervisor/resolution/evaluations/container.py
+++ b/supervisor/resolution/evaluations/container.py
@@ -75,6 +75,9 @@ class EvaluateContainer(EvaluateBase):
         try:
             containers = await self.sys_docker.containers.list()
             containers_metadata = await asyncio.gather(*[c.show() for c in containers])
+        except TimeoutError:
+            _LOGGER.error("Timeout while evaluating docker containers")
+            return False
         except aiodocker.DockerError as err:
             _LOGGER.error("Corrupt docker overlayfs detect: %s", err)
             self.sys_resolution.create_issue(

--- a/tests/docker/test_app.py
+++ b/tests/docker/test_app.py
@@ -26,7 +26,7 @@ from supervisor.docker.const import (
     PropagationMode,
 )
 from supervisor.docker.manager import DockerAPI
-from supervisor.exceptions import CoreDNSError, DockerNotFound
+from supervisor.exceptions import CoreDNSError, DockerNotFound, DockerTimeoutError
 from supervisor.hardware.data import Device
 from supervisor.host.const import HostFeature
 from supervisor.os.manager import OSManager
@@ -707,3 +707,92 @@ async def test_app_options_device_policy_check(
 
         # Verify cgroup permission was NOT granted due to policy block
         add_devices.assert_not_called()
+
+
+@pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
+async def test_app_build_builder_cleanup_timeout(
+    coresys: CoreSys, addonsdata_system: dict[str, Data]
+):
+    """Test _build raises DockerTimeoutError when builder cleanup times out."""
+    docker_app = get_docker_app(coresys, addonsdata_system, "basic-app-config.json")
+
+    mock_build_env = MagicMock()
+    mock_build_env.is_valid = AsyncMock()
+    coresys.docker.containers.get.return_value.delete.side_effect = TimeoutError()
+
+    with (
+        patch(
+            "supervisor.docker.app.AppBuild.create",
+            AsyncMock(return_value=mock_build_env),
+        ),
+        pytest.raises(
+            DockerTimeoutError, match="Timeout cleaning up existing builder container"
+        ),
+    ):
+        await docker_app.install(docker_app.version, need_build=True)
+
+
+@pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
+async def test_app_build_inspect_timeout(
+    coresys: CoreSys, addonsdata_system: dict[str, Data]
+):
+    """Test _build raises DockerTimeoutError when image inspect times out after build."""
+    docker_app = get_docker_app(coresys, addonsdata_system, "basic-app-config.json")
+
+    mock_build_env = MagicMock()
+    mock_build_env.is_valid = AsyncMock()
+    mock_build_env.get_docker_config_json.return_value = None
+    mock_build_env.get_docker_args.return_value = {}
+
+    coresys.docker.containers.get.side_effect = aiodocker.DockerError(
+        HTTPStatus.NOT_FOUND, {"message": "missing"}
+    )
+    coresys.docker.run_command = AsyncMock(return_value=MagicMock(exit_code=0, log=[]))
+    coresys.docker.images.inspect.side_effect = TimeoutError()
+
+    with (
+        patch(
+            "supervisor.docker.app.AppBuild.create",
+            AsyncMock(return_value=mock_build_env),
+        ),
+        pytest.raises(
+            DockerTimeoutError,
+            match="Timeout getting image metadata .* after build",
+        ),
+    ):
+        await docker_app.install(docker_app.version, need_build=True)
+
+
+@pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
+async def test_app_write_stdin_get_timeout(
+    coresys: CoreSys, addonsdata_system: dict[str, Data]
+):
+    """Test write_stdin raises DockerTimeoutError when containers.get times out."""
+    docker_app = get_docker_app(coresys, addonsdata_system, "basic-app-config.json")
+    coresys.docker.containers.get.side_effect = TimeoutError()
+
+    with pytest.raises(DockerTimeoutError, match="Timeout attaching to .* stdin"):
+        await docker_app.write_stdin(b"hello")
+
+
+@pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
+async def test_app_hardware_events_get_timeout(
+    coresys: CoreSys, addonsdata_system: dict[str, Data]
+):
+    """Test hardware event path raises DockerTimeoutError on container lookup timeout."""
+    docker_app = get_docker_app(coresys, addonsdata_system, "basic-app-config.json")
+    docker_app.app.data["devices"] = [TEST_DEV_PATH]
+
+    with patch.object(
+        type(coresys.host),
+        "features",
+        new=PropertyMock(return_value=[HostFeature.OS_AGENT]),
+    ):
+        with patch.object(App, "write_options"):
+            await docker_app.app.start()
+
+        coresys.docker.containers.get.side_effect = TimeoutError()
+        with pytest.raises(
+            DockerTimeoutError, match="Timeout processing Hardware Event"
+        ):
+            await fire_bus_event(coresys, BusEvent.HARDWARE_NEW_DEVICE, TEST_HW_DEVICE)

--- a/tests/docker/test_interface.py
+++ b/tests/docker/test_interface.py
@@ -55,7 +55,7 @@ async def test_docker_image_platform(
     coresys.docker.images.inspect.return_value = {"Id": "test:1.2.3"}
     await test_docker_interface.install(AwesomeVersion("1.2.3"), "test", arch=cpu_arch)
     coresys.docker.images.pull.assert_called_once_with(
-        "test", tag="1.2.3", platform=platform, auth=None, stream=True, timeout=None
+        "test", tag="1.2.3", platform=platform, auth=None, stream=True
     )
     coresys.docker.images.inspect.assert_called_once_with("test:1.2.3")
 
@@ -72,12 +72,7 @@ async def test_docker_image_default_platform(
     ):
         await test_docker_interface.install(AwesomeVersion("1.2.3"), "test")
         coresys.docker.images.pull.assert_called_once_with(
-            "test",
-            tag="1.2.3",
-            platform="linux/amd64",
-            auth=None,
-            stream=True,
-            timeout=None,
+            "test", tag="1.2.3", platform="linux/amd64", auth=None, stream=True
         )
 
     coresys.docker.images.inspect.assert_called_once_with("test:1.2.3")
@@ -132,7 +127,6 @@ async def test_private_registry_credentials_passed_to_pull(
         platform="linux/amd64",
         auth=expected_auth,
         stream=True,
-        timeout=None,
     )
 
 
@@ -442,12 +436,7 @@ async def test_install_fires_progress_events(
     ):
         await test_docker_interface.install(AwesomeVersion("1.2.3"), "test")
         coresys.docker.images.pull.assert_called_once_with(
-            "test",
-            tag="1.2.3",
-            platform="linux/amd64",
-            auth=None,
-            stream=True,
-            timeout=None,
+            "test", tag="1.2.3", platform="linux/amd64", auth=None, stream=True
         )
         coresys.docker.images.inspect.assert_called_once_with("test:1.2.3")
 
@@ -905,12 +894,7 @@ async def test_install_progress_containerd_snapshot(
     with patch.object(Supervisor, "arch", PropertyMock(return_value="amd64")):
         await test_docker_interface.mock_install()
         coresys.docker.images.pull.assert_called_once_with(
-            "test",
-            tag="1.2.3",
-            platform="linux/amd64",
-            auth=None,
-            stream=True,
-            timeout=None,
+            "test", tag="1.2.3", platform="linux/amd64", auth=None, stream=True
         )
         coresys.docker.images.inspect.assert_called_once_with("test:1.2.3")
 

--- a/tests/docker/test_interface.py
+++ b/tests/docker/test_interface.py
@@ -1142,3 +1142,35 @@ async def test_install_unknown_registry_rate_limit_raises_generic_exception(
     assert not isinstance(exc_info.value, GithubContainerRegistryRateLimitExceeded)
     _assert_docker_ratelimit_issue(coresys, False)
     capture_exception.assert_not_called()
+
+
+async def test_attach_container_get_timeout_falls_through_to_image(coresys: CoreSys):
+    """Test attach suppresses TimeoutError from containers.get and falls through to image inspect."""
+    coresys.docker.containers.get.side_effect = TimeoutError()
+    coresys.docker.images.inspect.return_value.setdefault("Config", {})["Image"] = (
+        "sha256:abc123"
+    )
+    # Should not raise - timeout is suppressed, falls back to image inspect
+    await coresys.homeassistant.core.instance.attach(AwesomeVersion("2022.7.3"))
+    coresys.docker.images.inspect.assert_called()
+
+
+async def test_attach_fallback_image_inspect_timeout(coresys: CoreSys):
+    """Test attach raises DockerTimeoutError when fallback image inspect times out."""
+    coresys.docker.containers.get.side_effect = aiodocker.DockerError(
+        500, {"message": "fail"}
+    )
+    coresys.docker.images.inspect.side_effect = TimeoutError()
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout occurred while inspecting image"
+    ):
+        await coresys.homeassistant.core.instance.attach(AwesomeVersion("2022.7.3"))
+
+
+async def test_exists_timeout_suppressed(
+    coresys: CoreSys, test_docker_interface: DockerInterface
+):
+    """Test exists returns False and suppresses TimeoutError from images.inspect."""
+    coresys.docker.images.inspect.side_effect = TimeoutError()
+    result = await test_docker_interface.exists()
+    assert result is False

--- a/tests/docker/test_manager.py
+++ b/tests/docker/test_manager.py
@@ -24,6 +24,7 @@ from supervisor.exceptions import (
     DockerError,
     DockerNoSpaceOnDevice,
     DockerRegistryRateLimitExceeded,
+    DockerTimeoutError,
 )
 
 
@@ -90,7 +91,7 @@ async def test_run_command_pulls_image_when_not_found(
     )
 
     # Verify pull was called
-    docker.images.pull.assert_called_once_with("alpine", tag="3.18")
+    docker.images.pull.assert_called_once_with("alpine", tag="3.18", timeout=None)
 
     # Verify the command still executed successfully
     assert result.exit_code == 0
@@ -596,3 +597,210 @@ def test_pull_log_entry_exception_generic_error():
     assert isinstance(err, DockerError)
     assert not isinstance(err, DockerRegistryRateLimitExceeded)
     assert not isinstance(err, DockerNoSpaceOnDevice)
+
+
+# ---------------------------------------------------------------------------
+# Timeout error path tests
+# ---------------------------------------------------------------------------
+
+
+async def test_post_init_system_info_timeout(docker: DockerAPI):
+    """Test post_init raises DockerTimeoutError when system.info times out."""
+    docker.docker.system.info.side_effect = TimeoutError()
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout while getting Docker information"
+    ):
+        await docker.post_init()
+
+
+@pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
+async def test_run_container_create_timeout(coresys: CoreSys):
+    """Test run raises DockerTimeoutError when containers.create times out."""
+    coresys.docker.containers.create.side_effect = TimeoutError()
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout creating container from alpine:latest"
+    ):
+        await coresys.docker.run("alpine", name="test", tag="latest")
+
+
+@pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
+async def test_run_container_start_timeout(coresys: CoreSys):
+    """Test run raises DockerTimeoutError when container.start times out."""
+    coresys.docker.containers.create.return_value.start.side_effect = TimeoutError()
+    with pytest.raises(DockerTimeoutError, match="Timeout starting"):
+        await coresys.docker.run("alpine", name="test", tag="latest")
+
+
+@pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
+async def test_run_metadata_timeout(coresys: CoreSys, container: DockerContainer):
+    """Test run() raises DockerTimeoutError when container.show times out after start."""
+    container.show.side_effect = TimeoutError()
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout inspecting started container"
+    ):
+        await coresys.docker.run("alpine", name="test", tag="latest")
+
+
+async def test_run_command_image_inspect_timeout(docker: DockerAPI):
+    """Test run_command raises DockerTimeoutError when image inspect times out."""
+    docker.images.inspect.side_effect = TimeoutError()
+    with pytest.raises(DockerTimeoutError, match="Timeout inspecting image"):
+        await docker.run_command(image="alpine", command=["echo", "hi"])
+
+
+async def test_repair_timeouts(
+    coresys: CoreSys, caplog: pytest.LogCaptureFixture, container: DockerContainer
+):
+    """Test repair logs warnings and continues when prune operations time out."""
+    coresys.docker.docker.containers.prune.side_effect = TimeoutError()
+    coresys.docker.docker.images.prune.side_effect = TimeoutError()
+    coresys.docker.docker.images.prune_builds.side_effect = TimeoutError()
+    coresys.docker.docker.volumes.prune.side_effect = TimeoutError()
+    coresys.docker.docker.networks.prune.side_effect = TimeoutError()
+    # prune_networks is called next; make networks.get raise DockerError to keep it short
+    coresys.docker.docker.networks.get.side_effect = aiodocker.DockerError(
+        HTTPStatus.NOT_FOUND, {"message": "missing"}
+    )
+
+    await coresys.docker.repair()
+
+    assert "Error for containers prune: timed out" in caplog.text
+    assert "Error for images prune: timed out" in caplog.text
+    assert "Error for builds prune: timed out" in caplog.text
+    assert "Error for volumes prune: timed out" in caplog.text
+    assert "Error for networks prune: timed out" in caplog.text
+
+
+async def test_prune_networks_get_timeout(
+    coresys: CoreSys, caplog: pytest.LogCaptureFixture
+):
+    """Test prune_networks raises DockerTimeoutError when networks.get/show times out."""
+    coresys.docker.docker.networks.get.side_effect = TimeoutError()
+    with pytest.raises(DockerTimeoutError, match="Timeout loading network metadata"):
+        await coresys.docker.prune_networks("hassio")
+
+
+async def test_prune_networks_container_get_timeout(
+    coresys: CoreSys, caplog: pytest.LogCaptureFixture
+):
+    """Test prune_networks raises DockerTimeoutError when containers.get times out."""
+    network = MagicMock(spec=DockerNetwork)
+    network.show.return_value = {"Containers": {"abc123": {"Name": "test"}}}
+    coresys.docker.docker.networks.get.return_value = network
+    coresys.docker.containers.get.side_effect = TimeoutError()
+    with pytest.raises(DockerTimeoutError, match="Timeout checking container abc123"):
+        await coresys.docker.prune_networks("hassio")
+
+
+async def test_container_is_initialized_timeout(
+    docker: DockerAPI, container: DockerContainer
+):
+    """Test container_is_initialized raises DockerTimeoutError when get/show times out."""
+    docker.containers.get.side_effect = TimeoutError()
+    with pytest.raises(DockerTimeoutError, match="Timeout getting container"):
+        await docker.container_is_initialized(
+            "mycontainer", "myimage", AwesomeVersion("1.0")
+        )
+
+
+async def test_stop_container_get_timeout(docker: DockerAPI):
+    """Test stop_container raises DockerTimeoutError when containers.get times out."""
+    docker.containers.get.side_effect = TimeoutError()
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout getting container .* for stopping"
+    ):
+        await docker.stop_container("mycontainer", timeout=10)
+
+
+async def test_start_container_get_timeout(docker: DockerAPI):
+    """Test start_container raises DockerTimeoutError when containers.get times out."""
+    docker.containers.get.side_effect = TimeoutError()
+    with pytest.raises(DockerTimeoutError, match="Timeout getting .* for starting up"):
+        await docker.start_container("mycontainer")
+
+
+async def test_start_container_start_timeout(
+    docker: DockerAPI, container: DockerContainer
+):
+    """Test start_container raises DockerTimeoutError when container.start times out."""
+    container.start.side_effect = TimeoutError()
+    with pytest.raises(DockerTimeoutError, match="Timeout starting mycontainer"):
+        await docker.start_container("mycontainer")
+
+
+async def test_restart_container_get_timeout(docker: DockerAPI):
+    """Test restart_container raises DockerTimeoutError when containers.get times out."""
+    docker.containers.get.side_effect = TimeoutError()
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout getting container .* for restarting"
+    ):
+        await docker.restart_container("mycontainer", timeout=10)
+
+
+async def test_container_logs_get_timeout(docker: DockerAPI):
+    """Test container_logs raises DockerTimeoutError when containers.get times out."""
+    docker.containers.get.side_effect = TimeoutError()
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout getting container .* for logs"
+    ):
+        await docker.container_logs("mycontainer")
+
+
+async def test_container_stats_get_timeout(docker: DockerAPI):
+    """Test container_stats raises DockerTimeoutError when containers.get times out."""
+    docker.containers.get.side_effect = TimeoutError()
+    with pytest.raises(DockerTimeoutError, match="Timeout inspecting container"):
+        await docker.container_stats("mycontainer")
+
+
+async def test_container_run_inside_get_timeout(docker: DockerAPI):
+    """Test container_run_inside raises DockerTimeoutError when containers.get times out."""
+    docker.containers.get.side_effect = TimeoutError()
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout getting container .* to run command"
+    ):
+        await docker.container_run_inside("mycontainer", "echo hi")
+
+
+async def test_container_run_inside_exec_timeout(
+    docker: DockerAPI, container: DockerContainer
+):
+    """Test container_run_inside raises DockerTimeoutError when exec stream times out."""
+    container.exec.side_effect = TimeoutError()
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout running command in container"
+    ):
+        await docker.container_run_inside("mycontainer", "echo hi")
+
+
+async def test_remove_image_latest_timeout(docker: DockerAPI):
+    """Test remove_image raises DockerTimeoutError when deleting latest tag times out."""
+    docker.images.delete.side_effect = TimeoutError()
+    with pytest.raises(DockerTimeoutError, match="Timeout removing image .*:latest"):
+        await docker.remove_image("myimage", AwesomeVersion("1.0"), latest=True)
+
+
+async def test_remove_image_version_timeout(docker: DockerAPI):
+    """Test remove_image raises DockerTimeoutError when deleting version tag times out."""
+    # latest delete succeeds (raises NOT_FOUND which is suppressed), version times out
+    docker.images.delete.side_effect = [
+        aiodocker.DockerError(HTTPStatus.NOT_FOUND, {"message": "not found"}),
+        TimeoutError(),
+    ]
+    with pytest.raises(DockerTimeoutError, match="Timeout removing image .*:1.0"):
+        await docker.remove_image("myimage", AwesomeVersion("1.0"), latest=True)
+
+
+async def test_cleanup_old_images_inspect_timeout(docker: DockerAPI):
+    """Test cleanup_old_images raises DockerTimeoutError when inspect times out."""
+    docker.images.inspect.side_effect = TimeoutError()
+    with pytest.raises(DockerTimeoutError, match="Timeout getting myimage for cleanup"):
+        await docker.cleanup_old_images("myimage", AwesomeVersion("1.0"))
+
+
+async def test_cleanup_old_images_list_timeout(docker: DockerAPI):
+    """Test cleanup_old_images raises DockerTimeoutError when image list times out."""
+    docker.images.inspect.return_value = {"Id": "abc123"}
+    docker.images.list.side_effect = TimeoutError()
+    with pytest.raises(DockerTimeoutError, match="Timeout listing images for cleanup"):
+        await docker.cleanup_old_images("myimage", AwesomeVersion("1.0"))

--- a/tests/docker/test_manager.py
+++ b/tests/docker/test_manager.py
@@ -632,6 +632,92 @@ async def test_run_container_start_timeout(coresys: CoreSys):
 
 
 @pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
+async def test_run_attach_network_failure_logs_warning(
+    coresys: CoreSys, caplog: pytest.LogCaptureFixture
+):
+    """Test run logs warning and continues when attach to hassio-network fails."""
+    with (
+        patch.object(
+            coresys.docker.network,
+            "attach_container",
+            new=AsyncMock(side_effect=DockerError("failed")),
+        ),
+        patch.object(
+            coresys.docker.network,
+            "detach_default_bridge",
+            new=AsyncMock(),
+        ) as detach_default_bridge,
+    ):
+        await coresys.docker.run("alpine", name="test", tag="latest")
+
+    assert "Can't attach test to hassio-network!" in caplog.text
+    detach_default_bridge.assert_not_called()
+
+
+@pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
+async def test_run_host_network_get_timeout(coresys: CoreSys):
+    """Test run raises DockerTimeoutError when loading host network times out."""
+    coresys.docker.docker.networks.get.side_effect = TimeoutError()
+
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout getting host network information"
+    ):
+        await coresys.docker.run(
+            "alpine", name="test", tag="latest", network_mode="host"
+        )
+
+
+@pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
+async def test_run_host_network_get_docker_error(coresys: CoreSys):
+    """Test run raises DockerError when loading host network fails."""
+    coresys.docker.docker.networks.get.side_effect = aiodocker.DockerError(
+        HTTPStatus.INTERNAL_SERVER_ERROR, {"message": "fail"}
+    )
+
+    with pytest.raises(
+        DockerError, match="Can't get host network information from Docker"
+    ):
+        await coresys.docker.run(
+            "alpine", name="test", tag="latest", network_mode="host"
+        )
+
+
+@pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
+async def test_run_host_network_disconnect_timeout(coresys: CoreSys):
+    """Test run raises DockerTimeoutError when disconnect from host network times out."""
+    host_network = MagicMock(spec=DockerNetwork)
+    host_network.show.return_value = {"Containers": {"abc": {"Name": "test"}}}
+    host_network.disconnect.side_effect = TimeoutError()
+    coresys.docker.docker.networks.get.return_value = host_network
+
+    with pytest.raises(
+        DockerTimeoutError,
+        match="Timeout disconnecting container test from host network",
+    ):
+        await coresys.docker.run(
+            "alpine", name="test", tag="latest", network_mode="host"
+        )
+
+
+@pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
+async def test_run_host_network_disconnect_non_not_found_error(coresys: CoreSys):
+    """Test run raises DockerError when host network disconnect fails with non-404."""
+    host_network = MagicMock(spec=DockerNetwork)
+    host_network.show.return_value = {"Containers": {"abc": {"Name": "test"}}}
+    host_network.disconnect.side_effect = aiodocker.DockerError(
+        HTTPStatus.INTERNAL_SERVER_ERROR, {"message": "fail"}
+    )
+    coresys.docker.docker.networks.get.return_value = host_network
+
+    with pytest.raises(
+        DockerError, match="Can't disconnect container test from host network"
+    ):
+        await coresys.docker.run(
+            "alpine", name="test", tag="latest", network_mode="host"
+        )
+
+
+@pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
 async def test_run_metadata_timeout(coresys: CoreSys, container: DockerContainer):
     """Test run() raises DockerTimeoutError when container.show times out after start."""
     container.show.side_effect = TimeoutError()

--- a/tests/docker/test_manager.py
+++ b/tests/docker/test_manager.py
@@ -91,7 +91,7 @@ async def test_run_command_pulls_image_when_not_found(
     )
 
     # Verify pull was called
-    docker.images.pull.assert_called_once_with("alpine", tag="3.18", timeout=None)
+    docker.images.pull.assert_called_once_with("alpine", tag="3.18")
 
     # Verify the command still executed successfully
     assert result.exit_code == 0

--- a/tests/docker/test_network.py
+++ b/tests/docker/test_network.py
@@ -18,6 +18,7 @@ from supervisor.docker.network import (
     DOCKER_NETWORK_PARAMS,
     DockerNetwork,
 )
+from supervisor.exceptions import DockerTimeoutError
 
 
 @pytest.mark.parametrize(
@@ -251,3 +252,67 @@ async def test_network_mtu_no_change(docker: DockerAPI):
 
     # Verify network was NOT recreated since MTU is the same
     docker.docker.networks.create.assert_not_called()
+
+
+async def test_post_init_get_network_timeout(docker: DockerAPI):
+    """Test post_init raises DockerTimeoutError on network get timeout."""
+    docker.docker.networks.get.side_effect = TimeoutError()
+
+    with pytest.raises(DockerTimeoutError, match="Timeout getting network from Docker"):
+        await DockerNetwork(docker.docker).post_init()
+
+
+async def test_reload_timeout(docker: DockerAPI):
+    """Test reload raises DockerTimeoutError on network show timeout."""
+    docker_network = await DockerNetwork(docker.docker).post_init()
+    docker_network.network.show.side_effect = TimeoutError()
+
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout getting network metadata from Docker"
+    ):
+        await docker_network.reload()
+
+
+async def test_attach_container_timeout(docker: DockerAPI):
+    """Test attach_container raises DockerTimeoutError on connect timeout."""
+    docker_network = await DockerNetwork(docker.docker).post_init()
+    docker_network.network.connect.side_effect = TimeoutError()
+
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout connecting test to Supervisor network"
+    ):
+        await docker_network.attach_container("abc123", "test")
+
+
+async def test_attach_container_by_name_timeout(docker: DockerAPI):
+    """Test attach_container_by_name raises DockerTimeoutError on get timeout."""
+    docker_network = await DockerNetwork(docker.docker).post_init()
+    docker.docker.containers.get.side_effect = TimeoutError()
+
+    with pytest.raises(DockerTimeoutError, match="Timeout finding test"):
+        await docker_network.attach_container_by_name("test")
+
+
+async def test_detach_default_bridge_timeout(docker: DockerAPI):
+    """Test detach_default_bridge raises DockerTimeoutError on disconnect timeout."""
+    docker_network = await DockerNetwork(docker.docker).post_init()
+    default_network = MagicMock(spec=AiodockerNetwork)
+    default_network.disconnect.side_effect = TimeoutError()
+    docker.docker.networks.get.return_value = default_network
+
+    with pytest.raises(
+        DockerTimeoutError,
+        match="Timeout disconnecting test from default network",
+    ):
+        await docker_network.detach_default_bridge("abc123", name="test")
+
+
+async def test_stale_cleanup_timeout(docker: DockerAPI):
+    """Test stale_cleanup raises DockerTimeoutError on disconnect timeout."""
+    docker_network = await DockerNetwork(docker.docker).post_init()
+    docker_network.network.disconnect.side_effect = TimeoutError()
+
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout disconnecting test from Supervisor network"
+    ):
+        await docker_network.stale_cleanup("test")

--- a/tests/docker/test_supervisor.py
+++ b/tests/docker/test_supervisor.py
@@ -1,0 +1,71 @@
+"""Test Supervisor Docker container timeout handling."""
+
+from awesomeversion import AwesomeVersion
+import pytest
+
+from supervisor.coresys import CoreSys
+from supervisor.exceptions import DockerTimeoutError
+
+
+async def test_supervisor_attach_get_timeout(coresys: CoreSys):
+    """Test DockerSupervisor.attach raises DockerTimeoutError when containers.get times out."""
+    coresys.docker.containers.get.side_effect = TimeoutError()
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout getting supervisor container"
+    ):
+        await coresys.supervisor.instance.attach(
+            coresys.supervisor.version or AwesomeVersion("2025.1.0")
+        )
+
+
+async def test_supervisor_retag_get_timeout(coresys: CoreSys):
+    """Test DockerSupervisor.retag raises DockerTimeoutError when containers.get times out."""
+    coresys.docker.containers.get.side_effect = TimeoutError()
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout getting Supervisor container for retag"
+    ):
+        await coresys.supervisor.instance.retag()
+
+
+async def test_supervisor_retag_tag_timeout(coresys: CoreSys):
+    """Test DockerSupervisor.retag raises DockerTimeoutError when images.tag times out."""
+    # Attach first to initialize metadata via the public API.
+    coresys.docker.containers.get.return_value.show.return_value = {
+        "ImageID": "sha256:abc123",
+        "Image": "sha256:abc123",
+        "Config": {
+            "Image": "ghcr.io/home-assistant/amd64-hassio-supervisor:latest",
+            "Labels": {"io.hass.version": "2025.1.0"},
+        },
+    }
+    await coresys.supervisor.instance.attach(AwesomeVersion("2025.1.0"))
+
+    coresys.docker.images.tag.side_effect = TimeoutError()
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout retagging Supervisor version"
+    ):
+        await coresys.supervisor.instance.retag()
+
+
+async def test_supervisor_update_start_tag_get_timeout(coresys: CoreSys):
+    """Test update_start_tag raises DockerTimeoutError when containers.get times out."""
+    coresys.docker.containers.get.side_effect = TimeoutError()
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout getting container to fix start tag"
+    ):
+        await coresys.supervisor.instance.update_start_tag(
+            "ghcr.io/home-assistant/amd64-hassio-supervisor",
+            AwesomeVersion("2025.1.0"),
+        )
+
+
+async def test_supervisor_update_start_tag_inspect_timeout(coresys: CoreSys):
+    """Test update_start_tag raises DockerTimeoutError when images.inspect times out."""
+    coresys.docker.images.inspect.side_effect = TimeoutError()
+    with pytest.raises(
+        DockerTimeoutError, match="Timeout getting image metadata to fix start tag"
+    ):
+        await coresys.supervisor.instance.update_start_tag(
+            "ghcr.io/home-assistant/amd64-hassio-supervisor",
+            AwesomeVersion("2025.1.0"),
+        )

--- a/tests/resolution/evaluations/test_container.py
+++ b/tests/resolution/evaluations/test_container.py
@@ -1,0 +1,67 @@
+"""Tests for EvaluateContainer."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import aiodocker
+from aiodocker.containers import DockerContainer
+import pytest
+
+from supervisor.const import CoreState
+from supervisor.coresys import CoreSys
+from supervisor.resolution.const import IssueType
+from supervisor.resolution.evaluations.container import EvaluateContainer
+
+
+async def test_evaluate_container_list_timeout(
+    coresys: CoreSys, caplog: pytest.LogCaptureFixture
+):
+    """Test evaluate returns False and logs on containers.list timeout, no corrupt issue."""
+    await coresys.core.set_state(CoreState.RUNNING)
+    coresys.docker.containers.list.side_effect = TimeoutError()
+
+    evaluation = EvaluateContainer(coresys)
+    result = await evaluation.evaluate()
+
+    assert result is False
+    assert "Timeout while evaluating docker containers" in caplog.text
+    # A timeout is not a sign of corrupt Docker; no issue should be created
+    assert not any(
+        issue.type == IssueType.CORRUPT_DOCKER for issue in coresys.resolution.issues
+    )
+
+
+async def test_evaluate_container_show_timeout(
+    coresys: CoreSys, caplog: pytest.LogCaptureFixture
+):
+    """Test evaluate returns False and logs when container.show times out, no corrupt issue."""
+    await coresys.core.set_state(CoreState.RUNNING)
+    mock_container = MagicMock(spec=DockerContainer)
+    mock_container.show = AsyncMock(side_effect=TimeoutError())
+    coresys.docker.containers.list.return_value = [mock_container]
+
+    evaluation = EvaluateContainer(coresys)
+    result = await evaluation.evaluate()
+
+    assert result is False
+    assert "Timeout while evaluating docker containers" in caplog.text
+    assert not any(
+        issue.type == IssueType.CORRUPT_DOCKER for issue in coresys.resolution.issues
+    )
+
+
+async def test_evaluate_container_docker_error_creates_corrupt_issue(
+    coresys: CoreSys,
+):
+    """Test evaluate creates CORRUPT_DOCKER issue on DockerError (original behavior)."""
+    await coresys.core.set_state(CoreState.RUNNING)
+    coresys.docker.containers.list.side_effect = aiodocker.DockerError(
+        500, {"message": "overlayfs error"}
+    )
+
+    evaluation = EvaluateContainer(coresys)
+    result = await evaluation.evaluate()
+
+    assert result is False
+    assert any(
+        issue.type == IssueType.CORRUPT_DOCKER for issue in coresys.resolution.issues
+    )


### PR DESCRIPTION
## Proposed change

Align Docker timeout handling with aiodocker timeout semantics and improve timeout error mapping and regression coverage.

This PR:
- maps actionable timeout paths to `DockerTimeoutError`
- removes timeout handling around `run_command`/`container_logs` paths that use aiodocker long-running infinite-timeout behavior
- extracts container network setup in Docker manager `_run` into a helper for clarity
- updates container resolution evaluation so transient timeouts no longer create `CORRUPT_DOCKER`
- adds focused timeout regression tests across manager/interface/supervisor/resolution

### Timeout semantics table

This table denotes the `aiodocker` methods identified that we use which have no timeout by default, `TimeoutError` handling is not required for these. All others require `TimeoutError` handling.

| Call site | aiodocker method | Timeout semantics | TimeoutError handling in Supervisor | Notes |
| --- | --- | --- | --- | --- |
| `DockerAPI.run_command()` | `container.wait()` | Long-running resolver default (effectively infinite) | **No** | Removed timeout wrapping for this path. |
| `DockerAPI.run_command()` | `container.log(..., follow=False)` | Long-running resolver default (effectively infinite) | **No** | Removed timeout wrapping for this path. |
| `DockerAPI.container_logs()` | `container.log(...)` | Long-running resolver default (effectively infinite) | **No** | Removed timeout wrapping for this path. |
| `DockerAPI.run_command()` image pull fallback | `images.pull(..., timeout=None)` | Explicit infinite timeout | **No** | Timeout handling intentionally omitted per policy. |
| `DockerAPI.pull_image()` streaming pull | `images.pull(..., stream=True, timeout=None)` | Explicit infinite timeout | **No** | Timeout handling intentionally omitted per policy. |

Additional rule applied in this PR: awaited Docker calls that can actually time out in finite operations are mapped to `DockerTimeoutError`.

### Sentry

This change is a follow-up to #6955 to address the many other places `TimeoutError` can be raised that ended up as issues in Sentry. There is quite a lot in this case so rather then list them individually I'll just list the search I used. If you search for [`title is TimeoutError`](https://home-assistant-io.sentry.io/issues/?project=5370612&query=title%3ATimeoutError&referrer=issue-list&statsPeriod=14d) in the Supervisor project almost all of those have source `aiodocker` in the frames. Since the `TimeoutError` has no message the exact search makes them quite easy to find.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/