### PR TITLE
Use local wheels for editable Supervisor install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,17 @@ RUN \
 ARG BUILD_VERSION="9999.09.9.dev9999"
 COPY . supervisor
 RUN \
-    sed -i "s/^SUPERVISOR_VERSION =.*/SUPERVISOR_VERSION = \"${BUILD_VERSION}\"/g" /usr/src/supervisor/supervisor/const.py \
+    --mount=type=bind,source=./wheels,target=/usr/src/wheels \
+    if ls /usr/src/wheels/musllinux/* >/dev/null 2>&1; then \
+        LOCAL_WHEELS=/usr/src/wheels/musllinux; \
+        echo "Using local wheels from: $LOCAL_WHEELS"; \
+    else \
+        LOCAL_WHEELS=; \
+        echo "No local wheels found"; \
+    fi \
+    && sed -i "s/^SUPERVISOR_VERSION =.*/SUPERVISOR_VERSION = \"${BUILD_VERSION}\"/g" /usr/src/supervisor/supervisor/const.py \
     && uv pip install --no-cache -e ./supervisor \
+        ${LOCAL_WHEELS:+--find-links $LOCAL_WHEELS} \
     && python3 -m compileall ./supervisor/supervisor
 
 # Copy the rest of rootfs files


### PR DESCRIPTION
## Proposed change

The editable install of the Supervisor package (`uv pip install -e ./supervisor`) builds the package with an isolated PEP 517 build environment, which resolves the build backend (`setuptools`, pinned via `build-system.requires` in `pyproject.toml`) from the configured package indexes. Unlike the runtime requirements install directly above it, this step was not given the locally built wheels, so it could only resolve build dependencies from the indexes.

When a pinned build dependency is newer than what the Home Assistant musllinux wheels index currently carries — for example a Dependabot `setuptools` bump that has not been mirrored yet — uv's default first-index strategy locks onto that index (where `setuptools` exists at an older version) and never falls through to PyPI. The editable install then fails with `No solution found when resolving: setuptools~=<version>`, even though the required version was already built into the local wheels and installed by the runtime requirements step.

This change passes the locally built wheels to the editable install via `--find-links`, mirroring what the runtime requirements step already does. The isolated build environment can then satisfy the pinned build dependency from the local wheels, so the build no longer depends on the wheels index having caught up.

Verified locally that uv forwards `--find-links` into the isolated build environment when resolving `build-system.requires`: with `--no-index` (so no index can supply the backend) plus `--find-links`, an editable install of a package pinning a specific `setuptools` version builds successfully from the local wheel alone.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
