### PR TITLE
Expose options from simple alternation match() schemas in UI schema

### DIFF
--- a/supervisor/apps/options.py
+++ b/supervisor/apps/options.py
@@ -55,7 +55,7 @@ _SCHEMA_LENGTH_PARTS = (
     "p_max",
 )
 
-_RE_MATCH_ALTERNATION = re.compile(r"^[A-Za-z0-9_ .,:/-]+(?:\|[A-Za-z0-9_ .,:/-]+)+$")
+_RE_MATCH_ALTERNATION = re.compile(r"^[A-Za-z0-9_ ,:/-]+(?:\|[A-Za-z0-9_ ,:/-]+)+$")
 
 
 class AppOptions(CoreSysAttributes):
@@ -449,10 +449,15 @@ class UiOptions(CoreSysAttributes):
 def _extract_match_options(pattern: str) -> list[str] | None:
     """Extract literal options from a simple alternation match regex.
 
-    Returns None unless the pattern is an anchored alternation of plain
-    literals, e.g. ``^(?i:(a|b|c))$``.
+    Returns None unless the pattern is a fully anchored alternation of
+    plain literals, e.g. ``^(?i:(a|b|c))$``. The extracted options are
+    exactly the values the pattern accepts (case-insensitively when the
+    pattern carries the ``(?i)`` flag).
     """
-    inner = pattern.removeprefix("(?i)").removeprefix("^").removesuffix("$")
+    inner = pattern.removeprefix("(?i)")
+    if not (inner.startswith("^") and inner.endswith("$")):
+        return None
+    inner = inner[1:-1]
     unwrapped = True
     while unwrapped:
         unwrapped = False

--- a/supervisor/apps/options.py
+++ b/supervisor/apps/options.py
@@ -55,6 +55,8 @@ _SCHEMA_LENGTH_PARTS = (
     "p_max",
 )
 
+_RE_MATCH_ALTERNATION = re.compile(r"^[A-Za-z0-9_ .,:/-]+(?:\|[A-Za-z0-9_ .,:/-]+)+$")
+
 
 class AppOptions(CoreSysAttributes):
     """Validate Apps Options."""
@@ -383,6 +385,8 @@ class UiOptions(CoreSysAttributes):
             ui_node["type"] = "integer"
         elif value.startswith(_MATCH):
             ui_node["type"] = "string"
+            if options := _extract_match_options(match.group("match")):
+                ui_node["options"] = options
         elif value.startswith(_LIST):
             ui_node["type"] = "select"
             ui_node["options"] = match.group("list").split("|")
@@ -440,6 +444,26 @@ class UiOptions(CoreSysAttributes):
 
         ui_node["schema"] = nested_schema
         ui_schema.append(ui_node)
+
+
+def _extract_match_options(pattern: str) -> list[str] | None:
+    """Extract literal options from a simple alternation match regex.
+
+    Returns None unless the pattern is an anchored alternation of plain
+    literals, e.g. ``^(?i:(a|b|c))$``.
+    """
+    inner = pattern.removeprefix("(?i)").removeprefix("^").removesuffix("$")
+    unwrapped = True
+    while unwrapped:
+        unwrapped = False
+        for prefix in ("(?i:", "(?:", "("):
+            if inner.startswith(prefix) and inner.endswith(")"):
+                inner = inner[len(prefix) : -1]
+                unwrapped = True
+                break
+    if _RE_MATCH_ALTERNATION.match(inner):
+        return list(dict.fromkeys(inner.split("|")))
+    return None
 
 
 def _create_device_filter(str_filter: str) -> dict[str, Any]:

--- a/tests/apps/test_options.py
+++ b/tests/apps/test_options.py
@@ -635,14 +635,15 @@ def test_ui_simple_device_schema_no_filter(coresys):
 
 
 def test_ui_schema_match_options(coresys):
-    """Test simple alternation match patterns expose options for the UI."""
+    """Test anchored alternation match patterns expose options for the UI."""
     data = UiOptions(coresys)(
         {
             "enabled_shares": [
                 "match(^(?i:(addons|addon_configs|backup|config|media|share|ssl))$)"
             ],
-            "protocol": "match(rsa|dsa|ecdsa|ed25519|rsa)",
+            "protocol": "match(^(rsa|dsa|rsa)$)",
             "port": "match(^(?:443|8443|10000)$)?",
+            "mode": {"level": "match(^(read-only|read-write|a b,c:d/e)$)"},
         }
     )
     assert data[0] == {
@@ -662,14 +663,16 @@ def test_ui_schema_match_options(coresys):
     }
     # Duplicates are removed while preserving order
     assert data[1]["type"] == "string"
-    assert data[1]["options"] == ["rsa", "dsa", "ecdsa", "ed25519"]
+    assert data[1]["options"] == ["rsa", "dsa"]
     assert data[2]["type"] == "string"
     assert data[2]["options"] == ["443", "8443", "10000"]
     assert data[2]["optional"] is True
+    # Nested dict schemas reach the same extraction
+    assert data[3]["schema"][0]["options"] == ["read-only", "read-write", "a b,c:d/e"]
 
 
 def test_ui_schema_match_no_options(coresys):
-    """Test non-enumerable match patterns stay plain string nodes."""
+    """Test match patterns the extractor can't safely reduce to options."""
     data = UiOptions(coresys)(
         {
             "token": "match(^[a-f0-9]{32}$)",
@@ -678,6 +681,13 @@ def test_ui_schema_match_no_options(coresys):
             "extra_literal": "match(^(a|b)-suffix$)",
             "domain": "match(.+\\.duckdns\\.org)",
             "escaped": "match(^(a\\|b|c)$)",
+            "unanchored": "match(rsa|dsa|ecdsa)",
+            "start_anchor_only": "match(^(a|b))",
+            "end_anchor_only": "match((a|b)$)",
+            "unescaped_dot": "match(^(1.0|2.0)$)",
+            "single_literal": "match(^(auto)$)",
+            "optional_group": "match(^(auto|manual)?$)",
+            "inline_flag_after_anchor": "match(^(?i)(a|b)$)",
         }
     )
     for node in data:
@@ -686,18 +696,24 @@ def test_ui_schema_match_no_options(coresys):
 
 
 def test_extract_match_options_validate():
-    """Test every extracted option validates against its source pattern."""
+    """Test extracted options are exactly the values their pattern accepts."""
     patterns = [
         "^(?i:(addons|addon_configs|backup|config|media|share|ssl))$",
-        "rsa|dsa|ecdsa|ed25519|rsa",
         "^(?:443|8443|10000)$",
         "(?i)^(auto|manual)$",
+        "^(?:(?i:a|b))$",
     ]
     for pattern in patterns:
         options = _extract_match_options(pattern)
         assert options
         for option in options:
             assert re.match(pattern, option)
+            assert not re.match(pattern, f"{option}X")
+
+    # Malformed or empty patterns bail to None without raising
+    assert _extract_match_options("") is None
+    assert _extract_match_options("(a|b") is None
+    assert _extract_match_options("(a|b))") is None
 
 
 def test_log_entry(coresys, caplog):

--- a/tests/apps/test_options.py
+++ b/tests/apps/test_options.py
@@ -1,11 +1,12 @@
 """Test apps schema to UI schema conversion."""
 
 from pathlib import Path
+import re
 
 import pytest
 import voluptuous as vol
 
-from supervisor.apps.options import AppOptions, UiOptions
+from supervisor.apps.options import AppOptions, UiOptions, _extract_match_options
 from supervisor.hardware.data import Device
 
 MOCK_ADDON_NAME = "Mock Add-on"
@@ -631,6 +632,72 @@ def test_ui_simple_device_schema_no_filter(coresys):
         ["/dev/serial/by-id/xyx", "/dev/ttyACM0", "/dev/ttyS0", "/dev/video1"]
     )
     assert data[-1]["type"] == "select"
+
+
+def test_ui_schema_match_options(coresys):
+    """Test simple alternation match patterns expose options for the UI."""
+    data = UiOptions(coresys)(
+        {
+            "enabled_shares": [
+                "match(^(?i:(addons|addon_configs|backup|config|media|share|ssl))$)"
+            ],
+            "protocol": "match(rsa|dsa|ecdsa|ed25519|rsa)",
+            "port": "match(^(?:443|8443|10000)$)?",
+        }
+    )
+    assert data[0] == {
+        "name": "enabled_shares",
+        "type": "string",
+        "multiple": True,
+        "required": True,
+        "options": [
+            "addons",
+            "addon_configs",
+            "backup",
+            "config",
+            "media",
+            "share",
+            "ssl",
+        ],
+    }
+    # Duplicates are removed while preserving order
+    assert data[1]["type"] == "string"
+    assert data[1]["options"] == ["rsa", "dsa", "ecdsa", "ed25519"]
+    assert data[2]["type"] == "string"
+    assert data[2]["options"] == ["443", "8443", "10000"]
+    assert data[2]["optional"] is True
+
+
+def test_ui_schema_match_no_options(coresys):
+    """Test non-enumerable match patterns stay plain string nodes."""
+    data = UiOptions(coresys)(
+        {
+            "token": "match(^[a-f0-9]{32}$)",
+            "network_key": "match(|[0-9a-fA-F]{32,32})?",
+            "nested_groups": "match(^(a|b)|(c|d)$)",
+            "extra_literal": "match(^(a|b)-suffix$)",
+            "domain": "match(.+\\.duckdns\\.org)",
+            "escaped": "match(^(a\\|b|c)$)",
+        }
+    )
+    for node in data:
+        assert node["type"] == "string"
+        assert "options" not in node
+
+
+def test_extract_match_options_validate():
+    """Test every extracted option validates against its source pattern."""
+    patterns = [
+        "^(?i:(addons|addon_configs|backup|config|media|share|ssl))$",
+        "rsa|dsa|ecdsa|ed25519|rsa",
+        "^(?:443|8443|10000)$",
+        "(?i)^(auto|manual)$",
+    ]
+    for pattern in patterns:
+        options = _extract_match_options(pattern)
+        assert options
+        for option in options:
+            assert re.match(pattern, option)
 
 
 def test_log_entry(coresys, caplog):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Schema elements of type `match()` are rendered in the UI as plain string fields
with no suggestions, even when the regex is a simple alternation of literal
values. The Samba add-on's `enabled_shares`
(`match(^(?i:(addons|addon_configs|backup|config|media|share|ssl))$)`) is the
visible case: the configuration UI shows a multi-value field with an empty
suggestion list (home-assistant/frontend#51510).

This extracts literal options from `match()` patterns that are fully anchored
alternations of plain literals and includes them as `options` on the UI schema
node. Extraction is strictly conservative: the pattern must be anchored with
`^...$`, and any regex metacharacter, escape, class, quantifier, or nested
group falls back to current behavior. Options are deduplicated preserving
order, and the added tests assert that the emitted options are exactly the
values the pattern accepts (case-insensitively for `(?i)` patterns), so
suggestions can never produce a value that fails validation.

Validation (`AppOptions`) is unchanged: fields still validate against the
original regex, so values that only match case-insensitively remain accepted.
Add-on schemas cannot simply switch such fields to `list()` without breaking
existing configs, since `list()` validates case-sensitively.

Surveyed all `match()` patterns across the official add-ons repository and the
largest community repositories (hassio-addons, alexbelgium): 20 of 22 distinct
patterns are unchanged; 2 gain options, both verified to be exactly the
accepted value set.

The frontend counterpart that consumes `options` on multi-value string nodes:
home-assistant/frontend#53077. Older frontends ignore the additional key.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/frontend#51510
- Link to documentation pull request: N/A (the UI schema node format is not
  documented in developers.home-assistant.io; authoring syntax is unchanged)
- Link to cli pull request: N/A (the CLI does not process the schema field)
- Link to client library pull request: N/A (aiohasupervisor types schema nodes
  as `dict[str, Any]`; the additive key needs no model change)

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
