### PR TITLE
Require PR template usage in agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,6 +3,11 @@
 This repository contains the Home Assistant Supervisor, a Python 3 based container
 orchestration and management system for Home Assistant.
 
+## Pull Request Requirements
+
+When opening a pull request in this repository, always use the description format
+from `.github/PULL_REQUEST_TEMPLATE.md`.
+
 ## Supervisor Capabilities & Features
 
 ### Architecture Overview


### PR DESCRIPTION
## Proposed change

Add explicit contributor guidance in the shared agent instructions file (`.github/copilot-instructions.md`) to always use `.github/PULL_REQUEST_TEMPLATE.md` when opening pull requests in this repository.

Because `AGENTS.md` and `CLAUDE.md` are symlinks to this file, this updates guidance for both entry points.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
