### PR TITLE
Refactor addon wording in non-compat comments and docstrings

### DIFF
--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -367,13 +367,13 @@ class Core(CoreSysAttributes):
     async def teardown_services(
         self, *, remove_homeassistant_container: bool = False
     ) -> None:
-        """Stop all add-ons and Home Assistant Core in correct order.
+        """Stop all apps and Home Assistant Core in correct order.
 
         Does not change Core state and does not stop plugins. Used during
         backup restore (state stays FREEZE, plugins keep running) and as
         the inner step of shutdown().
         """
-        # Stop application add-ons (using Home Assistant API)
+        # Stop application apps (using Home Assistant API)
         await self.sys_apps.shutdown(AppStartup.APPLICATION)
 
         # Close Home Assistant Core
@@ -382,7 +382,7 @@ class Core(CoreSysAttributes):
                 remove_container=remove_homeassistant_container
             )
 
-        # Stop system add-ons
+        # Stop system apps
         await self.sys_apps.shutdown(AppStartup.SERVICES)
         await self.sys_apps.shutdown(AppStartup.SYSTEM)
         await self.sys_apps.shutdown(AppStartup.INITIALIZE)

--- a/supervisor/docker/app.py
+++ b/supervisor/docker/app.py
@@ -779,7 +779,7 @@ class DockerApp(DockerInterface):
 
         _LOGGER.info("Build %s:%s done", self.image, version)
 
-        # Clean up old add-on builder images from previous Docker versions.
+        # Clean up old app builder images from previous Docker versions.
         # Done here after build because cleanup_old_images needs the current
         # image to exist, and the builder image is only pulled on first build
         # (in run_command) after a Docker engine update.

--- a/supervisor/hardware/helper.py
+++ b/supervisor/hardware/helper.py
@@ -18,7 +18,7 @@ _RE_BOOT_TIME: re.Pattern = re.compile(r"btime (\d+)")
 
 _RE_HIDE_SYSFS: re.Pattern = re.compile(r"/sys/devices/virtual/(?:tty|block|vc)/.*")
 
-# Candidate sysfs paths to expose to GPIO-enabled add-ons. Which subset
+# Candidate sysfs paths to expose to GPIO-enabled apps. Which subset
 # exists is determined by the kernel at boot and does not change at runtime,
 # so we resolve it once during hardware load.
 _GPIO_CANDIDATE_PATHS: tuple[str, ...] = (
@@ -48,7 +48,7 @@ class HwHelper(CoreSysAttributes):
 
     @property
     def gpio_mount_paths(self) -> tuple[str, ...]:
-        """Return existing sysfs paths to mount for GPIO add-ons."""
+        """Return existing sysfs paths to mount for GPIO apps."""
         return self._gpio_mount_paths
 
     async def load(self) -> None:


### PR DESCRIPTION
## Proposed change

This PR updates non-compatibility comments and docstrings that still used "add-on" terminology to use "app" terminology.

Scope is intentionally limited to wording-only updates in non-legacy, non-v1-API code paths:
- `supervisor/core.py`
- `supervisor/hardware/helper.py`
- `supervisor/docker/app.py`

No behavior changes.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/