### PR TITLE
Run the mypy pre-commit hook the same way as CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,9 +26,16 @@ repos:
       # pyenv and/or virtualenv activated; it may not have been e.g. if
       # committing from a GUI tool that was not launched from an activated
       # shell.
+      #
+      # mypy is a whole-program checker, so run it against the entire
+      # supervisor package (matching CI) in a single serial invocation rather
+      # than against the changed files. See python/mypy#13916 for why running
+      # mypy per-file under pre-commit is problematic.
       - id: mypy
         name: mypy
-        entry: script/run-in-env.sh mypy --ignore-missing-imports
+        entry: script/run-in-env.sh mypy supervisor
         language: script
         types_or: [python, pyi]
         files: ^supervisor/.+\.(py|pyi)$
+        pass_filenames: false
+        require_serial: true


### PR DESCRIPTION
## Proposed change

Run the `mypy` pre-commit hook the same way CI does, with `mypy supervisor`.

mypy is a whole-program checker, but the hook was configured to check only the changed files (the default `pass_filenames` behavior) and added `--ignore-missing-imports`. Neither matches the CI command (`mypy supervisor`), which leads to two problems:

- **Different results than CI.** Checking only the changed files instead of the whole package can both miss and invent errors compared to a full run, so the hook and CI can disagree. See [python/mypy#13916](https://github.com/python/mypy/issues/13916) for the whole-program-vs-per-file rationale.
- **Intermittent `INTERNAL ERROR` crashes.** When several `supervisor/` files change, pre-commit splits the file list and runs the hook concurrently. Since mypy 2.0 the SQLite cache is enabled by default, and the parallel mypy processes race on the shared `.mypy_cache/cache.db`: SQLite reports `database is locked` ([python/mypy#21525](https://github.com/python/mypy/issues/21525)), and an interrupted write can leave the database `malformed`. This is the failure mode that the cache-cleanup runbook in #6971 works around; this PR addresses the root cause instead.

The fix aligns the hook with CI:

- `pass_filenames: false` and an explicit `supervisor` target so the hook always checks the whole package in a single invocation.
- `require_serial: true` as a safeguard against pre-commit ever running the hook concurrently.
- Drop `--ignore-missing-imports`, which CI does not use and which is redundant anyway: `[tool.mypy]` already disables the `import-not-found` and `import-untyped` error codes.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: [python/mypy#21525](https://github.com/python/mypy/issues/21525), [python/mypy#13916](https://github.com/python/mypy/issues/13916), and #6971
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
