### PR TITLE
Rename Docker app container and builder names from addon_ to app_

### DIFF
--- a/supervisor/docker/app.py
+++ b/supervisor/docker/app.py
@@ -95,7 +95,7 @@ class DockerApp(DockerInterface):
     @staticmethod
     def slug_to_name(slug: str) -> str:
         """Convert slug to container name."""
-        return f"addon_{slug}"
+        return f"app_{slug}"
 
     @property
     def image(self) -> str | None:
@@ -719,7 +719,7 @@ class DockerApp(DockerInterface):
             f"{docker_version.major}.{docker_version.minor}.{docker_version.micro}-cli"
         )
 
-        builder_name = f"addon_builder_{self.app.slug}"
+        builder_name = f"app_builder_{self.app.slug}"
 
         # Remove dangling builder container if it exists by any chance
         # E.g. because of an abrupt host shutdown/reboot during a build

--- a/supervisor/docker/app.py
+++ b/supervisor/docker/app.py
@@ -9,6 +9,7 @@ from http import HTTPStatus
 from ipaddress import IPv4Address
 import logging
 from pathlib import Path
+import re
 import tempfile
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -164,6 +165,9 @@ class DockerApp(DockerInterface):
                 _LOGGER.error,
             ) from err
         except aiodocker.DockerError as err:
+            if err.status == HTTPStatus.NOT_FOUND:
+                # Legacy container removed between lookup and rename, nothing to migrate
+                return None
             raise DockerError(
                 f"Can't rename legacy app container {legacy_name} to {self.name}: {err!s}",
                 _LOGGER.error,
@@ -793,14 +797,17 @@ class DockerApp(DockerInterface):
             f"{docker_version.major}.{docker_version.minor}.{docker_version.micro}-cli"
         )
 
+        # app_builder is the new name used for the builder container but existing containers
+        # created by older versions of Supervisor might still use addon_builder
         builder_name = f"app_builder_{self.app.slug}"
-        legacy_builder_name = f"addon_builder_{self.app.slug}"
+        builder_name_pattern = rf"^(?:app|addon)_builder_{re.escape(self.app.slug)}$"
 
         # Remove dangling builder containers if they exist by any chance
         # E.g. because of an abrupt host shutdown/reboot during a build
         try:
             containers = await self.sys_docker.containers.list(
-                all=True, filters={"name": [builder_name, legacy_builder_name]}
+                all=True,
+                filters={"name": [builder_name_pattern]},
             )
             if containers:
                 await asyncio.gather(

--- a/supervisor/docker/app.py
+++ b/supervisor/docker/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import suppress
 from dataclasses import replace
 from http import HTTPStatus
@@ -113,16 +114,20 @@ class DockerApp(DockerInterface):
     ) -> None:
         """Attach to running Docker container with legacy name migration."""
         docker_container: DockerContainer | None | type[DEFAULT] = DEFAULT
-        if docker_container is DEFAULT:
-            try:
-                docker_container = await self.sys_docker.containers.get(self.name)
-            except TimeoutError:
-                # Keep DockerInterface.attach behavior for timeout while checking the
-                # primary name (it can still attach via image metadata fallback).
-                docker_container = DEFAULT
-            except aiodocker.DockerError as err:
-                if err.status == HTTPStatus.NOT_FOUND:
-                    docker_container = await self._migrate_legacy_container_name()
+        try:
+            docker_container = await self.sys_docker.containers.get(self.name)
+
+        # DockerInterface.attach behavior handles errors getting the container by fetching
+        # image metadata instead. Maintain that by not raising on errors here
+        except TimeoutError:
+            _LOGGER.error("Timeout while retrieving docker container %s", self.name)
+        except aiodocker.DockerError as err:
+            if err.status == HTTPStatus.NOT_FOUND:
+                docker_container = await self._migrate_legacy_container_name()
+            else:
+                _LOGGER.error(
+                    "Error while retrieving docker container %s: %s", self.name, err
+                )
 
         await self._attach(
             version=version,
@@ -130,25 +135,27 @@ class DockerApp(DockerInterface):
             docker_container=docker_container,
         )
 
-    async def _migrate_legacy_container_name(self) -> DockerContainer | None:
+    async def _migrate_legacy_container_name(
+        self,
+    ) -> DockerContainer | None | type[DEFAULT]:
         """Rename a legacy addon_* container to app_* if present."""
         legacy_name = f"addon_{self.app.slug}"
 
         try:
             legacy_container = await self.sys_docker.containers.get(legacy_name)
-        except TimeoutError as err:
-            raise DockerTimeoutError(
-                f"Timeout checking for legacy app container {legacy_name}",
-                _LOGGER.error,
-            ) from err
+        except TimeoutError:
+            _LOGGER.error("Timeout checking for legacy app container %s", legacy_name)
+            return DEFAULT
         except aiodocker.DockerError as err:
             if err.status == HTTPStatus.NOT_FOUND:
                 return None
-            raise DockerError(
-                f"Can't look up legacy app container {legacy_name}: {err!s}",
-                _LOGGER.error,
-            ) from err
+            _LOGGER.error(
+                "Error checking for legacy app container %s: %s", legacy_name, err
+            )
+            return DEFAULT
 
+        # Raise on a rename fail. This means we found the legacy container and could not rename it
+        # so follow-up actions like attach will not work properly regardless
         try:
             await legacy_container.rename(self.name)
         except TimeoutError as err:
@@ -788,26 +795,17 @@ class DockerApp(DockerInterface):
 
         builder_name = f"app_builder_{self.app.slug}"
         legacy_builder_name = f"addon_builder_{self.app.slug}"
-        builder_names = {builder_name, legacy_builder_name}
 
         # Remove dangling builder containers if they exist by any chance
         # E.g. because of an abrupt host shutdown/reboot during a build
         try:
-            containers = await self.sys_docker.containers.list(all=True)
-            for container in containers:
-                names = {
-                    name.removeprefix("/")
-                    for name in container["Names"]
-                    if isinstance(name, str)
-                }
-                if not names & builder_names:
-                    continue
-
-                try:
-                    await container.delete(force=True, v=True)
-                except aiodocker.DockerError as err:
-                    if err.status != HTTPStatus.NOT_FOUND:
-                        raise
+            containers = await self.sys_docker.containers.list(
+                all=True, filters={"name": [builder_name, legacy_builder_name]}
+            )
+            if containers:
+                await asyncio.gather(
+                    *(container.delete(force=True, v=True) for container in containers)
+                )
         except TimeoutError as err:
             raise DockerTimeoutError(
                 "Timeout cleaning up existing builder container",

--- a/supervisor/docker/app.py
+++ b/supervisor/docker/app.py
@@ -12,6 +12,7 @@ import tempfile
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import aiodocker
+from aiodocker.containers import DockerContainer
 from awesomeversion import AwesomeVersion
 
 from ..apps.build import AppBuild
@@ -42,6 +43,7 @@ from ..hardware.data import Device
 from ..jobs.const import JobConcurrency, JobCondition
 from ..jobs.decorator import Job
 from ..resolution.const import CGROUP_V2_VERSION, ContextType, IssueType, SuggestionType
+from ..utils.sentinel import DEFAULT
 from ..utils.sentry import async_capture_exception
 from .const import (
     ADDON_BUILDER_IMAGE,
@@ -101,6 +103,71 @@ class DockerApp(DockerInterface):
     def image(self) -> str | None:
         """Return name of Docker image."""
         return self.app.image
+
+    @Job(name="docker_app_attach", concurrency=JobConcurrency.GROUP_QUEUE)
+    async def attach(
+        self,
+        version: AwesomeVersion,
+        *,
+        skip_state_event_if_down: bool = False,
+    ) -> None:
+        """Attach to running Docker container with legacy name migration."""
+        docker_container: DockerContainer | None | type[DEFAULT] = DEFAULT
+        if docker_container is DEFAULT:
+            try:
+                docker_container = await self.sys_docker.containers.get(self.name)
+            except TimeoutError:
+                # Keep DockerInterface.attach behavior for timeout while checking the
+                # primary name (it can still attach via image metadata fallback).
+                docker_container = DEFAULT
+            except aiodocker.DockerError as err:
+                if err.status == HTTPStatus.NOT_FOUND:
+                    docker_container = await self._migrate_legacy_container_name()
+
+        await self._attach(
+            version=version,
+            skip_state_event_if_down=skip_state_event_if_down,
+            docker_container=docker_container,
+        )
+
+    async def _migrate_legacy_container_name(self) -> DockerContainer | None:
+        """Rename a legacy addon_* container to app_* if present."""
+        legacy_name = f"addon_{self.app.slug}"
+
+        try:
+            legacy_container = await self.sys_docker.containers.get(legacy_name)
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout checking for legacy app container {legacy_name}",
+                _LOGGER.error,
+            ) from err
+        except aiodocker.DockerError as err:
+            if err.status == HTTPStatus.NOT_FOUND:
+                return None
+            raise DockerError(
+                f"Can't look up legacy app container {legacy_name}: {err!s}",
+                _LOGGER.error,
+            ) from err
+
+        try:
+            await legacy_container.rename(self.name)
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout renaming legacy app container {legacy_name} to {self.name}",
+                _LOGGER.error,
+            ) from err
+        except aiodocker.DockerError as err:
+            raise DockerError(
+                f"Can't rename legacy app container {legacy_name} to {self.name}: {err!s}",
+                _LOGGER.error,
+            ) from err
+
+        _LOGGER.info(
+            "Migrated legacy app container name from %s to %s",
+            legacy_name,
+            self.name,
+        )
+        return legacy_container
 
     @property
     def ip_address(self) -> IPv4Address:
@@ -720,22 +787,37 @@ class DockerApp(DockerInterface):
         )
 
         builder_name = f"app_builder_{self.app.slug}"
+        legacy_builder_name = f"addon_builder_{self.app.slug}"
+        builder_names = {builder_name, legacy_builder_name}
 
-        # Remove dangling builder container if it exists by any chance
+        # Remove dangling builder containers if they exist by any chance
         # E.g. because of an abrupt host shutdown/reboot during a build
         try:
-            container = await self.sys_docker.containers.get(builder_name)
-            await container.delete(force=True, v=True)
+            containers = await self.sys_docker.containers.list(all=True)
+            for container in containers:
+                names = {
+                    name.removeprefix("/")
+                    for name in container["Names"]
+                    if isinstance(name, str)
+                }
+                if not names & builder_names:
+                    continue
+
+                try:
+                    await container.delete(force=True, v=True)
+                except aiodocker.DockerError as err:
+                    if err.status != HTTPStatus.NOT_FOUND:
+                        raise
         except TimeoutError as err:
             raise DockerTimeoutError(
                 "Timeout cleaning up existing builder container",
                 _LOGGER.error,
             ) from err
         except aiodocker.DockerError as err:
-            if err.status != HTTPStatus.NOT_FOUND:
-                raise DockerBuildError(
-                    f"Can't clean up existing builder container: {err!s}", _LOGGER.error
-                ) from err
+            raise DockerBuildError(
+                f"Can't clean up existing builder container: {err!s}",
+                _LOGGER.error,
+            ) from err
 
         # Generate Docker config with registry credentials for base image if needed
         docker_config_content = build_env.get_docker_config_json()

--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -13,6 +13,7 @@ from typing import Any
 from uuid import uuid4
 
 import aiodocker
+from aiodocker.containers import DockerContainer
 import aiohttp
 from awesomeversion import AwesomeVersion
 from awesomeversion.strategy import AwesomeVersionStrategy
@@ -42,6 +43,7 @@ from ..jobs.const import JOB_GROUP_DOCKER_INTERFACE, JobConcurrency
 from ..jobs.decorator import Job
 from ..jobs.job_group import JobGroup
 from ..resolution.const import ContextType, IssueType, SuggestionType
+from ..utils.sentinel import DEFAULT
 from ..utils.sentry import async_capture_exception
 from .const import (
     DOCKER_HUB,
@@ -437,28 +439,37 @@ class DockerInterface(JobGroup, ABC):
             return state
         return ContainerState.UNKNOWN
 
-    @Job(name="docker_interface_attach", concurrency=JobConcurrency.GROUP_QUEUE)
-    async def attach(
-        self, version: AwesomeVersion, *, skip_state_event_if_down: bool = False
+    async def _attach(
+        self,
+        version: AwesomeVersion,
+        *,
+        skip_state_event_if_down: bool = False,
+        docker_container: DockerContainer | None | type[DEFAULT] = DEFAULT,
     ) -> None:
         """Attach to running Docker container."""
         with suppress(aiodocker.DockerError, TimeoutError):
-            docker_container = await self.sys_docker.containers.get(self.name)
-            self._meta = await docker_container.show()
-            self.sys_docker.monitor.watch_container(self._meta)
+            if docker_container is DEFAULT:
+                docker_container = await self.sys_docker.containers.get(self.name)
+            if isinstance(docker_container, DockerContainer):
+                self._meta = await docker_container.show()
+                self.sys_docker.monitor.watch_container(self._meta)
 
-            state, exit_code = _container_state_from_model(self._meta)
-            if not (
-                skip_state_event_if_down
-                and state in [ContainerState.STOPPED, ContainerState.FAILED]
-            ):
-                # Fire event with current state of container
-                self.sys_bus.fire_event(
-                    BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
-                    DockerContainerStateEvent(
-                        self.name, state, docker_container.id, int(time()), exit_code
-                    ),
-                )
+                state, exit_code = _container_state_from_model(self._meta)
+                if not (
+                    skip_state_event_if_down
+                    and state in [ContainerState.STOPPED, ContainerState.FAILED]
+                ):
+                    # Fire event with current state of container
+                    self.sys_bus.fire_event(
+                        BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
+                        DockerContainerStateEvent(
+                            self.name,
+                            state,
+                            docker_container.id,
+                            int(time()),
+                            exit_code,
+                        ),
+                    )
 
         if not self._meta and self.image:
             try:
@@ -481,6 +492,19 @@ class DockerInterface(JobGroup, ABC):
                 f"Could not get metadata on container or image for {self.name}"
             )
         _LOGGER.info("Attaching to %s with version %s", self.image, self.version)
+
+    @Job(name="docker_interface_attach", concurrency=JobConcurrency.GROUP_QUEUE)
+    async def attach(
+        self,
+        version: AwesomeVersion,
+        *,
+        skip_state_event_if_down: bool = False,
+    ) -> None:
+        """Attach to running Docker container."""
+        await self._attach(
+            version=version,
+            skip_state_event_if_down=skip_state_event_if_down,
+        )
 
     @Job(
         name="docker_interface_run",

--- a/tests/api/test_apps.py
+++ b/tests/api/test_apps.py
@@ -199,12 +199,12 @@ async def test_api_app_start_healthcheck(
         await asyncio.sleep(0)
 
         await install_app_ssh.container_state_changed(
-            _create_test_event(f"addon_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
+            _create_test_event(f"app_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
         )
         state_changes.append(install_app_ssh.state)
 
         await install_app_ssh.container_state_changed(
-            _create_test_event(f"addon_{TEST_ADDON_SLUG}", ContainerState.HEALTHY)
+            _create_test_event(f"app_{TEST_ADDON_SLUG}", ContainerState.HEALTHY)
         )
 
     async def container_events_task(*args, **kwargs):
@@ -238,12 +238,12 @@ async def test_api_app_restart_healthcheck(
         await asyncio.sleep(0)
 
         await install_app_ssh.container_state_changed(
-            _create_test_event(f"addon_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
+            _create_test_event(f"app_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
         )
         state_changes.append(install_app_ssh.state)
 
         await install_app_ssh.container_state_changed(
-            _create_test_event(f"addon_{TEST_ADDON_SLUG}", ContainerState.HEALTHY)
+            _create_test_event(f"app_{TEST_ADDON_SLUG}", ContainerState.HEALTHY)
         )
 
     async def container_events_task(*args, **kwargs):
@@ -282,18 +282,18 @@ async def test_api_app_rebuild_healthcheck(
         nonlocal state_changes
 
         await install_app_ssh.container_state_changed(
-            _create_test_event(f"addon_{TEST_ADDON_SLUG}", ContainerState.STOPPED)
+            _create_test_event(f"app_{TEST_ADDON_SLUG}", ContainerState.STOPPED)
         )
         state_changes.append(install_app_ssh.state)
 
         await install_app_ssh.container_state_changed(
-            _create_test_event(f"addon_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
+            _create_test_event(f"app_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
         )
         state_changes.append(install_app_ssh.state)
         await asyncio.sleep(0)
 
         await install_app_ssh.container_state_changed(
-            _create_test_event(f"addon_{TEST_ADDON_SLUG}", ContainerState.HEALTHY)
+            _create_test_event(f"app_{TEST_ADDON_SLUG}", ContainerState.HEALTHY)
         )
 
     async def container_events_task(*args, **kwargs):
@@ -353,18 +353,18 @@ async def test_api_app_rebuild_force(
         nonlocal state_changes
 
         await install_app_ssh.container_state_changed(
-            _create_test_event(f"addon_{TEST_ADDON_SLUG}", ContainerState.STOPPED)
+            _create_test_event(f"app_{TEST_ADDON_SLUG}", ContainerState.STOPPED)
         )
         state_changes.append(install_app_ssh.state)
 
         await install_app_ssh.container_state_changed(
-            _create_test_event(f"addon_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
+            _create_test_event(f"app_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
         )
         state_changes.append(install_app_ssh.state)
         await asyncio.sleep(0)
 
         await install_app_ssh.container_state_changed(
-            _create_test_event(f"addon_{TEST_ADDON_SLUG}", ContainerState.HEALTHY)
+            _create_test_event(f"app_{TEST_ADDON_SLUG}", ContainerState.HEALTHY)
         )
 
     async def container_events_task(*args, **kwargs):

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -229,7 +229,7 @@ async def test_api_store_update_healthcheck(
 
         await install_app_ssh.container_state_changed(
             DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
+                name=f"app_{TEST_ADDON_SLUG}",
                 state=ContainerState.STOPPED,
                 id="abc123",
                 time=1,
@@ -239,7 +239,7 @@ async def test_api_store_update_healthcheck(
         state_changes.append(install_app_ssh.state)
         await install_app_ssh.container_state_changed(
             DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
+                name=f"app_{TEST_ADDON_SLUG}",
                 state=ContainerState.RUNNING,
                 id="abc123",
                 time=1,
@@ -249,7 +249,7 @@ async def test_api_store_update_healthcheck(
         state_changes.append(install_app_ssh.state)
         await install_app_ssh.container_state_changed(
             DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
+                name=f"app_{TEST_ADDON_SLUG}",
                 state=ContainerState.HEALTHY,
                 id="abc123",
                 time=1,

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -1363,15 +1363,15 @@ async def test_app_disable_boot_dismisses_boot_fail(
     ("docker_message", "port"),
     [
         (
-            "failed to set up container networking: driver failed programming external connectivity on endpoint addon_local_ssh (ea4d0fdaa72cf86f2c9199a04208e3eaf0c5a0d6fd34b3c7f4fab2daadb1f3a9): failed to bind host port for 0.0.0.0:2222:172.30.33.4:22/tcp: address already in use",
+            "failed to set up container networking: driver failed programming external connectivity on endpoint app_local_ssh (ea4d0fdaa72cf86f2c9199a04208e3eaf0c5a0d6fd34b3c7f4fab2daadb1f3a9): failed to bind host port for 0.0.0.0:2222:172.30.33.4:22/tcp: address already in use",
             2222,
         ),
         (
-            "failed to set up container networking: driver failed programming external connectivity on endpoint addon_local_ssh (ea4d0fdaa72cf86f2c9199a04208e3eaf0c5a0d6fd34b3c7f4fab2daadb1f3a9): Bind for 0.0.0.0:2222 failed: port is already allocated",
+            "failed to set up container networking: driver failed programming external connectivity on endpoint app_local_ssh (ea4d0fdaa72cf86f2c9199a04208e3eaf0c5a0d6fd34b3c7f4fab2daadb1f3a9): Bind for 0.0.0.0:2222 failed: port is already allocated",
             2222,
         ),
         (
-            "failed to set up container networking: driver failed programming external connectivity on endpoint addon_local_ssh (ea4d0fdaa72cf86f2c9199a04208e3eaf0c5a0d6fd34b3c7f4fab2daadb1f3a9): failed to bind host port 0.0.0.0:2222/tcp: address already in use",
+            "failed to set up container networking: driver failed programming external connectivity on endpoint app_local_ssh (ea4d0fdaa72cf86f2c9199a04208e3eaf0c5a0d6fd34b3c7f4fab2daadb1f3a9): failed to bind host port 0.0.0.0:2222/tcp: address already in use",
             2222,
         ),
     ],
@@ -1405,7 +1405,7 @@ async def test_app_start_port_conflict_error(
         await install_app_ssh.start()
 
     assert (
-        f"Cannot start container addon_local_ssh because port {port} is already in use"
+        f"Cannot start container app_local_ssh because port {port} is already in use"
         in caplog.text
     )
 
@@ -1436,7 +1436,7 @@ async def test_app_restart_port_conflict_creates_issue(
     port = 2222
     docker_message = (
         "failed to set up container networking: driver failed programming external "
-        "connectivity on endpoint addon_local_ssh: failed to bind host port for "
+        "connectivity on endpoint app_local_ssh: failed to bind host port for "
         "0.0.0.0:2222:172.30.33.4:22/tcp: address already in use"
     )
     install_app_ssh.data["image"] = "test/amd64-addon-ssh"

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -143,28 +143,26 @@ async def test_app_state_listener(coresys: CoreSys, install_app_ssh: App) -> Non
 
     with patch.object(App, "watchdog_container"):
         await _fire_test_event(
-            coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.RUNNING
+            coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.RUNNING
         )
         assert install_app_ssh.state == AppState.STARTED
 
         await _fire_test_event(
-            coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.STOPPED
+            coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.STOPPED
         )
         assert install_app_ssh.state == AppState.STOPPED
 
         await _fire_test_event(
-            coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.HEALTHY
+            coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.HEALTHY
         )
         assert install_app_ssh.state == AppState.STARTED
 
-        await _fire_test_event(
-            coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.FAILED
-        )
+        await _fire_test_event(coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.FAILED)
         assert install_app_ssh.state == AppState.ERROR
 
         # Test other apps are ignored
         await _fire_test_event(
-            coresys, "addon_local_non_installed", ContainerState.RUNNING
+            coresys, "app_local_non_installed", ContainerState.RUNNING
         )
         assert install_app_ssh.state == AppState.ERROR
 
@@ -183,7 +181,7 @@ async def test_app_failed_logs_exit_code(
         caplog.clear()
         await _fire_test_event(
             coresys,
-            f"addon_{TEST_ADDON_SLUG}",
+            f"app_{TEST_ADDON_SLUG}",
             ContainerState.FAILED,
             exit_code=143,
         )
@@ -197,7 +195,7 @@ async def test_app_failed_logs_exit_code(
         caplog.clear()
         await _fire_test_event(
             coresys,
-            f"addon_{TEST_ADDON_SLUG}",
+            f"app_{TEST_ADDON_SLUG}",
             ContainerState.FAILED,
             exit_code=1,
         )
@@ -206,9 +204,7 @@ async def test_app_failed_logs_exit_code(
 
         # No exit code available: stay silent
         caplog.clear()
-        await _fire_test_event(
-            coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.FAILED
-        )
+        await _fire_test_event(coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.FAILED)
         assert not any(
             "exit code" in r.message or "SIGTERM" in r.message for r in caplog.records
         )
@@ -234,7 +230,7 @@ async def test_app_watchdog(coresys: CoreSys, install_app_ssh: App) -> None:
         # Restart if it becomes unhealthy
         current_state.return_value = ContainerState.UNHEALTHY
         await _fire_test_event(
-            coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.UNHEALTHY
+            coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.UNHEALTHY
         )
         restart.assert_called_once()
         start.assert_not_called()
@@ -246,7 +242,7 @@ async def test_app_watchdog(coresys: CoreSys, install_app_ssh: App) -> None:
         with patch.object(DockerApp, "stop") as stop:
             await _fire_test_event(
                 coresys,
-                f"addon_{TEST_ADDON_SLUG}",
+                f"app_{TEST_ADDON_SLUG}",
                 ContainerState.FAILED,
                 exit_code=1,
             )
@@ -260,7 +256,7 @@ async def test_app_watchdog(coresys: CoreSys, install_app_ssh: App) -> None:
         current_state.return_value = ContainerState.HEALTHY
         await _fire_test_event(
             coresys,
-            f"addon_{TEST_ADDON_SLUG}",
+            f"app_{TEST_ADDON_SLUG}",
             ContainerState.FAILED,
             exit_code=1,
         )
@@ -270,7 +266,7 @@ async def test_app_watchdog(coresys: CoreSys, install_app_ssh: App) -> None:
         # Other apps ignored
         current_state.return_value = ContainerState.UNHEALTHY
         await _fire_test_event(
-            coresys, "addon_local_non_installed", ContainerState.UNHEALTHY
+            coresys, "app_local_non_installed", ContainerState.UNHEALTHY
         )
         restart.assert_not_called()
         start.assert_not_called()
@@ -299,7 +295,7 @@ async def test_watchdog_port_conflict_does_not_retry(
         caplog.clear()
         await _fire_test_event(
             coresys,
-            f"addon_{TEST_ADDON_SLUG}",
+            f"app_{TEST_ADDON_SLUG}",
             ContainerState.FAILED,
             exit_code=1,
         )
@@ -331,20 +327,20 @@ async def test_watchdog_on_stop(coresys: CoreSys, install_app_ssh: App) -> None:
     ):
         # Do not restart when app stopped by user
         await _fire_test_event(
-            coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.RUNNING
+            coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.RUNNING
         )
         await install_app_ssh.stop()
         await _fire_test_event(
-            coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.STOPPED
+            coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.STOPPED
         )
         restart.assert_not_called()
 
         # Do restart app if it stops and user didn't do it
         await _fire_test_event(
-            coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.RUNNING
+            coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.RUNNING
         )
         await _fire_test_event(
-            coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.STOPPED
+            coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.STOPPED
         )
         restart.assert_called_once()
 
@@ -372,7 +368,7 @@ async def test_listener_attached_on_install(coresys: CoreSys):
     # Normally this would be defaulted to False on start of the app but test skips that
     coresys.apps.get_local_only(TEST_ADDON_SLUG).watchdog = False
 
-    await _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
+    await _fire_test_event(coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
     assert coresys.apps.get(TEST_ADDON_SLUG).state == AppState.STARTED
 
 
@@ -412,7 +408,7 @@ async def test_watchdog_during_attach(
 
         await app.load()
         await _fire_test_event(
-            coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.STOPPED
+            coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.STOPPED
         )
 
         assert restart.call_count == restart_count
@@ -496,7 +492,7 @@ async def test_start(coresys: CoreSys, install_app_ssh: App) -> None:
     start_task = await install_app_ssh.start()
     assert start_task
 
-    await _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
+    await _fire_test_event(coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
     await start_task
     assert install_app_ssh.state == AppState.STARTED
 
@@ -519,12 +515,12 @@ async def test_start_wait_healthcheck(
     start_task = await install_app_ssh.start()
     assert start_task
 
-    await _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
+    await _fire_test_event(coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
 
     assert not start_task.done()
     assert install_app_ssh.state == AppState.STARTUP
 
-    await _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", state)
+    await _fire_test_event(coresys, f"app_{TEST_ADDON_SLUG}", state)
 
     assert start_task.done()
     assert install_app_ssh.state == AppState.STARTED
@@ -563,7 +559,7 @@ async def test_restart(coresys: CoreSys, install_app_ssh: App) -> None:
     start_task = await install_app_ssh.restart()
     assert start_task
 
-    await _fire_test_event(coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
+    await _fire_test_event(coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.RUNNING)
     await start_task
     assert install_app_ssh.state == AppState.STARTED
 
@@ -763,7 +759,7 @@ async def test_backup_cold_mode_with_watchdog(
         container.show.return_value["State"]["Status"] = "stopped"
         container.show.return_value["State"]["Running"] = False
         await _fire_test_event(
-            coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.STOPPED
+            coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.STOPPED
         )
 
     # Patching out the normal end of backup process leaves the container in a stopped state
@@ -849,7 +845,7 @@ async def test_restore_while_running_with_watchdog(
         container.show.return_value["State"]["Status"] = "stopped"
         container.show.return_value["State"]["Running"] = False
         await _fire_test_event(
-            coresys, f"addon_{TEST_ADDON_SLUG}", ContainerState.STOPPED
+            coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.STOPPED
         )
 
     # We restore a stopped backup so restore will not restart it

--- a/tests/apps/test_manager.py
+++ b/tests/apps/test_manager.py
@@ -272,7 +272,7 @@ async def test_load(coresys: CoreSys, caplog: pytest.LogCaptureFixture):
     caplog.clear()
 
     with (
-        patch.object(DockerInterface, "attach") as attach,
+        patch.object(DockerApp, "attach") as attach,
         patch.object(PluginDns, "write_hosts") as write_hosts,
     ):
         await coresys.apps.load()

--- a/tests/apps/test_manager.py
+++ b/tests/apps/test_manager.py
@@ -300,7 +300,7 @@ async def test_boot_waits_for_apps(coresys: CoreSys, install_app_ssh: App):
         coresys.bus.fire_event(
             BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
             DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
+                name=f"app_{TEST_ADDON_SLUG}",
                 state=ContainerState.RUNNING,
                 id="abc123",
                 time=1,
@@ -388,7 +388,7 @@ async def test_start_wait_resolved_on_uninstall_in_startup(
         coresys,
         BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
         DockerContainerStateEvent(
-            name=f"addon_{TEST_ADDON_SLUG}",
+            name=f"app_{TEST_ADDON_SLUG}",
             state=ContainerState.RUNNING,
             id="abc123",
             time=1,
@@ -506,7 +506,7 @@ async def test_watchdog_runs_during_update(
         coresys.bus.fire_event(
             BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
             DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
+                name=f"app_{TEST_ADDON_SLUG}",
                 state=ContainerState.STOPPED,
                 id="abc123",
                 time=1,

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -980,7 +980,7 @@ async def test_backup_with_healthcheck(
 
         await install_app_ssh.container_state_changed(
             DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
+                name=f"app_{TEST_ADDON_SLUG}",
                 state=ContainerState.STOPPED,
                 id="abc123",
                 time=1,
@@ -990,7 +990,7 @@ async def test_backup_with_healthcheck(
         state_changes.append(install_app_ssh.state)
         await install_app_ssh.container_state_changed(
             DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
+                name=f"app_{TEST_ADDON_SLUG}",
                 state=ContainerState.RUNNING,
                 id="abc123",
                 time=1,
@@ -1000,7 +1000,7 @@ async def test_backup_with_healthcheck(
         state_changes.append(install_app_ssh.state)
         await install_app_ssh.container_state_changed(
             DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
+                name=f"app_{TEST_ADDON_SLUG}",
                 state=ContainerState.HEALTHY,
                 id="abc123",
                 time=1,
@@ -1058,7 +1058,7 @@ async def test_restore_with_healthcheck(
 
         await install_app_ssh.container_state_changed(
             DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
+                name=f"app_{TEST_ADDON_SLUG}",
                 state=ContainerState.STOPPED,
                 id="abc123",
                 time=1,
@@ -1068,7 +1068,7 @@ async def test_restore_with_healthcheck(
         state_changes.append(install_app_ssh.state)
         await install_app_ssh.container_state_changed(
             DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
+                name=f"app_{TEST_ADDON_SLUG}",
                 state=ContainerState.RUNNING,
                 id="abc123",
                 time=1,
@@ -1078,7 +1078,7 @@ async def test_restore_with_healthcheck(
         state_changes.append(install_app_ssh.state)
         await install_app_ssh.container_state_changed(
             DockerContainerStateEvent(
-                name=f"addon_{TEST_ADDON_SLUG}",
+                name=f"app_{TEST_ADDON_SLUG}",
                 state=ContainerState.HEALTHY,
                 id="abc123",
                 time=1,

--- a/tests/docker/test_app.py
+++ b/tests/docker/test_app.py
@@ -5,7 +5,7 @@ from http import HTTPStatus
 from ipaddress import IPv4Address
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, Mock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, PropertyMock, call, patch
 
 import aiodocker
 import pytest
@@ -850,6 +850,48 @@ async def test_app_options_device_policy_check(
 
 
 @pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
+async def test_app_attach_migrates_legacy_container_name(
+    coresys: CoreSys,
+    install_app_ssh: App,
+    container: MagicMock,
+):
+    """Test attach renames legacy addon_* container names to app_* once."""
+    legacy_container = container
+    legacy_container.rename = AsyncMock()
+
+    coresys.docker.containers.get.reset_mock()
+    coresys.docker.containers.get.side_effect = [
+        aiodocker.DockerError(HTTPStatus.NOT_FOUND, {"message": "missing"}),
+        legacy_container,
+    ]
+
+    await install_app_ssh.instance.attach(install_app_ssh.version)
+
+    assert coresys.docker.containers.get.call_args_list == [
+        call(install_app_ssh.instance.name),
+        call(f"addon_{install_app_ssh.slug}"),
+    ]
+    legacy_container.rename.assert_called_once_with(install_app_ssh.instance.name)
+
+
+@pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
+async def test_app_attach_reuses_prefetched_container(
+    coresys: CoreSys,
+    install_app_ssh: App,
+    container: MagicMock,
+):
+    """Test attach only performs one get call when app_* container already exists."""
+    coresys.docker.containers.get.reset_mock()
+    coresys.docker.containers.get.return_value = container
+
+    await install_app_ssh.instance.attach(install_app_ssh.version)
+
+    assert coresys.docker.containers.get.call_args_list == [
+        call(install_app_ssh.instance.name)
+    ]
+
+
+@pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
 async def test_app_build_builder_cleanup_timeout(
     coresys: CoreSys, addonsdata_system: dict[str, Data]
 ):
@@ -858,7 +900,7 @@ async def test_app_build_builder_cleanup_timeout(
 
     mock_build_env = MagicMock()
     mock_build_env.is_valid = AsyncMock()
-    coresys.docker.containers.get.return_value.delete.side_effect = TimeoutError()
+    coresys.docker.containers.list.side_effect = TimeoutError()
 
     with (
         patch(
@@ -870,6 +912,54 @@ async def test_app_build_builder_cleanup_timeout(
         ),
     ):
         await docker_app.install(docker_app.version, need_build=True)
+
+
+@pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
+async def test_app_build_cleans_up_legacy_builder_container(
+    coresys: CoreSys, addonsdata_system: dict[str, Data]
+):
+    """Test _build also cleans up legacy addon_builder_* containers."""
+    docker_app = get_docker_app(coresys, addonsdata_system, "basic-app-config.json")
+
+    mock_build_env = MagicMock()
+    mock_build_env.is_valid = AsyncMock()
+    mock_build_env.get_docker_config_json.return_value = None
+    mock_build_env.get_docker_args.return_value = {}
+
+    unrelated_container = MagicMock()
+    unrelated_container.__getitem__.side_effect = lambda key: {
+        "Names": ["/unrelated_container"]
+    }[key]
+
+    legacy_builder_container = MagicMock()
+    legacy_builder_container.delete = AsyncMock()
+    legacy_builder_container.__getitem__.side_effect = lambda key: {
+        "Names": [f"/addon_builder_{docker_app.app.slug}"]
+    }[key]
+
+    app_builder_container = MagicMock()
+    app_builder_container.delete = AsyncMock()
+    app_builder_container.__getitem__.side_effect = lambda key: {
+        "Names": [f"/app_builder_{docker_app.app.slug}"]
+    }[key]
+
+    coresys.docker.containers.list.reset_mock()
+    coresys.docker.containers.list.return_value = [
+        unrelated_container,
+        legacy_builder_container,
+        app_builder_container,
+    ]
+    coresys.docker.run_command = AsyncMock(return_value=MagicMock(exit_code=0, log=[]))
+
+    with patch(
+        "supervisor.docker.app.AppBuild.create",
+        AsyncMock(return_value=mock_build_env),
+    ):
+        await docker_app.install(docker_app.version, need_build=True)
+
+    coresys.docker.containers.list.assert_called_once_with(all=True)
+    legacy_builder_container.delete.assert_called_once_with(force=True, v=True)
+    app_builder_container.delete.assert_called_once_with(force=True, v=True)
 
 
 @pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")

--- a/tests/docker/test_app.py
+++ b/tests/docker/test_app.py
@@ -939,12 +939,7 @@ async def test_app_build_cleans_up_builder_container(
 
     coresys.docker.containers.list.assert_called_once_with(
         all=True,
-        filters={
-            "name": [
-                f"app_builder_{docker_app.app.slug}",
-                f"addon_builder_{docker_app.app.slug}",
-            ]
-        },
+        filters={"name": ["^(?:app|addon)_builder_test_addon$"]},
     )
     builder_container.delete.assert_called_once_with(force=True, v=True)
 

--- a/tests/docker/test_app.py
+++ b/tests/docker/test_app.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, PropertyMock, call, patch
 
 import aiodocker
+from aiodocker.containers import DockerContainer
 import pytest
 
 from supervisor.apps import validate as vd
@@ -915,10 +916,10 @@ async def test_app_build_builder_cleanup_timeout(
 
 
 @pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
-async def test_app_build_cleans_up_legacy_builder_container(
+async def test_app_build_cleans_up_builder_container(
     coresys: CoreSys, addonsdata_system: dict[str, Data]
 ):
-    """Test _build also cleans up legacy addon_builder_* containers."""
+    """Test _build also cleans up existing builder containers."""
     docker_app = get_docker_app(coresys, addonsdata_system, "basic-app-config.json")
 
     mock_build_env = MagicMock()
@@ -926,29 +927,8 @@ async def test_app_build_cleans_up_legacy_builder_container(
     mock_build_env.get_docker_config_json.return_value = None
     mock_build_env.get_docker_args.return_value = {}
 
-    unrelated_container = MagicMock()
-    unrelated_container.__getitem__.side_effect = lambda key: {
-        "Names": ["/unrelated_container"]
-    }[key]
-
-    legacy_builder_container = MagicMock()
-    legacy_builder_container.delete = AsyncMock()
-    legacy_builder_container.__getitem__.side_effect = lambda key: {
-        "Names": [f"/addon_builder_{docker_app.app.slug}"]
-    }[key]
-
-    app_builder_container = MagicMock()
-    app_builder_container.delete = AsyncMock()
-    app_builder_container.__getitem__.side_effect = lambda key: {
-        "Names": [f"/app_builder_{docker_app.app.slug}"]
-    }[key]
-
-    coresys.docker.containers.list.reset_mock()
-    coresys.docker.containers.list.return_value = [
-        unrelated_container,
-        legacy_builder_container,
-        app_builder_container,
-    ]
+    builder_container = AsyncMock(spec=DockerContainer)
+    coresys.docker.containers.list.return_value = [builder_container]
     coresys.docker.run_command = AsyncMock(return_value=MagicMock(exit_code=0, log=[]))
 
     with patch(
@@ -957,9 +937,16 @@ async def test_app_build_cleans_up_legacy_builder_container(
     ):
         await docker_app.install(docker_app.version, need_build=True)
 
-    coresys.docker.containers.list.assert_called_once_with(all=True)
-    legacy_builder_container.delete.assert_called_once_with(force=True, v=True)
-    app_builder_container.delete.assert_called_once_with(force=True, v=True)
+    coresys.docker.containers.list.assert_called_once_with(
+        all=True,
+        filters={
+            "name": [
+                f"app_builder_{docker_app.app.slug}",
+                f"addon_builder_{docker_app.app.slug}",
+            ]
+        },
+    )
+    builder_container.delete.assert_called_once_with(force=True, v=True)
 
 
 @pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")

--- a/tests/homeassistant/test_api.py
+++ b/tests/homeassistant/test_api.py
@@ -218,7 +218,7 @@ async def test_container_state_changed_ignores_other_containers(
     caplog.clear()
     await api.container_state_changed(
         DockerContainerStateEvent(
-            name="addon_local_ssh",
+            name="app_local_ssh",
             state=ContainerState.STOPPED,
             id="abc123",
             time=1234567890,

--- a/tests/homeassistant/test_home_assistant_watchdog.py
+++ b/tests/homeassistant/test_home_assistant_watchdog.py
@@ -102,7 +102,7 @@ async def test_home_assistant_watchdog(coresys: CoreSys) -> None:
             coresys,
             BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
             DockerContainerStateEvent(
-                name="addon_local_other",
+                name="app_local_other",
                 state=ContainerState.UNHEALTHY,
                 id="abc123",
                 time=1,

--- a/tests/plugins/test_plugin_base.py
+++ b/tests/plugins/test_plugin_base.py
@@ -141,7 +141,7 @@ async def test_plugin_watchdog(coresys: CoreSys, plugin: PluginBase) -> None:
             coresys,
             BusEvent.DOCKER_CONTAINER_STATE_CHANGE,
             DockerContainerStateEvent(
-                name="addon_local_other",
+                name="app_local_other",
                 state=ContainerState.UNHEALTHY,
                 id="abc123",
                 time=1,

--- a/tests/resolution/check/test_check_docker_config.py
+++ b/tests/resolution/check/test_check_docker_config.py
@@ -87,7 +87,7 @@ async def test_base(coresys: CoreSys):
 async def test_check(docker: DockerAPI, coresys: CoreSys, folder: str):
     """Test check reports issue when containers have incorrect config."""
     docker.containers.get = _make_mock_container_get(
-        ["homeassistant", "hassio_audio", "addon_local_ssh"], folder
+        ["homeassistant", "hassio_audio", "app_local_ssh"], folder
     )
     # Use state used in setup()
     await coresys.core.set_state(CoreState.SETUP)
@@ -174,7 +174,7 @@ async def test_app_volume_mount_not_flagged(
 
     # Mock container that has VOLUME mount to media/share with wrong propagation
     docker.containers.get = _make_mock_container_get_with_volume_mount(
-        ["addon_local_ssh"], folder
+        ["app_local_ssh"], folder
     )
 
     await coresys.core.set_state(CoreState.SETUP)
@@ -237,7 +237,7 @@ async def test_app_configured_mount_still_flagged(
             },
             "Mounts": [],
         }
-        if name == "addon_local_ssh":
+        if name == "app_local_ssh":
             out.show.return_value["Mounts"].append(mount)
         return out
 
@@ -296,7 +296,7 @@ async def test_app_custom_target_path_flagged(
             "Propagation": "rprivate",  # Wrong propagation
         }
 
-        if name == "addon_local_ssh":
+        if name == "app_local_ssh":
             out.show.return_value["Mounts"].append(mount)
         return out
 

--- a/tests/resolution/fixup/test_app_execute_rebuild.py
+++ b/tests/resolution/fixup/test_app_execute_rebuild.py
@@ -75,7 +75,7 @@ async def test_fixup_stopped_core(
 
     assert not coresys.resolution.issues
     assert not coresys.resolution.suggestions
-    (await docker.containers.get("addon_local_ssh")).delete.assert_called_once_with(
+    (await docker.containers.get("app_local_ssh")).delete.assert_called_once_with(
         force=True, v=True
     )
     assert "App local_ssh is stopped" in caplog.text


### PR DESCRIPTION
## Proposed change

The Docker container name for each installed app (and its transient build container) was still derived as `addon_{slug}` / `addon_builder_{slug}`. This renames them to `app_{slug}` / `app_builder_{slug}` to match the broader addon→app rename.

The container naming pattern lives in `DockerApp.slug_to_name()` and `_build()` in `supervisor/docker/app.py`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #6744
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

While direct container name interaction is undocumented and not recommended, it was technically possible for users to reference containers by name (e.g. `docker exec addon_local_ssh ...`). Those names now become `app_local_ssh`, etc. This is intentionally a breaking change as part of the addon→app migration.

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
