### PR TITLE
Refactor internal addon identifiers to app naming

### DIFF
--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -135,7 +135,7 @@ _OPTIONS_MERGER: Final = Merger(
 
 # Backups just need to know if an app was running or not
 # Map other app states to those two
-_MAP_ADDON_STATE = {
+_MAP_APP_STATE = {
     AppState.STARTUP: AppState.STARTED,
     AppState.ERROR: AppState.STOPPED,
     AppState.UNKNOWN: AppState.STOPPED,
@@ -1536,7 +1536,7 @@ class App(AppModel):
             ATTR_USER: self.persist,
             ATTR_SYSTEM: self.data,
             ATTR_VERSION: self.version,
-            ATTR_STATE: _MAP_ADDON_STATE.get(self.state, self.state),
+            ATTR_STATE: _MAP_APP_STATE.get(self.state, self.state),
         }
         apparmor_profile = (
             self.slug if self.sys_host.apparmor.exists(self.slug) else None

--- a/supervisor/apps/model.py
+++ b/supervisor/apps/model.py
@@ -98,7 +98,7 @@ from ..exceptions import (
     AppNotSupportedMachineTypeError,
     HassioArchNotFound,
 )
-from ..jobs.const import JOB_GROUP_ADDON
+from ..jobs.const import JOB_GROUP_APP
 from ..jobs.job_group import JobGroup
 from ..utils import version_is_new_enough
 from ..utils.dt import utc_from_timestamp
@@ -125,7 +125,7 @@ class AppModel(JobGroup, ABC):
     def __init__(self, coresys: CoreSys, slug: str):
         """Initialize data holder."""
         super().__init__(
-            coresys, JOB_GROUP_ADDON.format_map(defaultdict(str, slug=slug)), slug
+            coresys, JOB_GROUP_APP.format_map(defaultdict(str, slug=slug)), slug
         )
         self.slug: str = slug
         self._path_icon_exists: bool = False

--- a/supervisor/const.py
+++ b/supervisor/const.py
@@ -21,7 +21,7 @@ DNS_DOCKER_NAME: str = f"{DOCKER_PREFIX}_dns"
 OBSERVER_DOCKER_NAME: str = f"{DOCKER_PREFIX}_observer"
 SUPERVISOR_DOCKER_NAME: str = f"{DOCKER_PREFIX}_supervisor"
 
-URL_HASSIO_ADDONS = "https://github.com/home-assistant/addons"
+URL_HASSIO_APPS = "https://github.com/home-assistant/addons"
 URL_HASSIO_APPARMOR = "https://version.home-assistant.io/apparmor_{channel}.txt"
 URL_HASSIO_VERSION = "https://version.home-assistant.io/{channel}.json"
 

--- a/supervisor/jobs/const.py
+++ b/supervisor/jobs/const.py
@@ -9,7 +9,7 @@ FILE_CONFIG_JOBS = Path(SUPERVISOR_DATA, "jobs.json")
 
 ATTR_IGNORE_CONDITIONS = "ignore_conditions"
 
-JOB_GROUP_ADDON = "addon_{slug}"
+JOB_GROUP_APP = "app_{slug}"
 JOB_GROUP_BACKUP = "backup_{slug}"
 JOB_GROUP_BACKUP_MANAGER = "backup_manager"
 JOB_GROUP_DOCKER_INTERFACE = "container_{name}"

--- a/supervisor/misc/tasks.py
+++ b/supervisor/misc/tasks.py
@@ -31,14 +31,14 @@ HASS_WATCHDOG_REANIMATE_FAILURES = "HASS_WATCHDOG_REANIMATE_FAILURES"
 HASS_WATCHDOG_MAX_API_ATTEMPTS = 2
 HASS_WATCHDOG_MAX_REANIMATE_ATTEMPTS = 5
 
-RUN_UPDATE_ADDONS = 57600
+RUN_UPDATE_APPS = 57600
 RUN_UPDATE_CLI = 43200  # 12h, staggered +2min per plugin
 RUN_UPDATE_DNS = 43320
 RUN_UPDATE_AUDIO = 43440
 RUN_UPDATE_MULTICAST = 43560
 RUN_UPDATE_OBSERVER = 43680
 
-RUN_RELOAD_ADDONS = 10800
+RUN_RELOAD_APPS = 10800
 RUN_RELOAD_BACKUPS = 72000
 RUN_RELOAD_HOST = 7600
 RUN_RELOAD_UPDATER = 86400  # 24h
@@ -47,7 +47,7 @@ RUN_RELOAD_MOUNTS = 900
 
 RUN_WATCHDOG_HOMEASSISTANT_API = 120
 
-RUN_WATCHDOG_ADDON_APPLICATON = 120
+RUN_WATCHDOG_APP_APPLICATION = 120
 RUN_WATCHDOG_OBSERVER_APPLICATION = 180
 
 RUN_CORE_BACKUP_CLEANUP = 86200
@@ -71,7 +71,7 @@ class Tasks(CoreSysAttributes):
     async def load(self):
         """Add Tasks to scheduler."""
         # Update
-        self.sys_scheduler.register_task(self._update_apps, RUN_UPDATE_ADDONS)
+        self.sys_scheduler.register_task(self._update_apps, RUN_UPDATE_APPS)
         self.sys_scheduler.register_task(self._update_cli, RUN_UPDATE_CLI)
         self.sys_scheduler.register_task(self._update_dns, RUN_UPDATE_DNS)
         self.sys_scheduler.register_task(self._update_audio, RUN_UPDATE_AUDIO)
@@ -79,7 +79,7 @@ class Tasks(CoreSysAttributes):
         self.sys_scheduler.register_task(self._update_observer, RUN_UPDATE_OBSERVER)
 
         # Reload
-        self.sys_scheduler.register_task(self._reload_store, RUN_RELOAD_ADDONS)
+        self.sys_scheduler.register_task(self._reload_store, RUN_RELOAD_APPS)
         self.sys_scheduler.register_task(self._reload_updater, RUN_RELOAD_UPDATER)
         self.sys_scheduler.register_task(self.sys_backups.reload, RUN_RELOAD_BACKUPS)
         self.sys_scheduler.register_task(self.sys_host.reload, RUN_RELOAD_HOST)
@@ -94,7 +94,7 @@ class Tasks(CoreSysAttributes):
             self._watchdog_observer_application, RUN_WATCHDOG_OBSERVER_APPLICATION
         )
         self.sys_scheduler.register_task(
-            self._watchdog_app_application, RUN_WATCHDOG_ADDON_APPLICATON
+            self._watchdog_app_application, RUN_WATCHDOG_APP_APPLICATION
         )
 
         # Cleanup

--- a/supervisor/store/__init__.py
+++ b/supervisor/store/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import Awaitable
 import logging
 
-from ..const import ATTR_REPOSITORIES, REPOSITORY_CORE, URL_HASSIO_ADDONS
+from ..const import ATTR_REPOSITORIES, REPOSITORY_CORE, URL_HASSIO_APPS
 from ..coresys import CoreSys, CoreSysAttributes
 from ..exceptions import (
     StoreError,
@@ -133,7 +133,7 @@ class StoreManager(CoreSysAttributes, FileConfiguration):
         self, url: str, *, persist: bool = True, issue_on_error: bool = False
     ) -> None:
         """Add a repository."""
-        if url == URL_HASSIO_ADDONS:
+        if url == URL_HASSIO_APPS:
             url = REPOSITORY_CORE
 
         repository = Repository.create(self.coresys, url)

--- a/supervisor/store/const.py
+++ b/supervisor/store/const.py
@@ -3,12 +3,7 @@
 from enum import StrEnum
 from pathlib import Path
 
-from ..const import (
-    REPOSITORY_CORE,
-    REPOSITORY_LOCAL,
-    SUPERVISOR_DATA,
-    URL_HASSIO_ADDONS,
-)
+from ..const import REPOSITORY_CORE, REPOSITORY_LOCAL, SUPERVISOR_DATA, URL_HASSIO_APPS
 
 FILE_HASSIO_STORE = Path(SUPERVISOR_DATA, "store.json")
 """Repository type definitions for the store."""
@@ -22,7 +17,7 @@ class BuiltinRepository(StrEnum):
 
     # Git-based built-in repositories
     CORE = REPOSITORY_CORE
-    COMMUNITY_ADDONS = "https://github.com/hassio-addons/repository"
+    COMMUNITY_APPS = "https://github.com/hassio-addons/repository"
     ESPHOME = "https://github.com/esphome/home-assistant-addon"
     MUSIC_ASSISTANT = "https://github.com/music-assistant/home-assistant-addon"
 
@@ -32,5 +27,5 @@ class BuiltinRepository(StrEnum):
         if self == BuiltinRepository.LOCAL:
             raise RuntimeError("Local repository does not have a git URL")
         if self == BuiltinRepository.CORE:
-            return URL_HASSIO_ADDONS
+            return URL_HASSIO_APPS
         return self.value  # For URL-based repos, value is the URL


### PR DESCRIPTION
## Proposed change

Refactors a small set of internal identifiers from addon/addons naming to app/apps naming, limited to non-API, non-compatibility symbols targeted for this PR:

- `JOB_GROUP_ADDON` -> `JOB_GROUP_APP` (and use `"app_{slug}"`)
- `RUN_UPDATE_ADDONS` -> `RUN_UPDATE_APPS`
- `RUN_RELOAD_ADDONS` -> `RUN_RELOAD_APPS`
- `RUN_WATCHDOG_ADDON_APPLICATON` -> `RUN_WATCHDOG_APP_APPLICATION`
- `URL_HASSIO_ADDONS` -> `URL_HASSIO_APPS`
- `COMMUNITY_ADDONS` -> `COMMUNITY_APPS`
- `_MAP_ADDON_STATE` -> `_MAP_APP_STATE`

The URL values and behavior are unchanged; this is strictly an internal naming refactor.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6698
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/