### PR TITLE
Migrate addon job names to app and scope legacy API compatibility

### DIFF
--- a/supervisor/api/jobs.py
+++ b/supervisor/api/jobs.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 
 from ..coresys import CoreSysAttributes
 from ..exceptions import APIError, APINotFound, JobNotFound
-from ..jobs import SupervisorJob
+from ..jobs import SupervisorJob, process_job_dict_for_legacy_compatibility
 from ..jobs.const import ATTR_IGNORE_CONDITIONS, JobCondition
 from .const import ATTR_JOBS
 from .utils import api_process, api_validate
@@ -67,7 +67,7 @@ class APIJobs(CoreSysAttributes):
             # We remove parent_id and instead use that info to represent jobs as a tree
             job_dict = current_job.as_dict() | {"child_jobs": child_jobs}
             job_dict.pop("parent_id")
-            current_list.append(job_dict)
+            current_list.append(process_job_dict_for_legacy_compatibility(job_dict))
 
             if current_job.uuid in jobs_by_parent:
                 queue.extend(

--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -863,7 +863,7 @@ class App(AppModel):
         _LOGGER.debug("App %s write options: %s", self.slug, options)
 
     @Job(
-        name="addon_unload",
+        name="app_unload",
         on_condition=AppsJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
     )
@@ -896,7 +896,7 @@ class App(AppModel):
             )
 
     @Job(
-        name="addon_install",
+        name="app_install",
         on_condition=AppsJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
     )
@@ -950,7 +950,7 @@ class App(AppModel):
             await self.sys_ingress.reload()
 
     @Job(
-        name="addon_uninstall",
+        name="app_uninstall",
         on_condition=AppsJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
     )
@@ -1018,7 +1018,7 @@ class App(AppModel):
             await self.sys_ingress.reload()
 
     @Job(
-        name="addon_update",
+        name="app_update",
         on_condition=AppsJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
     )
@@ -1078,7 +1078,7 @@ class App(AppModel):
         return out
 
     @Job(
-        name="addon_rebuild",
+        name="app_rebuild",
         on_condition=AppsJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
     )
@@ -1259,7 +1259,7 @@ class App(AppModel):
         )
 
     @Job(
-        name="addon_start",
+        name="app_start",
         on_condition=AppsJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
     )
@@ -1318,7 +1318,7 @@ class App(AppModel):
         return self._wait_for_startup_task
 
     @Job(
-        name="addon_stop",
+        name="app_stop",
         on_condition=AppsJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
     )
@@ -1333,7 +1333,7 @@ class App(AppModel):
             raise AppUnknownError(app=self.slug) from err
 
     @Job(
-        name="addon_restart",
+        name="app_restart",
         on_condition=AppsJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
     )
@@ -1367,7 +1367,7 @@ class App(AppModel):
             raise AppUnknownError(app=self.slug) from err
 
     @Job(
-        name="addon_write_stdin",
+        name="app_write_stdin",
         on_condition=AppsJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
     )
@@ -1405,7 +1405,7 @@ class App(AppModel):
             raise AppUnknownError(app=self.slug) from err
 
     @Job(
-        name="addon_begin_backup",
+        name="app_begin_backup",
         on_condition=AppsJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
     )
@@ -1427,7 +1427,7 @@ class App(AppModel):
         return True
 
     @Job(
-        name="addon_end_backup",
+        name="app_end_backup",
         on_condition=AppsJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
     )
@@ -1465,7 +1465,7 @@ class App(AppModel):
         return False
 
     @Job(
-        name="addon_backup",
+        name="app_backup",
         on_condition=AppsJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
     )
@@ -1578,7 +1578,7 @@ class App(AppModel):
         return wait_for_start
 
     @Job(
-        name="addon_restore",
+        name="app_restore",
         on_condition=AppsJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
     )
@@ -1727,11 +1727,12 @@ class App(AppModel):
         return wait_for_start
 
     @Job(
-        name="addon_restart_after_problem",
+        name="app_restart_after_problem",
         throttle_period=WATCHDOG_THROTTLE_PERIOD,
         throttle_max_calls=WATCHDOG_THROTTLE_MAX_CALLS,
         on_condition=AppsJobError,
         throttle=JobThrottle.GROUP_RATE_LIMIT,
+        internal=True,
     )
     async def _restart_after_problem(
         self, state: ContainerState, exit_code: int | None = None

--- a/supervisor/apps/manager.py
+++ b/supervisor/apps/manager.py
@@ -205,7 +205,7 @@ class AppManager(CoreSysAttributes):
                 await async_capture_exception(err)
 
     @Job(
-        name="addon_manager_install",
+        name="app_manager_install",
         conditions=APP_UPDATE_CONDITIONS,
         on_condition=AppsJobError,
         concurrency=JobConcurrency.QUEUE,
@@ -236,7 +236,7 @@ class AppManager(CoreSysAttributes):
 
         _LOGGER.info("App '%s' successfully installed", slug)
 
-    @Job(name="addon_manager_uninstall")
+    @Job(name="app_manager_uninstall")
     async def uninstall(self, slug: str, *, remove_config: bool = False) -> None:
         """Remove an app."""
         if slug not in self.local:
@@ -256,7 +256,7 @@ class AppManager(CoreSysAttributes):
         _LOGGER.info("App '%s' successfully removed", slug)
 
     @Job(
-        name="addon_manager_update",
+        name="app_manager_update",
         conditions=APP_UPDATE_CONDITIONS,
         on_condition=AppsJobError,
         # We assume for now the docker image pull is 100% of this task for progress
@@ -312,7 +312,7 @@ class AppManager(CoreSysAttributes):
         return task
 
     @Job(
-        name="addon_manager_rebuild",
+        name="app_manager_rebuild",
         conditions=[
             JobCondition.FREE_SPACE,
             JobCondition.INTERNET_HOST,
@@ -345,7 +345,7 @@ class AppManager(CoreSysAttributes):
         return await app.rebuild()
 
     @Job(
-        name="addon_manager_restore",
+        name="app_manager_restore",
         conditions=[
             JobCondition.FREE_SPACE,
             JobCondition.INTERNET_HOST,
@@ -385,7 +385,7 @@ class AppManager(CoreSysAttributes):
         return wait_for_start
 
     @Job(
-        name="addon_manager_repair",
+        name="app_manager_repair",
         conditions=[JobCondition.FREE_SPACE, JobCondition.INTERNET_HOST],
     )
     async def repair(self) -> None:

--- a/supervisor/backups/backup.py
+++ b/supervisor/backups/backup.py
@@ -612,7 +612,7 @@ class Backup(JobGroup):
             self.sys_jobs.current.capture_error(BackupError("Can't write backup"))
             _LOGGER.error("Can't write backup: %s", err)
 
-    @Job(name="backup_addon_save", cleanup=False)
+    @Job(name="backup_app_save", cleanup=False)
     async def _app_save(self, app: App) -> asyncio.Task | None:
         """Store an app into backup."""
         self.sys_jobs.current.reference = slug = app.slug
@@ -655,7 +655,7 @@ class Backup(JobGroup):
 
         return start_task
 
-    @Job(name="backup_store_addons", cleanup=False)
+    @Job(name="backup_store_apps", cleanup=False)
     async def store_apps(self, app_list: list[App]) -> list[asyncio.Task]:
         """Add a list of apps into backup.
 
@@ -675,7 +675,7 @@ class Backup(JobGroup):
 
         return start_tasks
 
-    @Job(name="backup_addon_restore", cleanup=False)
+    @Job(name="backup_app_restore", cleanup=False)
     async def _app_restore(self, app_slug: str) -> asyncio.Task | None:
         """Restore an app from backup."""
         self.sys_jobs.current.reference = app_slug
@@ -704,7 +704,7 @@ class Backup(JobGroup):
                 f"Can't restore backup {app_slug}", _LOGGER.error
             ) from err
 
-    @Job(name="backup_restore_addons", cleanup=False)
+    @Job(name="backup_restore_apps", cleanup=False)
     async def restore_apps(
         self, app_list: list[str]
     ) -> tuple[bool, list[asyncio.Task]]:
@@ -724,7 +724,7 @@ class Backup(JobGroup):
 
         return (success, start_tasks)
 
-    @Job(name="backup_remove_delta_addons", cleanup=False)
+    @Job(name="backup_remove_delta_apps", cleanup=False)
     async def remove_delta_apps(self) -> bool:
         """Remove apps which are not in this backup."""
         success = True

--- a/supervisor/docker/app.py
+++ b/supervisor/docker/app.py
@@ -589,9 +589,10 @@ class DockerApp(DockerInterface):
         return mounts
 
     @Job(
-        name="docker_addon_run",
+        name="docker_app_run",
         on_condition=DockerJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
+        internal=True,
     )
     async def run(self) -> None:
         """Run Docker image."""
@@ -654,9 +655,10 @@ class DockerApp(DockerInterface):
             )
 
     @Job(
-        name="docker_addon_update",
+        name="docker_app_update",
         on_condition=DockerJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
+        internal=True,
     )
     async def update(
         self,
@@ -682,9 +684,10 @@ class DockerApp(DockerInterface):
         )
 
     @Job(
-        name="docker_addon_install",
+        name="docker_app_install",
         on_condition=DockerJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
+        internal=True,
     )
     async def install(
         self,
@@ -822,9 +825,10 @@ class DockerApp(DockerInterface):
         await self.sys_docker.export_image(self.image, self.version, tar_file)
 
     @Job(
-        name="docker_addon_import_image",
+        name="docker_app_import_image",
         on_condition=DockerJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
+        internal=True,
     )
     async def import_image(self, tar_file: Path) -> None:
         """Import a tar file as image."""
@@ -835,7 +839,11 @@ class DockerApp(DockerInterface):
             with suppress(DockerError):
                 await self.cleanup()
 
-    @Job(name="docker_addon_cleanup", concurrency=JobConcurrency.GROUP_QUEUE)
+    @Job(
+        name="docker_app_cleanup",
+        concurrency=JobConcurrency.GROUP_QUEUE,
+        internal=True,
+    )
     async def cleanup(
         self,
         old_image: str | None = None,
@@ -862,9 +870,10 @@ class DockerApp(DockerInterface):
         )
 
     @Job(
-        name="docker_addon_write_stdin",
+        name="docker_app_write_stdin",
         on_condition=DockerJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
+        internal=True,
     )
     async def write_stdin(self, data: bytes) -> None:
         """Write to app stdin."""
@@ -892,9 +901,10 @@ class DockerApp(DockerInterface):
             ) from err
 
     @Job(
-        name="docker_addon_stop",
+        name="docker_app_stop",
         on_condition=DockerJobError,
         concurrency=JobConcurrency.GROUP_REJECT,
+        internal=True,
     )
     async def stop(self, remove_container: bool = True) -> None:
         """Stop/remove Docker container."""
@@ -922,7 +932,7 @@ class DockerApp(DockerInterface):
             self.sys_resolution.dismiss_issue(issue)
 
     @Job(
-        name="docker_addon_hardware_events",
+        name="docker_app_hardware_events",
         conditions=[JobCondition.OS_AGENT],
         internal=True,
         concurrency=JobConcurrency.QUEUE,

--- a/supervisor/jobs/__init__.py
+++ b/supervisor/jobs/__init__.py
@@ -35,26 +35,16 @@ _CURRENT_JOB: ContextVar[str | None] = ContextVar("current_job", default=None)
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
-_LEGACY_JOB_NAMES: dict[str, str] = {
-    "app_manager_install": "addon_manager_install",
-    "app_manager_uninstall": "addon_manager_uninstall",
-    "app_manager_update": "addon_manager_update",
-    "backup_app_save": "backup_addon_save",
-    "backup_store_apps": "backup_store_addons",
-    "backup_app_restore": "backup_addon_restore",
-    "backup_restore_apps": "backup_restore_addons",
-    "backup_remove_delta_apps": "backup_remove_delta_addons",
-}
-
 
 def process_job_dict_for_legacy_compatibility(
     job_data: dict[str, Any],
 ) -> dict[str, Any]:
     """Map new job names to legacy names for API compatibility."""
-    if isinstance(name := job_data.get("name"), str) and (
-        legacy_name := _LEGACY_JOB_NAMES.get(name)
-    ):
-        return job_data | {"name": legacy_name}
+    # Home Assistant Core's hassio integration listens for this specific job name
+    # via the Supervisor websocket API. Core v2026.8 supports both names, so this
+    # compatibility can be removed when Core v2026.7 is no longer supported.
+    if job_data.get("name") == "app_manager_update":
+        return job_data | {"name": "addon_manager_update"}
     return job_data
 
 

--- a/supervisor/jobs/__init__.py
+++ b/supervisor/jobs/__init__.py
@@ -35,6 +35,28 @@ _CURRENT_JOB: ContextVar[str | None] = ContextVar("current_job", default=None)
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
+_LEGACY_JOB_NAMES: dict[str, str] = {
+    "app_manager_install": "addon_manager_install",
+    "app_manager_uninstall": "addon_manager_uninstall",
+    "app_manager_update": "addon_manager_update",
+    "backup_app_save": "backup_addon_save",
+    "backup_store_apps": "backup_store_addons",
+    "backup_app_restore": "backup_addon_restore",
+    "backup_restore_apps": "backup_restore_addons",
+    "backup_remove_delta_apps": "backup_remove_delta_addons",
+}
+
+
+def process_job_dict_for_legacy_compatibility(
+    job_data: dict[str, Any],
+) -> dict[str, Any]:
+    """Map new job names to legacy names for API compatibility."""
+    if isinstance(name := job_data.get("name"), str) and (
+        legacy_name := _LEGACY_JOB_NAMES.get(name)
+    ):
+        return job_data | {"name": legacy_name}
+    return job_data
+
 
 @dataclass
 class JobSchedulerOptions:
@@ -287,7 +309,9 @@ class JobManager(FileConfiguration, CoreSysAttributes):
         # Job object will be before the change. Combine the change with current data
         if attribute.name == "errors":
             value = [err.as_dict() for err in value]
-        job_data = job.as_dict() | {attribute.name: value}
+        job_data = process_job_dict_for_legacy_compatibility(
+            job.as_dict() | {attribute.name: value}
+        )
 
         # Notify Home Assistant of change if its not internal
         if not job.internal:

--- a/supervisor/misc/tasks.py
+++ b/supervisor/misc/tasks.py
@@ -105,8 +105,9 @@ class Tasks(CoreSysAttributes):
         _LOGGER.info("All core tasks are scheduled")
 
     @Job(
-        name="tasks_update_addons",
+        name="tasks_update_apps",
         conditions=APP_UPDATE_CONDITIONS + [JobCondition.RUNNING],
+        internal=True,
     )
     async def _update_apps(self):
         """Check if an update is available for an App and update it."""
@@ -235,7 +236,11 @@ class Tasks(CoreSysAttributes):
         finally:
             self._cache[HASS_WATCHDOG_API_FAILURES] = 0
 
-    @Job(name="tasks_update_cli", conditions=PLUGIN_AUTO_UPDATE_CONDITIONS)
+    @Job(
+        name="tasks_update_cli",
+        conditions=PLUGIN_AUTO_UPDATE_CONDITIONS,
+        internal=True,
+    )
     async def _update_cli(self):
         """Check and run update of cli."""
         if not self.sys_plugins.cli.need_update:
@@ -246,7 +251,11 @@ class Tasks(CoreSysAttributes):
         )
         await self.sys_plugins.cli.update()
 
-    @Job(name="tasks_update_dns", conditions=PLUGIN_AUTO_UPDATE_CONDITIONS)
+    @Job(
+        name="tasks_update_dns",
+        conditions=PLUGIN_AUTO_UPDATE_CONDITIONS,
+        internal=True,
+    )
     async def _update_dns(self):
         """Check and run update of CoreDNS plugin."""
         if not self.sys_plugins.dns.need_update:
@@ -258,7 +267,11 @@ class Tasks(CoreSysAttributes):
         )
         await self.sys_plugins.dns.update()
 
-    @Job(name="tasks_update_audio", conditions=PLUGIN_AUTO_UPDATE_CONDITIONS)
+    @Job(
+        name="tasks_update_audio",
+        conditions=PLUGIN_AUTO_UPDATE_CONDITIONS,
+        internal=True,
+    )
     async def _update_audio(self):
         """Check and run update of PulseAudio plugin."""
         if not self.sys_plugins.audio.need_update:
@@ -270,7 +283,11 @@ class Tasks(CoreSysAttributes):
         )
         await self.sys_plugins.audio.update()
 
-    @Job(name="tasks_update_observer", conditions=PLUGIN_AUTO_UPDATE_CONDITIONS)
+    @Job(
+        name="tasks_update_observer",
+        conditions=PLUGIN_AUTO_UPDATE_CONDITIONS,
+        internal=True,
+    )
     async def _update_observer(self):
         """Check and run update of Observer plugin."""
         if not self.sys_plugins.observer.need_update:
@@ -282,7 +299,11 @@ class Tasks(CoreSysAttributes):
         )
         await self.sys_plugins.observer.update()
 
-    @Job(name="tasks_update_multicast", conditions=PLUGIN_AUTO_UPDATE_CONDITIONS)
+    @Job(
+        name="tasks_update_multicast",
+        conditions=PLUGIN_AUTO_UPDATE_CONDITIONS,
+        internal=True,
+    )
     async def _update_multicast(self):
         """Check and run update of multicast."""
         if not self.sys_plugins.multicast.need_update:
@@ -348,12 +369,13 @@ class Tasks(CoreSysAttributes):
             JobCondition.OS_SUPPORTED,
             JobCondition.HOME_ASSISTANT_CORE_SUPPORTED,
         ],
+        internal=True,
     )
     async def _reload_store(self) -> None:
         """Reload store and check for app updates."""
         await self.sys_store.reload()
 
-    @Job(name="tasks_reload_updater")
+    @Job(name="tasks_reload_updater", internal=True)
     async def _reload_updater(self) -> None:
         """Check for new versions of Home Assistant, Supervisor, OS, etc."""
         await self.sys_updater.reload()
@@ -374,6 +396,7 @@ class Tasks(CoreSysAttributes):
             JobCondition.ARCHITECTURE_SUPPORTED,
         ],
         concurrency=JobConcurrency.REJECT,
+        internal=True,
     )
     async def _auto_update_supervisor(self):
         """Auto update Supervisor if enabled."""
@@ -387,7 +410,11 @@ class Tasks(CoreSysAttributes):
         with suppress(SupervisorUpdateError):
             await self.sys_supervisor.update()
 
-    @Job(name="tasks_core_backup_cleanup", conditions=[JobCondition.HEALTHY])
+    @Job(
+        name="tasks_core_backup_cleanup",
+        conditions=[JobCondition.HEALTHY],
+        internal=True,
+    )
     async def _core_backup_cleanup(self) -> None:
         """Core backup is intended for transient use, remove any old backups that got left behind."""
         old_backups = [

--- a/supervisor/resolution/checks/app_pwned.py
+++ b/supervisor/resolution/checks/app_pwned.py
@@ -29,10 +29,11 @@ class CheckAppPwned(CheckBase):
         return "addon_pwned"
 
     @Job(
-        name="check_addon_pwned_run",
+        name="check_app_pwned_run",
         conditions=[JobCondition.INTERNET_SYSTEM],
         throttle_period=timedelta(hours=24),
         throttle=JobThrottle.THROTTLE,
+        internal=True,
     )
     async def run_check(self) -> None:
         """Run check if not affected by issue."""
@@ -73,7 +74,11 @@ class CheckAppPwned(CheckBase):
                 except PwnedError:
                     pass
 
-    @Job(name="check_addon_pwned_approve", conditions=[JobCondition.INTERNET_SYSTEM])
+    @Job(
+        name="check_app_pwned_approve",
+        conditions=[JobCondition.INTERNET_SYSTEM],
+        internal=True,
+    )
     async def approve_check(self, issue: Issue) -> bool:
         """Approve check if it is affected by issue."""
         if not issue.reference:

--- a/supervisor/resolution/checks/dns_server.py
+++ b/supervisor/resolution/checks/dns_server.py
@@ -40,6 +40,7 @@ class CheckDNSServer(CheckBase):
         conditions=[JobCondition.INTERNET_SYSTEM],
         throttle_period=timedelta(hours=24),
         throttle=JobThrottle.THROTTLE,
+        internal=True,
     )
     async def run_check(self) -> None:
         """Run check if not affected by issue."""
@@ -58,7 +59,11 @@ class CheckDNSServer(CheckBase):
                 )
                 await async_capture_exception(result)
 
-    @Job(name="check_dns_server_approve", conditions=[JobCondition.INTERNET_SYSTEM])
+    @Job(
+        name="check_dns_server_approve",
+        conditions=[JobCondition.INTERNET_SYSTEM],
+        internal=True,
+    )
     async def approve_check(self, issue: Issue) -> bool:
         """Approve check if it is affected by issue."""
         if issue.reference not in self.dns_servers:

--- a/supervisor/resolution/checks/dns_server_ipv6.py
+++ b/supervisor/resolution/checks/dns_server_ipv6.py
@@ -29,6 +29,7 @@ class CheckDNSServerIPv6(CheckBase):
         conditions=[JobCondition.INTERNET_SYSTEM],
         throttle_period=timedelta(hours=24),
         throttle=JobThrottle.THROTTLE,
+        internal=True,
     )
     async def run_check(self) -> None:
         """Run check if not affected by issue."""
@@ -51,7 +52,9 @@ class CheckDNSServerIPv6(CheckBase):
                 await async_capture_exception(result)
 
     @Job(
-        name="check_dns_server_ipv6_approve", conditions=[JobCondition.INTERNET_SYSTEM]
+        name="check_dns_server_ipv6_approve",
+        conditions=[JobCondition.INTERNET_SYSTEM],
+        internal=True,
     )
     async def approve_check(self, issue: Issue) -> bool:
         """Approve check if it is affected by issue."""

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -391,7 +391,7 @@ async def test_api_backup_restore_background(
     assert job["child_jobs"][1]["reference"] == backup_slug
 
     if backup_type == "full":
-        assert job["child_jobs"][2]["name"] == "backup_remove_delta_addons"
+        assert job["child_jobs"][2]["name"] == "backup_remove_delta_apps"
         assert job["child_jobs"][2]["reference"] == backup_slug
 
 
@@ -443,9 +443,9 @@ async def test_api_backup_errors(
     assert job["errors"] == []
     assert job["child_jobs"][0]["name"] == "backup_store_homeassistant"
     assert job["child_jobs"][0]["reference"] == slug
-    assert job["child_jobs"][1]["name"] == "backup_store_addons"
+    assert job["child_jobs"][1]["name"] == "backup_store_apps"
     assert job["child_jobs"][1]["reference"] == slug
-    assert job["child_jobs"][1]["child_jobs"][0]["name"] == "backup_addon_save"
+    assert job["child_jobs"][1]["child_jobs"][0]["name"] == "backup_app_save"
     assert job["child_jobs"][1]["child_jobs"][0]["reference"] == "local_ssh"
     assert job["child_jobs"][1]["child_jobs"][0]["errors"] == [
         {

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -1584,7 +1584,7 @@ async def test_pre_post_backup_command_error(
     job_id = body["data"]["job_id"]
     job: SupervisorJob | None = None
     for j in coresys.jobs.jobs:
-        if j.name == "backup_store_addons" and j.parent_id == job_id:
+        if j.name == "backup_store_apps" and j.parent_id == job_id:
             job = j
             break
 

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -1,7 +1,7 @@
 """Test Docker API."""
 
 import asyncio
-from unittest.mock import ANY
+from unittest.mock import ANY, AsyncMock
 
 from aiohttp.test_utils import TestClient
 import pytest
@@ -422,3 +422,32 @@ async def test_job_with_error(
             ],
         },
     ]
+
+
+async def test_api_jobs_legacy_name_compatibility(
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    ha_ws_client: AsyncMock,
+):
+    """Test renamed job names are mapped back to legacy names in API outputs."""
+    api_client, prefix = api_client_with_prefix
+    job = coresys.jobs.new_job("app_manager_update", reference="local_example")
+    job.stage = "update"
+    job.progress = 50
+    with job.start():
+        pass
+
+    resp = await api_client.get(f"{prefix}/jobs/info")
+    assert resp.status == 200
+    result = await resp.json()
+    assert result["data"]["jobs"][0]["name"] == "addon_manager_update"
+
+    job_events = [
+        evt.args[0]["data"]["data"]
+        for evt in ha_ws_client.async_send_command.call_args_list
+        if "data" in evt.args[0] and evt.args[0]["data"]["event"] == "job"
+    ]
+    assert any(job_event["name"] == "addon_manager_update" for job_event in job_events)
+    assert not any(
+        job_event["name"] == "app_manager_update" for job_event in job_events
+    )

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -890,7 +890,7 @@ async def test_api_store_apps_app_availability_installed_app(
 @pytest.mark.parametrize(
     ("action", "job_name", "app_slug"),
     [
-        ("install", "addon_manager_install", "local_ssh"),
+        ("install", "app_manager_install", "local_ssh"),
         ("update", "addon_manager_update", "local_example"),
     ],
 )

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -585,7 +585,7 @@ async def test_app_install_in_background(api_client: TestClient, coresys: CoreSy
     assert resp.status == 200
     body = await resp.json()
     assert (job := coresys.jobs.get_job(body["data"]["job_id"]))
-    assert job.name == "addon_manager_install"
+    assert job.name == "app_manager_install"
     event.set()
 
 
@@ -649,7 +649,7 @@ async def test_app_update_in_background(
     assert resp.status == 200
     body = await resp.json()
     assert (job := coresys.jobs.get_job(body["data"]["job_id"]))
-    assert job.name == "addon_manager_update"
+    assert job.name == "app_manager_update"
     event.set()
 
 


### PR DESCRIPTION
## Proposed change

This PR continues the addon->app migration for supervisor job names by renaming `@Job` names that still used `addon`/`addons` to `app`/`apps`.

Because job names are exposed over the API, this is intentionally treated as a breaking-change PR. To reduce compatibility risk while still moving forward:

- Keep a minimal compatibility mapping for API-exposed legacy names only.
- Retain legacy mapping for `app_manager_install`, `app_manager_uninstall`, and `app_manager_update`.
- Retain legacy mapping for backup jobs that use `cleanup=False`.
- Remove broader legacy aliases so those names now change as part of the breaking change.
- Mark `app_restart_after_problem`, `docker_app_*`, `tasks_*`, and `check_*` jobs as internal.

This keeps the compatibility surface focused while preserving the known legacy listener dependency for manager install/uninstall/update and long-lived backup jobs.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6698
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/