### PR TITLE
Make /os/update stop auto-rebooting after OS update

### DIFF
--- a/supervisor/os/manager.py
+++ b/supervisor/os/manager.py
@@ -325,9 +325,14 @@ class OSManager(CoreSysAttributes):
         # Update success
         if 0 in completed:
             _LOGGER.info(
-                "Install of Home Assistant Operating System %s success", version
+                "Install of Home Assistant Operating System %s success; reboot required",
+                version,
             )
-            self.sys_create_task(self.sys_host.control.reboot())
+            self.sys_resolution.create_issue(
+                IssueType.REBOOT_REQUIRED,
+                ContextType.SYSTEM,
+                suggestions=[SuggestionType.EXECUTE_REBOOT],
+            )
             return
 
         # Update failed

--- a/tests/api/test_os.py
+++ b/tests/api/test_os.py
@@ -7,10 +7,12 @@ from awesomeversion import AwesomeVersion
 from dbus_fast import DBusError, ErrorType
 import pytest
 
+from supervisor.const import CoreState
 from supervisor.coresys import CoreSys
 from supervisor.dbus.agent import OSAgent
 from supervisor.dbus.agent.boards import BoardManager
 from supervisor.dbus.agent.boards.interface import BoardProxy
+from supervisor.exceptions import DBusError as SupervisorDBusError
 from supervisor.host.control import SystemControl
 from supervisor.os.manager import OSManager
 from supervisor.resolution.const import ContextType, IssueType, SuggestionType
@@ -240,6 +242,101 @@ async def test_api_set_boot_slot_error(
     result = await resp.json()
     assert result["message"] == "Can't mark A as active!"
     capture_exception.assert_called_once()
+
+
+async def test_api_os_update_no_auto_reboot_creates_issue(
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    tmp_supervisor_data,
+    path_extern: None,
+    supervisor_internet,
+):
+    """Successful OS update does not auto-reboot and creates a reboot issue."""
+    api_client, prefix = api_client_with_prefix
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    coresys.os._available = True
+    coresys.os._board = "generic-x86-64"
+    coresys.os._os_name = "haos"
+    coresys.os._version = AwesomeVersion("12.0")
+    coresys.updater._data = {
+        "ota": (
+            "https://github.com/home-assistant/operating-system/releases/download/"
+            "{version}/{os_name}_{board}-{version}.raucb"
+        ),
+        "hassos_unrestricted": AwesomeVersion("13.0"),
+    }
+
+    async def fake_download(url, raucb) -> None:
+        raucb.touch()
+
+    with (
+        patch.object(coresys.os, "_download_raucb", side_effect=fake_download),
+        patch.object(coresys.host.control, "reboot") as reboot,
+    ):
+        resp = await api_client.post(f"{prefix}/os/update", json={})
+
+    assert resp.status == 200
+    reboot.assert_not_called()
+    assert (
+        Issue(IssueType.REBOOT_REQUIRED, ContextType.SYSTEM)
+        in coresys.resolution.issues
+    )
+    assert (
+        Suggestion(SuggestionType.EXECUTE_REBOOT, ContextType.SYSTEM)
+        in coresys.resolution.suggestions
+    )
+
+
+async def test_api_os_update_failure_no_reboot_no_issue(
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    tmp_supervisor_data,
+    path_extern: None,
+    supervisor_internet,
+):
+    """Failed OS update does not auto-reboot and does not create reboot issue."""
+    api_client, prefix = api_client_with_prefix
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    coresys.os._available = True
+    coresys.os._board = "generic-x86-64"
+    coresys.os._os_name = "haos"
+    coresys.os._version = AwesomeVersion("12.0")
+    coresys.updater._data = {
+        "ota": (
+            "https://github.com/home-assistant/operating-system/releases/download/"
+            "{version}/{os_name}_{board}-{version}.raucb"
+        ),
+        "hassos_unrestricted": AwesomeVersion("13.0"),
+    }
+
+    async def fake_download(url, raucb) -> None:
+        raucb.touch()
+
+    with (
+        patch.object(coresys.os, "_download_raucb", side_effect=fake_download),
+        patch.object(
+            coresys.dbus.rauc,
+            "install",
+            side_effect=SupervisorDBusError("fail"),
+        ),
+        patch.object(coresys.host.control, "reboot") as reboot,
+    ):
+        resp = await api_client.post(f"{prefix}/os/update", json={})
+
+    assert resp.status == 400
+    result = await resp.json()
+    assert result["message"] == "Rauc communication error"
+    reboot.assert_not_called()
+    assert (
+        Issue(IssueType.REBOOT_REQUIRED, ContextType.SYSTEM)
+        not in coresys.resolution.issues
+    )
+    assert (
+        Suggestion(SuggestionType.EXECUTE_REBOOT, ContextType.SYSTEM)
+        not in coresys.resolution.suggestions
+    )
 
 
 async def test_api_board_yellow_info(

--- a/tests/api/test_os.py
+++ b/tests/api/test_os.py
@@ -250,31 +250,25 @@ async def test_api_os_update_no_auto_reboot_creates_issue(
     tmp_supervisor_data,
     path_extern: None,
     supervisor_internet,
+    os_available,
 ):
     """Successful OS update does not auto-reboot and creates a reboot issue."""
     api_client, prefix = api_client_with_prefix
     await coresys.core.set_state(CoreState.RUNNING)
 
-    coresys.os._available = True
-    coresys.os._board = "generic-x86-64"
-    coresys.os._os_name = "haos"
-    coresys.os._version = AwesomeVersion("12.0")
-    coresys.updater._data = {
-        "ota": (
-            "https://github.com/home-assistant/operating-system/releases/download/"
-            "{version}/{os_name}_{board}-{version}.raucb"
-        ),
-        "hassos_unrestricted": AwesomeVersion("13.0"),
-    }
-
     async def fake_download(url, raucb) -> None:
         raucb.touch()
 
     with (
+        patch.object(
+            coresys.os,
+            "_get_download_url",
+            return_value="https://example.invalid/update.raucb",
+        ),
         patch.object(coresys.os, "_download_raucb", side_effect=fake_download),
         patch.object(coresys.host.control, "reboot") as reboot,
     ):
-        resp = await api_client.post(f"{prefix}/os/update", json={})
+        resp = await api_client.post(f"{prefix}/os/update", json={"version": "13.0"})
 
     assert resp.status == 200
     reboot.assert_not_called()
@@ -294,27 +288,21 @@ async def test_api_os_update_failure_no_reboot_no_issue(
     tmp_supervisor_data,
     path_extern: None,
     supervisor_internet,
+    os_available,
 ):
     """Failed OS update does not auto-reboot and does not create reboot issue."""
     api_client, prefix = api_client_with_prefix
     await coresys.core.set_state(CoreState.RUNNING)
 
-    coresys.os._available = True
-    coresys.os._board = "generic-x86-64"
-    coresys.os._os_name = "haos"
-    coresys.os._version = AwesomeVersion("12.0")
-    coresys.updater._data = {
-        "ota": (
-            "https://github.com/home-assistant/operating-system/releases/download/"
-            "{version}/{os_name}_{board}-{version}.raucb"
-        ),
-        "hassos_unrestricted": AwesomeVersion("13.0"),
-    }
-
     async def fake_download(url, raucb) -> None:
         raucb.touch()
 
     with (
+        patch.object(
+            coresys.os,
+            "_get_download_url",
+            return_value="https://example.invalid/update.raucb",
+        ),
         patch.object(coresys.os, "_download_raucb", side_effect=fake_download),
         patch.object(
             coresys.dbus.rauc,
@@ -323,7 +311,7 @@ async def test_api_os_update_failure_no_reboot_no_issue(
         ),
         patch.object(coresys.host.control, "reboot") as reboot,
     ):
-        resp = await api_client.post(f"{prefix}/os/update", json={})
+        resp = await api_client.post(f"{prefix}/os/update", json={"version": "13.0"})
 
     assert resp.status == 400
     result = await resp.json()

--- a/tests/os/test_manager.py
+++ b/tests/os/test_manager.py
@@ -10,7 +10,12 @@ import pytest
 from supervisor.const import CoreState
 from supervisor.coresys import CoreSys
 from supervisor.exceptions import HassOSJobError
-from supervisor.resolution.const import UnhealthyReason
+from supervisor.resolution.const import (
+    ContextType,
+    IssueType,
+    SuggestionType,
+    UnhealthyReason,
+)
 
 from tests.common import MockResponse
 from tests.dbus_service_mocks.base import DBusServiceMock
@@ -136,6 +141,18 @@ async def test_update_success_cleans_up_bundle(
 
     bundle = coresys.config.path_tmp / "hassos-13.0.raucb"
     assert not bundle.exists()
+    reboot_mock.assert_not_called()
+    assert (
+        IssueType.REBOOT_REQUIRED,
+        ContextType.SYSTEM,
+    ) in {(issue.type, issue.context) for issue in coresys.resolution.issues}
+    assert (
+        SuggestionType.EXECUTE_REBOOT,
+        ContextType.SYSTEM,
+    ) in {
+        (suggestion.type, suggestion.context)
+        for suggestion in coresys.resolution.suggestions
+    }
 
 
 async def test_board_name_supervised(coresys: CoreSys) -> None:


### PR DESCRIPTION
## Proposed change

Changes OS update behavior so calling `/os/update` no longer automatically reboots the host after a successful update.

Instead, on successful update Supervisor now:
- Logs that the OS update completed and a reboot is required.
- Creates a `REBOOT_REQUIRED` issue with `EXECUTE_REBOOT` suggestion, matching the behavior used for Raspberry Pi firmware updates.

This is intentional and breaking for API consumers that previously relied on automatic reboot as part of `/os/update`.

Test updates in this PR:
- Updated OS manager success test to assert actual resolution issue/suggestion state instead of mocking `create_issue`.
- Added API tests for `/os/update`:
  - success path: no reboot occurs and reboot-required issue/suggestion are created
  - failure path: no reboot occurs and reboot-required issue/suggestion are not created

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #6978
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3214
- Link to cli pull request: https://github.com/home-assistant/cli/pull/662
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/