### PR TITLE
Replace `addon` with `app` in docker container names for apps

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -612,8 +612,11 @@ class RestAPI(CoreSysAttributes):
 
             @api_process_raw(CONTENT_TYPE_TEXT, error_type=CONTENT_TYPE_TEXT)
             async def get_app_logs(request, *args, **kwargs):
-                addon = api_apps.get_app_for_request(request)
-                kwargs["identifier"] = f"addon_{addon.slug}"
+                app_obj = api_apps.get_app_for_request(request)
+                kwargs["identifier"] = [
+                    f"addon_{app_obj.slug}",
+                    f"app_{app_obj.slug}",
+                ]
                 return await self._api_host.advanced_logs(request, *args, **kwargs)
 
             # Legacy routing to support requests for not installed apps
@@ -673,8 +676,11 @@ class RestAPI(CoreSysAttributes):
 
             @api_process_raw(CONTENT_TYPE_TEXT, error_type=CONTENT_TYPE_TEXT)
             async def get_app_logs_v2(request, *args, **kwargs):
-                addon = api_apps.get_app_for_request(request)
-                kwargs["identifier"] = f"addon_{addon.slug}"
+                app_obj = api_apps.get_app_for_request(request)
+                kwargs["identifier"] = [
+                    f"addon_{app_obj.slug}",
+                    f"app_{app_obj.slug}",
+                ]
                 return await self._api_host.advanced_logs(request, *args, **kwargs)
 
             app.add_routes(

--- a/supervisor/api/host.py
+++ b/supervisor/api/host.py
@@ -231,12 +231,13 @@ class APIHost(CoreSysAttributes):
                     "Latest logs can only be fetched for a specific identifier."
                 )
 
-            identifiers = [identifier] if isinstance(identifier, str) else identifier
-
             try:
-                epoch = await self._get_latest_container_epoch(identifiers)
+                epoch = await self._get_container_last_epoch(identifier)
                 params["CONTAINER_LOG_EPOCH"] = epoch
             except HostLogError as err:
+                identifiers = (
+                    [identifier] if isinstance(identifier, str) else identifier
+                )
                 raise APIError(
                     "Cannot determine CONTAINER_LOG_EPOCH of "
                     f"{', '.join(identifiers)}, latest logs not available."
@@ -337,28 +338,6 @@ class APIHost(CoreSysAttributes):
             request, identifier, follow, latest, no_colors, default_verbose
         )
 
-    async def _get_latest_container_epoch(self, identifiers: list[str]) -> str:
-        """Get newest available container log epoch from one or more identifiers."""
-        latest_epoch: int | None = None
-
-        for identifier in identifiers:
-            try:
-                epoch = await self._get_container_last_epoch(identifier)
-                if epoch is None:
-                    continue
-                latest_epoch = max(latest_epoch or 0, int(epoch))
-            except (HostLogError, ValueError, TypeError):
-                # One identifier may not have logs yet during migration; try others.
-                continue
-
-        if latest_epoch is None:
-            raise HostLogError(
-                "Could not get last container epoch from systemd-journal-gatewayd",
-                _LOGGER.error,
-            )
-
-        return str(latest_epoch)
-
     @api_process
     async def disk_usage(self, request: web.Request) -> dict[str, Any]:
         """Return a breakdown of storage usage for the system."""
@@ -409,8 +388,8 @@ class APIHost(CoreSysAttributes):
             ],
         }
 
-    async def _get_container_last_epoch(self, identifier: str) -> str | None:
-        """Get Docker's internal log epoch of the latest log entry for the given identifier."""
+    async def _get_container_last_epoch(self, identifier: str | list[str]) -> str:
+        """Get Docker's internal log epoch of the latest log entry for given identifier(s)."""
         try:
             async with self.sys_host.logs.journald_logs(
                 params={"CONTAINER_NAME": identifier},
@@ -428,7 +407,9 @@ class APIHost(CoreSysAttributes):
         try:
             return json.loads(text.strip().split("\n")[-1])["CONTAINER_LOG_EPOCH"]
         except (json.JSONDecodeError, KeyError, IndexError) as err:
+            identifiers = [identifier] if isinstance(identifier, str) else identifier
             raise HostLogError(
-                f"Failed to parse CONTAINER_LOG_EPOCH of {identifier} container, got: {text}",
+                "Failed to parse CONTAINER_LOG_EPOCH of "
+                f"{', '.join(identifiers)} container, got: {text}",
                 _LOGGER.error,
             ) from err

--- a/supervisor/api/host.py
+++ b/supervisor/api/host.py
@@ -204,7 +204,7 @@ class APIHost(CoreSysAttributes):
     async def advanced_logs_handler(
         self,
         request: web.Request,
-        identifier: str | None = None,
+        identifier: str | list[str] | None = None,
         follow: bool = False,
         latest: bool = False,
         no_colors: bool = False,
@@ -231,12 +231,15 @@ class APIHost(CoreSysAttributes):
                     "Latest logs can only be fetched for a specific identifier."
                 )
 
+            identifiers = [identifier] if isinstance(identifier, str) else identifier
+
             try:
-                epoch = await self._get_container_last_epoch(identifier)
+                epoch = await self._get_latest_container_epoch(identifiers)
                 params["CONTAINER_LOG_EPOCH"] = epoch
             except HostLogError as err:
                 raise APIError(
-                    f"Cannot determine CONTAINER_LOG_EPOCH of {identifier}, latest logs not available."
+                    "Cannot determine CONTAINER_LOG_EPOCH of "
+                    f"{', '.join(identifiers)}, latest logs not available."
                 ) from err
 
         accept_header = request.headers.get(ACCEPT)
@@ -323,7 +326,7 @@ class APIHost(CoreSysAttributes):
     async def advanced_logs(
         self,
         request: web.Request,
-        identifier: str | None = None,
+        identifier: str | list[str] | None = None,
         follow: bool = False,
         latest: bool = False,
         no_colors: bool = False,
@@ -333,6 +336,28 @@ class APIHost(CoreSysAttributes):
         return await self.advanced_logs_handler(
             request, identifier, follow, latest, no_colors, default_verbose
         )
+
+    async def _get_latest_container_epoch(self, identifiers: list[str]) -> str:
+        """Get newest available container log epoch from one or more identifiers."""
+        latest_epoch: int | None = None
+
+        for identifier in identifiers:
+            try:
+                epoch = await self._get_container_last_epoch(identifier)
+                if epoch is None:
+                    continue
+                latest_epoch = max(latest_epoch or 0, int(epoch))
+            except (HostLogError, ValueError, TypeError):
+                # One identifier may not have logs yet during migration; try others.
+                continue
+
+        if latest_epoch is None:
+            raise HostLogError(
+                "Could not get last container epoch from systemd-journal-gatewayd",
+                _LOGGER.error,
+            )
+
+        return str(latest_epoch)
 
     @api_process
     async def disk_usage(self, request: web.Request) -> dict[str, Any]:

--- a/supervisor/api/host.py
+++ b/supervisor/api/host.py
@@ -37,7 +37,12 @@ from ..const import (
     ATTR_TIMEZONE,
 )
 from ..coresys import CoreSysAttributes
-from ..exceptions import APIDBMigrationInProgress, APIError, HostLogError
+from ..exceptions import (
+    APIDBMigrationInProgress,
+    APIError,
+    HostContainerLogEpochError,
+    HostLogError,
+)
 from ..host.const import (
     PARAM_BOOT_ID,
     PARAM_FOLLOW,
@@ -231,17 +236,8 @@ class APIHost(CoreSysAttributes):
                     "Latest logs can only be fetched for a specific identifier."
                 )
 
-            try:
-                epoch = await self._get_container_last_epoch(identifier)
-                params["CONTAINER_LOG_EPOCH"] = epoch
-            except HostLogError as err:
-                identifiers = (
-                    [identifier] if isinstance(identifier, str) else identifier
-                )
-                raise APIError(
-                    "Cannot determine CONTAINER_LOG_EPOCH of "
-                    f"{', '.join(identifiers)}, latest logs not available."
-                ) from err
+            epoch = await self._get_container_last_epoch(identifier)
+            params["CONTAINER_LOG_EPOCH"] = epoch
 
         accept_header = request.headers.get(ACCEPT)
 
@@ -390,6 +386,8 @@ class APIHost(CoreSysAttributes):
 
     async def _get_container_last_epoch(self, identifier: str | list[str]) -> str:
         """Get Docker's internal log epoch of the latest log entry for given identifier(s)."""
+        identifiers = [identifier] if isinstance(identifier, str) else identifier
+
         try:
             async with self.sys_host.logs.journald_logs(
                 params={"CONTAINER_NAME": identifier},
@@ -399,17 +397,20 @@ class APIHost(CoreSysAttributes):
             ) as resp:
                 text = await resp.text()
         except (ClientError, TimeoutError) as err:
-            raise HostLogError(
-                "Could not get last container epoch from systemd-journal-gatewayd",
-                _LOGGER.error,
+            _LOGGER.error(
+                "Could not get last container epoch from systemd-journal-gatewayd for identifiers: %s",
+                ", ".join(identifiers),
+            )
+            raise HostContainerLogEpochError(
+                identifiers=identifiers,
             ) from err
 
         try:
             return json.loads(text.strip().split("\n")[-1])["CONTAINER_LOG_EPOCH"]
         except (json.JSONDecodeError, KeyError, IndexError) as err:
-            identifiers = [identifier] if isinstance(identifier, str) else identifier
-            raise HostLogError(
-                "Failed to parse CONTAINER_LOG_EPOCH of "
-                f"{', '.join(identifiers)} container, got: {text}",
-                _LOGGER.error,
-            ) from err
+            _LOGGER.error(
+                "Failed to parse CONTAINER_LOG_EPOCH from systemd-journald response for identifiers %s: %s",
+                ", ".join(identifiers),
+                text,
+            )
+            raise HostContainerLogEpochError(identifiers=identifiers) from err

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -811,6 +811,23 @@ class HostLogError(HostError):
     """Internal error with host log."""
 
 
+class HostContainerLogEpochError(APIUnknownSupervisorError, HostLogError):
+    """Failed to determine container log epoch via journald."""
+
+    error_key = "host_container_log_epoch_error"
+    message_template = "Cannot determine CONTAINER_LOG_EPOCH of {identifiers}"
+
+    def __init__(
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        identifiers: list[str],
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"identifiers": ", ".join(identifiers)}
+        super().__init__(logger)
+
+
 class HostInvalidHostnameError(HostError, APIError):
     """Hostname rejected by the host as semantically invalid."""
 

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -815,7 +815,7 @@ class HostContainerLogEpochError(APIUnknownSupervisorError, HostLogError):
     """Failed to determine container log epoch via journald."""
 
     error_key = "host_container_log_epoch_error"
-    message_template = "Cannot determine CONTAINER_LOG_EPOCH of {identifiers}"
+    message_template = "Cannot determine {symbol} of {identifiers}"
 
     def __init__(
         self,
@@ -824,7 +824,10 @@ class HostContainerLogEpochError(APIUnknownSupervisorError, HostLogError):
         identifiers: list[str],
     ) -> None:
         """Initialize exception."""
-        self.extra_fields = {"identifiers": ", ".join(identifiers)}
+        self.extra_fields = {
+            "symbol": "CONTAINER_LOG_EPOCH",
+            "identifiers": ", ".join(identifiers),
+        }
         super().__init__(logger)
 
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -76,20 +76,15 @@ async def _common_test_api_advanced_logs(
     )
     journald_logs.return_value.__aenter__.return_value = mock_response
 
-    identifiers = (
-        [syslog_identifier] if isinstance(syslog_identifier, str) else syslog_identifier
-    )
-
     resp = await api_client.get(f"{path_prefix}/logs/latest")
     assert resp.status == 200
 
-    assert journald_logs.call_count == len(identifiers) + 1
+    assert journald_logs.call_count == 2
 
-    # Check the calls for getting epoch(s)
-    for idx, identifier in enumerate(identifiers):
-        epoch_call = journald_logs.call_args_list[idx]
-        assert epoch_call[1]["params"] == {"CONTAINER_NAME": identifier}
-        assert epoch_call[1]["range_header"] == "entries=:-1:2"
+    # Check the call for getting epoch(s)
+    epoch_call = journald_logs.call_args_list[0]
+    assert epoch_call[1]["params"] == {"CONTAINER_NAME": syslog_identifier}
+    assert epoch_call[1]["range_header"] == "entries=:-1:2"
 
     # Check the second call for getting logs with the epoch
     logs_call = journald_logs.call_args_list[-1]

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -19,7 +19,7 @@ DEFAULT_LOG_RANGE_FOLLOW = "entries=:-99:18446744073709551615"
 
 async def _common_test_api_advanced_logs(
     path_prefix: str,
-    syslog_identifier: str,
+    syslog_identifier: str | list[str],
     formatter: LogFormatter,
     api_client: TestClient,
     journald_logs: MagicMock,
@@ -76,18 +76,23 @@ async def _common_test_api_advanced_logs(
     )
     journald_logs.return_value.__aenter__.return_value = mock_response
 
+    identifiers = (
+        [syslog_identifier] if isinstance(syslog_identifier, str) else syslog_identifier
+    )
+
     resp = await api_client.get(f"{path_prefix}/logs/latest")
     assert resp.status == 200
 
-    assert journald_logs.call_count == 2
+    assert journald_logs.call_count == len(identifiers) + 1
 
-    # Check the first call for getting epoch
-    epoch_call = journald_logs.call_args_list[0]
-    assert epoch_call[1]["params"] == {"CONTAINER_NAME": syslog_identifier}
-    assert epoch_call[1]["range_header"] == "entries=:-1:2"
+    # Check the calls for getting epoch(s)
+    for idx, identifier in enumerate(identifiers):
+        epoch_call = journald_logs.call_args_list[idx]
+        assert epoch_call[1]["params"] == {"CONTAINER_NAME": identifier}
+        assert epoch_call[1]["range_header"] == "entries=:-1:2"
 
     # Check the second call for getting logs with the epoch
-    logs_call = journald_logs.call_args_list[1]
+    logs_call = journald_logs.call_args_list[-1]
     assert logs_call[1]["params"]["SYSLOG_IDENTIFIER"] == syslog_identifier
     assert logs_call[1]["params"]["CONTAINER_LOG_EPOCH"] == "12345"
     assert logs_call[1]["range_header"] == "entries=:0:18446744073709551615"
@@ -143,7 +148,7 @@ async def advanced_logs_tester(
 
     async def test_logs(
         path_prefix: str,
-        syslog_identifier: str,
+        syslog_identifier: str | list[str],
         formatter: LogFormatter = LogFormatter.PLAIN,
         *,
         v2_path_prefix: str | None = None,

--- a/tests/api/test_apps.py
+++ b/tests/api/test_apps.py
@@ -3,7 +3,7 @@
 import asyncio
 from collections.abc import Awaitable, Callable
 from pathlib import PurePath
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import aiodocker
 from aiodocker.containers import DockerContainer
@@ -145,6 +145,27 @@ async def test_api_app_logs_not_installed(api_client: TestClient):
     assert resp.content_type == "text/plain"
     content = await resp.text()
     assert content == "App hic_sunt_leones does not exist"
+
+
+@pytest.mark.usefixtures("install_app_ssh")
+async def test_api_app_logs_latest_epoch_error(
+    api_client: TestClient, journald_logs: MagicMock
+):
+    """Test latest app logs returns sanitized error when epoch lookup fails."""
+    mock_response = MagicMock()
+    mock_response.text = AsyncMock(return_value="not-json")
+    journald_logs.return_value.__aenter__.return_value = mock_response
+
+    resp = await api_client.get("/addons/local_ssh/logs/latest")
+
+    assert resp.status == 500
+    assert resp.content_type == "text/plain"
+    content = await resp.text()
+    assert (
+        content
+        == "Cannot determine CONTAINER_LOG_EPOCH of addon_local_ssh, app_local_ssh. "
+        "Check Supervisor logs for details"
+    )
 
 
 @pytest.mark.usefixtures("docker_logs", "install_app_ssh")

--- a/tests/api/test_apps.py
+++ b/tests/api/test_apps.py
@@ -127,11 +127,13 @@ async def test_apps_info_not_installed(
 
 @pytest.mark.usefixtures("install_app_ssh")
 async def test_api_app_logs(
-    advanced_logs_tester: Callable[[str, str], Awaitable[None]],
+    advanced_logs_tester: Callable[[str, str | list[str]], Awaitable[None]],
 ):
     """Test app logs."""
     await advanced_logs_tester(
-        "/addons/local_ssh", "addon_local_ssh", v2_path_prefix="/apps/local_ssh"
+        "/addons/local_ssh",
+        ["addon_local_ssh", "app_local_ssh"],
+        v2_path_prefix="/apps/local_ssh",
     )
 
 


### PR DESCRIPTION
## Proposed change

This PR prepares app log retrieval for the upcoming container name prefix change from `addon_` to `app_`.

Today app log endpoints query journald with a single identifier (`addon_<slug>`). That breaks visibility during migration because container recreation happens on app restart, so systems can contain a mix of old and new container names for an extended period.

Changes in this PR:
- App log endpoints now query journald with both identifiers:
  - `addon_<slug>`
  - `app_<slug>`
- `advanced_logs_handler` now accepts one or many identifiers.
- `latest` log mode now resolves the newest available `CONTAINER_LOG_EPOCH` across all provided identifiers (instead of assuming one).
- API tests were updated to assert both identifiers are passed through to journald and that epoch lookup is performed for both.

This preserves log continuity before and after the container naming change.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/