### PR TITLE
Queue Home Assistant Core restart/stop behind a running start

### DIFF
--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -493,7 +493,7 @@ class HomeAssistantCore(JobGroup):
     @Job(
         name="home_assistant_core_stop",
         on_condition=HomeAssistantJobError,
-        concurrency=JobConcurrency.GROUP_REJECT,
+        concurrency=JobConcurrency.GROUP_QUEUE,
     )
     async def stop(self, *, remove_container: bool = False) -> None:
         """Stop Home Assistant Docker."""
@@ -505,7 +505,7 @@ class HomeAssistantCore(JobGroup):
     @Job(
         name="home_assistant_core_restart",
         on_condition=HomeAssistantJobError,
-        concurrency=JobConcurrency.GROUP_REJECT,
+        concurrency=JobConcurrency.GROUP_QUEUE,
     )
     async def restart(self, *, safe_mode: bool = False) -> None:
         """Restart Home Assistant Docker."""

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -667,6 +667,53 @@ async def test_restart(coresys: CoreSys, container: DockerContainer):
     container.stop.assert_not_called()
 
 
+@pytest.mark.usefixtures("path_extern")
+@pytest.mark.parametrize("method", ["restart", "stop"])
+async def test_lifecycle_op_queues_behind_running_start(
+    coresys: CoreSys, container: DockerContainer, method: str
+) -> None:
+    """A restart/stop waits for an in-progress start instead of being rejected.
+
+    Core may ask Supervisor to restart while it is still starting Core (for
+    example to apply a reverted HTTP config). With GROUP_QUEUE the request must
+    queue behind the running start job rather than fail with a job-group
+    conflict.
+    """
+    coresys.docker.images.inspect.return_value = {"Id": "123"}
+    container.show.return_value["Image"] = "123"
+    container.show.return_value["State"]["Status"] = "exited"
+    container.show.return_value["State"]["Running"] = False
+
+    start_holds_group = asyncio.Event()
+    release_start = asyncio.Event()
+
+    async def _hold_group() -> None:
+        start_holds_group.set()
+        await release_start.wait()
+
+    with (
+        patch.object(
+            HomeAssistant,
+            "version",
+            new=PropertyMock(return_value=AwesomeVersion("2023.7.0")),
+        ),
+        patch.object(HomeAssistantCore, "_block_till_run", side_effect=_hold_group),
+    ):
+        start_task = asyncio.create_task(coresys.homeassistant.core.start())
+        await start_holds_group.wait()
+
+        op_task = asyncio.create_task(getattr(coresys.homeassistant.core, method)())
+        # Let the op run until it blocks on the job group lock.
+        for _ in range(3):
+            await asyncio.sleep(0)
+        assert not op_task.done()
+
+        release_start.set()
+        await start_task
+        # Completes without raising a job-group conflict.
+        await op_task
+
+
 @pytest.mark.parametrize(
     "get_error",
     [


### PR DESCRIPTION
## Proposed change

The `home_assistant_core` job group used `GROUP_REJECT` for `start`, `stop` and `restart`. Because `start` holds the group for the entire duration of `_block_till_run()` (polling Core's API until it reports `RUNNING`), any `stop`/`restart` requested *while Core is still starting* is rejected outright with:

```
Another job is running for job group home_assistant_core
```

This breaks legitimate early restarts. Concretely: Home Assistant Core's new UI-managed HTTP config applies a changed config as a "pending" trial and, when that config cannot bind (e.g. the port is already taken), reverts by restarting Core — which happens *during* Core startup. Supervisor refused that restart (see https://github.com/home-assistant/core/pull/176076):

```
aiohasupervisor.exceptions.SupervisorBadRequestError: Another job is running for job group home_assistant_core
```

This switches `stop` and `restart` to `GROUP_QUEUE`, so such a request **waits** for the in-progress `start` to finish and then runs, instead of failing. `start` keeps `GROUP_REJECT`. Reentrant same-group calls (e.g. `rebuild` → `start`) are unaffected: `JobGroup.acquire()` already short-circuits when the current job chain owns the lock.

### Note / follow-up

Now that `restart`/`stop` can be held open (queued) rather than returning immediately, callers using the client library's default 10s request timeout (`aiohasupervisor` `DEFAULT_TIMEOUT`) can hit a spurious `SupervisorTimeoutError` while the request is queued, even though the operation ultimately succeeds. These long-running lifecycle calls should use `timeout=None` (as `core/update` already does) in the [client library][client-library-repository]. That is a separate, independently-correct fix.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
