### PR TITLE
Detect pending OS update after marking the booted slot good

### DIFF
--- a/supervisor/os/manager.py
+++ b/supervisor/os/manager.py
@@ -259,7 +259,6 @@ class OSManager(CoreSysAttributes):
         self._os_name = cpe.get_product()[0]
 
         await self.reload()
-        await self._detect_pending_update()
 
         await self.datadisk.load()
 
@@ -275,6 +274,11 @@ class OSManager(CoreSysAttributes):
         A successful rauc install makes the target slot the primary boot slot
         while the old version keeps running until reboot. Supervisor may
         restart in that window, so recover the pending state from rauc.
+
+        Must run after the booted slot was marked good: rauc's GRUB backend
+        only treats a slot as primary once it has no boot attempts pending,
+        so until the boot attempt counter of the booted slot is reset,
+        GetPrimary reports the previous slot as primary on every boot.
         """
         try:
             primary = await self.sys_dbus.rauc.get_primary()
@@ -450,7 +454,19 @@ class OSManager(CoreSysAttributes):
     async def mark_healthy(self) -> None:
         """Set booted partition as good for rauc."""
         try:
-            responses = []
+            # Marking the booted slot good resets its boot attempt counter,
+            # which the pending update detection below relies on: rauc's GRUB
+            # backend only treats a slot as primary once it has no boot
+            # attempts pending.
+            responses = [await self.sys_dbus.rauc.mark(RaucState.GOOD, "booted")]
+        except DBusError:
+            _LOGGER.exception("Can't mark booted partition as healthy!")
+            return
+
+        await self.reload()
+        await self._detect_pending_update()
+
+        try:
             # Marking the booted slot as active makes it the primary boot
             # slot again, which would cancel an installed update that still
             # awaits a reboot to activate.
@@ -458,16 +474,16 @@ class OSManager(CoreSysAttributes):
                 responses.append(
                     await self.sys_dbus.rauc.mark(RaucState.ACTIVE, "booted")
                 )
-            responses.append(await self.sys_dbus.rauc.mark(RaucState.GOOD, "booted"))
+                await self.reload()
         except DBusError:
-            _LOGGER.exception("Can't mark booted partition as healthy!")
-        else:
-            _LOGGER.info(
-                "Rauc: slot %s - %s",
-                self.sys_dbus.rauc.boot_slot,
-                ", ".join(response[1] for response in responses),
-            )
-            await self.reload()
+            _LOGGER.exception("Can't mark booted partition as active!")
+            return
+
+        _LOGGER.info(
+            "Rauc: slot %s - %s",
+            self.sys_dbus.rauc.boot_slot,
+            ", ".join(response[1] for response in responses),
+        )
 
     @Job(
         name="os_manager_set_boot_slot",

--- a/supervisor/os/manager.py
+++ b/supervisor/os/manager.py
@@ -458,10 +458,11 @@ class OSManager(CoreSysAttributes):
             # which the pending update detection below relies on: rauc's GRUB
             # backend only treats a slot as primary once it has no boot
             # attempts pending.
-            responses = [await self.sys_dbus.rauc.mark(RaucState.GOOD, "booted")]
+            response = await self.sys_dbus.rauc.mark(RaucState.GOOD, "booted")
         except DBusError:
             _LOGGER.exception("Can't mark booted partition as healthy!")
             return
+        _LOGGER.info("Rauc: slot %s - %s", self.sys_dbus.rauc.boot_slot, response[1])
 
         await self.reload()
         await self._detect_pending_update()
@@ -471,19 +472,13 @@ class OSManager(CoreSysAttributes):
             # slot again, which would cancel an installed update that still
             # awaits a reboot to activate.
             if not self.version_pending:
-                responses.append(
-                    await self.sys_dbus.rauc.mark(RaucState.ACTIVE, "booted")
-                )
+                response = await self.sys_dbus.rauc.mark(RaucState.ACTIVE, "booted")
                 await self.reload()
+                _LOGGER.info(
+                    "Rauc: slot %s - %s", self.sys_dbus.rauc.boot_slot, response[1]
+                )
         except DBusError:
             _LOGGER.exception("Can't mark booted partition as active!")
-            return
-
-        _LOGGER.info(
-            "Rauc: slot %s - %s",
-            self.sys_dbus.rauc.boot_slot,
-            ", ".join(response[1] for response in responses),
-        )
 
     @Job(
         name="os_manager_set_boot_slot",

--- a/tests/os/test_manager.py
+++ b/tests/os/test_manager.py
@@ -209,7 +209,7 @@ async def test_mark_healthy_keeps_pending_update(coresys: CoreSys) -> None:
 
 
 async def test_mark_healthy_marks_active_without_pending(coresys: CoreSys) -> None:
-    """Test mark_healthy marks booted slot active and good without pending update."""
+    """Test mark_healthy marks booted slot good and active without pending update."""
     coresys.os._available = True
 
     with patch.object(
@@ -220,8 +220,8 @@ async def test_mark_healthy_marks_active_without_pending(coresys: CoreSys) -> No
         await coresys.os.mark_healthy()
 
     assert mark.call_args_list == [
-        call(RaucState.ACTIVE, "booted"),
         call(RaucState.GOOD, "booted"),
+        call(RaucState.ACTIVE, "booted"),
     ]
 
 
@@ -350,15 +350,21 @@ async def test_load_slot_status_fresh_install(
     assert coresys.os.get_slot_name("B") == "kernel.1"
 
 
-async def test_load_detects_pending_update(
+async def test_mark_healthy_detects_pending_update(
     coresys: CoreSys,
     all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ) -> None:
-    """Test load recovers a pending update from rauc and raises a reboot issue."""
+    """Test mark_healthy recovers a pending update and raises a reboot issue."""
     rauc_service: RaucService = all_dbus_services["rauc"]
     rauc_service.response_get_primary = "kernel.0"
 
     await coresys.os.load()
+    with patch.object(
+        coresys.dbus.rauc,
+        "mark",
+        AsyncMock(return_value=["kernel.1", "marked slot kernel.1 as good"]),
+    ) as mark:
+        await coresys.os.mark_healthy()
 
     assert coresys.os.version_pending == AwesomeVersion("9.0.dev20220818")
     assert (
@@ -372,17 +378,63 @@ async def test_load_detects_pending_update(
         (suggestion.type, suggestion.context)
         for suggestion in coresys.resolution.suggestions
     }
+    # The pending update must not be cancelled by marking the booted slot active
+    mark.assert_called_once_with(RaucState.GOOD, "booted")
 
 
-async def test_load_no_pending_update(coresys: CoreSys) -> None:
-    """Test load finds no pending update when the primary slot is booted."""
+async def test_mark_healthy_no_pending_update(coresys: CoreSys) -> None:
+    """Test mark_healthy finds no pending update when the primary slot is booted."""
     await coresys.os.load()
+    with patch.object(
+        coresys.dbus.rauc,
+        "mark",
+        AsyncMock(return_value=["kernel.1", "marked slot kernel.1 as good"]),
+    ):
+        await coresys.os.mark_healthy()
 
     assert coresys.os.version_pending is None
     assert (
         IssueType.REBOOT_REQUIRED,
         ContextType.SYSTEM,
     ) not in {(issue.type, issue.context) for issue in coresys.resolution.issues}
+
+
+async def test_mark_healthy_stale_primary_before_mark_good(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+) -> None:
+    """Test pending update detection runs after the booted slot is marked good.
+
+    rauc's GRUB backend does not treat a slot with boot attempts pending as
+    primary. The booted slot has a boot attempt recorded until it is marked
+    good, so on every boot GetPrimary reports the previous slot as primary
+    until then. Detecting the pending update from that stale response raised
+    a bogus reboot issue on every boot on GRUB systems.
+    """
+    rauc_service: RaucService = all_dbus_services["rauc"]
+    rauc_service.response_get_primary = "kernel.0"
+
+    async def mark(state: RaucState, slot_identifier: str) -> list[str]:
+        # Marking the booted slot good resets its boot attempt counter,
+        # making it eligible as primary again
+        rauc_service.response_get_primary = "kernel.1"
+        return ["kernel.1", f"marked slot kernel.1 as {state}"]
+
+    await coresys.os.load()
+    assert coresys.os.version_pending is None
+
+    with patch.object(coresys.dbus.rauc, "mark", side_effect=mark) as mark_mock:
+        await coresys.os.mark_healthy()
+
+    assert coresys.os.version_pending is None
+    assert (
+        IssueType.REBOOT_REQUIRED,
+        ContextType.SYSTEM,
+    ) not in {(issue.type, issue.context) for issue in coresys.resolution.issues}
+    assert mark_mock.call_args_list == [
+        call(RaucState.GOOD, "booted"),
+        call(RaucState.ACTIVE, "booted"),
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Since #7006 Supervisor recovers an OS update that is installed but still pending a reboot by comparing rauc's primary boot slot with the booted one at load time. On GRUB-based systems (generic-x86-64, OVA, generic-aarch64) this misfires on every boot: grub.cfg increments the booted slot's boot attempt counter on each boot attempt, and rauc's GRUB backend only treats a slot as primary once it has no boot attempts pending. Until the booted slot is marked good — which happens later in `Core.start()` — `GetPrimary` reports the previous slot as primary, so Supervisor misdetected the previous slot's (older) version as a pending update. This raised a bogus reboot-required issue on every boot (#7016), and since `/os/info` reports a pending version as the current version, it also made Core offer an "update" to the already running version, which Supervisor then rejected as already installed (#7017).

Move the detection from `load()` into `mark_healthy()` and mark the booted slot good first: that resets the boot attempt counter, making `GetPrimary` trustworthy. Marking the booted slot active remains conditional on no pending update and now runs after the detection, so a genuinely pending update (which can also be a deliberate downgrade) still isn't cancelled by a Supervisor restart.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #7016
- This PR is related to issue: #7017, #7006
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
