### PR TITLE
Avoid app's own mapped ports for dynamic ingress port

### DIFF
--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -888,8 +888,15 @@ class App(AppModel):
             return
 
         if self.data[ATTR_INGRESS_PORT] == 0:
+            # Reserve the ports the app maps itself so the dynamic ingress port
+            # can never coincide with a port the app exposes directly (which
+            # would bypass ingress authentication).
+            reserved_ports = {
+                int(container_port.partition("/")[0])
+                for container_port in (self.ports or {})
+            }
             self.data[ATTR_INGRESS_PORT] = await self.sys_ingress.get_dynamic_port(
-                self.slug
+                self.slug, reserved_ports
             )
 
     @Job(

--- a/supervisor/ingress.py
+++ b/supervisor/ingress.py
@@ -158,15 +158,25 @@ class Ingress(FileConfiguration, CoreSysAttributes):
 
         return True
 
-    async def get_dynamic_port(self, app_slug: str) -> int:
-        """Get/Create a dynamic port from range."""
+    async def get_dynamic_port(
+        self, app_slug: str, reserved_ports: set[int] | None = None
+    ) -> int:
+        """Get/Create a dynamic port from range.
+
+        reserved_ports lists ports the app maps to the host itself. Avoiding
+        them makes sure the dynamically chosen ingress port can never coincide
+        with a port the app exposes directly, which would make the ingress
+        endpoint reachable on the host bypassing ingress authentication.
+        """
         if app_slug in self.ports:
             return self.ports[app_slug]
 
+        reserved_ports = reserved_ports or set()
         port = None
         while (
             port is None
             or port in self.ports.values()
+            or port in reserved_ports
             or await check_port(self.sys_docker.network.gateway, port)
         ):
             port = random.randint(62000, 65500)

--- a/tests/test_ingress.py
+++ b/tests/test_ingress.py
@@ -71,6 +71,18 @@ async def test_dynamic_ports(coresys: CoreSys):
     assert port_test1 <= 65500
 
 
+async def test_dynamic_port_avoids_reserved_ports(coresys: CoreSys):
+    """Test dynamic port allocation avoids the app's own mapped ports."""
+    # Reserve all but a single port from the range so the only valid choice
+    # is the one not reserved.
+    reserved_ports = set(range(62000, 65501)) - {62345}
+
+    port = await coresys.ingress.get_dynamic_port("test", reserved_ports)
+
+    assert port == 62345
+    assert port not in reserved_ports
+
+
 async def test_ingress_save_data(coresys: CoreSys, tmp_supervisor_data: Path):
     """Test saving ingress data to file."""
     config_file = tmp_supervisor_data / "ingress.json"

--- a/tests/test_ingress.py
+++ b/tests/test_ingress.py
@@ -73,14 +73,17 @@ async def test_dynamic_ports(coresys: CoreSys):
 
 async def test_dynamic_port_avoids_reserved_ports(coresys: CoreSys):
     """Test dynamic port allocation avoids the app's own mapped ports."""
-    # Reserve all but a single port from the range so the only valid choice
-    # is the one not reserved.
-    reserved_ports = set(range(62000, 65501)) - {62345}
+    with (
+        patch("supervisor.ingress.check_port", return_value=False),
+        patch(
+            "supervisor.ingress.random.randint", side_effect=[62345, 62346]
+        ) as randint,
+    ):
+        port = await coresys.ingress.get_dynamic_port("test", {62345})
 
-    port = await coresys.ingress.get_dynamic_port("test", reserved_ports)
-
-    assert port == 62345
-    assert port not in reserved_ports
+    # First draw hits the reserved port and is rejected, second is accepted.
+    assert randint.call_count == 2
+    assert port == 62346
 
 
 async def test_ingress_save_data(coresys: CoreSys, tmp_supervisor_data: Path):


### PR DESCRIPTION
## Proposed change

When an app uses dynamic ingress port selection (`ingress_port: 0`), `Ingress.get_dynamic_port()` picks a random port from the 62000-65500 range. It only avoids ports already assigned as dynamic ingress ports to other apps and ports currently in use on the Docker gateway. It never consulted the app's own port mappings.

Because of that, the dynamically chosen ingress port could in principle land on a container port that the app also publishes to the host. In that case the ingress endpoint would be reachable directly on the host, bypassing ingress authentication.

This change passes the app's mapped container ports to `get_dynamic_port()` and excludes them when picking a port, so the dynamic ingress port can never coincide with a port the app exposes directly. This is only a problem if an app maps a container port in the 62000-65500 range in its `ports` config; none of the popular apps do that, but nothing structurally prevented it before.

This only affects dynamic ingress port selection. Apps that statically configure the same value for `ingress_port` and a published port are unchanged.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
