### PR TITLE
Fix backup delete error message

### DIFF
--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -365,7 +365,7 @@ class BackupManager(FileConfiguration, JobGroup):
                     _LOGGER.error,
                 ) from err
             except OSError as err:
-                msg = f"Could delete backup at {backup_tarfile.as_posix()}: {err!s}"
+                msg = f"Cannot delete backup at {backup_tarfile.as_posix()}: {err!s}"
                 if location in {None, LOCATION_CLOUD_BACKUP}:
                     self.sys_resolution.check_oserror(err)
                 raise BackupError(msg, _LOGGER.error) from err

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -1842,12 +1842,12 @@ async def test_backup_remove_error(
     tar_file_mock.unlink.side_effect = (err := OSError())
 
     err.errno = errno.EBUSY
-    with pytest.raises(BackupError):
+    with pytest.raises(BackupError, match="Cannot delete backup at"):
         await coresys.backups.remove(backup)
     assert coresys.core.healthy is True
 
     err.errno = errno.EBADMSG
-    with pytest.raises(BackupError):
+    with pytest.raises(BackupError, match="Cannot delete backup at"):
         await coresys.backups.remove(backup)
     assert coresys.core.healthy is healthy_expected
 


### PR DESCRIPTION
## Proposed change

Change the backup removal error message from `Could delete backup at ...` to
`Cannot delete backup at ...`.

This message is emitted when deleting a backup file fails with `OSError`, so
`Cannot delete` matches the actual failure path and is consistent with the
neighboring `FileNotFoundError` message.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A
- Link to cli pull request: N/A
- Link to client library pull request: N/A

The confusing wording appears in `home-assistant/core#175100` and has also been
noticed in the community:
https://community.home-assistant.io/t/ha-not-playing-nice-with-truenas-13-0-u6-8/961628

I also initially read the warning as saying that the backup had been deleted
successfully, especially because the log entry is emitted as a warning rather
than an error.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

Not applicable: this only changes an existing error message and test assertion.

## Testing

```text
pytest -q tests/backups/test_manager.py::test_backup_remove_error
ruff check supervisor/backups/manager.py tests/backups/test_manager.py
ruff format --check supervisor/backups/manager.py tests/backups/test_manager.py
pre-commit run --files supervisor/backups/manager.py tests/backups/test_manager.py
```

## AI Disclosure

Code drafted with OpenAI Codex, reviewed and modified before submission. The
change was verified locally with the commands listed above.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
