### PR TITLE
Reject apps mapping a dynamic ingress port range port

### DIFF
--- a/supervisor/apps/validate.py
+++ b/supervisor/apps/validate.py
@@ -97,6 +97,8 @@ from ..const import (
     ATTR_VIDEO,
     ATTR_WATCHDOG,
     ATTR_WEBUI,
+    INGRESS_DYNAMIC_PORT_MAX,
+    INGRESS_DYNAMIC_PORT_MIN,
     MACHINE_DEPRECATED,
     ROLE_ALL,
     ROLE_DEFAULT,
@@ -244,6 +246,27 @@ def _warn_app_config(config: dict[str, Any]):
             "App '%s' uses deprecated 'codenotary' field in config. This field is no longer used and will be ignored. Please report this to the maintainer.",
             name,
         )
+
+    # Dynamic ingress port selection (ingress_port: 0) picks a random port from
+    # the INGRESS_DYNAMIC_PORT_MIN-INGRESS_DYNAMIC_PORT_MAX range. An app must
+    # not map a port from that range to the host itself, as the dynamically
+    # chosen ingress port could then coincide with it, exposing the ingress
+    # endpoint on the host and bypassing ingress authentication.
+    if config.get(ATTR_INGRESS) and config.get(ATTR_INGRESS_PORT) == 0:
+        for container_port in config.get(ATTR_PORTS, {}):
+            port_number = str(container_port).partition("/")[0]
+            if (
+                port_number.isdigit()
+                and INGRESS_DYNAMIC_PORT_MIN
+                <= int(port_number)
+                <= INGRESS_DYNAMIC_PORT_MAX
+            ):
+                raise vol.Invalid(
+                    f"App '{name}' uses dynamic ingress port selection (ingress_port: 0) "
+                    f"but maps port {port_number} which is reserved for dynamic ingress "
+                    f"ports ({INGRESS_DYNAMIC_PORT_MIN}-{INGRESS_DYNAMIC_PORT_MAX}). "
+                    "Please report this to the maintainer of the app."
+                )
 
     return config
 

--- a/supervisor/const.py
+++ b/supervisor/const.py
@@ -57,6 +57,10 @@ DOCKER_IPV6_NETWORK_MASK = IPv6Network("fd0c:ac1e:2100::/48")
 DOCKER_IPV4_NETWORK_MASK = IPv4Network("172.30.32.0/23")
 DOCKER_IPV4_NETWORK_RANGE = IPv4Network("172.30.33.0/24")
 
+# Range used for dynamically assigned ingress ports (ingress_port: 0).
+INGRESS_DYNAMIC_PORT_MIN = 62000
+INGRESS_DYNAMIC_PORT_MAX = 65500
+
 # This needs to match the dockerd --cpu-rt-runtime= argument.
 DOCKER_CPU_RUNTIME_TOTAL = 950_000
 

--- a/supervisor/ingress.py
+++ b/supervisor/ingress.py
@@ -11,6 +11,8 @@ from .const import (
     ATTR_SESSION,
     ATTR_SESSION_DATA,
     FILE_HASSIO_INGRESS,
+    INGRESS_DYNAMIC_PORT_MAX,
+    INGRESS_DYNAMIC_PORT_MIN,
     IngressSessionData,
     IngressSessionDataDict,
 )
@@ -169,7 +171,7 @@ class Ingress(FileConfiguration, CoreSysAttributes):
             or port in self.ports.values()
             or await check_port(self.sys_docker.network.gateway, port)
         ):
-            port = random.randint(62000, 65500)
+            port = random.randint(INGRESS_DYNAMIC_PORT_MIN, INGRESS_DYNAMIC_PORT_MAX)
 
         # Save port for next time
         self.ports[app_slug] = port

--- a/tests/apps/test_config.py
+++ b/tests/apps/test_config.py
@@ -122,6 +122,51 @@ def test_invalid_repository():
         vd.SCHEMA_APP_CONFIG(config)
 
 
+def test_dynamic_ingress_port_rejects_reserved_port():
+    """Validate dynamic ingress port rejects mapping a reserved port."""
+    config = load_json_fixture("basic-app-config.json")
+    config["ingress"] = True
+    config["ingress_port"] = 0
+
+    # A port inside the dynamic ingress range is rejected.
+    config["ports"] = {"63000/tcp": 8080}
+    with pytest.raises(vol.Invalid):
+        vd.SCHEMA_APP_CONFIG(config)
+
+    # The range boundaries are inclusive.
+    config["ports"] = {"62000/tcp": 8080}
+    with pytest.raises(vol.Invalid):
+        vd.SCHEMA_APP_CONFIG(config)
+
+    config["ports"] = {"65500/tcp": 8080}
+    with pytest.raises(vol.Invalid):
+        vd.SCHEMA_APP_CONFIG(config)
+
+
+def test_dynamic_ingress_port_allows_other_ports():
+    """Validate dynamic ingress port allows ports outside the reserved range."""
+    config = load_json_fixture("basic-app-config.json")
+    config["ingress"] = True
+    config["ingress_port"] = 0
+    config["ports"] = {"8080/tcp": 8080, "61999/tcp": 61999, "65501/tcp": 65501}
+
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
+
+    assert valid_config["ingress_port"] == 0
+
+
+def test_static_ingress_port_allows_reserved_port():
+    """Validate a static ingress port may still map a port in the range."""
+    config = load_json_fixture("basic-app-config.json")
+    config["ingress"] = True
+    config["ingress_port"] = 8099
+    config["ports"] = {"63000/tcp": 8080}
+
+    valid_config = vd.SCHEMA_APP_CONFIG(config)
+
+    assert valid_config["ingress_port"] == 8099
+
+
 def test_valid_repository():
     """Validate basic config with different valid repositories."""
     config = load_json_fixture("basic-app-config.json")


### PR DESCRIPTION
## Proposed change

When an app uses dynamic ingress port selection (`ingress_port: 0`), `Ingress.get_dynamic_port()` picks a random port from the 62000-65500 range and hands it to the app to listen on for ingress. That port is reached only over the internal Docker network at the app's container IP (`api/ingress.py`); it is never published to the host.

If an app *also* maps a container port from that same range to the host via its `ports` config, the dynamically chosen ingress port could coincide with it. Docker would then publish that container port to the host, making the ingress endpoint reachable directly on the host and bypassing ingress authentication.

Rather than working around this at allocation time, this rejects such configs during validation: an app using dynamic ingress port selection must not map a port from the dynamic ingress port range itself. Validation runs on every config parse/update, so it also covers an app that introduces such a mapping in a later version (which an allocation-time check would miss, since the dynamic port is allocated once and persisted).

The container ports come exclusively from the app's `config.json` (users can only set host-port values for existing keys), so validating the app config fully covers this. The range bounds are extracted into `INGRESS_DYNAMIC_PORT_MIN`/`INGRESS_DYNAMIC_PORT_MAX` constants shared between the validator and the allocator.

This only affects apps that combine `ingress_port: 0` with a mapped port in the 62000-65500 range; none of the popular apps do that. Apps with a static ingress port are unaffected, and may still map a port in that range.

Alternative to #6983.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
