### PR TITLE
Migrate simple attrs classes to stdlib dataclasses

### DIFF
--- a/supervisor/api/resolution.py
+++ b/supervisor/api/resolution.py
@@ -2,10 +2,10 @@
 
 import asyncio
 from collections.abc import Awaitable
+from dataclasses import asdict
 from typing import Any
 
 from aiohttp import web
-import attr
 import voluptuous as vol
 
 from ..const import (
@@ -45,7 +45,7 @@ class APIResolution(CoreSysAttributes):
 
     def _generate_suggestion_information(self, suggestion: Suggestion):
         """Generate suggestion information for response."""
-        resp = attr.asdict(suggestion)
+        resp = asdict(suggestion)
         resp[ATTR_AUTO] = bool(
             [
                 fix
@@ -65,7 +65,7 @@ class APIResolution(CoreSysAttributes):
                 self._generate_suggestion_information(suggestion)
                 for suggestion in self.sys_resolution.suggestions
             ],
-            ATTR_ISSUES: [attr.asdict(issue) for issue in self.sys_resolution.issues],
+            ATTR_ISSUES: [asdict(issue) for issue in self.sys_resolution.issues],
             ATTR_CHECKS: [
                 {ATTR_ENABLED: check.enabled, ATTR_SLUG: check.slug}
                 for check in self.sys_resolution.check.all_checks

--- a/supervisor/apps/manager.py
+++ b/supervisor/apps/manager.py
@@ -3,10 +3,10 @@
 import asyncio
 from collections.abc import Awaitable
 from contextlib import suppress
+from dataclasses import replace
 import logging
 from typing import Self, Union
 
-from attr import evolve
 from securetar import SecureTarFile
 
 from ..const import FILE_HASSIO_ADDONS, FILE_HASSIO_APPS, AppBoot, AppStartup, AppState
@@ -155,7 +155,7 @@ class AppManager(CoreSysAttributes):
                     wait_boot.append(start_task)
             except HassioError:
                 self.sys_resolution.add_issue(
-                    evolve(app.boot_failed_issue),
+                    replace(app.boot_failed_issue),
                     suggestions=[
                         SuggestionType.EXECUTE_START,
                         SuggestionType.DISABLE_BOOT,
@@ -175,7 +175,7 @@ class AppManager(CoreSysAttributes):
         for app in tasks:
             if app.state in {AppState.ERROR, AppState.UNKNOWN}:
                 self.sys_resolution.add_issue(
-                    evolve(app.boot_failed_issue),
+                    replace(app.boot_failed_issue),
                     suggestions=[
                         SuggestionType.EXECUTE_START,
                         SuggestionType.DISABLE_BOOT,

--- a/supervisor/bus.py
+++ b/supervisor/bus.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from asyncio import Task
 from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
 import logging
 from typing import Any
-
-import attr
 
 from .const import BusEvent
 from .coresys import CoreSys, CoreSysAttributes
@@ -15,12 +14,12 @@ from .coresys import CoreSys, CoreSysAttributes
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
-@attr.s(slots=True, frozen=True)
+@dataclass(slots=True, frozen=True)
 class EventListener:
     """Event listener."""
 
-    event_type: BusEvent = attr.ib()
-    callback: Callable[[Any], Coroutine[Any, Any, None]] = attr.ib()
+    event_type: BusEvent
+    callback: Callable[[Any], Coroutine[Any, Any, None]]
 
 
 class Bus(CoreSysAttributes):

--- a/supervisor/discovery/__init__.py
+++ b/supervisor/discovery/__init__.py
@@ -28,7 +28,7 @@ CMD_NEW = "post"
 CMD_DEL = "delete"
 
 
-@dataclass
+@dataclass(slots=True)
 class Message:
     """Represent a single Discovery message."""
 

--- a/supervisor/discovery/__init__.py
+++ b/supervisor/discovery/__init__.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
+from dataclasses import asdict, dataclass, field
 import logging
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
-
-import attr
 
 from ..const import (
     ATTR_ADDON,
@@ -29,14 +28,14 @@ CMD_NEW = "post"
 CMD_DEL = "delete"
 
 
-@attr.s
+@dataclass
 class Message:
     """Represent a single Discovery message."""
 
-    app: str = attr.ib()
-    service: str = attr.ib()
-    config: dict[str, Any] = attr.ib(eq=False)
-    uuid: str = attr.ib(factory=lambda: uuid4().hex, eq=False)
+    app: str
+    service: str
+    config: dict[str, Any] = field(compare=False)
+    uuid: str = field(default_factory=lambda: uuid4().hex, compare=False)
 
 
 class Discovery(CoreSysAttributes, FileConfiguration):
@@ -62,7 +61,7 @@ class Discovery(CoreSysAttributes, FileConfiguration):
         """Write discovery message into data file."""
         messages: list[dict[str, Any]] = []
         for message in self.list_messages:
-            messages.append(attr.asdict(message))
+            messages.append(asdict(message))
 
         self._data[ATTR_DISCOVERY].clear()
         self._data[ATTR_DISCOVERY].extend(messages)
@@ -121,7 +120,7 @@ class Discovery(CoreSysAttributes, FileConfiguration):
             _LOGGER.info("Discovery %s message ignore", message.uuid)
             return
 
-        data = attr.asdict(message)
+        data = asdict(message)
         data.pop(ATTR_CONFIG)
         # Home Assistant expects the legacy "addon" key in the push payload.
         data[ATTR_ADDON] = data.pop(ATTR_APP)

--- a/supervisor/docker/app.py
+++ b/supervisor/docker/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import suppress
+from dataclasses import replace
 from http import HTTPStatus
 from ipaddress import IPv4Address
 import logging
@@ -11,7 +12,6 @@ import tempfile
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import aiodocker
-from attr import evolve
 from awesomeversion import AwesomeVersion
 
 from ..apps.build import AppBuild
@@ -937,7 +937,7 @@ class DockerApp(DockerInterface):
             and not self.sys_os.available
         ):
             self.sys_resolution.add_issue(
-                evolve(self.app.device_access_missing_issue),
+                replace(self.app.device_access_missing_issue),
                 suggestions=[SuggestionType.EXECUTE_RESTART],
             )
             return

--- a/supervisor/hardware/data.py
+++ b/supervisor/hardware/data.py
@@ -2,24 +2,24 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from pathlib import Path
 
-import attr
 import pyudev
 
 
-@attr.s(slots=True, frozen=True)
+@dataclass(slots=True, frozen=True)
 class Device:
     """Represent a device."""
 
-    name: str = attr.ib(eq=False)
-    path: Path = attr.ib(eq=False)
-    sysfs: Path = attr.ib(eq=True)
-    subsystem: str = attr.ib(eq=False)
-    parent: Path | None = attr.ib(eq=False)
-    links: list[Path] = attr.ib(eq=False)
-    attributes: dict[str, str] = attr.ib(eq=False)
-    children: list[Path] = attr.ib(eq=False)
+    name: str = field(compare=False)
+    path: Path = field(compare=False)
+    sysfs: Path
+    subsystem: str = field(compare=False)
+    parent: Path | None = field(compare=False)
+    links: list[Path] = field(compare=False)
+    attributes: dict[str, str] = field(compare=False)
+    children: list[Path] = field(compare=False)
 
     @property
     def major(self) -> int:

--- a/supervisor/host/services.py
+++ b/supervisor/host/services.py
@@ -101,7 +101,7 @@ class ServiceManager(CoreSysAttributes):
             _LOGGER.warning("Can't update host service information!")
 
 
-@dataclass(frozen=True)
+@dataclass(slots=True, frozen=True)
 class ServiceInfo:
     """Represent a single Service."""
 

--- a/supervisor/host/services.py
+++ b/supervisor/host/services.py
@@ -1,9 +1,8 @@
 """Service control for host."""
 
 from collections.abc import Awaitable
+from dataclasses import dataclass
 import logging
-
-import attr
 
 from ..coresys import CoreSysAttributes
 from ..dbus.const import StartUnitMode, StopUnitMode
@@ -102,13 +101,13 @@ class ServiceManager(CoreSysAttributes):
             _LOGGER.warning("Can't update host service information!")
 
 
-@attr.s(frozen=True)
+@dataclass(frozen=True)
 class ServiceInfo:
     """Represent a single Service."""
 
-    name: str = attr.ib()
-    description: str = attr.ib()
-    state: str = attr.ib()
+    name: str
+    description: str
+    state: str
 
     @staticmethod
     def read_from(unit):

--- a/supervisor/misc/filter.py
+++ b/supervisor/misc/filter.py
@@ -1,5 +1,6 @@
 """Filter tools."""
 
+from dataclasses import asdict
 import ipaddress
 import logging
 import os
@@ -7,7 +8,6 @@ import re
 from typing import cast
 
 from aiohttp import hdrs
-import attr
 from sentry_sdk.types import Event, Hint
 
 from ..const import DOCKER_IPV4_NETWORK_MASK, HEADER_TOKEN, HEADER_TOKEN_OLD, CoreState
@@ -127,10 +127,9 @@ def filter_data(coresys: CoreSys, event: Event, hint: Hint) -> Event | None:
                 "storage_driver": coresys.docker.info.storage,
             },
             "resolution": {
-                "issues": [attr.asdict(issue) for issue in coresys.resolution.issues],
+                "issues": [asdict(issue) for issue in coresys.resolution.issues],
                 "suggestions": [
-                    attr.asdict(suggestion)
-                    for suggestion in coresys.resolution.suggestions
+                    asdict(suggestion) for suggestion in coresys.resolution.suggestions
                 ],
                 "unhealthy": sorted(coresys.resolution.unhealthy),
             },

--- a/supervisor/misc/scheduler.py
+++ b/supervisor/misc/scheduler.py
@@ -2,11 +2,10 @@
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
 import logging
 from uuid import UUID, uuid4
-
-import attr
 
 from ..const import CoreState
 from ..coresys import CoreSys, CoreSysAttributes
@@ -14,16 +13,16 @@ from ..coresys import CoreSys, CoreSysAttributes
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
-@attr.s(slots=True)
+@dataclass(slots=True)
 class _Task:
     """Task object."""
 
-    id: UUID = attr.ib()
-    coro_callback: Callable[..., Awaitable[None]] = attr.ib(eq=False)
-    interval: float | time = attr.ib(eq=False)
-    repeat: bool = attr.ib(eq=False)
-    job: asyncio.tasks.Task | None = attr.ib(eq=False)
-    next: asyncio.TimerHandle | None = attr.ib(eq=False)
+    id: UUID
+    coro_callback: Callable[..., Awaitable[None]] = field(compare=False)
+    interval: float | time = field(compare=False)
+    repeat: bool = field(compare=False)
+    job: asyncio.tasks.Task | None = field(compare=False)
+    next: asyncio.TimerHandle | None = field(compare=False)
 
 
 class Scheduler(CoreSysAttributes):

--- a/supervisor/mounts/manager.py
+++ b/supervisor/mounts/manager.py
@@ -2,12 +2,10 @@
 
 import asyncio
 from collections.abc import Awaitable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import logging
 from pathlib import PurePath
 from typing import Self
-
-from attr import evolve
 
 from ..const import ATTR_NAME
 from ..coresys import CoreSys, CoreSysAttributes
@@ -182,7 +180,7 @@ class MountManager(FileConfiguration, CoreSysAttributes):
                 await async_capture_exception(err)
 
             self.sys_resolution.add_issue(
-                evolve(mounts[i].failed_issue),
+                replace(mounts[i].failed_issue),
                 suggestions=[
                     SuggestionType.EXECUTE_RELOAD,
                     SuggestionType.EXECUTE_REMOVE,

--- a/supervisor/plugins/dns.py
+++ b/supervisor/plugins/dns.py
@@ -5,11 +5,11 @@ Code: https://github.com/home-assistant/plugin-dns
 
 import asyncio
 from contextlib import suppress
+from dataclasses import dataclass
 from ipaddress import IPv4Address
 import logging
 from pathlib import Path
 
-import attr
 from awesomeversion import AwesomeVersion
 import jinja2
 import voluptuous as vol
@@ -55,12 +55,12 @@ RESOLV_TMPL: Path = Path(__file__).parents[1].joinpath("data/resolv.tmpl")
 HOST_RESOLV: Path = Path("/etc/resolv.conf")
 
 
-@attr.s
+@dataclass
 class HostEntry:
     """Single entry in hosts."""
 
-    ip_address: IPv4Address = attr.ib()
-    names: list[str] = attr.ib()
+    ip_address: IPv4Address
+    names: list[str]
 
 
 class PluginDns(PluginBase):

--- a/supervisor/plugins/dns.py
+++ b/supervisor/plugins/dns.py
@@ -55,7 +55,7 @@ RESOLV_TMPL: Path = Path(__file__).parents[1].joinpath("data/resolv.tmpl")
 HOST_RESOLV: Path = Path("/etc/resolv.conf")
 
 
-@dataclass
+@dataclass(slots=True, frozen=True)
 class HostEntry:
     """Single entry in hosts."""
 

--- a/supervisor/resolution/data.py
+++ b/supervisor/resolution/data.py
@@ -1,9 +1,8 @@
 """Data objects."""
 
+from dataclasses import dataclass, field
 from typing import Any
 from uuid import uuid4
-
-import attr
 
 from .const import (
     ContextType,
@@ -14,39 +13,39 @@ from .const import (
 )
 
 
-@attr.s(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True)
 class Issue:
     """Represent an Issue."""
 
-    type: IssueType = attr.ib()
-    context: ContextType = attr.ib()
-    reference: str | None = attr.ib(default=None)
-    reference_extra: dict[str, Any] | None = attr.ib(default=None, hash=False)
-    uuid: str = attr.ib(factory=lambda: uuid4().hex, eq=False, init=False)
+    type: IssueType
+    context: ContextType
+    reference: str | None = None
+    reference_extra: dict[str, Any] | None = field(default=None, hash=False)
+    uuid: str = field(default_factory=lambda: uuid4().hex, compare=False, init=False)
 
 
-@attr.s(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True)
 class Suggestion:
     """Represent an Suggestion."""
 
-    type: SuggestionType = attr.ib()
-    context: ContextType = attr.ib()
-    reference: str | None = attr.ib(default=None)
-    reference_extra: dict[str, Any] | None = attr.ib(default=None, hash=False)
-    uuid: str = attr.ib(factory=lambda: uuid4().hex, eq=False, init=False)
+    type: SuggestionType
+    context: ContextType
+    reference: str | None = None
+    reference_extra: dict[str, Any] | None = field(default=None, hash=False)
+    uuid: str = field(default_factory=lambda: uuid4().hex, compare=False, init=False)
 
 
-@attr.s(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True)
 class HealthChanged:
     """Describe change in system health."""
 
-    healthy: bool = attr.ib()
-    unhealthy_reasons: list[UnhealthyReason] | None = attr.ib(default=None)
+    healthy: bool
+    unhealthy_reasons: list[UnhealthyReason] | None = None
 
 
-@attr.s(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True)
 class SupportedChanged:
     """Describe change in system supported."""
 
-    supported: bool = attr.ib()
-    unsupported_reasons: list[UnsupportedReason] | None = attr.ib(default=None)
+    supported: bool
+    unsupported_reasons: list[UnsupportedReason] | None = None

--- a/supervisor/resolution/module.py
+++ b/supervisor/resolution/module.py
@@ -1,10 +1,9 @@
 """Supervisor resolution center."""
 
+from dataclasses import asdict
 import errno
 import logging
 from typing import Any
-
-import attr
 
 from ..bus import EventListener
 from ..coresys import CoreSys, CoreSysAttributes
@@ -138,7 +137,7 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
         self._unsupported.add(reason)
         self.sys_homeassistant.websocket.supervisor_event(
             WSEvent.SUPPORTED_CHANGED,
-            attr.asdict(SupportedChanged(False, sorted(self.unsupported))),
+            asdict(SupportedChanged(False, sorted(self.unsupported))),
         )
 
     @property
@@ -153,7 +152,7 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
         self._unhealthy.add(reason)
         self.sys_homeassistant.websocket.supervisor_event(
             WSEvent.HEALTH_CHANGED,
-            attr.asdict(HealthChanged(False, sorted(self.unhealthy))),
+            asdict(HealthChanged(False, sorted(self.unhealthy))),
         )
 
     _OSERROR_UNHEALTHY_REASONS: dict[int, UnhealthyReason] = {
@@ -171,10 +170,9 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
 
     def _make_issue_message(self, issue: Issue) -> dict[str, Any]:
         """Make issue into message for core."""
-        return attr.asdict(issue) | {
+        return asdict(issue) | {
             "suggestions": [
-                attr.asdict(suggestion)
-                for suggestion in self.suggestions_for_issue(issue)
+                asdict(suggestion) for suggestion in self.suggestions_for_issue(issue)
             ]
         }
 
@@ -293,7 +291,7 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
 
         # Event on issue removal
         self.sys_homeassistant.websocket.supervisor_event(
-            WSEvent.ISSUE_REMOVED, attr.asdict(issue)
+            WSEvent.ISSUE_REMOVED, asdict(issue)
         )
 
         # Clean up any orphaned suggestions
@@ -308,7 +306,7 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
         self._unsupported.remove(reason)
         self.sys_homeassistant.websocket.supervisor_event(
             WSEvent.SUPPORTED_CHANGED,
-            attr.asdict(
+            asdict(
                 SupportedChanged(
                     self.sys_core.supported, sorted(self.unsupported) or None
                 )

--- a/supervisor/utils/whoami.py
+++ b/supervisor/utils/whoami.py
@@ -3,11 +3,11 @@
 https://github.com/home-assistant/whoami.home-assistant.io
 """
 
+from dataclasses import dataclass
 from datetime import datetime
 import logging
 
 import aiohttp
-import attr
 
 from ..exceptions import WhoamiConnectivityError, WhoamiError, WhoamiSSLError
 from .dt import utc_from_timestamp
@@ -16,12 +16,12 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 _API_CALL: str = "services.home-assistant.io/whoami/v1"
 
 
-@attr.s(slots=True, frozen=True)
+@dataclass(slots=True, frozen=True)
 class WhoamiData:
     """Client Whoami data."""
 
-    timezone: str = attr.ib()
-    dt_utc: datetime = attr.ib()
+    timezone: str
+    dt_utc: datetime
 
 
 async def retrieve_whoami(

--- a/tests/docker/test_app.py
+++ b/tests/docker/test_app.py
@@ -8,7 +8,6 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, PropertyMock, patch
 
 import aiodocker
-import attr
 import pytest
 
 from supervisor.apps import validate as vd
@@ -614,7 +613,7 @@ async def test_app_options_device_hw_listener(
     # Re-enumerated device: same by-id symlink, different kernel node and minor number.
     # When a USB device is unplugged and plugged back in, the kernel may assign a new
     # device node (ttyACM0 → ttyACM1) with a different minor number.
-    reenumerated_device = attr.evolve(
+    reenumerated_device = replace(
         TEST_HW_DEVICE,
         name="ttyACM1",
         path=Path("/dev/ttyACM1"),


### PR DESCRIPTION
# Migrate simple attrs classes to stdlib dataclasses

## Proposed change

Several plain data-holder classes still used the attrs library while newer code in the project uses stdlib dataclasses. This change converts `EventListener` (bus), `Issue`/`Suggestion`/`HealthChanged`/`SupportedChanged` (resolution), `Device` (hardware), `Message` (discovery), `HostEntry` (DNS plugin), `ServiceInfo` (host services), `WhoamiData` and the scheduler's `_Task` to `@dataclass`, and switches the `attr.evolve`/`attr.asdict` call sites to `dataclasses.replace`/`dataclasses.asdict`. Field semantics map 1:1: `eq=False` becomes `compare=False`, `hash=False` and default factories carry over directly, so equality, hashing and copy behavior are unchanged (including the regenerated `uuid` on `replace()` of an `Issue`, matching `attr.evolve`).

Following review feedback, `slots=True` is now enabled on all converted classes (the attrs originals of `ServiceInfo`, `Message` and `HostEntry` were not slotted), and `HostEntry` is additionally frozen since instances are never mutated after creation. `Message` stays unfrozen on purpose: `Discovery.send()` updates the `config` field of an existing message when an app re-sends a discovery message with changed configuration.

The jobs module keeps using attrs for its validators and setter hooks, which have no stdlib dataclass equivalent, so the attrs dependency itself remains.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
