### PR TITLE
Add Raspberry Pi firmware update repair

### DIFF
--- a/supervisor/api/os.py
+++ b/supervisor/api/os.py
@@ -7,7 +7,6 @@ import re
 from typing import Any
 
 from aiohttp import web
-from awesomeversion import AwesomeVersion
 import voluptuous as vol
 
 from ..const import (
@@ -36,8 +35,9 @@ from ..const import (
 )
 from ..coresys import CoreSysAttributes
 from ..exceptions import APIError, APINotFound, BoardInvalidError
+from ..os.const import RPI_FIRMWARE_MIN_OS_AGENT_VERSION
 from ..resolution.const import ContextType, IssueType, SuggestionType
-from ..resolution.data import Issue
+from ..resolution.utils import sync_rpi_firmware_issues
 from ..validate import version_tag
 from .const import (
     ATTR_BOOT_SLOT,
@@ -55,10 +55,6 @@ from .const import (
 from .utils import api_process, api_validate
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
-
-# Raspberry Pi firmware management requires the io.hass.os.Boards.RaspberryPi
-# .Firmware D-Bus interface first shipped in this OS Agent release.
-RPI_FIRMWARE_MIN_OS_AGENT_VERSION: AwesomeVersion = AwesomeVersion("1.9.0")
 
 # pylint: disable=no-value-for-parameter
 SCHEMA_VERSION = vol.Schema({vol.Optional(ATTR_VERSION): version_tag})
@@ -250,7 +246,7 @@ class APIOS(CoreSysAttributes):
         """Get Raspberry Pi firmware state."""
         self._check_rpi_firmware_available()
         rpi = self.sys_dbus.agent.board.rpi_firmware
-        self._sync_rpi_firmware_blocked_issue(rpi.update_blocked)
+        sync_rpi_firmware_issues(self.coresys, rpi)
         return {
             ATTR_CURRENT_VERSION: rpi.current_version,
             ATTR_LATEST_VERSION: rpi.latest_version,
@@ -269,25 +265,15 @@ class APIOS(CoreSysAttributes):
         # also reject it, but raising here keeps the resolution state in sync
         # without waiting for the next coordinator poll.
         if self.sys_dbus.agent.board.rpi_firmware.update_blocked:
-            self._sync_rpi_firmware_blocked_issue(True)
+            sync_rpi_firmware_issues(
+                self.coresys, self.sys_dbus.agent.board.rpi_firmware
+            )
             raise APIError(
                 "Raspberry Pi firmware update is unavailable on this boot device",
                 _LOGGER.warning,
             )
 
         await asyncio.shield(self.sys_os.update_raspberrypi_firmware())
-
-    def _sync_rpi_firmware_blocked_issue(self, blocked: bool) -> None:
-        """Create or dismiss the RPI_FIRMWARE_UPDATE_BLOCKED issue based on agent state."""
-        issue = Issue(IssueType.RPI_FIRMWARE_UPDATE_BLOCKED, ContextType.SYSTEM)
-        existing = self.sys_resolution.get_issue_if_present(issue)
-        if blocked:
-            if existing is None:
-                self.sys_resolution.create_issue(
-                    IssueType.RPI_FIRMWARE_UPDATE_BLOCKED, ContextType.SYSTEM
-                )
-        elif existing is not None:
-            self.sys_resolution.dismiss_issue(existing)
 
     @api_process
     async def boards_other_info(self, request: web.Request) -> dict[str, Any]:

--- a/supervisor/os/const.py
+++ b/supervisor/os/const.py
@@ -1,7 +1,13 @@
 """Constants for OS."""
 
+from awesomeversion import AwesomeVersion
+
 FILESYSTEM_LABEL_DATA_DISK = "hassos-data"
 FILESYSTEM_LABEL_DISABLED_DATA_DISK = "hassos-data-dis"
 FILESYSTEM_LABEL_OLD_DATA_DISK = "hassos-data-old"
 PARTITION_NAME_EXTERNAL_DATA_DISK = "hassos-data-external"
 PARTITION_NAME_OLD_EXTERNAL_DATA_DISK = "hassos-data-external-old"
+
+# Raspberry Pi firmware management requires the io.hass.os.Boards.RaspberryPi
+# .Firmware D-Bus interface first shipped in this OS Agent release.
+RPI_FIRMWARE_MIN_OS_AGENT_VERSION: AwesomeVersion = AwesomeVersion("1.9.0")

--- a/supervisor/os/manager.py
+++ b/supervisor/os/manager.py
@@ -22,6 +22,7 @@ from ..exceptions import (
 from ..jobs.const import JobConcurrency, JobCondition
 from ..jobs.decorator import Job
 from ..resolution.const import ContextType, IssueType, SuggestionType
+from ..resolution.utils import dismiss_rpi_firmware_update_issues
 from .data_disk import DataDisk
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -374,6 +375,7 @@ class OSManager(CoreSysAttributes):
             ) from err
 
         _LOGGER.info("Raspberry Pi firmware update completed; reboot required")
+        dismiss_rpi_firmware_update_issues(self.coresys)
         self.sys_resolution.create_issue(
             IssueType.REBOOT_REQUIRED,
             ContextType.SYSTEM,

--- a/supervisor/resolution/checks/rpi_firmware_update.py
+++ b/supervisor/resolution/checks/rpi_firmware_update.py
@@ -1,0 +1,65 @@
+"""Check for Raspberry Pi firmware updates."""
+
+from ...const import CoreState
+from ...coresys import CoreSys
+from ...os.const import RPI_FIRMWARE_MIN_OS_AGENT_VERSION
+from ..const import ContextType, IssueType
+from ..data import Issue
+from ..utils import sync_rpi_firmware_issues
+from .base import CheckBase
+
+
+def setup(coresys: CoreSys) -> CheckBase:
+    """Check setup function."""
+    return CheckRpiFirmwareUpdate(coresys)
+
+
+class CheckRpiFirmwareUpdate(CheckBase):
+    """Check for Raspberry Pi firmware updates."""
+
+    async def __call__(self) -> None:
+        """Execute the check."""
+        if self.sys_core.state not in self.states:
+            return
+
+        await self.run_check()
+
+    def _has_rpi_firmware_management(self) -> bool:
+        """Return true if Raspberry Pi firmware management is available."""
+        return (
+            self.sys_dbus.agent.is_connected
+            and self.sys_dbus.agent.version >= RPI_FIRMWARE_MIN_OS_AGENT_VERSION
+            and self.sys_dbus.agent.board.has_rpi_firmware
+        )
+
+    async def run_check(self) -> None:
+        """Run check if not affected by issue."""
+        if not self._has_rpi_firmware_management():
+            return
+
+        sync_rpi_firmware_issues(self.coresys, self.sys_dbus.agent.board.rpi_firmware)
+
+    async def approve_check(self, issue: Issue) -> bool:
+        """Approve check if it is affected by issue."""
+        if not self._has_rpi_firmware_management():
+            return False
+
+        rpi = self.sys_dbus.agent.board.rpi_firmware
+        return (
+            rpi.update_available and not rpi.update_blocked and not rpi.update_pending
+        )
+
+    @property
+    def issue(self) -> IssueType:
+        """Return a IssueType enum."""
+        return IssueType.RPI_FIRMWARE_UPDATE_AVAILABLE
+
+    @property
+    def context(self) -> ContextType:
+        """Return a ContextType enum."""
+        return ContextType.SYSTEM
+
+    @property
+    def states(self) -> list[CoreState]:
+        """Return a list of valid states when this check can run."""
+        return [CoreState.RUNNING, CoreState.STARTUP]

--- a/supervisor/resolution/const.py
+++ b/supervisor/resolution/const.py
@@ -105,6 +105,7 @@ class IssueType(StrEnum):
     NTP_SYNC_FAILED = "ntp_sync_failed"
     PWNED = "pwned"
     REBOOT_REQUIRED = "reboot_required"
+    RPI_FIRMWARE_UPDATE_AVAILABLE = "rpi_firmware_update_available"
     RPI_FIRMWARE_UPDATE_BLOCKED = "rpi_firmware_update_blocked"
     SECURITY = "security"
     UPDATE_FAILED = "update_failed"
@@ -132,3 +133,4 @@ class SuggestionType(StrEnum):
     EXECUTE_UPDATE = "execute_update"
     REGISTRY_LOGIN = "registry_login"
     RENAME_DATA_DISK = "rename_data_disk"
+    UPDATE_RPI_FIRMWARE = "update_rpi_firmware"

--- a/supervisor/resolution/fixups/system_update_rpi_firmware.py
+++ b/supervisor/resolution/fixups/system_update_rpi_firmware.py
@@ -1,0 +1,40 @@
+"""Update Raspberry Pi firmware fixup."""
+
+import asyncio
+import logging
+
+from ...coresys import CoreSys
+from ..const import ContextType, IssueType, SuggestionType
+from ..data import Suggestion
+from .base import FixupBase
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+def setup(coresys: CoreSys) -> FixupBase:
+    """Check setup function."""
+    return FixupSystemUpdateRpiFirmware(coresys)
+
+
+class FixupSystemUpdateRpiFirmware(FixupBase):
+    """Storage class for fixup."""
+
+    async def process_fixup(self, suggestion: Suggestion) -> None:
+        """Update Raspberry Pi firmware."""
+        _LOGGER.info("Updating Raspberry Pi firmware")
+        await asyncio.shield(self.sys_os.update_raspberrypi_firmware())
+
+    @property
+    def suggestion(self) -> SuggestionType:
+        """Return a SuggestionType enum."""
+        return SuggestionType.UPDATE_RPI_FIRMWARE
+
+    @property
+    def context(self) -> ContextType:
+        """Return a ContextType enum."""
+        return ContextType.SYSTEM
+
+    @property
+    def issues(self) -> list[IssueType]:
+        """Return a IssueType enum list."""
+        return [IssueType.RPI_FIRMWARE_UPDATE_AVAILABLE]

--- a/supervisor/resolution/utils.py
+++ b/supervisor/resolution/utils.py
@@ -1,0 +1,93 @@
+"""Helpers for resolution manager state."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .const import ContextType, IssueType, SuggestionType
+
+if TYPE_CHECKING:
+    from ..coresys import CoreSys
+    from ..dbus.agent.boards.rpi_firmware import RPiFirmware
+
+
+RPI_FIRMWARE_UPDATE_ISSUES = (
+    IssueType.RPI_FIRMWARE_UPDATE_AVAILABLE,
+    IssueType.RPI_FIRMWARE_UPDATE_BLOCKED,
+)
+
+
+def _dismiss_issue_type(coresys: CoreSys, issue_type: IssueType) -> None:
+    """Dismiss all system issues of a type."""
+    for issue in list(coresys.resolution.issues):
+        if issue.type == issue_type and issue.context == ContextType.SYSTEM:
+            coresys.resolution.dismiss_issue(issue)
+
+
+def dismiss_rpi_firmware_update_issues(coresys: CoreSys) -> None:
+    """Dismiss all Raspberry Pi firmware update issues."""
+    for issue_type in RPI_FIRMWARE_UPDATE_ISSUES:
+        _dismiss_issue_type(coresys, issue_type)
+
+
+def _upsert_issue(
+    coresys: CoreSys,
+    issue_type: IssueType,
+    *,
+    suggestions: list[SuggestionType] | None = None,
+    reference_extra: dict[str, Any] | None = None,
+) -> None:
+    """Create a system issue, replacing stale metadata for that issue type."""
+    for issue in list(coresys.resolution.issues):
+        if issue.type != issue_type or issue.context != ContextType.SYSTEM:
+            continue
+        if issue.reference_extra == reference_extra:
+            break
+        coresys.resolution.dismiss_issue(issue)
+
+    coresys.resolution.create_issue(
+        issue_type,
+        ContextType.SYSTEM,
+        suggestions=suggestions,
+        reference_extra=reference_extra,
+    )
+
+
+def sync_rpi_firmware_issues(coresys: CoreSys, rpi_firmware: RPiFirmware) -> None:
+    """Sync Raspberry Pi firmware state into resolution issues."""
+    if rpi_firmware.update_pending:
+        dismiss_rpi_firmware_update_issues(coresys)
+        coresys.resolution.create_issue(
+            IssueType.REBOOT_REQUIRED,
+            ContextType.SYSTEM,
+            suggestions=[SuggestionType.EXECUTE_REBOOT],
+        )
+        return
+
+    if rpi_firmware.update_blocked:
+        _dismiss_issue_type(coresys, IssueType.RPI_FIRMWARE_UPDATE_AVAILABLE)
+        _upsert_issue(
+            coresys,
+            IssueType.RPI_FIRMWARE_UPDATE_BLOCKED,
+            reference_extra={
+                "current_version": rpi_firmware.current_version,
+                "latest_version": rpi_firmware.latest_version,
+                "blocked_reason": rpi_firmware.blocked_reason,
+            },
+        )
+        return
+
+    _dismiss_issue_type(coresys, IssueType.RPI_FIRMWARE_UPDATE_BLOCKED)
+    if rpi_firmware.update_available:
+        _upsert_issue(
+            coresys,
+            IssueType.RPI_FIRMWARE_UPDATE_AVAILABLE,
+            suggestions=[SuggestionType.UPDATE_RPI_FIRMWARE],
+            reference_extra={
+                "current_version": rpi_firmware.current_version,
+                "latest_version": rpi_firmware.latest_version,
+            },
+        )
+        return
+
+    _dismiss_issue_type(coresys, IssueType.RPI_FIRMWARE_UPDATE_AVAILABLE)

--- a/tests/api/test_os.py
+++ b/tests/api/test_os.py
@@ -574,6 +574,7 @@ async def test_api_config_swap_old_os(
 @pytest.mark.usefixtures("os_agent_version")
 async def test_api_board_raspberrypi_info(
     api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
     os_agent_services: dict[str, DBusServiceMock],
     os_available,
 ):
@@ -591,6 +592,26 @@ async def test_api_board_raspberrypi_info(
         "update_pending": False,
         "blocked_reason": None,
     }
+    issue = Issue(
+        IssueType.RPI_FIRMWARE_UPDATE_AVAILABLE,
+        ContextType.SYSTEM,
+        reference_extra={
+            "current_version": "1618412973",
+            "latest_version": "1700000000",
+        },
+    )
+    assert issue in coresys.resolution.issues
+    assert (
+        Suggestion(
+            SuggestionType.UPDATE_RPI_FIRMWARE,
+            ContextType.SYSTEM,
+            reference_extra={
+                "current_version": "1618412973",
+                "latest_version": "1700000000",
+            },
+        )
+        in coresys.resolution.suggestions
+    )
 
 
 @pytest.mark.usefixtures("os_agent_version")
@@ -609,7 +630,15 @@ async def test_api_board_raspberrypi_info_blocked_creates_issue(
     resp = await api_client.get(f"{prefix}/os/boards/raspberrypi/firmware")
     assert resp.status == 200
     assert (
-        Issue(IssueType.RPI_FIRMWARE_UPDATE_BLOCKED, ContextType.SYSTEM)
+        Issue(
+            IssueType.RPI_FIRMWARE_UPDATE_BLOCKED,
+            ContextType.SYSTEM,
+            reference_extra={
+                "current_version": "1618412973",
+                "latest_version": "1700000000",
+                "blocked_reason": "unsupported_boot_device",
+            },
+        )
         in coresys.resolution.issues
     )
 
@@ -618,10 +647,12 @@ async def test_api_board_raspberrypi_info_blocked_creates_issue(
     await coresys.dbus.agent.board.rpi_firmware.update()
     resp = await api_client.get(f"{prefix}/os/boards/raspberrypi/firmware")
     assert resp.status == 200
-    assert (
-        Issue(IssueType.RPI_FIRMWARE_UPDATE_BLOCKED, ContextType.SYSTEM)
-        not in coresys.resolution.issues
-    )
+    assert not [
+        issue
+        for issue in coresys.resolution.issues
+        if issue.type == IssueType.RPI_FIRMWARE_UPDATE_BLOCKED
+        and issue.context == ContextType.SYSTEM
+    ]
 
 
 @pytest.mark.usefixtures("os_agent_version")
@@ -635,6 +666,11 @@ async def test_api_board_raspberrypi_update(
     api_client, prefix = api_client_with_prefix
     rpi_service: RPiFirmwareService = os_agent_services["agent_boards_rpi_firmware"]
     assert rpi_service.update_called is False
+    coresys.resolution.create_issue(
+        IssueType.RPI_FIRMWARE_UPDATE_AVAILABLE,
+        ContextType.SYSTEM,
+        suggestions=[SuggestionType.UPDATE_RPI_FIRMWARE],
+    )
 
     resp = await api_client.post(f"{prefix}/os/boards/raspberrypi/firmware/update")
     assert resp.status == 200
@@ -649,6 +685,12 @@ async def test_api_board_raspberrypi_update(
         Suggestion(SuggestionType.EXECUTE_REBOOT, ContextType.SYSTEM)
         in coresys.resolution.suggestions
     )
+    assert not [
+        issue
+        for issue in coresys.resolution.issues
+        if issue.type == IssueType.RPI_FIRMWARE_UPDATE_AVAILABLE
+        and issue.context == ContextType.SYSTEM
+    ]
 
 
 @pytest.mark.usefixtures("os_agent_version")
@@ -668,7 +710,15 @@ async def test_api_board_raspberrypi_update_blocked(
     assert resp.status == 400
     assert rpi_service.update_called is False
     assert (
-        Issue(IssueType.RPI_FIRMWARE_UPDATE_BLOCKED, ContextType.SYSTEM)
+        Issue(
+            IssueType.RPI_FIRMWARE_UPDATE_BLOCKED,
+            ContextType.SYSTEM,
+            reference_extra={
+                "current_version": "1618412973",
+                "latest_version": "1700000000",
+                "blocked_reason": "unsupported_boot_device",
+            },
+        )
         in coresys.resolution.issues
     )
     # No reboot issue should be raised when the update was rejected.

--- a/tests/resolution/check/test_check_rpi_firmware_update.py
+++ b/tests/resolution/check/test_check_rpi_firmware_update.py
@@ -1,0 +1,168 @@
+"""Test Raspberry Pi firmware update check."""
+
+from unittest.mock import PropertyMock, patch
+
+from awesomeversion import AwesomeVersion
+import pytest
+
+from supervisor.const import CoreState
+from supervisor.coresys import CoreSys
+from supervisor.dbus.agent import OSAgent
+from supervisor.resolution.checks.rpi_firmware_update import CheckRpiFirmwareUpdate
+from supervisor.resolution.const import ContextType, IssueType, SuggestionType
+from supervisor.resolution.data import Issue, Suggestion
+
+from tests.dbus_service_mocks.agent_boards_rpi_firmware import (
+    RPiFirmware as RPiFirmwareService,
+)
+from tests.dbus_service_mocks.base import DBusServiceMock
+
+
+@pytest.fixture(autouse=True)
+def fixture_os_agent_version():
+    """Mock OS Agent version with Raspberry Pi firmware support."""
+    with patch.object(
+        OSAgent, "version", new=PropertyMock(return_value=AwesomeVersion("1.9.0"))
+    ):
+        yield
+
+
+async def test_check_creates_issue(
+    coresys: CoreSys,
+    os_agent_services: dict[str, DBusServiceMock],
+):
+    """Test check creates issue when Raspberry Pi firmware update is available."""
+    rpi_service: RPiFirmwareService = os_agent_services["agent_boards_rpi_firmware"]
+    await coresys.dbus.agent.board.rpi_firmware.update()
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    check = CheckRpiFirmwareUpdate(coresys)
+    await check()
+
+    assert (
+        Issue(
+            IssueType.RPI_FIRMWARE_UPDATE_AVAILABLE,
+            ContextType.SYSTEM,
+            reference_extra={
+                "current_version": "1618412973",
+                "latest_version": "1700000000",
+            },
+        )
+        in coresys.resolution.issues
+    )
+    assert (
+        Suggestion(
+            SuggestionType.UPDATE_RPI_FIRMWARE,
+            ContextType.SYSTEM,
+            reference_extra={
+                "current_version": "1618412973",
+                "latest_version": "1700000000",
+            },
+        )
+        in coresys.resolution.suggestions
+    )
+    assert rpi_service.update_called is False
+
+
+async def test_check_cleans_issue_when_update_no_longer_available(
+    coresys: CoreSys,
+    os_agent_services: dict[str, DBusServiceMock],
+):
+    """Test check dismisses issue when Raspberry Pi firmware is current."""
+    rpi_service: RPiFirmwareService = os_agent_services["agent_boards_rpi_firmware"]
+    await coresys.dbus.agent.board.rpi_firmware.update()
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    check = CheckRpiFirmwareUpdate(coresys)
+    await check()
+    assert [
+        issue
+        for issue in coresys.resolution.issues
+        if issue.type == IssueType.RPI_FIRMWARE_UPDATE_AVAILABLE
+    ]
+
+    rpi_service.set_state(update_available=False)
+    await coresys.dbus.agent.board.rpi_firmware.update()
+    await check()
+
+    assert not [
+        issue
+        for issue in coresys.resolution.issues
+        if issue.type == IssueType.RPI_FIRMWARE_UPDATE_AVAILABLE
+    ]
+
+
+async def test_check_replaces_available_issue_with_blocked_issue(
+    coresys: CoreSys,
+    os_agent_services: dict[str, DBusServiceMock],
+):
+    """Test check replaces available issue when update becomes blocked."""
+    rpi_service: RPiFirmwareService = os_agent_services["agent_boards_rpi_firmware"]
+    await coresys.dbus.agent.board.rpi_firmware.update()
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    check = CheckRpiFirmwareUpdate(coresys)
+    await check()
+    assert [
+        issue
+        for issue in coresys.resolution.issues
+        if issue.type == IssueType.RPI_FIRMWARE_UPDATE_AVAILABLE
+    ]
+
+    rpi_service.set_state(update_blocked=True, blocked_reason="unsupported_boot_device")
+    await coresys.dbus.agent.board.rpi_firmware.update()
+    await check()
+
+    assert not [
+        issue
+        for issue in coresys.resolution.issues
+        if issue.type == IssueType.RPI_FIRMWARE_UPDATE_AVAILABLE
+    ]
+    assert (
+        Issue(
+            IssueType.RPI_FIRMWARE_UPDATE_BLOCKED,
+            ContextType.SYSTEM,
+            reference_extra={
+                "current_version": "1618412973",
+                "latest_version": "1700000000",
+                "blocked_reason": "unsupported_boot_device",
+            },
+        )
+        in coresys.resolution.issues
+    )
+
+
+async def test_check_ignored_without_supported_os_agent(
+    coresys: CoreSys,
+):
+    """Test check is ignored when OS Agent does not expose firmware management."""
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    with patch.object(
+        OSAgent, "version", new=PropertyMock(return_value=AwesomeVersion("1.8.0"))
+    ):
+        await CheckRpiFirmwareUpdate(coresys)()
+
+    assert not coresys.resolution.issues
+
+
+async def test_check_creates_reboot_issue_when_update_pending(
+    coresys: CoreSys,
+    os_agent_services: dict[str, DBusServiceMock],
+):
+    """Test check creates reboot issue when Raspberry Pi firmware update is pending."""
+    rpi_service: RPiFirmwareService = os_agent_services["agent_boards_rpi_firmware"]
+    rpi_service.set_state(update_available=False, update_pending=True)
+    await coresys.dbus.agent.board.rpi_firmware.update()
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    await CheckRpiFirmwareUpdate(coresys)()
+
+    assert (
+        Issue(IssueType.REBOOT_REQUIRED, ContextType.SYSTEM)
+        in coresys.resolution.issues
+    )
+    assert (
+        Suggestion(SuggestionType.EXECUTE_REBOOT, ContextType.SYSTEM)
+        in coresys.resolution.suggestions
+    )

--- a/tests/resolution/fixup/test_system_update_rpi_firmware.py
+++ b/tests/resolution/fixup/test_system_update_rpi_firmware.py
@@ -1,0 +1,33 @@
+"""Test update Raspberry Pi firmware fixup."""
+
+from unittest.mock import AsyncMock
+
+from supervisor.coresys import CoreSys
+from supervisor.resolution.const import ContextType, IssueType, SuggestionType
+from supervisor.resolution.data import Issue, Suggestion
+from supervisor.resolution.fixups.system_update_rpi_firmware import (
+    FixupSystemUpdateRpiFirmware,
+)
+
+
+async def test_fixup(coresys: CoreSys):
+    """Test fixup."""
+    update_rpi_firmware = FixupSystemUpdateRpiFirmware(coresys)
+
+    assert update_rpi_firmware.auto is False
+
+    coresys.resolution.add_suggestion(
+        Suggestion(SuggestionType.UPDATE_RPI_FIRMWARE, ContextType.SYSTEM)
+    )
+    coresys.resolution.add_issue(
+        Issue(IssueType.RPI_FIRMWARE_UPDATE_AVAILABLE, ContextType.SYSTEM)
+    )
+
+    mock_update = AsyncMock()
+    coresys.os.update_raspberrypi_firmware = mock_update
+
+    await update_rpi_firmware()
+
+    mock_update.assert_called_once()
+    assert len(coresys.resolution.suggestions) == 0
+    assert len(coresys.resolution.issues) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Surface Raspberry Pi firmware updates in the Supervisor resolution system.

When OS Agent reports a Raspberry Pi firmware update is available, Supervisor now creates a `rpi_firmware_update_available` issue with an `update_rpi_firmware` suggestion. Applying that suggestion runs the existing Raspberry Pi firmware update job. If the update is blocked, Supervisor keeps the existing blocked issue in sync with the firmware metadata. If an update is pending, Supervisor creates the existing reboot-required issue.

This lets the frontend show a repairable Supervisor issue for outdated Raspberry Pi EEPROM firmware instead of requiring users to discover the `ha os boards raspberrypi firmware` CLI command manually. This was prompted by the feature request discussion at https://github.com/orgs/home-assistant/discussions/4165.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/orgs/home-assistant/discussions/4165
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

Validated with Supervisor's OS Agent D-Bus Raspberry Pi firmware mock. A real Raspberry Pi 5 was used to confirm the existing `ha os boards raspberrypi firmware` read path reports firmware state, but the firmware update action was not run on physical hardware.

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository] (not applicable; no API endpoint or add-on configuration was added/changed)
- [ ] [CLI][cli-repository] updated (if necessary) (not applicable)
- [ ] [Client library][client-library-repository] updated (if necessary) (not applicable)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
