### PR TITLE
Only report systemd unit failures to Sentry on Home Assistant OS

### DIFF
--- a/supervisor/resolution/checks/systemd_unit_failure.py
+++ b/supervisor/resolution/checks/systemd_unit_failure.py
@@ -63,6 +63,11 @@ class CheckSystemdUnitFailure(CheckBase):
 
     async def run_check(self) -> None:
         """Run check to list failed systemd units."""
+        # On a supervised installation the host units are not managed by us,
+        # only report failed units on Home Assistant OS
+        if not self.sys_os.available:
+            return
+
         # Get all failed units
         failed_units = await self._get_failed_units()
         capture_coroutines: list[Awaitable[None]] = []

--- a/supervisor/resolution/checks/systemd_unit_failure.py
+++ b/supervisor/resolution/checks/systemd_unit_failure.py
@@ -63,11 +63,6 @@ class CheckSystemdUnitFailure(CheckBase):
 
     async def run_check(self) -> None:
         """Run check to list failed systemd units."""
-        # On a supervised installation the host units are not managed by us,
-        # only report failed units on Home Assistant OS
-        if not self.sys_os.available:
-            return
-
         # Get all failed units
         failed_units = await self._get_failed_units()
         capture_coroutines: list[Awaitable[None]] = []
@@ -133,12 +128,15 @@ class CheckSystemdUnitFailure(CheckBase):
             if issue in self.sys_resolution.issues:
                 continue
 
-            capture_coroutines.append(
-                async_capture_message(
-                    f"Systemd unit failed: {unit_name}",
-                    level="error",
+            # Only report failed units to Sentry on Home Assistant OS, there
+            # is nothing we can do about units of a supervised installation
+            if self.sys_os.available:
+                capture_coroutines.append(
+                    async_capture_message(
+                        f"Systemd unit failed: {unit_name}",
+                        level="error",
+                    )
                 )
-            )
             self.sys_resolution.add_issue(
                 issue,
                 suggestions=[

--- a/tests/resolution/check/test_check_systemd_unit_failure.py
+++ b/tests/resolution/check/test_check_systemd_unit_failure.py
@@ -44,6 +44,7 @@ async def test_base(coresys: CoreSys):
     assert systemd_unit_failure.states == [CoreState.SETUP]
 
 
+@pytest.mark.usefixtures("os_available")
 async def test_check_creates_issue_and_captures_message(
     coresys: CoreSys, capture_message: Mock
 ):
@@ -70,6 +71,7 @@ async def test_check_creates_issue_and_captures_message(
     )
 
 
+@pytest.mark.usefixtures("os_available")
 async def test_mount_unit_failures_ignored(coresys: CoreSys, capture_message: Mock):
     """Test mount unit failures are ignored."""
     systemd_unit_failure = CheckSystemdUnitFailure(coresys)
@@ -89,6 +91,7 @@ async def test_mount_unit_failures_ignored(coresys: CoreSys, capture_message: Mo
     capture_message.assert_not_called()
 
 
+@pytest.mark.usefixtures("os_available")
 async def test_firewall_service_failure_ignored(
     coresys: CoreSys, capture_message: Mock
 ):
@@ -125,6 +128,25 @@ async def test_nm_wait_online_failure_ignored(coresys: CoreSys, capture_message:
     capture_message.assert_not_called()
 
 
+async def test_check_skipped_on_supervised(coresys: CoreSys, capture_message: Mock):
+    """Test check does nothing when not running on Home Assistant OS."""
+    systemd_unit_failure = CheckSystemdUnitFailure(coresys)
+
+    with patch.object(
+        coresys.dbus.systemd,
+        "list_units_filtered",
+        new_callable=AsyncMock,
+        return_value=[("example.service",)],
+    ) as list_units_filtered:
+        await systemd_unit_failure.run_check()
+
+    list_units_filtered.assert_not_called()
+    assert not coresys.resolution.issues
+    assert not coresys.resolution.suggestions
+    capture_message.assert_not_called()
+
+
+@pytest.mark.usefixtures("os_available")
 @pytest.mark.parametrize(
     ("unit_name", "unhealthy_reason"),
     [

--- a/tests/resolution/check/test_check_systemd_unit_failure.py
+++ b/tests/resolution/check/test_check_systemd_unit_failure.py
@@ -71,7 +71,6 @@ async def test_check_creates_issue_and_captures_message(
     )
 
 
-@pytest.mark.usefixtures("os_available")
 async def test_mount_unit_failures_ignored(coresys: CoreSys, capture_message: Mock):
     """Test mount unit failures are ignored."""
     systemd_unit_failure = CheckSystemdUnitFailure(coresys)
@@ -91,7 +90,6 @@ async def test_mount_unit_failures_ignored(coresys: CoreSys, capture_message: Mo
     capture_message.assert_not_called()
 
 
-@pytest.mark.usefixtures("os_available")
 async def test_firewall_service_failure_ignored(
     coresys: CoreSys, capture_message: Mock
 ):
@@ -128,8 +126,10 @@ async def test_nm_wait_online_failure_ignored(coresys: CoreSys, capture_message:
     capture_message.assert_not_called()
 
 
-async def test_check_skipped_on_supervised(coresys: CoreSys, capture_message: Mock):
-    """Test check does nothing when not running on Home Assistant OS."""
+async def test_check_creates_issue_without_sentry_on_supervised(
+    coresys: CoreSys, capture_message: Mock
+):
+    """Test check creates issue but no sentry message when not on Home Assistant OS."""
     systemd_unit_failure = CheckSystemdUnitFailure(coresys)
 
     with patch.object(
@@ -137,16 +137,19 @@ async def test_check_skipped_on_supervised(coresys: CoreSys, capture_message: Mo
         "list_units_filtered",
         new_callable=AsyncMock,
         return_value=[("example.service",)],
-    ) as list_units_filtered:
+    ):
         await systemd_unit_failure.run_check()
 
-    list_units_filtered.assert_not_called()
-    assert not coresys.resolution.issues
-    assert not coresys.resolution.suggestions
+    assert len(coresys.resolution.issues) == 1
+    assert coresys.resolution.issues[0] == Issue(
+        IssueType.SYSTEMD_UNIT_FAILED,
+        ContextType.SYSTEM,
+        reference="example.service",
+    )
+    assert len(coresys.resolution.suggestions) == 2
     capture_message.assert_not_called()
 
 
-@pytest.mark.usefixtures("os_available")
 @pytest.mark.parametrize(
     ("unit_name", "unhealthy_reason"),
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The systemd unit failure check introduced in #6976 creates a repair issue and reports to Sentry for any failed systemd unit on the host. On supervised installations the first week of the 2026.07.0 rollout surfaced failed units like `gdm.service`, `tomcat8.service`, `isc-dhcp-server.service` or `snap.remmina.ssh-agent.service` — units entirely unrelated to Home Assistant, where there is nothing we can do with the report, it is pure noise in Sentry.

Only report failed units to Sentry when running on Home Assistant OS. The check itself still runs on supervised installations and keeps creating resolution issues, since a failed unit can be useful information for the admin of such a system.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6976
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
