### PR TITLE
Check OSError for known filesystem issues on cleanup unlinks

### DIFF
--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -474,7 +474,12 @@ class BackupManager(FileConfiguration, JobGroup):
         )
         if not await backup.load():
             # Remove invalid backup from location it was moved to
-            await self.sys_run_in_executor(backup.tarfile.unlink)
+            try:
+                await self.sys_run_in_executor(backup.tarfile.unlink)
+            except OSError as err:
+                if location in {LOCATION_CLOUD_BACKUP, None}:
+                    self.sys_resolution.check_oserror(err)
+                _LOGGER.error("Can't remove invalid backup file: %s", err)
             return None
         _LOGGER.info("Successfully imported %s", backup.slug)
 
@@ -487,7 +492,12 @@ class BackupManager(FileConfiguration, JobGroup):
             try:
                 self._backups[backup.slug].consolidate(backup)
             except BackupInvalidError as err:
-                await self.sys_run_in_executor(backup.tarfile.unlink)
+                try:
+                    await self.sys_run_in_executor(backup.tarfile.unlink)
+                except OSError as unlink_err:
+                    if location in {LOCATION_CLOUD_BACKUP, None}:
+                        self.sys_resolution.check_oserror(unlink_err)
+                    _LOGGER.error("Can't remove invalid backup file: %s", unlink_err)
                 raise BackupInvalidError(
                     f"Cannot import backup {backup.slug} due to: {err!s}", _LOGGER.error
                 ) from err

--- a/supervisor/plugins/dns.py
+++ b/supervisor/plugins/dns.py
@@ -332,8 +332,11 @@ class PluginDns(PluginBase):
         await self.save_data()
 
         # Resets hosts
-        with suppress(OSError):
+        try:
             await self.sys_run_in_executor(self.hosts.unlink)
+        except OSError as err:
+            self.sys_resolution.check_oserror(err)
+            _LOGGER.debug("Can't remove hosts file: %s", err)
         await self._init_hosts()
 
         # Reset loop protection

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -2172,6 +2172,68 @@ async def test_backup_multiple_locations_oserror(
     ) is unhealthy
 
 
+@pytest.mark.usefixtures("tmp_supervisor_data", "path_extern")
+@pytest.mark.parametrize(
+    ("error_num", "unhealthy"),
+    [(errno.EBUSY, False), (errno.EBADMSG, True)],
+)
+async def test_import_backup_invalid_unlink_oserror(
+    coresys: CoreSys, error_num: int, unhealthy: bool
+):
+    """Test import backup where load fails and cleanup unlink raises OSError."""
+    tar_file = Path(
+        copy(get_fixture_path("backup_example.tar"), coresys.config.path_tmp)
+    )
+
+    err = OSError()
+    err.errno = error_num
+
+    with (
+        patch.object(Backup, "load", side_effect=[True, False]),
+        patch("pathlib.Path.unlink", side_effect=err),
+    ):
+        backup = await coresys.backups.import_backup(tar_file)
+
+    assert backup is None
+    assert (
+        UnhealthyReason.OSERROR_BAD_MESSAGE in coresys.resolution.unhealthy
+    ) is unhealthy
+
+
+@pytest.mark.usefixtures("tmp_supervisor_data", "path_extern")
+@pytest.mark.parametrize(
+    ("error_num", "unhealthy"),
+    [(errno.EBUSY, False), (errno.EBADMSG, True)],
+)
+async def test_import_backup_consolidate_unlink_oserror(
+    coresys: CoreSys, error_num: int, unhealthy: bool
+):
+    """Test import backup where consolidate fails and cleanup unlink raises OSError."""
+    copy(get_fixture_path("backup_example.tar"), coresys.config.path_backup)
+    await coresys.backups.reload()
+    assert coresys.backups.get("7fed74c8")
+
+    tar_file = Path(
+        copy(get_fixture_path("backup_example.tar"), coresys.config.path_tmp)
+    )
+
+    err = OSError()
+    err.errno = error_num
+
+    with (
+        patch.object(
+            Backup, "consolidate", side_effect=BackupInvalidError("Test error")
+        ),
+        patch("pathlib.Path.unlink", side_effect=err),
+        pytest.raises(BackupInvalidError),
+    ):
+        await coresys.backups.import_backup(tar_file, location=".cloud_backup")
+
+    assert (
+        UnhealthyReason.OSERROR_BAD_MESSAGE in coresys.resolution.unhealthy
+    ) is unhealthy
+
+
 @pytest.mark.parametrize("same_mount", [True, False])
 async def test_get_upload_path_for_backup_location(coresys: CoreSys, same_mount: bool):
     """Test get_upload_path_for_location with local backup location."""

--- a/tests/plugins/test_dns.py
+++ b/tests/plugins/test_dns.py
@@ -15,7 +15,12 @@ from supervisor.docker.const import ContainerState
 from supervisor.docker.dns import DockerDNS
 from supervisor.docker.monitor import DockerContainerStateEvent
 from supervisor.plugins.dns import HostEntry, PluginDns
-from supervisor.resolution.const import ContextType, IssueType, SuggestionType
+from supervisor.resolution.const import (
+    ContextType,
+    IssueType,
+    SuggestionType,
+    UnhealthyReason,
+)
 from supervisor.resolution.data import Issue, Suggestion
 
 
@@ -144,6 +149,28 @@ async def test_reset(coresys: CoreSys):
                 names=["observer", "observer.local.hass.io"],
             ),
         ]
+
+
+@pytest.mark.parametrize(
+    ("error_num", "unhealthy"),
+    [(errno.EBUSY, False), (errno.EBADMSG, True)],
+)
+async def test_reset_hosts_unlink_oserror(
+    coresys: CoreSys, error_num: int, unhealthy: bool
+):
+    """Test reset does not fail if hosts cannot be removed but checks OSError."""
+    err = OSError()
+    err.errno = error_num
+
+    with (
+        patch.object(type(coresys.plugins.dns.hosts), "unlink", side_effect=err),
+        patch.object(type(coresys.plugins.dns), "write_hosts"),
+    ):
+        await coresys.plugins.dns.reset()
+
+    assert (
+        UnhealthyReason.OSERROR_BAD_MESSAGE in coresys.resolution.unhealthy
+    ) is unhealthy
 
 
 async def test_loop_detection_on_failure(coresys: CoreSys, container: DockerContainer):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to review feedback on #7003 and #7004: the cleanup unlinks in `CoreDNS.reset()` and `BackupManager.import_backup()` now pass any `OSError` to `sys_resolution.check_oserror()` so known filesystem issues (e.g. `EBADMSG`) mark the system unhealthy early. For the backup paths the check only applies to local locations (default and cloud backup), matching the existing handling in `remove()` and `_copy_to_location()`.

This also covers the second unlink in `import_backup()` (cleanup after a failed `load()`) which was missing this handling as well, and stops `OSError` from bubbling out of both cleanup paths unhandled to the job: the error is now logged, and the method still returns `None` or raises the original `BackupInvalidError`.

Tests cover all three paths, checking that `EBADMSG` marks the system unhealthy while other errors (`EBUSY`) do not.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/supervisor/pull/7003#discussion_r3530581655, https://github.com/home-assistant/supervisor/pull/7004#discussion_r3530638737
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
