### PR TITLE
Add label actions for core-issue and docker-corruption

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,0 +1,38 @@
+core-issue:
+  comment: >
+    :wave: @{issue-author}, thanks for reporting an issue!
+
+
+    It looks like this issue is related to Home Assistant Core. Please check
+    the [Home Assistant Core](https://github.com/home-assistant/core/issues)
+    repository, the issue might have been reported already. Open a new issue
+    in that repository if you can't find a matching issue.
+  close: true
+  close-reason: not planned
+
+docker-corruption:
+  comment: >
+    :wave: @{issue-author}, thanks for reporting an issue!
+
+
+    The symptoms described here (e.g. crashes with missing files or modules,
+    `ModuleNotFoundError`, or corrupt binaries inside a container) indicate
+    local corruption of the Docker image storage. This typically happens when
+    the system loses power or is reset while Docker writes an image to disk,
+    or due to failing storage. Docker verifies image checksums only while
+    pulling — once an image is written to disk, its integrity is not checked
+    again, so such corruption can stay dormant until the affected container
+    is recreated (e.g. on a host reboot).
+
+
+    Note that deleting and re-pulling the affected image does not necessarily
+    help: image layers are shared between images and reused across versions,
+    and `docker pull` skips layers it believes are already present locally.
+
+
+    To recover, make a full backup, download it, then reinstall Home
+    Assistant OS and restore the backup. A dedicated feature to reset the
+    Docker image storage is tracked in
+    [#6555](https://github.com/home-assistant/supervisor/issues/6555).
+  close: true
+  close-reason: not planned

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -15,12 +15,12 @@ docker-corruption:
     :wave: @{issue-author}, thanks for reporting an issue!
 
 
-    The symptoms described here (e.g. crashes with missing files or modules,
-    `ModuleNotFoundError`, or corrupt binaries inside a container) indicate
-    local corruption of the Docker image storage. This typically happens when
-    the system loses power or is reset while Docker writes an image to disk,
-    or due to failing storage. Docker verifies image checksums only while
-    pulling — once an image is written to disk, its integrity is not checked
+    The symptoms described here (e.g. 0-byte or empty files, missing files
+    or directories, or corrupt binaries inside a container) indicate local
+    corruption of the Docker image storage. This typically happens when the
+    system loses power or is reset while Docker writes an image to disk, or
+    due to failing storage. Docker verifies image checksums only while
+    pulling. Once an image is written to disk, its integrity is not checked
     again, so such corruption can stay dormant until the affected container
     is recreated (e.g. on a host reboot).
 

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -15,24 +15,31 @@ docker-corruption:
     :wave: @{issue-author}, thanks for reporting an issue!
 
 
+    Home Assistant uses Docker container images under the hood to run all
+    parts of the system (Home Assistant Core, add-ons and other components).
     The symptoms described here (e.g. 0-byte or empty files, missing files
-    or directories, or corrupt binaries inside a container) indicate local
-    corruption of the Docker image storage. This typically happens when the
-    system loses power or is reset while Docker writes an image to disk, or
-    due to failing storage. Docker verifies image checksums only while
-    pulling. Once an image is written to disk, its integrity is not checked
-    again, so such corruption can stay dormant until the affected container
-    is recreated (e.g. on a host reboot).
+    or directories, or corrupt binaries inside a container) indicate that
+    this Docker image storage got corrupted on your system. This is a local
+    problem, typically caused by a power loss or forced reset while the
+    system was writing to disk, or by failing storage. It is not a problem
+    in the published image or in Home Assistant itself.
 
 
-    Note that deleting and re-pulling the affected image does not necessarily
-    help: image layers are shared between images and reused across versions,
-    and `docker pull` skips layers it believes are already present locally.
+    **What to do:** Create a full backup and download it to another machine.
+    Then reinstall Home Assistant OS and restore the backup. This rewrites
+    all container images and reliably resolves the problem.
 
 
-    To recover, make a full backup, download it, then reinstall Home
-    Assistant OS and restore the backup. A dedicated feature to reset the
-    Docker image storage is tracked in
+    For those familiar with Docker, some background on why this is the only
+    reliable fix: Docker verifies image checksums only while pulling. Once
+    an image is written to disk, its integrity is never checked again, so
+    corruption can stay dormant until the affected container is recreated,
+    e.g. on a host reboot. Deleting and re-pulling the affected image does
+    not necessarily help either: image layers are shared between images and
+    reused across versions, and `docker pull` skips layers it believes are
+    already present locally, so the corrupted data survives a re-pull. A
+    dedicated feature to reset the Docker image storage completely is
+    tracked in
     [#6555](https://github.com/home-assistant/supervisor/issues/6555).
   close: true
   close-reason: not planned

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -1,0 +1,17 @@
+name: 'Label Actions'
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  discussions: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/label-actions@65225c179d3b2502f6eda7b3d15101a3f412366b # v5.0.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Introduce the [dessant/label-actions](https://github.com/dessant/label-actions) workflow to this repository, mirroring the existing setup in the [operating-system repository](https://github.com/home-assistant/operating-system/blob/dev/.github/label-actions.yml). Applying a configured label to an issue posts a canned reply and closes the issue as not planned.

Two label actions are configured:

- **core-issue**: Points the reporter to the Home Assistant Core issue tracker (same text as the equivalent label action in the operating-system repository).
- **docker-corruption**: For the recurring reports where a container crashes due to locally corrupted Docker image storage (e.g. `ModuleNotFoundError` for files missing inside the container, see #6950 for a recent example). The reply explains that Docker verifies image checksums only on pull, why deleting and re-pulling an image does not necessarily help (shared layers), how to recover (backup + reinstall), and links the Docker storage reset feature request #6555.

The `core-issue` and `docker-corruption` labels need to be created in this repository for the workflow to be usable.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6555, #6950
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
