### PR TITLE
Scope job names by API version and negotiate websocket event version

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -345,12 +345,20 @@ class RestAPI(CoreSysAttributes):
         api_jobs = APIJobs()
         api_jobs.coresys = self.coresys
 
+        # V1 keeps the legacy job names, V2 exposes the new ones.
+        if app is self.versions[AppVersion.V2]:
+            info_handler = api_jobs.info
+            job_info_handler = api_jobs.job_info
+        else:
+            info_handler = api_jobs.info_v1
+            job_info_handler = api_jobs.job_info_v1
+
         app.add_routes(
             [
-                web.get("/jobs/info", api_jobs.info),
+                web.get("/jobs/info", info_handler),
                 web.post("/jobs/options", api_jobs.options),
                 web.post("/jobs/reset", api_jobs.reset),
-                web.get("/jobs/{uuid}", api_jobs.job_info),
+                web.get("/jobs/{uuid}", job_info_handler),
                 web.delete("/jobs/{uuid}", api_jobs.remove_job),
             ]
         )

--- a/supervisor/api/jobs.py
+++ b/supervisor/api/jobs.py
@@ -30,7 +30,9 @@ class APIJobs(CoreSysAttributes):
         except JobNotFound:
             raise APINotFound("Job does not exist") from None
 
-    def _list_jobs(self, start: SupervisorJob | None = None) -> list[dict[str, Any]]:
+    def _list_jobs(
+        self, start: SupervisorJob | None = None, *, legacy_names: bool = False
+    ) -> list[dict[str, Any]]:
         """Return current job tree.
 
         Jobs are added to cache as they are created so by default they are in oldest to newest.
@@ -67,7 +69,9 @@ class APIJobs(CoreSysAttributes):
             # We remove parent_id and instead use that info to represent jobs as a tree
             job_dict = current_job.as_dict() | {"child_jobs": child_jobs}
             job_dict.pop("parent_id")
-            current_list.append(process_job_dict_for_legacy_compatibility(job_dict))
+            if legacy_names:
+                job_dict = process_job_dict_for_legacy_compatibility(job_dict)
+            current_list.append(job_dict)
 
             if current_job.uuid in jobs_by_parent:
                 queue.extend(
@@ -85,6 +89,14 @@ class APIJobs(CoreSysAttributes):
         return {
             ATTR_IGNORE_CONDITIONS: self.sys_jobs.ignore_conditions,
             ATTR_JOBS: self._list_jobs(),
+        }
+
+    @api_process
+    async def info_v1(self, request: web.Request) -> dict[str, Any]:
+        """Return JobManager information with legacy job names."""
+        return {
+            ATTR_IGNORE_CONDITIONS: self.sys_jobs.ignore_conditions,
+            ATTR_JOBS: self._list_jobs(legacy_names=True),
         }
 
     @api_process
@@ -109,6 +121,12 @@ class APIJobs(CoreSysAttributes):
         """Get details of a job by ID."""
         job = self._extract_job(request)
         return self._list_jobs(job)[0]
+
+    @api_process
+    async def job_info_v1(self, request: web.Request) -> dict[str, Any]:
+        """Get details of a job by ID with legacy job names."""
+        job = self._extract_job(request)
+        return self._list_jobs(job, legacy_names=True)[0]
 
     @api_process
     async def remove_job(self, request: web.Request) -> None:

--- a/supervisor/homeassistant/const.py
+++ b/supervisor/homeassistant/const.py
@@ -25,12 +25,23 @@ CLOSING_STATES = [
     CoreState.CLOSE,
 ]
 
+# Supervisor event versions offered to Core when the websocket connection is
+# established. Core replies with the version it wants; a Core without support
+# for the negotiation command gets DEFAULT_EVENT_VERSION. Version 1 sends job
+# events with the legacy job names, version 2 with the new (app_*) names.
+DEFAULT_EVENT_VERSION = 1
+EVENT_VERSION_APP_JOB_NAMES = 2
+SUPPORTED_EVENT_VERSIONS = frozenset(
+    {DEFAULT_EVENT_VERSION, EVENT_VERSION_APP_JOB_NAMES}
+)
+
 
 class WSType(StrEnum):
     """Websocket types."""
 
     AUTH = "auth"
     SUPERVISOR_EVENT = "supervisor/event"
+    SUPERVISOR_EVENT_VERSION = "supervisor/event_version"
     BACKUP_START = "backup/start"
     BACKUP_END = "backup/end"
     HASSIO_UPDATE_ADDON = "hassio/update/addon"

--- a/supervisor/homeassistant/websocket.py
+++ b/supervisor/homeassistant/websocket.py
@@ -14,8 +14,10 @@ from ..const import (
     ATTR_ACCESS_TOKEN,
     ATTR_DATA,
     ATTR_EVENT,
+    ATTR_SUPPORTED,
     ATTR_TYPE,
     ATTR_UPDATE_KEY,
+    ATTR_VERSION,
     STARTING_STATES,
     BusEvent,
     CoreState,
@@ -26,8 +28,16 @@ from ..exceptions import (
     HomeAssistantWSConnectionError,
     HomeAssistantWSError,
 )
+from ..jobs import process_job_dict_for_legacy_compatibility
 from ..utils.json import json_dumps
-from .const import CLOSING_STATES, WSEvent, WSType
+from .const import (
+    CLOSING_STATES,
+    DEFAULT_EVENT_VERSION,
+    EVENT_VERSION_APP_JOB_NAMES,
+    SUPPORTED_EVENT_VERSIONS,
+    WSEvent,
+    WSType,
+)
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -37,6 +47,26 @@ T = TypeVar("T")
 # by the ingress proxy; Supervisor's own control channel never gets close to
 # this but shares the setting for simplicity. See issue #4392.
 MAX_MESSAGE_SIZE_FROM_CORE = 64 * 1024 * 1024
+
+
+def _map_job_event_to_legacy_names(message: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of a job event message using the legacy job name.
+
+    Consumers of event version 1 expect the legacy job names. Messages other
+    than job events pass through unchanged.
+    """
+    if (
+        message.get(ATTR_TYPE) != WSType.SUPERVISOR_EVENT
+        or not isinstance(data := message.get(ATTR_DATA), dict)
+        or data.get(ATTR_EVENT) != WSEvent.JOB
+        or not isinstance(job_data := data.get(ATTR_DATA), dict)
+    ):
+        return message
+
+    return message | {
+        ATTR_DATA: data
+        | {ATTR_DATA: process_job_dict_for_legacy_compatibility(job_data)}
+    }
 
 
 class WSClient:
@@ -50,6 +80,7 @@ class WSClient:
         """Initialise the WS client."""
         self.ha_version = ha_version
         self.client = client
+        self.event_version: int = DEFAULT_EVENT_VERSION
         self._message_id: int = 0
         self._futures: dict[int, asyncio.Future[T]] = {}  # type: ignore
 
@@ -84,6 +115,41 @@ class WSClient:
             return await self._futures[message["id"]]
         finally:
             self._futures.pop(message["id"])
+
+    async def negotiate_event_version(self) -> None:
+        """Negotiate the supervisor event version with Core.
+
+        Offers the supported versions to Core, which replies with the one it
+        wants to receive. A Core without support for the command rejects it
+        and the default version stays in use.
+
+        Raises HomeAssistantWSConnectionError if the connection fails.
+        """
+        try:
+            result: dict[str, Any] = await self.async_send_command(
+                {
+                    ATTR_TYPE: WSType.SUPERVISOR_EVENT_VERSION,
+                    ATTR_SUPPORTED: sorted(SUPPORTED_EVENT_VERSIONS),
+                }
+            )
+        except HomeAssistantWSConnectionError:
+            raise
+        except HomeAssistantWSError:
+            _LOGGER.debug(
+                "Core does not support event version negotiation, using version %s",
+                self.event_version,
+            )
+            return
+
+        version = result.get(ATTR_VERSION) if isinstance(result, dict) else None
+        if version in SUPPORTED_EVENT_VERSIONS:
+            self.event_version = version
+        else:
+            _LOGGER.warning(
+                "Core requested unsupported event version %s, using version %s",
+                version,
+                self.event_version,
+            )
 
     async def start_listener(self) -> None:
         """Start listening to the websocket."""
@@ -267,6 +333,7 @@ class HomeAssistantWebSocket(CoreSysAttributes):
             client = await self.sys_homeassistant.api.connect_websocket()
 
             self.sys_create_task(client.start_listener())
+            await client.negotiate_event_version()
             return client
 
     async def _ensure_connected(self) -> None:
@@ -315,6 +382,9 @@ class HomeAssistantWebSocket(CoreSysAttributes):
 
         # _ensure_connected guarantees self.client is set
         assert self.client
+
+        if self.client.event_version < EVENT_VERSION_APP_JOB_NAMES:
+            message = _map_job_event_to_legacy_names(message)
 
         try:
             await self.client.async_send_command(message)

--- a/supervisor/jobs/__init__.py
+++ b/supervisor/jobs/__init__.py
@@ -36,15 +36,45 @@ _CURRENT_JOB: ContextVar[str | None] = ContextVar("current_job", default=None)
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
+# Externally visible jobs renamed in the addon->app migration keep their old
+# names on the V1 surfaces: the V1 REST API and the websocket events consumed
+# by Home Assistant Core and the frontend. The new names are exposed on the
+# V2 REST API only. Add an entry here whenever an externally visible job is
+# renamed; the table can be dropped once V1 compatibility is no longer needed.
+_LEGACY_JOB_NAMES: dict[str, str] = {
+    "app_backup": "addon_backup",
+    "app_begin_backup": "addon_begin_backup",
+    "app_end_backup": "addon_end_backup",
+    "app_install": "addon_install",
+    "app_manager_install": "addon_manager_install",
+    "app_manager_rebuild": "addon_manager_rebuild",
+    "app_manager_repair": "addon_manager_repair",
+    "app_manager_restore": "addon_manager_restore",
+    "app_manager_uninstall": "addon_manager_uninstall",
+    "app_manager_update": "addon_manager_update",
+    "app_rebuild": "addon_rebuild",
+    "app_restart": "addon_restart",
+    "app_restore": "addon_restore",
+    "app_start": "addon_start",
+    "app_stop": "addon_stop",
+    "app_uninstall": "addon_uninstall",
+    "app_unload": "addon_unload",
+    "app_update": "addon_update",
+    "app_write_stdin": "addon_write_stdin",
+    "backup_app_restore": "backup_addon_restore",
+    "backup_app_save": "backup_addon_save",
+    "backup_remove_delta_apps": "backup_remove_delta_addons",
+    "backup_restore_apps": "backup_restore_addons",
+    "backup_store_apps": "backup_store_addons",
+}
+
+
 def process_job_dict_for_legacy_compatibility(
     job_data: dict[str, Any],
 ) -> dict[str, Any]:
-    """Map new job names to legacy names for API compatibility."""
-    # Home Assistant Core's hassio integration listens for this specific job name
-    # via the Supervisor websocket API. Core v2026.8 supports both names, so this
-    # compatibility can be removed when Core v2026.7 is no longer supported.
-    if job_data.get("name") == "app_manager_update":
-        return job_data | {"name": "addon_manager_update"}
+    """Map new job names to legacy names for V1 API and websocket compatibility."""
+    if legacy_name := _LEGACY_JOB_NAMES.get(job_data["name"]):
+        return job_data | {"name": legacy_name}
     return job_data
 
 
@@ -299,6 +329,9 @@ class JobManager(FileConfiguration, CoreSysAttributes):
         # Job object will be before the change. Combine the change with current data
         if attribute.name == "errors":
             value = [err.as_dict() for err in value]
+        # Websocket events keep the legacy job names as Home Assistant Core and
+        # the frontend still match on them. Switch to the new names once the
+        # consumers can handle them (e.g. gated on the connected Core version).
         job_data = process_job_dict_for_legacy_compatibility(
             job.as_dict() | {attribute.name: value}
         )

--- a/supervisor/jobs/__init__.py
+++ b/supervisor/jobs/__init__.py
@@ -37,10 +37,11 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
 # Externally visible jobs renamed in the addon->app migration keep their old
-# names on the V1 surfaces: the V1 REST API and the websocket events consumed
-# by Home Assistant Core and the frontend. The new names are exposed on the
-# V2 REST API only. Add an entry here whenever an externally visible job is
-# renamed; the table can be dropped once V1 compatibility is no longer needed.
+# names on the V1 surfaces: the V1 REST API and websocket job events sent with
+# event version 1 (the default, see homeassistant/websocket.py). The new names
+# are exposed on the V2 REST API and with event version 2. Add an entry here
+# whenever an externally visible job is renamed; the table can be dropped once
+# V1 compatibility is no longer needed.
 _LEGACY_JOB_NAMES: dict[str, str] = {
     "app_backup": "addon_backup",
     "app_begin_backup": "addon_begin_backup",
@@ -329,12 +330,7 @@ class JobManager(FileConfiguration, CoreSysAttributes):
         # Job object will be before the change. Combine the change with current data
         if attribute.name == "errors":
             value = [err.as_dict() for err in value]
-        # Websocket events keep the legacy job names as Home Assistant Core and
-        # the frontend still match on them. Switch to the new names once the
-        # consumers can handle them (e.g. gated on the connected Core version).
-        job_data = process_job_dict_for_legacy_compatibility(
-            job.as_dict() | {attribute.name: value}
-        )
+        job_data = job.as_dict() | {attribute.name: value}
 
         # Notify Home Assistant of change if its not internal
         if not job.internal:

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -391,7 +391,7 @@ async def test_api_backup_restore_background(
     assert job["child_jobs"][1]["reference"] == backup_slug
 
     if backup_type == "full":
-        assert job["child_jobs"][2]["name"] == "backup_remove_delta_apps"
+        assert job["child_jobs"][2]["name"] == "backup_remove_delta_addons"
         assert job["child_jobs"][2]["reference"] == backup_slug
 
 
@@ -443,9 +443,9 @@ async def test_api_backup_errors(
     assert job["errors"] == []
     assert job["child_jobs"][0]["name"] == "backup_store_homeassistant"
     assert job["child_jobs"][0]["reference"] == slug
-    assert job["child_jobs"][1]["name"] == "backup_store_apps"
+    assert job["child_jobs"][1]["name"] == "backup_store_addons"
     assert job["child_jobs"][1]["reference"] == slug
-    assert job["child_jobs"][1]["child_jobs"][0]["name"] == "backup_app_save"
+    assert job["child_jobs"][1]["child_jobs"][0]["name"] == "backup_addon_save"
     assert job["child_jobs"][1]["child_jobs"][0]["reference"] == "local_ssh"
     assert job["child_jobs"][1]["child_jobs"][0]["errors"] == [
         {

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -429,8 +429,9 @@ async def test_api_jobs_legacy_name_compatibility(
     coresys: CoreSys,
     ha_ws_client: AsyncMock,
 ):
-    """Test renamed job names are mapped back to legacy names in API outputs."""
+    """Test V1 API maps renamed jobs to legacy names while V2 uses new names."""
     api_client, prefix = api_client_with_prefix
+    expected_name = "app_manager_update" if prefix else "addon_manager_update"
     job = coresys.jobs.new_job("app_manager_update", reference="local_example")
     job.stage = "update"
     job.progress = 50
@@ -440,8 +441,14 @@ async def test_api_jobs_legacy_name_compatibility(
     resp = await api_client.get(f"{prefix}/jobs/info")
     assert resp.status == 200
     result = await resp.json()
-    assert result["data"]["jobs"][0]["name"] == "addon_manager_update"
+    assert result["data"]["jobs"][0]["name"] == expected_name
 
+    resp = await api_client.get(f"{prefix}/jobs/{job.uuid}")
+    assert resp.status == 200
+    result = await resp.json()
+    assert result["data"]["name"] == expected_name
+
+    # Websocket events always use the legacy names Core and frontend expect
     job_events = [
         evt.args[0]["data"]["data"]
         for evt in ha_ws_client.async_send_command.call_args_list

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -890,7 +890,8 @@ async def test_api_store_apps_app_availability_installed_app(
 @pytest.mark.parametrize(
     ("action", "job_name", "app_slug"),
     [
-        ("install", "app_manager_install", "local_ssh"),
+        # Websocket job events use the legacy job names
+        ("install", "addon_manager_install", "local_ssh"),
         ("update", "addon_manager_update", "local_example"),
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -563,7 +563,7 @@ async def coresys(
         return_value=APIState("RUNNING", False)
     )
     coresys_obj.homeassistant._websocket.client = AsyncMock(
-        ha_version=AwesomeVersion("2021.2.4")
+        ha_version=AwesomeVersion("2021.2.4"), event_version=1
     )
 
     if not request.node.get_closest_marker("no_mock_init_websession"):

--- a/tests/homeassistant/test_websocket.py
+++ b/tests/homeassistant/test_websocket.py
@@ -5,11 +5,16 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
+from awesomeversion import AwesomeVersion
 import pytest
 
 from supervisor.const import CoreState
 from supervisor.coresys import CoreSys
-from supervisor.exceptions import HomeAssistantAPIError, HomeAssistantWSConnectionError
+from supervisor.exceptions import (
+    HomeAssistantAPIError,
+    HomeAssistantWSConnectionError,
+    HomeAssistantWSError,
+)
 from supervisor.homeassistant.const import WSEvent, WSType
 from supervisor.homeassistant.websocket import WSClient
 
@@ -74,6 +79,59 @@ async def test_fire_and_forget_during_startup(
         "test", {"lorem": "ipsum"}
     )
     ha_ws_client.async_send_command.assert_not_called()
+
+
+async def test_job_event_uses_legacy_names_with_event_version_1(
+    coresys: CoreSys, ha_ws_client: AsyncMock
+):
+    """Test job events map renamed jobs to legacy names with event version 1."""
+    assert ha_ws_client.event_version == 1
+    await coresys.homeassistant.websocket.async_supervisor_event_custom(
+        WSEvent.JOB, {"data": {"name": "app_manager_update", "progress": 50}}
+    )
+    ha_ws_client.async_send_command.assert_called_with(
+        {
+            "type": WSType.SUPERVISOR_EVENT,
+            "data": {
+                "event": WSEvent.JOB,
+                "data": {"name": "addon_manager_update", "progress": 50},
+            },
+        }
+    )
+
+
+async def test_job_event_uses_new_names_with_event_version_2(
+    coresys: CoreSys, ha_ws_client: AsyncMock
+):
+    """Test job events keep the new job names with event version 2."""
+    ha_ws_client.event_version = 2
+    await coresys.homeassistant.websocket.async_supervisor_event_custom(
+        WSEvent.JOB, {"data": {"name": "app_manager_update", "progress": 50}}
+    )
+    ha_ws_client.async_send_command.assert_called_with(
+        {
+            "type": WSType.SUPERVISOR_EVENT,
+            "data": {
+                "event": WSEvent.JOB,
+                "data": {"name": "app_manager_update", "progress": 50},
+            },
+        }
+    )
+
+
+async def test_connect_negotiates_event_version(coresys: CoreSys):
+    """Test the event version is negotiated when a connection is established."""
+    ws_client = AsyncMock(connected=True, event_version=1)
+    coresys.homeassistant.websocket.client = None
+    with (
+        patch.object(coresys.homeassistant.api, "check_api_state", return_value=True),
+        patch.object(
+            coresys.homeassistant.api, "connect_websocket", return_value=ws_client
+        ),
+    ):
+        await coresys.homeassistant.websocket.async_send_command({"type": "test"})
+
+    ws_client.negotiate_event_version.assert_awaited_once()
 
 
 async def test_send_command_core_not_reachable(
@@ -233,6 +291,58 @@ async def test_connect_with_auth_missing_key():
             session, "ws://localhost/api/websocket", "token"
         )
     ws.close.assert_called_once()
+
+
+async def test_negotiate_event_version_core_supported():
+    """Test negotiation uses the version Core replies with."""
+    client = WSClient(AwesomeVersion("2026.8.0"), _mock_ws_client([]))
+    with patch.object(
+        WSClient, "async_send_command", return_value={"version": 2}
+    ) as send_command:
+        await client.negotiate_event_version()
+
+    send_command.assert_called_once_with(
+        {"type": WSType.SUPERVISOR_EVENT_VERSION, "supported": [1, 2]}
+    )
+    assert client.event_version == 2
+
+
+async def test_negotiate_event_version_core_unsupported():
+    """Test negotiation keeps the default version when Core rejects the command."""
+    client = WSClient(AwesomeVersion("2026.7.0"), _mock_ws_client([]))
+    with patch.object(
+        WSClient,
+        "async_send_command",
+        side_effect=HomeAssistantWSError("Unknown command"),
+    ):
+        await client.negotiate_event_version()
+
+    assert client.event_version == 1
+
+
+async def test_negotiate_event_version_invalid_reply():
+    """Test negotiation keeps the default version on an invalid reply."""
+    client = WSClient(AwesomeVersion("2026.8.0"), _mock_ws_client([]))
+    with patch.object(WSClient, "async_send_command", return_value={"version": 99}):
+        await client.negotiate_event_version()
+
+    assert client.event_version == 1
+
+
+async def test_negotiate_event_version_connection_error():
+    """Test negotiation propagates connection errors."""
+    client = WSClient(AwesomeVersion("2026.8.0"), _mock_ws_client([]))
+    with (
+        patch.object(
+            WSClient,
+            "async_send_command",
+            side_effect=HomeAssistantWSConnectionError("Connection was closed"),
+        ),
+        pytest.raises(HomeAssistantWSConnectionError),
+    ):
+        await client.negotiate_event_version()
+
+    assert client.event_version == 1
 
 
 async def test_ws_client_close():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #7014, which renamed externally visible job names from `addon_*` to `app_*` and shipped as a breaking change with a minimal legacy name mapping. This PR removes the need for the breaking change by scoping the job names to API surfaces:

- The v1 REST API (`/jobs`) maps all renamed jobs back to their legacy names, while the v2 REST API (`/v2/jobs`) exposes the new `app_*` names. The legacy name table covers every renamed job that is externally visible; internal jobs never surface through the API or websocket events.
- Websocket job events sent to Home Assistant Core use a per-connection negotiated event version: once the connection is established, Supervisor offers its supported versions via a new `supervisor/event_version` command and Core replies with the version it wants to receive. Version 1 sends job events with the legacy job names, version 2 with the new names. A Core without support for the command rejects it and Supervisor keeps the default version 1. Negotiation runs on every (re)connect, so a Core update or downgrade takes effect with the reconnection that follows it.

To make the per-connection decision possible, the legacy name mapping moves from job event creation time to send time: events queued during Supervisor startup are now mapped when they are actually sent, against the connection that carries them.

This allows Core to do the rename cleanly from one version to the next: switch to the v2 REST API and v2 websocket events in a single release, without a compatibility window where both name sets must be handled. Deprecating the legacy names is then tied to the v1 REST API and event version 1 as a whole, rather than to individual job names.

Core currently matches on the legacy names (`addon_manager_update` via websocket, `backup_store_addons`/`backup_addon_save` via the v1 REST API) and continues to work unchanged. Opting into version 2 requires a Core-side counterpart implementing the `supervisor/event_version` command in the hassio integration. The frontend consumes neither job events nor the jobs REST API today.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6698
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
