### PR TITLE
Don't roll back Core update when frontend probe can't connect over SSL

### DIFF
--- a/supervisor/homeassistant/frontend_check.py
+++ b/supervisor/homeassistant/frontend_check.py
@@ -30,13 +30,17 @@ _WS_RECEIVE_TIMEOUT = 10.0
 class ProbeResult(Enum):
     """Outcome of an external frontend probe.
 
-    The distinction between BAD_RESPONSE and NO_RESPONSE matters: a bad
-    response means we connected and the endpoint is genuinely broken (roll
-    back), while no response means the request never completed (the connection
-    dropped at the TLS handshake, transport, or read). The latter is expected
-    when Core requires a client certificate (`ssl_peer_certificate`) and
-    rejects our unauthenticated connection, so it must not by itself be
-    treated as a broken frontend.
+    The distinction between BAD_RESPONSE and NO_RESPONSE matters: both mean
+    the frontend is genuinely broken and warrant a rollback, except that
+    NO_RESPONSE is specifically a connection that was reset or dropped before
+    we got anything. That is exactly how Core rejects us when it requires a
+    client certificate (`ssl_peer_certificate`) that we don't present, so
+    NO_RESPONSE must not by itself be treated as a broken frontend.
+
+    A timeout is deliberately BAD_RESPONSE, not NO_RESPONSE: mutual TLS
+    rejects an unauthenticated connection within a few packets, so it never
+    manifests as a timeout. A probe that times out reached the listener but
+    never answered, which points to a real problem rather than mutual TLS.
     """
 
     OK = "ok"
@@ -61,7 +65,10 @@ async def check_frontend(coresys: CoreSys) -> ProbeResult:
                     content_type,
                 )
                 return ProbeResult.BAD_RESPONSE
-    except (aiohttp.ClientError, TimeoutError) as err:
+    except TimeoutError:
+        _LOGGER.error("Frontend at %s did not respond in time", url)
+        return ProbeResult.BAD_RESPONSE
+    except aiohttp.ClientError as err:
         _LOGGER.error("Cannot reach frontend at %s: %s", url, err)
         return ProbeResult.NO_RESPONSE
 
@@ -83,7 +90,10 @@ async def check_websocket(coresys: CoreSys) -> ProbeResult:
             coresys.websession.ws_connect(url, ssl=False),
             timeout=_WS_HANDSHAKE_TIMEOUT,
         )
-    except (aiohttp.ClientError, TimeoutError) as err:
+    except TimeoutError:
+        _LOGGER.error("WebSocket handshake with %s did not complete in time", url)
+        return ProbeResult.BAD_RESPONSE
+    except aiohttp.ClientError as err:
         _LOGGER.error("WebSocket probe to %s failed: %s", url, err)
         return ProbeResult.NO_RESPONSE
 

--- a/supervisor/homeassistant/frontend_check.py
+++ b/supervisor/homeassistant/frontend_check.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
+from enum import Enum
 import logging
 
 import aiohttp
@@ -26,7 +27,24 @@ _WS_HANDSHAKE_TIMEOUT = 30.0
 _WS_RECEIVE_TIMEOUT = 10.0
 
 
-async def check_frontend(coresys: CoreSys) -> bool:
+class ProbeResult(Enum):
+    """Outcome of an external frontend probe.
+
+    The distinction between BAD_RESPONSE and NO_RESPONSE matters: a bad
+    response means we connected and the endpoint is genuinely broken (roll
+    back), while no response means the request never completed (the connection
+    dropped at the TLS handshake, transport, or read). The latter is expected
+    when Core requires a client certificate (`ssl_peer_certificate`) and
+    rejects our unauthenticated connection, so it must not by itself be
+    treated as a broken frontend.
+    """
+
+    OK = "ok"
+    BAD_RESPONSE = "bad_response"
+    NO_RESPONSE = "no_response"
+
+
+async def check_frontend(coresys: CoreSys) -> ProbeResult:
     """Verify the frontend serves HTML on the root path."""
     url = f"{coresys.homeassistant.api_url}/"
     try:
@@ -35,23 +53,23 @@ async def check_frontend(coresys: CoreSys) -> bool:
         ) as resp:
             if resp.status != 200:
                 _LOGGER.error("Frontend returned status %s", resp.status)
-                return False
+                return ProbeResult.BAD_RESPONSE
             content_type = resp.headers.get(hdrs.CONTENT_TYPE, "")
             if "text/html" not in content_type:
                 _LOGGER.error(
                     "Frontend responded with unexpected content type: %s",
                     content_type,
                 )
-                return False
+                return ProbeResult.BAD_RESPONSE
     except (aiohttp.ClientError, TimeoutError) as err:
         _LOGGER.error("Cannot reach frontend at %s: %s", url, err)
-        return False
+        return ProbeResult.NO_RESPONSE
 
     _LOGGER.debug("Frontend is accessible and serving HTML")
-    return True
+    return ProbeResult.OK
 
 
-async def check_websocket(coresys: CoreSys) -> bool:
+async def check_websocket(coresys: CoreSys) -> ProbeResult:
     """Verify the WebSocket endpoint accepts a handshake.
 
     We don't authenticate. A working endpoint sends an `auth_required`
@@ -65,26 +83,89 @@ async def check_websocket(coresys: CoreSys) -> bool:
             coresys.websession.ws_connect(url, ssl=False),
             timeout=_WS_HANDSHAKE_TIMEOUT,
         )
+    except (aiohttp.ClientError, TimeoutError) as err:
+        _LOGGER.error("WebSocket probe to %s failed: %s", url, err)
+        return ProbeResult.NO_RESPONSE
+
+    try:
         msg = await ws.receive(timeout=_WS_RECEIVE_TIMEOUT)
         if msg.type != aiohttp.WSMsgType.TEXT:
             _LOGGER.error("WebSocket handshake returned non-text message: %s", msg.type)
-            return False
+            return ProbeResult.BAD_RESPONSE
         data = msg.json()
         if not isinstance(data, dict) or data.get("type") != "auth_required":
             _LOGGER.error("WebSocket did not send auth_required, got: %s", data)
-            return False
-    except (aiohttp.ClientError, TimeoutError, ValueError) as err:
-        _LOGGER.error("WebSocket probe to %s failed: %s", url, err)
-        return False
+            return ProbeResult.BAD_RESPONSE
+    except (TimeoutError, ValueError) as err:
+        # The handshake already succeeded; failing to read or parse the first
+        # frame means the endpoint connected but is misbehaving.
+        _LOGGER.error("WebSocket handshake on %s returned no valid frame: %s", url, err)
+        return ProbeResult.BAD_RESPONSE
     finally:
-        if ws is not None:
-            with suppress(Exception):
-                await ws.close()
+        with suppress(Exception):
+            await ws.close()
 
     _LOGGER.debug("WebSocket endpoint accepted handshake")
+    return ProbeResult.OK
+
+
+async def check_api_reachable(coresys: CoreSys) -> bool:
+    """Verify Core is accepting connections on its API port.
+
+    This only establishes a TCP connection; it does not attempt a TLS
+    handshake or send any data. It's used as a fallback when the HTTP and
+    WebSocket probes can't connect at all, which is expected for a mutual-TLS
+    setup (`ssl_peer_certificate`): Core resets the handshake because we don't
+    present a client certificate. Reaching the listener is the most we can
+    confirm in that case.
+    """
+    host = str(coresys.homeassistant.ip_address)
+    port = coresys.homeassistant.api_port
+    writer: asyncio.StreamWriter | None = None
+    try:
+        _, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port), timeout=_PROBE_TIMEOUT.total
+        )
+    except (OSError, TimeoutError) as err:
+        _LOGGER.error("Cannot reach Core API at %s:%s: %s", host, port, err)
+        return False
+    finally:
+        if writer is not None:
+            writer.close()
+            with suppress(OSError):
+                await writer.wait_closed()
+
+    _LOGGER.debug("Core API port is reachable")
     return True
 
 
 async def verify_frontend(coresys: CoreSys) -> bool:
-    """Run both frontend probes; return True only if both succeed."""
-    return await check_frontend(coresys) and await check_websocket(coresys)
+    """Verify the frontend is available after an update.
+
+    A probe that connects but returns a bad response means the frontend is
+    genuinely broken, so we fail regardless of SSL. If the probes can't
+    connect at all while Core is configured with SSL, we can't rule out a
+    mutual-TLS setup (`ssl_peer_certificate`) rejecting our unauthenticated
+    connection, so we fall back to a plain TCP reachability check instead of
+    forcing a rollback, relying on the component check done by the caller.
+    """
+    frontend = await check_frontend(coresys)
+    websocket = await check_websocket(coresys)
+
+    if frontend == ProbeResult.OK and websocket == ProbeResult.OK:
+        return True
+
+    if ProbeResult.BAD_RESPONSE in (frontend, websocket):
+        return False
+
+    # Neither probe got a response. Outside of SSL that's a plain
+    # connectivity failure; under SSL it's most likely mutual TLS rejecting
+    # us, so confirm the listener is up rather than rolling back blindly.
+    if coresys.homeassistant.api_ssl:
+        _LOGGER.debug(
+            "Frontend probes could not connect while Core uses SSL, "
+            "falling back to API port reachability check"
+        )
+        return await check_api_reachable(coresys)
+
+    return False

--- a/tests/homeassistant/test_frontend_check.py
+++ b/tests/homeassistant/test_frontend_check.py
@@ -60,6 +60,12 @@ async def test_check_frontend_connection_error(coresys: CoreSys, websession: Mag
     assert await check_frontend(coresys) is ProbeResult.NO_RESPONSE
 
 
+async def test_check_frontend_timeout(coresys: CoreSys, websession: MagicMock):
+    """Frontend check returns BAD_RESPONSE on timeout (not a mutual-TLS reject)."""
+    websession.get = MagicMock(side_effect=TimeoutError())
+    assert await check_frontend(coresys) is ProbeResult.BAD_RESPONSE
+
+
 # --- check_websocket ---
 
 
@@ -95,6 +101,14 @@ async def test_check_websocket_connect_error(coresys: CoreSys, websession: Magic
     """Websocket check returns NO_RESPONSE if the handshake fails."""
     websession.ws_connect = AsyncMock(side_effect=aiohttp.ClientConnectionError("nope"))
     assert await check_websocket(coresys) is ProbeResult.NO_RESPONSE
+
+
+async def test_check_websocket_handshake_timeout(
+    coresys: CoreSys, websession: MagicMock
+):
+    """Websocket check returns BAD_RESPONSE on handshake timeout, not NO_RESPONSE."""
+    websession.ws_connect = AsyncMock(side_effect=TimeoutError())
+    assert await check_websocket(coresys) is ProbeResult.BAD_RESPONSE
 
 
 async def test_check_websocket_non_dict_payload(

--- a/tests/homeassistant/test_frontend_check.py
+++ b/tests/homeassistant/test_frontend_check.py
@@ -1,13 +1,15 @@
 """Test external frontend probes."""
 
 from contextlib import asynccontextmanager
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
 
 from supervisor.coresys import CoreSys
 from supervisor.homeassistant.frontend_check import (
+    ProbeResult,
+    check_api_reachable,
     check_frontend,
     check_websocket,
     verify_frontend,
@@ -33,100 +35,176 @@ def _mock_ws(receive_msg) -> AsyncMock:
 
 
 async def test_check_frontend_ok(coresys: CoreSys, websession: MagicMock):
-    """Frontend check returns True for HTML 200."""
+    """Frontend check returns OK for HTML 200."""
     websession.get = MagicMock(return_value=_mock_response(200, "text/html"))
-    assert await check_frontend(coresys) is True
+    assert await check_frontend(coresys) is ProbeResult.OK
 
 
 async def test_check_frontend_wrong_status(coresys: CoreSys, websession: MagicMock):
-    """Frontend check returns False on non-200 status."""
+    """Frontend check returns BAD_RESPONSE on non-200 status."""
     websession.get = MagicMock(return_value=_mock_response(503, "text/html"))
-    assert await check_frontend(coresys) is False
+    assert await check_frontend(coresys) is ProbeResult.BAD_RESPONSE
 
 
 async def test_check_frontend_wrong_content_type(
     coresys: CoreSys, websession: MagicMock
 ):
-    """Frontend check returns False when content-type is not HTML."""
+    """Frontend check returns BAD_RESPONSE when content-type is not HTML."""
     websession.get = MagicMock(return_value=_mock_response(200, "application/json"))
-    assert await check_frontend(coresys) is False
+    assert await check_frontend(coresys) is ProbeResult.BAD_RESPONSE
 
 
 async def test_check_frontend_connection_error(coresys: CoreSys, websession: MagicMock):
-    """Frontend check returns False on connection errors."""
+    """Frontend check returns NO_RESPONSE on connection errors."""
     websession.get = MagicMock(side_effect=aiohttp.ClientConnectionError("boom"))
-    assert await check_frontend(coresys) is False
+    assert await check_frontend(coresys) is ProbeResult.NO_RESPONSE
 
 
 # --- check_websocket ---
 
 
 async def test_check_websocket_ok(coresys: CoreSys, websession: MagicMock):
-    """Websocket check returns True when auth_required is received."""
+    """Websocket check returns OK when auth_required is received."""
     msg = MagicMock()
     msg.type = aiohttp.WSMsgType.TEXT
     msg.json.return_value = {"type": "auth_required"}
     websession.ws_connect = AsyncMock(return_value=_mock_ws(msg))
-    assert await check_websocket(coresys) is True
+    assert await check_websocket(coresys) is ProbeResult.OK
 
 
 async def test_check_websocket_close_frame(coresys: CoreSys, websession: MagicMock):
-    """Websocket check returns False on close frame (issue #6802 case)."""
+    """Websocket check returns BAD_RESPONSE on close frame (issue #6802 case)."""
     msg = MagicMock()
     msg.type = aiohttp.WSMsgType.CLOSE
     websession.ws_connect = AsyncMock(return_value=_mock_ws(msg))
-    assert await check_websocket(coresys) is False
+    assert await check_websocket(coresys) is ProbeResult.BAD_RESPONSE
 
 
 async def test_check_websocket_unexpected_message(
     coresys: CoreSys, websession: MagicMock
 ):
-    """Websocket check returns False when first frame is not auth_required."""
+    """Websocket check returns BAD_RESPONSE when first frame is not auth_required."""
     msg = MagicMock()
     msg.type = aiohttp.WSMsgType.TEXT
     msg.json.return_value = {"type": "result"}
     websession.ws_connect = AsyncMock(return_value=_mock_ws(msg))
-    assert await check_websocket(coresys) is False
+    assert await check_websocket(coresys) is ProbeResult.BAD_RESPONSE
 
 
 async def test_check_websocket_connect_error(coresys: CoreSys, websession: MagicMock):
-    """Websocket check returns False if the handshake fails."""
+    """Websocket check returns NO_RESPONSE if the handshake fails."""
     websession.ws_connect = AsyncMock(side_effect=aiohttp.ClientConnectionError("nope"))
-    assert await check_websocket(coresys) is False
+    assert await check_websocket(coresys) is ProbeResult.NO_RESPONSE
 
 
 async def test_check_websocket_non_dict_payload(
     coresys: CoreSys, websession: MagicMock
 ):
-    """Websocket check returns False when payload is valid JSON but not an object."""
+    """Websocket check returns BAD_RESPONSE when payload is JSON but not an object."""
     msg = MagicMock()
     msg.type = aiohttp.WSMsgType.TEXT
     msg.json.return_value = ["auth_required"]
     websession.ws_connect = AsyncMock(return_value=_mock_ws(msg))
-    assert await check_websocket(coresys) is False
+    assert await check_websocket(coresys) is ProbeResult.BAD_RESPONSE
+
+
+# --- check_api_reachable ---
+
+
+async def test_check_api_reachable_ok(coresys: CoreSys):
+    """API reachability check returns True when a TCP connection succeeds."""
+    writer = MagicMock()
+    writer.wait_closed = AsyncMock()
+    with patch(
+        "supervisor.homeassistant.frontend_check.asyncio.open_connection",
+        AsyncMock(return_value=(MagicMock(), writer)),
+    ):
+        assert await check_api_reachable(coresys) is True
+    writer.close.assert_called_once()
+
+
+async def test_check_api_reachable_connection_error(coresys: CoreSys):
+    """API reachability check returns False when the connection fails."""
+    with patch(
+        "supervisor.homeassistant.frontend_check.asyncio.open_connection",
+        AsyncMock(side_effect=ConnectionResetError("boom")),
+    ):
+        assert await check_api_reachable(coresys) is False
 
 
 # --- verify_frontend ---
 
 
 @pytest.mark.parametrize(
-    ("frontend_ok", "ws_ok", "expected"),
-    [(True, True, True), (False, True, False), (True, False, False)],
+    ("frontend", "websocket", "expected"),
+    [
+        (ProbeResult.OK, ProbeResult.OK, True),
+        (ProbeResult.BAD_RESPONSE, ProbeResult.OK, False),
+        (ProbeResult.OK, ProbeResult.BAD_RESPONSE, False),
+        # No response without SSL is a plain connectivity failure.
+        (ProbeResult.NO_RESPONSE, ProbeResult.NO_RESPONSE, False),
+    ],
 )
 async def test_verify_frontend(
     coresys: CoreSys,
-    websession: MagicMock,
-    frontend_ok: bool,
-    ws_ok: bool,
+    frontend: ProbeResult,
+    websocket: ProbeResult,
     expected: bool,
 ):
-    """verify_frontend is True only if both probes succeed."""
-    websession.get = MagicMock(
-        return_value=_mock_response(200 if frontend_ok else 500, "text/html")
-    )
-    msg = MagicMock()
-    msg.type = aiohttp.WSMsgType.TEXT
-    msg.json.return_value = {"type": "auth_required" if ws_ok else "result"}
-    websession.ws_connect = AsyncMock(return_value=_mock_ws(msg))
+    """verify_frontend combines both probe results without SSL."""
+    with (
+        patch(
+            "supervisor.homeassistant.frontend_check.check_frontend",
+            AsyncMock(return_value=frontend),
+        ),
+        patch(
+            "supervisor.homeassistant.frontend_check.check_websocket",
+            AsyncMock(return_value=websocket),
+        ),
+    ):
+        assert await verify_frontend(coresys) is expected
 
-    assert await verify_frontend(coresys) is expected
+
+async def test_verify_frontend_ssl_bad_response_fails(coresys: CoreSys):
+    """A bad response under SSL is a genuine failure, not a mutual-TLS reject."""
+    coresys.homeassistant.api_ssl = True
+    with (
+        patch(
+            "supervisor.homeassistant.frontend_check.check_frontend",
+            AsyncMock(return_value=ProbeResult.BAD_RESPONSE),
+        ),
+        patch(
+            "supervisor.homeassistant.frontend_check.check_websocket",
+            AsyncMock(return_value=ProbeResult.NO_RESPONSE),
+        ),
+        patch(
+            "supervisor.homeassistant.frontend_check.check_api_reachable",
+            AsyncMock(return_value=True),
+        ) as reachable,
+    ):
+        assert await verify_frontend(coresys) is False
+    reachable.assert_not_called()
+
+
+@pytest.mark.parametrize("reachable", [True, False])
+async def test_verify_frontend_ssl_no_response_uses_tcp_check(
+    coresys: CoreSys, reachable: bool
+):
+    """Probes that get no response under SSL fall back to the TCP check (#6987)."""
+    coresys.homeassistant.api_ssl = True
+    with (
+        patch(
+            "supervisor.homeassistant.frontend_check.check_frontend",
+            AsyncMock(return_value=ProbeResult.NO_RESPONSE),
+        ),
+        patch(
+            "supervisor.homeassistant.frontend_check.check_websocket",
+            AsyncMock(return_value=ProbeResult.NO_RESPONSE),
+        ),
+        patch(
+            "supervisor.homeassistant.frontend_check.check_api_reachable",
+            AsyncMock(return_value=reachable),
+        ) as check,
+    ):
+        assert await verify_frontend(coresys) is reachable
+    check.assert_awaited_once_with(coresys)


### PR DESCRIPTION
## Proposed change

The post-update frontend probe added in #6811 connects to Core's internal address (e.g. `https://172.30.32.1:8123/`) as a plain external HTTP/WebSocket client. When Core is configured with `ssl_peer_certificate` it requires mutual TLS, so it resets the unauthenticated probe connection during the handshake (`[Errno 104] Connection reset by peer`). The probe reported this as a failure and rolled back the Core update even though the update succeeded and the frontend was perfectly reachable through the user's authenticated reverse proxy.

Supervisor only knows whether Core uses SSL, not whether a peer certificate is required, so it can't tell mutual TLS apart from plain HTTPS up front. Instead of giving up the probe for all SSL setups, this change distinguishes *how* a probe fails:

- A **bad response** (non-200, non-HTML, or a missing WebSocket `auth_required` frame) means the endpoint is reachable but genuinely broken — this still fails the update, regardless of SSL.
- An **inability to connect at all** only triggers a rollback when Core is not using SSL. When the probes can't connect while SSL is enabled, we can't rule out mutual TLS rejecting our unauthenticated connection, so we fall back to a plain TCP reachability check (no TLS handshake) and otherwise rely on the existing `http`/`frontend`/`websocket_api` component check.

This keeps the full HTML and WebSocket verification for plain HTTPS setups while no longer rolling back updates for mutual-TLS deployments. A genuinely broken frontend behind mutual TLS can't be probed by any external client, but is still covered by the component check.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #6987
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
