### PR TITLE
Ignore wait-online unit failures in systemd unit failure check

### DIFF
--- a/supervisor/resolution/checks/systemd_unit_failure.py
+++ b/supervisor/resolution/checks/systemd_unit_failure.py
@@ -26,6 +26,10 @@ OS_FSCK_UNITS = {
 # Systemd fsck unit for data filesystem
 DATA_FSCK_UNIT = "systemd-fsck@dev-disk-by\\x2dlabel-hassos\\x2ddata.service"
 
+# Oneshot unit which ends up failed when the network is not up in time at
+# boot. Home Assistant works offline, so the failure is not actionable.
+NM_WAIT_ONLINE_SERVICE = "NetworkManager-wait-online.service"
+
 
 def setup(coresys: CoreSys) -> CheckBase:
     """Check setup function."""
@@ -88,6 +92,15 @@ class CheckSystemdUnitFailure(CheckBase):
             if unit_name == FIREWALL_SERVICE:
                 _LOGGER.debug(
                     "Ignoring failed firewall service '%s' which handles its own health state",
+                    unit_name,
+                )
+                continue
+
+            # Skip NetworkManager-wait-online which fails when the network is
+            # slow to come up at boot, Home Assistant works offline
+            if unit_name == NM_WAIT_ONLINE_SERVICE:
+                _LOGGER.debug(
+                    "Ignoring failed wait-online unit '%s'",
                     unit_name,
                 )
                 continue

--- a/tests/resolution/check/test_check_systemd_unit_failure.py
+++ b/tests/resolution/check/test_check_systemd_unit_failure.py
@@ -13,6 +13,7 @@ from supervisor.jobs.decorator import Job
 from supervisor.resolution.checks.systemd_unit_failure import (
     DATA_FSCK_UNIT,
     FIREWALL_SERVICE,
+    NM_WAIT_ONLINE_SERVICE,
     OS_FSCK_UNITS,
     CheckSystemdUnitFailure,
 )
@@ -99,6 +100,23 @@ async def test_firewall_service_failure_ignored(
         "list_units_filtered",
         new_callable=AsyncMock,
         return_value=[(FIREWALL_SERVICE,)],
+    ):
+        await systemd_unit_failure.run_check()
+
+    assert not coresys.resolution.issues
+    assert not coresys.resolution.suggestions
+    capture_message.assert_not_called()
+
+
+async def test_nm_wait_online_failure_ignored(coresys: CoreSys, capture_message: Mock):
+    """Test NetworkManager-wait-online failure is ignored."""
+    systemd_unit_failure = CheckSystemdUnitFailure(coresys)
+
+    with patch.object(
+        coresys.dbus.systemd,
+        "list_units_filtered",
+        new_callable=AsyncMock,
+        return_value=[(NM_WAIT_ONLINE_SERVICE,)],
     ):
         await systemd_unit_failure.run_check()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The systemd unit failure check introduced in #6976 creates a repair issue and reports to Sentry for any failed systemd unit. Wait-online oneshot units such as `NetworkManager-wait-online.service` end up in failed state whenever the network is not up in time at boot. Within the first week of the 2026.07.0 rollout, `NetworkManager-wait-online.service` alone is one of the most frequent Sentry reports of this check (72 users), with `systemd-networkd-wait-online.service` also appearing on supervised systems.

Home Assistant works offline, so a failed wait-online unit is transient and not actionable for the user. Skip units matching the `-wait-online.service` suffix in the check, the same way the firewall service is already skipped, so they no longer create repair issues or Sentry noise.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6976
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
