### PR TITLE
Keep config-declared ports visible after customizing app ports

### DIFF
--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -591,14 +591,16 @@ class App(AppModel):
 
     @property
     def ports(self) -> dict[str, int | None] | None:
-        """Return ports of app."""
+        """Return effective ports, merging user overrides over config defaults.
+
+        This keeps every config-declared port visible even when the user only
+        remapped a subset, so optional ports left unpublished (and ports newly
+        added by an app update) stay visible and keep applying their defaults.
+        """
         config_ports = super().ports
         if config_ports is None:
             return self.persist.get(ATTR_NETWORK)
 
-        # Merge persisted overrides on top of the config-declared ports so
-        # ports the user hasn't remapped (e.g. optional ports left unpublished)
-        # stay visible and can still be enabled.
         persisted = self.persist.get(ATTR_NETWORK, {})
         return {
             container_port: persisted.get(container_port, default_host_port)
@@ -619,6 +621,14 @@ class App(AppModel):
                 new_ports[container_port] = host_port
 
         self.persist[ATTR_NETWORK] = new_ports
+
+    def user_ports(self) -> dict[str, int | None]:
+        """Return only the user's persisted port overrides.
+
+        Unlike ``ports`` this excludes config defaults the user never touched,
+        so callers persisting a change only write back real user overrides.
+        """
+        return self.persist.get(ATTR_NETWORK, {})
 
     @property
     def ingress_url(self) -> str | None:

--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -592,7 +592,18 @@ class App(AppModel):
     @property
     def ports(self) -> dict[str, int | None] | None:
         """Return ports of app."""
-        return self.persist.get(ATTR_NETWORK, super().ports)
+        config_ports = super().ports
+        if config_ports is None:
+            return self.persist.get(ATTR_NETWORK)
+
+        # Merge persisted overrides on top of the config-declared ports so
+        # ports the user hasn't remapped (e.g. optional ports left unpublished)
+        # stay visible and can still be enabled.
+        persisted = self.persist.get(ATTR_NETWORK, {})
+        return {
+            container_port: persisted.get(container_port, default_host_port)
+            for container_port, default_host_port in config_ports.items()
+        }
 
     @ports.setter
     def ports(self, value: dict[str, int | None] | None) -> None:

--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -628,7 +628,7 @@ class App(AppModel):
         Unlike ``ports`` this excludes config defaults the user never touched,
         so callers persisting a change only write back real user overrides.
         """
-        return self.persist.get(ATTR_NETWORK, {})
+        return dict(self.persist.get(ATTR_NETWORK) or {})
 
     @property
     def ingress_url(self) -> str | None:

--- a/supervisor/resolution/fixups/app_clear_port_config.py
+++ b/supervisor/resolution/fixups/app_clear_port_config.py
@@ -57,8 +57,10 @@ class FixupAppClearPortConfig(FixupBase):
             )
             return
 
-        ports[port_key] = None
-        app.ports = ports
+        # Persist only the cleared port as a user override on top of any
+        # existing ones, so clearing one conflicting port doesn't turn the
+        # current config defaults into user changes.
+        app.ports = {**app.user_ports(), port_key: None}
         await app.save_persist()
 
         _LOGGER.info(

--- a/supervisor/resolution/fixups/app_clear_port_config.py
+++ b/supervisor/resolution/fixups/app_clear_port_config.py
@@ -58,6 +58,7 @@ class FixupAppClearPortConfig(FixupBase):
             return
 
         ports[port_key] = None
+        app.ports = ports
         await app.save_persist()
 
         _LOGGER.info(

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -18,7 +18,14 @@ from securetar import SecureTarArchive, SecureTarFile
 from supervisor.apps.app import App
 from supervisor.apps.const import AppBackupMode
 from supervisor.apps.model import AppModel
-from supervisor.const import ATTR_ADVANCED, ATTR_LOCATION, AppBoot, AppState, BusEvent
+from supervisor.const import (
+    ATTR_ADVANCED,
+    ATTR_LOCATION,
+    ATTR_PORTS,
+    AppBoot,
+    AppState,
+    BusEvent,
+)
 from supervisor.coresys import CoreSys
 from supervisor.docker.app import DockerApp
 from supervisor.docker.const import ContainerState
@@ -977,6 +984,22 @@ async def test_local_example_ingress_port_set(install_app_example: App):
     await install_app_example.load()
 
     assert install_app_example.ingress_port != 0
+
+
+@pytest.mark.usefixtures("tmp_supervisor_data")
+async def test_ports_merge_config_defaults_with_user_overrides(install_app_ssh: App):
+    """Test custom ports don't hide config-declared ports left unpublished."""
+    app = install_app_ssh
+    # Simulate a multi-port add-on (e.g. NGINX proxy) with optional ports
+    app.data[ATTR_PORTS] = {"22/tcp": None, "443/tcp": 443, "443/udp": None}
+
+    # Without user customization the config ports are returned as-is
+    assert app.ports == {"22/tcp": None, "443/tcp": 443, "443/udp": None}
+
+    # Publishing a single port must not drop the other config-declared ports,
+    # otherwise they can no longer be enabled from the UI
+    app.ports = {"443/tcp": 8443}
+    assert app.ports == {"22/tcp": None, "443/tcp": 8443, "443/udp": None}
 
 
 @pytest.mark.usefixtures("tmp_supervisor_data")

--- a/tests/resolution/fixup/test_app_clear_port_config.py
+++ b/tests/resolution/fixup/test_app_clear_port_config.py
@@ -3,10 +3,24 @@
 import pytest
 
 from supervisor.apps.app import App
+from supervisor.const import ATTR_PORTS
 from supervisor.coresys import CoreSys
 from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.data import Issue
 from supervisor.resolution.fixups.app_clear_port_config import FixupAppClearPortConfig
+
+
+def _add_conflict_suggestion(coresys: CoreSys, slug: str, port: int) -> None:
+    """Register a port conflict issue with a clear-port-config suggestion."""
+    coresys.resolution.add_issue(
+        Issue(
+            IssueType.APP_PORT_CONFLICT,
+            ContextType.ADDON,
+            reference=slug,
+            reference_extra={"port": port},
+        ),
+        suggestions=[SuggestionType.CLEAR_PORT_CONFIG],
+    )
 
 
 @pytest.mark.usefixtures("tmp_supervisor_data")
@@ -19,21 +33,35 @@ async def test_fixup_clears_conflicting_port(coresys: CoreSys, install_app_ssh: 
     fixup = FixupAppClearPortConfig(coresys)
     assert not fixup.auto
 
-    coresys.resolution.add_issue(
-        Issue(
-            IssueType.APP_PORT_CONFLICT,
-            ContextType.ADDON,
-            reference=app.slug,
-            reference_extra={"port": 2222},
-        ),
-        suggestions=[SuggestionType.CLEAR_PORT_CONFIG],
-    )
-
+    _add_conflict_suggestion(coresys, app.slug, 2222)
     await fixup()
 
     # The conflicting mapping must be cleared in the persisted config, not just
     # in a throwaway copy returned by the getter.
     assert app.ports == {"22/tcp": None}
     assert app.persist["network"] == {"22/tcp": None}
+    assert coresys.resolution.issues == []
+    assert coresys.resolution.suggestions == []
+
+
+@pytest.mark.usefixtures("tmp_supervisor_data")
+async def test_fixup_persists_only_the_cleared_port(
+    coresys: CoreSys, install_app_ssh: App
+):
+    """Test clearing one port doesn't freeze the other config defaults."""
+    app = install_app_ssh
+    # Multi-port app: 80/tcp published by config default, 22/tcp mapped by user
+    app.data[ATTR_PORTS] = {"22/tcp": None, "80/tcp": 80, "443/tcp": None}
+    app.persist["network"] = {"22/tcp": 2222}
+    assert app.ports == {"22/tcp": 2222, "80/tcp": 80, "443/tcp": None}
+
+    _add_conflict_suggestion(coresys, app.slug, 80)
+    await FixupAppClearPortConfig(coresys)()
+
+    # Only the existing user override and the cleared port are persisted; the
+    # untouched config defaults stay out of the user config so future config
+    # changes to them keep applying.
+    assert app.persist["network"] == {"22/tcp": 2222, "80/tcp": None}
+    assert app.ports == {"22/tcp": 2222, "80/tcp": None, "443/tcp": None}
     assert coresys.resolution.issues == []
     assert coresys.resolution.suggestions == []

--- a/tests/resolution/fixup/test_app_clear_port_config.py
+++ b/tests/resolution/fixup/test_app_clear_port_config.py
@@ -1,0 +1,39 @@
+"""Test fixup clearing a conflicting app port mapping."""
+
+import pytest
+
+from supervisor.apps.app import App
+from supervisor.coresys import CoreSys
+from supervisor.resolution.const import ContextType, IssueType, SuggestionType
+from supervisor.resolution.data import Issue
+from supervisor.resolution.fixups.app_clear_port_config import FixupAppClearPortConfig
+
+
+@pytest.mark.usefixtures("tmp_supervisor_data")
+async def test_fixup_clears_conflicting_port(coresys: CoreSys, install_app_ssh: App):
+    """Test the conflicting port mapping is cleared and persisted."""
+    app = install_app_ssh
+    app.persist["network"] = {"22/tcp": 2222}
+    assert app.ports == {"22/tcp": 2222}
+
+    fixup = FixupAppClearPortConfig(coresys)
+    assert not fixup.auto
+
+    coresys.resolution.add_issue(
+        Issue(
+            IssueType.APP_PORT_CONFLICT,
+            ContextType.ADDON,
+            reference=app.slug,
+            reference_extra={"port": 2222},
+        ),
+        suggestions=[SuggestionType.CLEAR_PORT_CONFIG],
+    )
+
+    await fixup()
+
+    # The conflicting mapping must be cleared in the persisted config, not just
+    # in a throwaway copy returned by the getter.
+    assert app.ports == {"22/tcp": None}
+    assert app.persist["network"] == {"22/tcp": None}
+    assert coresys.resolution.issues == []
+    assert coresys.resolution.suggestions == []


### PR DESCRIPTION
## Proposed change

The `App.ports` getter returned the persisted network mapping wholesale whenever the user had customized any port, instead of reconciling it with the ports declared in the app's config. As a result, config-declared ports absent from the persisted set silently disappeared from the app's port list.

This surfaces for apps that declare optional, unpublished ports (host port `null`). Once a user publishes a single port, the persisted set only contains what was submitted, so the remaining config-declared ports vanish from the info output and can no longer be enabled from the UI. A concrete case is the NGINX SSL proxy app: after `443/udp` (HTTP/3 QUIC) was added to its config, users who had already customized their ports never saw the new port and had no way to publish it short of resetting to defaults.

The getter now merges the persisted overrides on top of the config-declared ports, keying off the current config. This keeps every declared port visible with the user's overrides applied, backfills ports added to the config after the last save, and drops stale entries removed from the config on update.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
