### PR TITLE
Fix media/share mounts staying empty after mount reload fixup

### DIFF
--- a/supervisor/mounts/manager.py
+++ b/supervisor/mounts/manager.py
@@ -262,7 +262,12 @@ class MountManager(FileConfiguration, CoreSysAttributes):
         _LOGGER.info("Reloading mount: %s", name)
         await self._mounts[name].reload()
 
-        if (bound_mount := self._bound_mounts.get(name)) and bound_mount.emergency:
+        # Always re-create the bind mount into media/share. systemd adds an
+        # implicit Requires= dependency from the bind unit to the data mount
+        # unit (via RequiresMountsFor= on its What= path), so stopping or
+        # restarting a failed data mount tears down the bind mount as well —
+        # our BoundMount bookkeeping cannot know whether that happened.
+        if bound_mount := self._bound_mounts.get(name):
             await self._bind_mount(bound_mount.mount, bound_mount.bind_mount.where)
 
     async def _bind_media(self, mount: Mount) -> None:

--- a/tests/mounts/test_manager.py
+++ b/tests/mounts/test_manager.py
@@ -430,13 +430,58 @@ async def test_reload_mount_healthy_skips_systemd(
     all_dbus_services: dict[str, DBusServiceMock],
     mount: Mount,
 ):
-    """A healthy mount (active + probe passes) skips the systemd reload."""
+    """A healthy mount (active + probe passes) skips the systemd reload but rebinds."""
     systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_service.ReloadOrRestartUnit.calls.clear()
+    systemd_service.StartTransientUnit.calls.clear()
+    systemd_service.StopUnit.calls.clear()
+
+    systemd_service.response_get_unit = [
+        "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
+        ERROR_NO_UNIT,
+        "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
+    ]
 
     await coresys.mounts.reload_mount(mount.name)
 
     assert systemd_service.ReloadOrRestartUnit.calls == []
+    assert [call[0] for call in systemd_service.StopUnit.calls] == [
+        "mnt-data-supervisor-media-media_test.mount"
+    ]
+    assert [call[0] for call in systemd_service.StartTransientUnit.calls] == [
+        "mnt-data-supervisor-media-media_test.mount"
+    ]
+
+
+async def test_reload_mount_recreates_bind_mount_removed_by_systemd(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock],
+    mount: Mount,
+):
+    """Reload re-creates a bind mount that systemd tore down with the data mount.
+
+    systemd's implicit Requires= dependency from the bind unit to the data
+    mount unit means a stop/restart of a failed data mount unmounts the bind
+    mount as well, while the BoundMount bookkeeping still says it is bound.
+    """
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_service.StartTransientUnit.calls.clear()
+    systemd_service.StopUnit.calls.clear()
+
+    # Bind mount unit is gone: unmount is skipped, load mounts it again
+    systemd_service.response_get_unit = [
+        ERROR_NO_UNIT,
+        ERROR_NO_UNIT,
+        "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
+    ]
+
+    assert not coresys.mounts.bound_mounts[0].emergency
+    await coresys.mounts.reload_mount(mount.name)
+
+    assert systemd_service.StopUnit.calls == []
+    assert [call[0] for call in systemd_service.StartTransientUnit.calls] == [
+        "mnt-data-supervisor-media-media_test.mount"
+    ]
 
 
 async def test_reload_mount_probe_failure_triggers_systemd_reload(
@@ -659,7 +704,6 @@ async def test_reload_mounts_attempts_initial_mount(
         "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
     ]
     systemd_service.response_reload_or_restart_unit = ERROR_NO_UNIT
-    coresys.mounts.bound_mounts[0].emergency = True
 
     await coresys.mounts.reload()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

When a media/share network mount fails at runtime (e.g. the NFS server goes down), the reload fixup or the periodic mount reload escalates to stopping/restarting the data mount unit. systemd adds an implicit `RequiresMountsFor=` dependency from the bind mount unit to the data mount unit through its `What=` path (resulting in `Requires=` + `After=`, see `mount_add_mount_dependencies()` in systemd's `src/core/mount.c`), so the explicit stop/restart of the data mount unmounts the bind mount into media/share as well. Supervisor's `BoundMount` bookkeeping doesn't reflect that: after a successful reload, `MountManager.reload_mount()` only re-created the bind mount when it had been set up as an emergency fallback during load. The result is the sequence reported in #6938: the repair succeeds and the data mount is active again, but `/media/<name>` (resp. `/share/<name>`) stays an empty directory until the user re-sends the mount config via the API, which recreates all units.

Always re-create the bind mount after a successful reload instead. This also covers the case where the mount recovered on its own (probe passes, so the systemd reload is skipped) while the bind mount had already been torn down by an earlier failed restart cycle. `_bind_mount()` already handles unmounting a present bind mount and the emergency fallback, so the unconditional rebind is safe; and since `reload_mount()` only runs when the mount was failing (the periodic reload only calls it for probe failures, and the fixup only exists while a `MOUNT_FAILED` issue is present), the brief unmount/remount window doesn't disturb a healthy share.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #6938
- This PR is related to issue: #6827
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
