### PR TITLE
Add mypy cache-fix skill documentation

### DIFF
--- a/.github/skills/mypy-cache-fix/SKILL.md
+++ b/.github/skills/mypy-cache-fix/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: mypy-cache-fix
+description: >-
+  Diagnose and fix mypy pre-commit failures in this repo. Use when: mypy hook
+  crashes with INTERNAL ERROR, mypy exits with code 2, mypy fails silently, or
+  you suspect mypy cache corruption after seeing sqlite3 DatabaseError.
+---
+
+# Fix mypy Cache Corruption
+
+When the mypy pre-commit hook exits with an INTERNAL ERROR, the most common cause
+is a corrupted `.mypy_cache` SQLite database.
+
+## Diagnose
+
+Run mypy directly with `--show-traceback` to see the real error:
+
+```bash
+script/run-in-env.sh mypy --ignore-missing-imports --show-traceback supervisor
+```
+
+### Interpret the traceback
+
+- **`sqlite3.DatabaseError: database disk image is malformed`** — cache corruption.
+  Proceed to the fix below.
+- **Any other error** — unrelated mypy issue. Read the traceback and either debug
+  the type error or report it to the team.
+
+## Fix (cache corruption only)
+
+```bash
+rm -rf .mypy_cache
+```
+
+Then re-run pre-commit to confirm the hook passes:
+
+```bash
+pre-commit run --files <changed files>
+```


### PR DESCRIPTION
## Proposed change

Add a repository skill document at `.github/skills/mypy-cache-fix/SKILL.md` describing how to diagnose and fix intermittent mypy internal errors caused by cache corruption.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
