### PR TITLE
Add unhealthy reasons for fsck failures and issues for other systemd failures

### DIFF
--- a/supervisor/dbus/systemd.py
+++ b/supervisor/dbus/systemd.py
@@ -236,6 +236,13 @@ class Systemd(DBusInterfaceProxy):
         return await self.connected_dbus.Manager.call("list_units")
 
     @dbus_connected
+    async def list_units_filtered(
+        self, states: list[str]
+    ) -> list[tuple[str, str, str, str, str, str, str, int, str, str]]:
+        """Return a list of available systemd services filtered by state."""
+        return await self.connected_dbus.Manager.call("list_units_filtered", states)
+
+    @dbus_connected
     async def get_system_state(self) -> SystemState:
         """Return the systemd manager state."""
         return SystemState(await self.connected_dbus.Manager.get("system_state"))

--- a/supervisor/resolution/checks/systemd_unit_failure.py
+++ b/supervisor/resolution/checks/systemd_unit_failure.py
@@ -1,0 +1,157 @@
+"""Check for failed systemd units."""
+
+import asyncio
+from collections.abc import Awaitable
+from datetime import timedelta
+import logging
+
+from ...const import CoreState
+from ...coresys import CoreSys
+from ...host.firewall import FIREWALL_SERVICE
+from ...jobs.const import JobThrottle
+from ...jobs.decorator import Job
+from ...utils.sentry import async_capture_message
+from ..const import ContextType, IssueType, SuggestionType, UnhealthyReason
+from ..data import Issue
+from .base import CheckBase
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+# Systemd fsck units for OS boot and overlay
+OS_FSCK_UNITS = {
+    "systemd-fsck@dev-disk-by\\x2dlabel-hassos\\x2dboot.service",
+    "systemd-fsck@dev-disk-by\\x2dlabel-hassos\\x2doverlay.service",
+}
+
+# Systemd fsck unit for data filesystem
+DATA_FSCK_UNIT = "systemd-fsck@dev-disk-by\\x2dlabel-hassos\\x2ddata.service"
+
+
+def setup(coresys: CoreSys) -> CheckBase:
+    """Check setup function."""
+    return CheckSystemdUnitFailure(coresys)
+
+
+class CheckSystemdUnitFailure(CheckBase):
+    """Check for failed systemd units and create repair suggestions."""
+
+    def __init__(self, coresys: CoreSys) -> None:
+        """Initialize systemd unit failure check."""
+        super().__init__(coresys)
+        self._failed_units_cache: list[tuple[str, ...]] = []
+
+    @Job(
+        name="resolution_check_systemd_unit_failure_list_units_filtered",
+        throttle=JobThrottle.THROTTLE,
+        throttle_period=timedelta(seconds=60),
+        internal=True,
+    )
+    async def _refresh_failed_units_cache(self) -> None:
+        """Refresh cached failed units at most once per throttle period."""
+        self._failed_units_cache = await self.sys_dbus.systemd.list_units_filtered(
+            ["failed"]
+        )
+
+    async def _get_failed_units(self) -> list[tuple[str, ...]]:
+        """Return failed units using a throttled cached fetch."""
+        await self._refresh_failed_units_cache()
+        return self._failed_units_cache
+
+    async def run_check(self) -> None:
+        """Run check to list failed systemd units."""
+        # Get all failed units
+        failed_units = await self._get_failed_units()
+        capture_coroutines: list[Awaitable[None]] = []
+
+        if not failed_units:
+            return
+
+        # Get managed mount unit names from mounts and bound_mounts
+        managed_mounts = set()
+        for mount in self.sys_mounts.mounts:
+            managed_mounts.add(mount.unit_name)
+        for bound_mount in self.sys_mounts.bound_mounts:
+            managed_mounts.add(bound_mount.mount.unit_name)
+
+        for unit in failed_units:
+            unit_name = unit[0]
+
+            # Skip mount units managed by MountManager
+            if unit_name in managed_mounts:
+                _LOGGER.debug(
+                    "Ignoring failed mount unit '%s' managed by MountManager",
+                    unit_name,
+                )
+                continue
+
+            # Skip firewall service which handles its own health state
+            if unit_name == FIREWALL_SERVICE:
+                _LOGGER.debug(
+                    "Ignoring failed firewall service '%s' which handles its own health state",
+                    unit_name,
+                )
+                continue
+
+            # Check for OS fsck failures
+            if unit_name in OS_FSCK_UNITS:
+                _LOGGER.error("OS filesystem check failed: %s", unit_name)
+                self.sys_resolution.add_unhealthy_reason(
+                    UnhealthyReason.OS_FILESYSTEM_CHECK_ERROR
+                )
+                continue
+
+            # Check for data fsck failure
+            if unit_name == DATA_FSCK_UNIT:
+                _LOGGER.error("Data filesystem check failed: %s", unit_name)
+                self.sys_resolution.add_unhealthy_reason(
+                    UnhealthyReason.DATA_FILESYSTEM_CHECK_ERROR
+                )
+                continue
+
+            # Create issue for other failed units
+            issue = Issue(
+                IssueType.SYSTEMD_UNIT_FAILED, ContextType.SYSTEM, reference=unit_name
+            )
+            if issue in self.sys_resolution.issues:
+                continue
+
+            capture_coroutines.append(
+                async_capture_message(
+                    f"Systemd unit failed: {unit_name}",
+                    level="error",
+                )
+            )
+            self.sys_resolution.add_issue(
+                issue,
+                suggestions=[
+                    SuggestionType.EXECUTE_RESET,
+                    SuggestionType.EXECUTE_RESTART,
+                ],
+            )
+
+        if capture_coroutines:
+            await asyncio.gather(*capture_coroutines)
+
+    async def approve_check(self, issue: Issue) -> bool:
+        """Approve check if it is affected by issue."""
+        if not issue.reference:
+            return False
+
+        # Check if the failed unit still exists in failed units
+        failed_units = await self._get_failed_units()
+        return any(unit[0] == issue.reference for unit in failed_units)
+
+    @property
+    def issue(self) -> IssueType:
+        """Return an IssueType enum."""
+        return IssueType.SYSTEMD_UNIT_FAILED
+
+    @property
+    def context(self) -> ContextType:
+        """Return a ContextType enum."""
+        return ContextType.SYSTEM
+
+    @property
+    def states(self) -> list[CoreState]:
+        """Return a list of valid states when this check can run."""
+        return [CoreState.SETUP]

--- a/supervisor/resolution/const.py
+++ b/supervisor/resolution/const.py
@@ -64,10 +64,12 @@ class UnsupportedReason(StrEnum):
 class UnhealthyReason(StrEnum):
     """Reasons for unsupported status."""
 
+    DATA_FILESYSTEM_CHECK_ERROR = "data_filesystem_check_error"
     DOCKER = "docker"
     DOCKER_GATEWAY_UNPROTECTED = "docker_gateway_unprotected"
     DUPLICATE_OS_INSTALLATION = "duplicate_os_installation"
     OSERROR_BAD_MESSAGE = "oserror_bad_message"
+    OS_FILESYSTEM_CHECK_ERROR = "os_filesystem_check_error"
     PRIVILEGED = "privileged"
     SETUP = "setup"
     SUPERVISOR = "supervisor"
@@ -107,6 +109,7 @@ class IssueType(StrEnum):
     REBOOT_REQUIRED = "reboot_required"
     RPI_FIRMWARE_UPDATE_BLOCKED = "rpi_firmware_update_blocked"
     SECURITY = "security"
+    SYSTEMD_UNIT_FAILED = "systemd_unit_failed"
     UPDATE_FAILED = "update_failed"
     UPDATE_ROLLBACK = "update_rollback"
 

--- a/supervisor/resolution/fixups/systemd_unit_execute_reset.py
+++ b/supervisor/resolution/fixups/systemd_unit_execute_reset.py
@@ -1,0 +1,56 @@
+"""Fixup to reset failed systemd unit."""
+
+import logging
+
+from ...coresys import CoreSys
+from ...exceptions import DBusError, DBusSystemdNoSuchUnit, ResolutionFixupError
+from ...resolution.const import ContextType, IssueType, SuggestionType
+from ...resolution.data import Suggestion
+from .base import FixupBase
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+def setup(coresys: CoreSys) -> FixupBase:
+    """Fixup setup function."""
+    return FixupSystemdUnitExecuteReset(coresys)
+
+
+class FixupSystemdUnitExecuteReset(FixupBase):
+    """Fixup to reset failed state of a systemd unit."""
+
+    async def process_fixup(self, suggestion: Suggestion) -> None:
+        """Reset the failed state of the unit."""
+        if not suggestion.reference:
+            _LOGGER.warning("No unit reference provided for systemd reset fixup")
+            return
+
+        unit_name = suggestion.reference
+        try:
+            _LOGGER.info("Resetting failed state of systemd unit: %s", unit_name)
+            await self.sys_dbus.systemd.reset_failed_unit(unit_name)
+        except DBusSystemdNoSuchUnit:
+            _LOGGER.warning("Systemd unit not found: %s", unit_name)
+        except DBusError as err:
+            _LOGGER.error("Failed to reset systemd unit %s: %s", unit_name, err)
+            raise ResolutionFixupError from err
+
+    @property
+    def suggestion(self) -> SuggestionType:
+        """Return SuggestionType enum."""
+        return SuggestionType.EXECUTE_RESET
+
+    @property
+    def context(self) -> ContextType:
+        """Return ContextType enum."""
+        return ContextType.SYSTEM
+
+    @property
+    def issues(self) -> list[IssueType]:
+        """Return affected IssueType enums."""
+        return [IssueType.SYSTEMD_UNIT_FAILED]
+
+    @property
+    def auto(self) -> bool:
+        """Return if auto fixup is enabled."""
+        return False

--- a/supervisor/resolution/fixups/systemd_unit_execute_restart.py
+++ b/supervisor/resolution/fixups/systemd_unit_execute_restart.py
@@ -1,0 +1,57 @@
+"""Fixup to restart failed systemd unit."""
+
+import logging
+
+from ...coresys import CoreSys
+from ...dbus.const import StartUnitMode
+from ...exceptions import DBusError, DBusSystemdNoSuchUnit, ResolutionFixupError
+from ...resolution.const import ContextType, IssueType, SuggestionType
+from ...resolution.data import Suggestion
+from .base import FixupBase
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+def setup(coresys: CoreSys) -> FixupBase:
+    """Fixup setup function."""
+    return FixupSystemdUnitExecuteRestart(coresys)
+
+
+class FixupSystemdUnitExecuteRestart(FixupBase):
+    """Fixup to restart a failed systemd unit."""
+
+    async def process_fixup(self, suggestion: Suggestion) -> None:
+        """Restart the unit."""
+        if not suggestion.reference:
+            _LOGGER.warning("No unit reference provided for systemd restart fixup")
+            return
+
+        unit_name = suggestion.reference
+        try:
+            _LOGGER.info("Restarting systemd unit: %s", unit_name)
+            await self.sys_dbus.systemd.restart_unit(unit_name, StartUnitMode.REPLACE)
+        except DBusSystemdNoSuchUnit:
+            _LOGGER.warning("Systemd unit not found: %s", unit_name)
+        except DBusError as err:
+            _LOGGER.error("Failed to restart systemd unit %s: %s", unit_name, err)
+            raise ResolutionFixupError from err
+
+    @property
+    def suggestion(self) -> SuggestionType:
+        """Return SuggestionType enum."""
+        return SuggestionType.EXECUTE_RESTART
+
+    @property
+    def context(self) -> ContextType:
+        """Return ContextType enum."""
+        return ContextType.SYSTEM
+
+    @property
+    def issues(self) -> list[IssueType]:
+        """Return affected IssueType enums."""
+        return [IssueType.SYSTEMD_UNIT_FAILED]
+
+    @property
+    def auto(self) -> bool:
+        """Return if auto fixup is enabled."""
+        return False

--- a/supervisor/utils/sentry.py
+++ b/supervisor/utils/sentry.py
@@ -79,6 +79,22 @@ async def async_capture_exception(err: BaseException) -> None:
         )
 
 
+async def async_capture_message(
+    msg: str,
+    level: Literal["fatal", "critical", "error", "warning", "info", "debug"]
+    | None = "warning",
+) -> None:
+    """Capture a message and send to sentry.
+
+    Safe to call in event loop.
+    """
+    if sentry_sdk.is_initialized():
+        await asyncio.get_running_loop().run_in_executor(
+            None,
+            partial(sentry_sdk.capture_message, msg, level=level),
+        )
+
+
 def fire_and_forget_capture_message(
     msg: str,
     level: Literal["fatal", "critical", "error", "warning", "info", "debug"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -922,6 +922,16 @@ async def capture_exception() -> Mock:
 
 
 @pytest.fixture
+async def capture_message() -> Mock:
+    """Mock capture message method for testing."""
+    with (
+        patch("supervisor.utils.sentry.sentry_sdk.is_initialized", return_value=True),
+        patch("supervisor.utils.sentry.sentry_sdk.capture_message") as capture_message,
+    ):
+        yield capture_message
+
+
+@pytest.fixture
 async def os_available(request: pytest.FixtureRequest) -> None:
     """Mock os as available."""
     version = (

--- a/tests/dbus/test_systemd.py
+++ b/tests/dbus/test_systemd.py
@@ -169,6 +169,25 @@ async def test_list_units(dbus_session_bus: MessageBus):
     assert units[3][2] == "loaded"
 
 
+async def test_list_units_filtered(
+    systemd_service: SystemdService, dbus_session_bus: MessageBus
+):
+    """Test list units filtered by state."""
+    systemd_service.ListUnitsFiltered.calls.clear()
+    systemd = Systemd()
+
+    with pytest.raises(DBusNotConnectedError):
+        await systemd.list_units_filtered(["failed"])
+
+    await systemd.connect(dbus_session_bus)
+
+    units = await systemd.list_units_filtered(["not-found"])
+    assert len(units) == 1
+    assert units[0][0] == "firewalld.service"
+    assert units[0][2] == "not-found"
+    assert systemd_service.ListUnitsFiltered.calls == [(["not-found"],)]
+
+
 async def test_start_transient_unit(
     systemd_service: SystemdService, dbus_session_bus: MessageBus
 ):

--- a/tests/dbus_service_mocks/systemd.py
+++ b/tests/dbus_service_mocks/systemd.py
@@ -43,6 +43,60 @@ class Systemd(DBusServiceMock):
     )
     mock_systemd_unit: SystemdUnit | None = None
 
+    @staticmethod
+    def _units() -> list[list[str | int]]:
+        """Return static unit rows in ListUnits shape."""
+        return [
+            [
+                "etc-machine\\x2did.mount",
+                "/etc/machine-id",
+                "loaded",
+                "active",
+                "mounted",
+                "",
+                "/org/freedesktop/systemd1/unit/etc_2dmachine_5cx2did_2emount",
+                0,
+                "",
+                "/",
+            ],
+            [
+                "firewalld.service",
+                "firewalld.service",
+                "not-found",
+                "inactive",
+                "dead",
+                "",
+                "/org/freedesktop/systemd1/unit/firewalld_2eservice",
+                0,
+                "",
+                "/",
+            ],
+            [
+                "sys-devices-virtual-tty-ttypd.device",
+                "/sys/devices/virtual/tty/ttypd",
+                "loaded",
+                "active",
+                "plugged",
+                "",
+                "/org/freedesktop/systemd1/unit/sys_2ddevices_2dvirtual_2dtty_2dttypd_2edevice",
+                0,
+                "",
+                "/",
+            ],
+            [
+                "zram-swap.service",
+                "HassOS ZRAM swap",
+                "loaded",
+                "active",
+                "exited",
+                "",
+                "/org/freedesktop/systemd1/unit/zram_2dswap_2eservice",
+                0,
+                "",
+                "/",
+            ],
+        ]
+
     @dbus_property(access=PropertyAccess.READ)
     def Version(self) -> "s":
         """Get Version."""
@@ -752,53 +806,17 @@ class Systemd(DBusServiceMock):
         self,
     ) -> "a(ssssssouso)":
         """Return a list of available services."""
+        return self._units()
+
+    @dbus_method()
+    def ListUnitsFiltered(self, states: "as") -> "a(ssssssouso)":
+        """Return a list of available services filtered by state."""
+        units = self._units()
+        if not states:
+            return units
+
         return [
-            [
-                "etc-machine\\x2did.mount",
-                "/etc/machine-id",
-                "loaded",
-                "active",
-                "mounted",
-                "",
-                "/org/freedesktop/systemd1/unit/etc_2dmachine_5cx2did_2emount",
-                0,
-                "",
-                "/",
-            ],
-            [
-                "firewalld.service",
-                "firewalld.service",
-                "not-found",
-                "inactive",
-                "dead",
-                "",
-                "/org/freedesktop/systemd1/unit/firewalld_2eservice",
-                0,
-                "",
-                "/",
-            ],
-            [
-                "sys-devices-virtual-tty-ttypd.device",
-                "/sys/devices/virtual/tty/ttypd",
-                "loaded",
-                "active",
-                "plugged",
-                "",
-                "/org/freedesktop/systemd1/unit/sys_2ddevices_2dvirtual_2dtty_2dttypd_2edevice",
-                0,
-                "",
-                "/",
-            ],
-            [
-                "zram-swap.service",
-                "HassOS ZRAM swap",
-                "loaded",
-                "active",
-                "exited",
-                "",
-                "/org/freedesktop/systemd1/unit/zram_2dswap_2eservice",
-                0,
-                "",
-                "/",
-            ],
+            unit
+            for unit in units
+            if unit[2] in states or unit[3] in states or unit[4] in states
         ]

--- a/tests/resolution/check/test_check_systemd_unit_failure.py
+++ b/tests/resolution/check/test_check_systemd_unit_failure.py
@@ -1,0 +1,200 @@
+"""Test check for systemd unit failures."""
+
+# pylint: disable=protected-access
+from datetime import datetime
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from supervisor.const import CoreState
+from supervisor.coresys import CoreSys
+from supervisor.jobs.decorator import Job
+from supervisor.resolution.checks.systemd_unit_failure import (
+    DATA_FSCK_UNIT,
+    FIREWALL_SERVICE,
+    OS_FSCK_UNITS,
+    CheckSystemdUnitFailure,
+)
+from supervisor.resolution.const import ContextType, IssueType, UnhealthyReason
+from supervisor.resolution.data import Issue
+
+
+@pytest.fixture(autouse=True)
+def reset_systemd_unit_failure_throttle() -> None:
+    """Reset throttle state for deterministic tests."""
+    job = cast(
+        Job,
+        CheckSystemdUnitFailure._refresh_failed_units_cache.__closure__[
+            1
+        ].cell_contents,
+    )
+    job._last_call.clear()
+    job.set_last_call(datetime.min)
+
+
+async def test_base(coresys: CoreSys):
+    """Test check basics."""
+    systemd_unit_failure = CheckSystemdUnitFailure(coresys)
+    assert systemd_unit_failure.slug == "systemd_unit_failure"
+    assert systemd_unit_failure.enabled
+    assert systemd_unit_failure.issue == IssueType.SYSTEMD_UNIT_FAILED
+    assert systemd_unit_failure.context == ContextType.SYSTEM
+    assert systemd_unit_failure.states == [CoreState.SETUP]
+
+
+async def test_check_creates_issue_and_captures_message(
+    coresys: CoreSys, capture_message: Mock
+):
+    """Test check creates issue and captures a sentry message."""
+    systemd_unit_failure = CheckSystemdUnitFailure(coresys)
+
+    with patch.object(
+        coresys.dbus.systemd,
+        "list_units_filtered",
+        new_callable=AsyncMock,
+        return_value=[("example.service",)],
+    ):
+        await systemd_unit_failure.run_check()
+
+    assert len(coresys.resolution.issues) == 1
+    assert coresys.resolution.issues[0] == Issue(
+        IssueType.SYSTEMD_UNIT_FAILED,
+        ContextType.SYSTEM,
+        reference="example.service",
+    )
+    assert len(coresys.resolution.suggestions) == 2
+    capture_message.assert_called_once_with(
+        "Systemd unit failed: example.service", level="error"
+    )
+
+
+async def test_mount_unit_failures_ignored(coresys: CoreSys, capture_message: Mock):
+    """Test mount unit failures are ignored."""
+    systemd_unit_failure = CheckSystemdUnitFailure(coresys)
+    coresys.mounts._mounts = {"test": MagicMock(unit_name="mnt-data.mount")}
+    coresys.mounts._bound_mounts = {}
+
+    with patch.object(
+        coresys.dbus.systemd,
+        "list_units_filtered",
+        new_callable=AsyncMock,
+        return_value=[("mnt-data.mount",)],
+    ):
+        await systemd_unit_failure.run_check()
+
+    assert not coresys.resolution.issues
+    assert not coresys.resolution.suggestions
+    capture_message.assert_not_called()
+
+
+async def test_firewall_service_failure_ignored(
+    coresys: CoreSys, capture_message: Mock
+):
+    """Test firewall service failure is ignored."""
+    systemd_unit_failure = CheckSystemdUnitFailure(coresys)
+
+    with patch.object(
+        coresys.dbus.systemd,
+        "list_units_filtered",
+        new_callable=AsyncMock,
+        return_value=[(FIREWALL_SERVICE,)],
+    ):
+        await systemd_unit_failure.run_check()
+
+    assert not coresys.resolution.issues
+    assert not coresys.resolution.suggestions
+    capture_message.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("unit_name", "unhealthy_reason"),
+    [
+        (
+            "systemd-fsck@dev-disk-by\\x2dlabel-hassos\\x2dboot.service",
+            UnhealthyReason.OS_FILESYSTEM_CHECK_ERROR,
+        ),
+        (
+            "systemd-fsck@dev-disk-by\\x2dlabel-hassos\\x2doverlay.service",
+            UnhealthyReason.OS_FILESYSTEM_CHECK_ERROR,
+        ),
+        (
+            DATA_FSCK_UNIT,
+            UnhealthyReason.DATA_FILESYSTEM_CHECK_ERROR,
+        ),
+    ],
+)
+async def test_fsck_failures_set_correct_unhealthy_reason(
+    coresys: CoreSys,
+    capture_message: Mock,
+    unit_name: str,
+    unhealthy_reason: UnhealthyReason,
+):
+    """Test fsck failures set expected unhealthy reason."""
+    systemd_unit_failure = CheckSystemdUnitFailure(coresys)
+    assert unit_name in OS_FSCK_UNITS or unit_name == DATA_FSCK_UNIT
+
+    with patch.object(
+        coresys.dbus.systemd,
+        "list_units_filtered",
+        new_callable=AsyncMock,
+        return_value=[(unit_name,)],
+    ):
+        await systemd_unit_failure.run_check()
+
+    assert unhealthy_reason in coresys.resolution.unhealthy
+    assert not coresys.resolution.issues
+    assert not coresys.resolution.suggestions
+    capture_message.assert_not_called()
+
+
+async def test_throttled_approve_only_calls_dbus_once_for_multiple_issues(
+    coresys: CoreSys,
+):
+    """Test approve checks reuse throttled cache for multiple issues."""
+    systemd_unit_failure = CheckSystemdUnitFailure(coresys)
+    await coresys.core.set_state(CoreState.SETUP)
+
+    coresys.resolution.add_issue(
+        Issue(IssueType.SYSTEMD_UNIT_FAILED, ContextType.SYSTEM, reference="a.service")
+    )
+    coresys.resolution.add_issue(
+        Issue(IssueType.SYSTEMD_UNIT_FAILED, ContextType.SYSTEM, reference="b.service")
+    )
+
+    with patch.object(
+        coresys.dbus.systemd,
+        "list_units_filtered",
+        new_callable=AsyncMock,
+        return_value=[("a.service",), ("b.service",)],
+    ) as list_units_filtered:
+        await systemd_unit_failure()
+
+    assert list_units_filtered.await_count == 1
+    assert len(coresys.resolution.issues) == 2
+
+
+async def test_did_run(coresys: CoreSys):
+    """Test that the check runs only in expected states."""
+    systemd_unit_failure = CheckSystemdUnitFailure(coresys)
+    should_run = systemd_unit_failure.states
+    should_not_run = [state for state in CoreState if state not in should_run]
+    assert should_run == [CoreState.SETUP]
+    assert len(should_not_run) != 0
+
+    with patch.object(
+        CheckSystemdUnitFailure,
+        "run_check",
+        return_value=None,
+    ) as check:
+        for state in should_run:
+            await coresys.core.set_state(state)
+            await systemd_unit_failure()
+            check.assert_called_once()
+            check.reset_mock()
+
+        for state in should_not_run:
+            await coresys.core.set_state(state)
+            await systemd_unit_failure()
+            check.assert_not_called()
+            check.reset_mock()

--- a/tests/resolution/fixup/test_systemd_unit_execute_reset.py
+++ b/tests/resolution/fixup/test_systemd_unit_execute_reset.py
@@ -1,0 +1,79 @@
+"""Test fixup systemd unit execute reset."""
+
+from unittest.mock import AsyncMock, patch
+
+from supervisor.coresys import CoreSys
+from supervisor.exceptions import DBusError, DBusSystemdNoSuchUnit
+from supervisor.resolution.const import ContextType, IssueType, SuggestionType
+from supervisor.resolution.data import Issue, Suggestion
+from supervisor.resolution.fixups.systemd_unit_execute_reset import (
+    FixupSystemdUnitExecuteReset,
+)
+
+ISSUE = Issue(IssueType.SYSTEMD_UNIT_FAILED, ContextType.SYSTEM, reference="a.service")
+SUGGESTION = Suggestion(
+    SuggestionType.EXECUTE_RESET,
+    ContextType.SYSTEM,
+    reference="a.service",
+)
+
+
+async def test_fixup_reset_success(coresys: CoreSys):
+    """Test reset fixup succeeds and cleans issue/suggestion."""
+    systemd_unit_execute_reset = FixupSystemdUnitExecuteReset(coresys)
+    assert systemd_unit_execute_reset.suggestion == SuggestionType.EXECUTE_RESET
+    assert systemd_unit_execute_reset.context == ContextType.SYSTEM
+    assert systemd_unit_execute_reset.issues == [IssueType.SYSTEMD_UNIT_FAILED]
+    assert systemd_unit_execute_reset.auto is False
+
+    coresys.resolution.add_suggestion(SUGGESTION)
+    coresys.resolution.add_issue(ISSUE)
+
+    with patch.object(
+        coresys.dbus.systemd,
+        "reset_failed_unit",
+        new_callable=AsyncMock,
+    ) as reset_failed_unit:
+        await systemd_unit_execute_reset()
+
+    reset_failed_unit.assert_awaited_once_with("a.service")
+    assert not coresys.resolution.suggestions
+    assert not coresys.resolution.issues
+
+
+async def test_fixup_reset_no_such_unit(coresys: CoreSys):
+    """Test no-such-unit is tolerated and clears issue/suggestion."""
+    systemd_unit_execute_reset = FixupSystemdUnitExecuteReset(coresys)
+    coresys.resolution.add_suggestion(SUGGESTION)
+    coresys.resolution.add_issue(ISSUE)
+
+    with patch.object(
+        coresys.dbus.systemd,
+        "reset_failed_unit",
+        new_callable=AsyncMock,
+        side_effect=DBusSystemdNoSuchUnit("missing"),
+    ) as reset_failed_unit:
+        await systemd_unit_execute_reset()
+
+    reset_failed_unit.assert_awaited_once_with("a.service")
+    assert not coresys.resolution.suggestions
+    assert not coresys.resolution.issues
+
+
+async def test_fixup_reset_dbus_error_keeps_issue(coresys: CoreSys):
+    """Test DBus error keeps issue/suggestion in place."""
+    systemd_unit_execute_reset = FixupSystemdUnitExecuteReset(coresys)
+    coresys.resolution.add_suggestion(SUGGESTION)
+    coresys.resolution.add_issue(ISSUE)
+
+    with patch.object(
+        coresys.dbus.systemd,
+        "reset_failed_unit",
+        new_callable=AsyncMock,
+        side_effect=DBusError("boom"),
+    ) as reset_failed_unit:
+        await systemd_unit_execute_reset()
+
+    reset_failed_unit.assert_awaited_once_with("a.service")
+    assert ISSUE in coresys.resolution.issues
+    assert SUGGESTION in coresys.resolution.suggestions

--- a/tests/resolution/fixup/test_systemd_unit_execute_restart.py
+++ b/tests/resolution/fixup/test_systemd_unit_execute_restart.py
@@ -1,0 +1,80 @@
+"""Test fixup systemd unit execute restart."""
+
+from unittest.mock import AsyncMock, patch
+
+from supervisor.coresys import CoreSys
+from supervisor.dbus.const import StartUnitMode
+from supervisor.exceptions import DBusError, DBusSystemdNoSuchUnit
+from supervisor.resolution.const import ContextType, IssueType, SuggestionType
+from supervisor.resolution.data import Issue, Suggestion
+from supervisor.resolution.fixups.systemd_unit_execute_restart import (
+    FixupSystemdUnitExecuteRestart,
+)
+
+ISSUE = Issue(IssueType.SYSTEMD_UNIT_FAILED, ContextType.SYSTEM, reference="a.service")
+SUGGESTION = Suggestion(
+    SuggestionType.EXECUTE_RESTART,
+    ContextType.SYSTEM,
+    reference="a.service",
+)
+
+
+async def test_fixup_restart_success(coresys: CoreSys):
+    """Test restart fixup succeeds and cleans issue/suggestion."""
+    systemd_unit_execute_restart = FixupSystemdUnitExecuteRestart(coresys)
+    assert systemd_unit_execute_restart.suggestion == SuggestionType.EXECUTE_RESTART
+    assert systemd_unit_execute_restart.context == ContextType.SYSTEM
+    assert systemd_unit_execute_restart.issues == [IssueType.SYSTEMD_UNIT_FAILED]
+    assert systemd_unit_execute_restart.auto is False
+
+    coresys.resolution.add_suggestion(SUGGESTION)
+    coresys.resolution.add_issue(ISSUE)
+
+    with patch.object(
+        coresys.dbus.systemd,
+        "restart_unit",
+        new_callable=AsyncMock,
+    ) as restart_unit:
+        await systemd_unit_execute_restart()
+
+    restart_unit.assert_awaited_once_with("a.service", StartUnitMode.REPLACE)
+    assert not coresys.resolution.suggestions
+    assert not coresys.resolution.issues
+
+
+async def test_fixup_restart_no_such_unit(coresys: CoreSys):
+    """Test no-such-unit is tolerated and clears issue/suggestion."""
+    systemd_unit_execute_restart = FixupSystemdUnitExecuteRestart(coresys)
+    coresys.resolution.add_suggestion(SUGGESTION)
+    coresys.resolution.add_issue(ISSUE)
+
+    with patch.object(
+        coresys.dbus.systemd,
+        "restart_unit",
+        new_callable=AsyncMock,
+        side_effect=DBusSystemdNoSuchUnit("missing"),
+    ) as restart_unit:
+        await systemd_unit_execute_restart()
+
+    restart_unit.assert_awaited_once_with("a.service", StartUnitMode.REPLACE)
+    assert not coresys.resolution.suggestions
+    assert not coresys.resolution.issues
+
+
+async def test_fixup_restart_dbus_error_keeps_issue(coresys: CoreSys):
+    """Test DBus error keeps issue/suggestion in place."""
+    systemd_unit_execute_restart = FixupSystemdUnitExecuteRestart(coresys)
+    coresys.resolution.add_suggestion(SUGGESTION)
+    coresys.resolution.add_issue(ISSUE)
+
+    with patch.object(
+        coresys.dbus.systemd,
+        "restart_unit",
+        new_callable=AsyncMock,
+        side_effect=DBusError("boom"),
+    ) as restart_unit:
+        await systemd_unit_execute_restart()
+
+    restart_unit.assert_awaited_once_with("a.service", StartUnitMode.REPLACE)
+    assert ISSUE in coresys.resolution.issues
+    assert SUGGESTION in coresys.resolution.suggestions

--- a/tests/utils/test_sentry.py
+++ b/tests/utils/test_sentry.py
@@ -7,6 +7,7 @@ import pytest
 from sentry_sdk.worker import BackgroundWorker
 
 from supervisor.bootstrap import initialize_coresys, warning_handler
+from supervisor.utils.sentry import async_capture_message
 
 
 @pytest.mark.usefixtures("supervisor_name", "docker")
@@ -55,3 +56,10 @@ def test_warning_handler_captures_on_main_thread():
         warning = UserWarning("test")
         warning_handler(warning, UserWarning, "test.py", 1, None, None)
         mock_capture.assert_called_once_with(warning)
+
+
+async def test_async_capture_message(capture_message):
+    """Test async capture message helper sends expected message."""
+    await async_capture_message("systemd unit failed", level="error")
+
+    capture_message.assert_called_once_with("systemd unit failed", level="error")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

New check which marks the system as unhealthy when `fsck` fails on the OS or Data partition to denote there is a corrupted filesystem. Also looks for any other systemd unit failures. For any that aren't related to mount failures or our firewall service (since that handles itself) it creates issues out of them and reports a message to sentry so we can keep track of this.

The issues will only live in Supervisor, I don't plan to make generic systemd unit repairs. These will be sysadmin/developer level issues only visible in the CLI. If we identify other common and problematic repairs we'll add to this check to report new types of issues/unhealthy reasons that we do make into repairs.  It was also just a convenient way to keep track of which failures we'd already reported to sentry so we don't report the same failure repeatedly. 

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #6040
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46471
- Link to cli pull request:
- Link to client library pull request: https://github.com/home-assistant-libs/python-supervisor-client/pull/362
- Link to core pull request: https://github.com/home-assistant/core/pull/176928

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/