### PR TITLE
Avoid unnecessary full network connection re-activation

### DIFF
--- a/supervisor/dbus/network/interface.py
+++ b/supervisor/dbus/network/interface.py
@@ -117,6 +117,16 @@ class NetworkInterface(DBusInterfaceProxy):
 
         self._wireless = wireless
 
+    @dbus_connected
+    async def reapply(self) -> None:
+        """Reapply the active connection's settings to the device.
+
+        Applies changed settings without a full re-activation cycle. Raises
+        if NetworkManager cannot reapply the changes (e.g. a change to the
+        wireless security settings).
+        """
+        await self.connected_dbus.Device.call("reapply", {}, 0, 0)
+
     def __eq__(self, other: object) -> bool:
         """Is object equal to another."""
         return (

--- a/supervisor/dbus/network/setting/__init__.py
+++ b/supervisor/dbus/network/setting/__init__.py
@@ -177,12 +177,12 @@ class NetworkSetting(DBusInterface):
         Secrets (e.g. Wi-Fi PSK) are not part of GetSettings, so a change to
         secrets only is not detected.
         """
-        new_settings: dict[
+        current_settings: dict[
             str, dict[str, Variant]
         ] = await self.connected_dbus.Settings.Connection.call(
             "get_settings", unpack_variants=False
         )
-        old_settings = deepcopy(new_settings)
+        new_settings = deepcopy(current_settings)
 
         _merge_settings_attribute(
             new_settings,
@@ -220,7 +220,7 @@ class NetworkSetting(DBusInterface):
         ] = await self.connected_dbus.Settings.Connection.call(
             "get_settings", unpack_variants=False
         )
-        return old_settings != updated_settings
+        return current_settings != updated_settings
 
     @dbus_connected
     async def delete(self) -> None:

--- a/supervisor/dbus/network/setting/__init__.py
+++ b/supervisor/dbus/network/setting/__init__.py
@@ -1,5 +1,6 @@
 """Connection object for Network Manager."""
 
+from copy import deepcopy
 import logging
 from typing import Any
 
@@ -169,13 +170,19 @@ class NetworkSetting(DBusInterface):
         return await self.connected_dbus.Settings.Connection.call("get_settings")
 
     @dbus_connected
-    async def update(self, settings: dict[str, dict[str, Variant]]) -> None:
-        """Update connection settings."""
+    async def update(self, settings: dict[str, dict[str, Variant]]) -> bool:
+        """Update connection settings.
+
+        Return True if the settings as normalized by NetworkManager changed.
+        Secrets (e.g. Wi-Fi PSK) are not part of GetSettings, so a change to
+        secrets only is not detected.
+        """
         new_settings: dict[
             str, dict[str, Variant]
         ] = await self.connected_dbus.Settings.Connection.call(
             "get_settings", unpack_variants=False
         )
+        old_settings = deepcopy(new_settings)
 
         _merge_settings_attribute(
             new_settings,
@@ -204,6 +211,16 @@ class NetworkSetting(DBusInterface):
         _merge_settings_attribute(new_settings, settings, CONF_ATTR_MATCH)
 
         await self.connected_dbus.Settings.Connection.call("update", new_settings)
+
+        # NetworkManager normalizes the settings on update (e.g. drops
+        # properties at their default value). Comparing its normalized view
+        # before and after tells whether the update actually changed anything.
+        updated_settings: dict[
+            str, dict[str, Variant]
+        ] = await self.connected_dbus.Settings.Connection.call(
+            "get_settings", unpack_variants=False
+        )
+        return old_settings != updated_settings
 
     @dbus_connected
     async def delete(self) -> None:

--- a/supervisor/host/network.py
+++ b/supervisor/host/network.py
@@ -272,14 +272,29 @@ class NetworkManager(CoreSysAttributes):
             )
 
             try:
-                await inet.settings.update(settings)
-                con = activated = await self.sys_dbus.network.activate_connection(
-                    inet.settings.object_path, inet.object_path
-                )
-                _LOGGER.debug(
-                    "activate_connection returns %s",
-                    activated.object_path,
-                )
+                settings_changed = await inet.settings.update(settings)
+                # On startup (update_only) skip re-activation if the profile is
+                # unchanged and the connection is already active. A full
+                # re-activation cycle briefly disrupts connectivity, so only do
+                # it when the updated settings need to be applied.
+                if (
+                    update_only
+                    and not settings_changed
+                    and inet.connection
+                    and inet.connection.state == ConnectionState.ACTIVATED
+                ):
+                    _LOGGER.debug(
+                        "Settings for %s unchanged, skipping activation",
+                        interface.name,
+                    )
+                else:
+                    con = activated = await self.sys_dbus.network.activate_connection(
+                        inet.settings.object_path, inet.object_path
+                    )
+                    _LOGGER.debug(
+                        "activate_connection returns %s",
+                        activated.object_path,
+                    )
             except DBusError as err:
                 raise HostNetworkError(
                     f"Can't update config on {interface.name}: {err}", _LOGGER.error

--- a/supervisor/host/network.py
+++ b/supervisor/host/network.py
@@ -5,6 +5,8 @@ from contextlib import suppress
 import logging
 from typing import Any
 
+from dbus_fast import Variant
+
 from ..const import ATTR_HOST_INTERNET
 from ..coresys import CoreSys, CoreSysAttributes
 from ..dbus.const import (
@@ -20,6 +22,7 @@ from ..dbus.const import (
     WirelessMethodType,
 )
 from ..dbus.network.connection import NetworkConnection
+from ..dbus.network.interface import NetworkInterface
 from ..dbus.network.setting import (
     CONF_ATTR_802_WIRELESS_SECURITY,
     CONF_ATTR_802_WIRELESS_SECURITY_PSK,
@@ -244,6 +247,58 @@ class NetworkManager(CoreSysAttributes):
 
         await self.update(force_connectivity_check=True)
 
+    async def _apply_settings_in_place(
+        self,
+        inet: NetworkInterface,
+        interface: Interface,
+        settings: dict[str, dict[str, Variant]],
+        settings_changed: bool,
+        *,
+        update_only: bool,
+    ) -> bool:
+        """Try to make updated connection settings effective in place.
+
+        Return True if the settings are in effect without a full re-activation
+        cycle (unchanged or reapplied in place), False if the connection needs
+        to be activated.
+        """
+        # Secrets (Wi-Fi PSK) are excluded from GetSettings and ignored by
+        # NetworkManager's Reapply, so a change to them is neither detected
+        # nor applied in place. Always re-activate when the payload contains
+        # a PSK.
+        if CONF_ATTR_802_WIRELESS_SECURITY_PSK in settings.get(
+            CONF_ATTR_802_WIRELESS_SECURITY, {}
+        ):
+            return False
+
+        # In-place application requires an active connection
+        if not inet.connection or inet.connection.state != ConnectionState.ACTIVATED:
+            return False
+
+        if not settings_changed:
+            # User-initiated updates with unchanged settings still re-activate,
+            # both as a way to force a reconnect and to cover secret-only
+            # changes.
+            if not update_only:
+                return False
+            _LOGGER.debug(
+                "Settings for %s unchanged, skipping activation", interface.name
+            )
+            return True
+
+        try:
+            await inet.reapply()
+        except DBusError as err:
+            _LOGGER.debug(
+                "Can't reapply settings for %s in place: %s", interface.name, err
+            )
+            return False
+
+        _LOGGER.info(
+            "Reapplied changed settings for interface %s in place", interface.name
+        )
+        return True
+
     async def apply_changes(
         self, interface: Interface, *, update_only: bool = False
     ) -> None:
@@ -275,52 +330,15 @@ class NetworkManager(CoreSysAttributes):
                 uuid=inet.settings.connection.uuid,
             )
 
-            # Secrets (Wi-Fi PSK) are excluded from GetSettings and ignored by
-            # NetworkManager's Reapply, so a change to them is neither detected
-            # nor applied in place. Always re-activate when the payload
-            # contains a PSK.
-            contains_secrets = CONF_ATTR_802_WIRELESS_SECURITY_PSK in settings.get(
-                CONF_ATTR_802_WIRELESS_SECURITY, {}
-            )
-
             try:
                 settings_changed = await inet.settings.update(settings)
-                # Avoid a full re-activation cycle if possible since it briefly
-                # disrupts connectivity: reapply changed settings in place, and
-                # on startup (update_only) skip activation entirely if the
-                # profile is unchanged. User-initiated updates with unchanged
-                # settings still re-activate, both as a way to force a
-                # reconnect and to cover secret-only changes.
-                activate = True
-                if (
-                    not contains_secrets
-                    and inet.connection
-                    and inet.connection.state == ConnectionState.ACTIVATED
+                if not await self._apply_settings_in_place(
+                    inet,
+                    interface,
+                    settings,
+                    settings_changed,
+                    update_only=update_only,
                 ):
-                    if not settings_changed:
-                        if update_only:
-                            _LOGGER.debug(
-                                "Settings for %s unchanged, skipping activation",
-                                interface.name,
-                            )
-                            activate = False
-                    else:
-                        try:
-                            await inet.reapply()
-                        except DBusError as err:
-                            _LOGGER.debug(
-                                "Can't reapply settings for %s in place: %s",
-                                interface.name,
-                                err,
-                            )
-                        else:
-                            _LOGGER.info(
-                                "Reapplied changed settings for interface %s in place",
-                                interface.name,
-                            )
-                            activate = False
-
-                if activate:
                     _LOGGER.info(
                         "Activating connection for interface %s", interface.name
                     )

--- a/supervisor/host/network.py
+++ b/supervisor/host/network.py
@@ -300,13 +300,16 @@ class NetworkManager(CoreSysAttributes):
                                 err,
                             )
                         else:
-                            _LOGGER.debug(
-                                "Reapplied changed settings for %s in place",
+                            _LOGGER.info(
+                                "Reapplied changed settings for interface %s in place",
                                 interface.name,
                             )
                             activate = False
 
                 if activate:
+                    _LOGGER.info(
+                        "Activating connection for interface %s", interface.name
+                    )
                     con = activated = await self.sys_dbus.network.activate_connection(
                         inet.settings.object_path, inet.object_path
                     )
@@ -328,7 +331,9 @@ class NetworkManager(CoreSysAttributes):
 
         # Create new configuration and activate interface
         elif interface.enabled:
-            _LOGGER.debug("Create new configuration for %s", interface.name)
+            _LOGGER.info(
+                "Creating and activating connection for interface %s", interface.name
+            )
             settings = get_connection_from_interface(interface, self.sys_dbus.network)
 
             try:

--- a/supervisor/host/network.py
+++ b/supervisor/host/network.py
@@ -273,21 +273,40 @@ class NetworkManager(CoreSysAttributes):
 
             try:
                 settings_changed = await inet.settings.update(settings)
-                # On startup (update_only) skip re-activation if the profile is
-                # unchanged and the connection is already active. A full
-                # re-activation cycle briefly disrupts connectivity, so only do
-                # it when the updated settings need to be applied.
+                # On startup (update_only) avoid a full re-activation cycle if
+                # possible since it briefly disrupts connectivity: skip it
+                # entirely if the profile is unchanged and the connection is
+                # already active, and try to reapply changed settings in place
+                # first.
+                activate = True
                 if (
                     update_only
-                    and not settings_changed
                     and inet.connection
                     and inet.connection.state == ConnectionState.ACTIVATED
                 ):
-                    _LOGGER.debug(
-                        "Settings for %s unchanged, skipping activation",
-                        interface.name,
-                    )
-                else:
+                    if not settings_changed:
+                        _LOGGER.debug(
+                            "Settings for %s unchanged, skipping activation",
+                            interface.name,
+                        )
+                        activate = False
+                    else:
+                        try:
+                            await inet.reapply()
+                        except DBusError as err:
+                            _LOGGER.debug(
+                                "Can't reapply settings for %s in place: %s",
+                                interface.name,
+                                err,
+                            )
+                        else:
+                            _LOGGER.debug(
+                                "Reapplied changed settings for %s in place",
+                                interface.name,
+                            )
+                            activate = False
+
+                if activate:
                     con = activated = await self.sys_dbus.network.activate_connection(
                         inet.settings.object_path, inet.object_path
                     )

--- a/supervisor/host/network.py
+++ b/supervisor/host/network.py
@@ -20,6 +20,10 @@ from ..dbus.const import (
     WirelessMethodType,
 )
 from ..dbus.network.connection import NetworkConnection
+from ..dbus.network.setting import (
+    CONF_ATTR_802_WIRELESS_SECURITY,
+    CONF_ATTR_802_WIRELESS_SECURITY_PSK,
+)
 from ..dbus.network.setting.generate import get_connection_from_interface
 from ..exceptions import (
     DBusError,
@@ -271,25 +275,35 @@ class NetworkManager(CoreSysAttributes):
                 uuid=inet.settings.connection.uuid,
             )
 
+            # Secrets (Wi-Fi PSK) are excluded from GetSettings and ignored by
+            # NetworkManager's Reapply, so a change to them is neither detected
+            # nor applied in place. Always re-activate when the payload
+            # contains a PSK.
+            contains_secrets = CONF_ATTR_802_WIRELESS_SECURITY_PSK in settings.get(
+                CONF_ATTR_802_WIRELESS_SECURITY, {}
+            )
+
             try:
                 settings_changed = await inet.settings.update(settings)
-                # On startup (update_only) avoid a full re-activation cycle if
-                # possible since it briefly disrupts connectivity: skip it
-                # entirely if the profile is unchanged and the connection is
-                # already active, and try to reapply changed settings in place
-                # first.
+                # Avoid a full re-activation cycle if possible since it briefly
+                # disrupts connectivity: reapply changed settings in place, and
+                # on startup (update_only) skip activation entirely if the
+                # profile is unchanged. User-initiated updates with unchanged
+                # settings still re-activate, both as a way to force a
+                # reconnect and to cover secret-only changes.
                 activate = True
                 if (
-                    update_only
+                    not contains_secrets
                     and inet.connection
                     and inet.connection.state == ConnectionState.ACTIVATED
                 ):
                     if not settings_changed:
-                        _LOGGER.debug(
-                            "Settings for %s unchanged, skipping activation",
-                            interface.name,
-                        )
-                        activate = False
+                        if update_only:
+                            _LOGGER.debug(
+                                "Settings for %s unchanged, skipping activation",
+                                interface.name,
+                            )
+                            activate = False
                     else:
                         try:
                             await inet.reapply()

--- a/tests/dbus/network/setting/test_init.py
+++ b/tests/dbus/network/setting/test_init.py
@@ -57,7 +57,7 @@ async def test_ethernet_update(
         uuid=dbus_interface.settings.connection.uuid,
     )
 
-    await dbus_interface.settings.update(conn)
+    assert await dbus_interface.settings.update(conn) is True
 
     assert len(connection_settings_service.Update.calls) == 1
     settings = connection_settings_service.Update.calls[0][0]
@@ -119,6 +119,10 @@ async def test_ethernet_update(
         assert "powersave" not in settings["802-11-wireless"]
 
         assert "802-11-wireless-security" not in settings
+
+    # Applying the same settings again does not change the profile
+    assert await dbus_interface.settings.update(conn) is False
+    assert len(connection_settings_service.Update.calls) == 2
 
 
 async def test_ipv6_disabled_is_link_local(

--- a/tests/dbus/network/test_interface.py
+++ b/tests/dbus/network/test_interface.py
@@ -97,6 +97,21 @@ async def test_network_interface_ethernet(
     assert interface.managed is True
 
 
+async def test_reapply(
+    device_eth0_service: DeviceService, dbus_session_bus: MessageBus
+):
+    """Test reapply on network interface."""
+    device_eth0_service.Reapply.calls.clear()
+
+    interface = NetworkInterface("/org/freedesktop/NetworkManager/Devices/1")
+    await interface.connect(dbus_session_bus)
+
+    await interface.reapply()
+    assert device_eth0_service.Reapply.calls == [
+        ("/org/freedesktop/NetworkManager/Devices/1", {}, 0, 0)
+    ]
+
+
 async def test_network_interface_wlan(
     device_wlan0_service: DeviceService, dbus_session_bus: MessageBus
 ):

--- a/tests/dbus_service_mocks/network_device.py
+++ b/tests/dbus_service_mocks/network_device.py
@@ -3,7 +3,7 @@
 from ctypes import c_uint32
 from dataclasses import dataclass
 
-from dbus_fast import Variant
+from dbus_fast import DBusError, Variant
 from dbus_fast.service import PropertyAccess, dbus_property, signal
 
 from .base import DBusServiceMock, dbus_method
@@ -283,6 +283,7 @@ class Device(DBusServiceMock):
         super().__init__()
         self.object_path = object_path
         self.fixture: DeviceFixture = FIXTURES[object_path]
+        self.reapply_error: DBusError | None = None
 
     @dbus_property(access=PropertyAccess.READ)
     def Udi(self) -> "s":
@@ -459,9 +460,11 @@ class Device(DBusServiceMock):
         """Signal StateChanged."""
         return [120, 100, 1]
 
-    @dbus_method()
+    @dbus_method(track_obj_path=True)
     def Reapply(self, connection: "a{sa{sv}}", version_id: "t", flags: "u") -> None:
         """Do Reapply method."""
+        if self.reapply_error is not None:
+            raise self.reapply_error
 
     @dbus_method()
     def GetAppliedConnection(self, flags: "u") -> "a{sa{sv}}t":

--- a/tests/host/test_network.py
+++ b/tests/host/test_network.py
@@ -4,7 +4,7 @@ import asyncio
 from ipaddress import IPv4Address, IPv6Address
 from unittest.mock import AsyncMock, patch
 
-from dbus_fast import Variant
+from dbus_fast import DBusError, Variant
 import pytest
 
 from supervisor.const import CoreState
@@ -22,6 +22,7 @@ from tests.dbus_service_mocks.network_connection_settings import (
     SETTINGS_1_FIXTURE,
     ConnectionSettings as ConnectionSettingsService,
 )
+from tests.dbus_service_mocks.network_device import Device as DeviceService
 from tests.dbus_service_mocks.network_device_wireless import (
     DeviceWireless as DeviceWirelessService,
 )
@@ -38,14 +39,26 @@ async def fixture_wireless_service(
     return network_manager_services["network_device_wireless"]
 
 
+@pytest.fixture(name="device_eth0_service")
+async def fixture_device_eth0_service(
+    network_manager_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+) -> DeviceService:
+    """Return mock device eth0 service."""
+    return network_manager_services["network_device"][
+        "/org/freedesktop/NetworkManager/Devices/1"
+    ]
+
+
 async def test_load(
     coresys: CoreSys,
     network_manager_service: NetworkManagerService,
     connection_settings_service: ConnectionSettingsService,
+    device_eth0_service: DeviceService,
 ):
     """Test network manager load."""
     network_manager_service.ActivateConnection.calls.clear()
     network_manager_service.CheckConnectivity.calls.clear()
+    device_eth0_service.Reapply.calls.clear()
 
     await coresys.host.network.load()
 
@@ -95,44 +108,74 @@ async def test_load(
     assert "eth0.10" in name_dict
     assert name_dict["eth0.10"].enabled is True
 
-    assert len(network_manager_service.ActivateConnection.calls) == 2
+    # The profiles changed (Supervisor defaults applied) with the connections
+    # active, so the settings are reapplied in place without re-activation
+    assert len(device_eth0_service.Reapply.calls) == 2
     assert (
-        "/org/freedesktop/NetworkManager/Settings/38",
-        "/org/freedesktop/NetworkManager/Devices/38",
-        "/",
-    ) in network_manager_service.ActivateConnection.calls
-    assert (
-        "/org/freedesktop/NetworkManager/Settings/1",
         "/org/freedesktop/NetworkManager/Devices/1",
-        "/",
-    ) in network_manager_service.ActivateConnection.calls
+        {},
+        0,
+        0,
+    ) in device_eth0_service.Reapply.calls
+    assert (
+        "/org/freedesktop/NetworkManager/Devices/38",
+        {},
+        0,
+        0,
+    ) in device_eth0_service.Reapply.calls
+    assert network_manager_service.ActivateConnection.calls == []
     assert network_manager_service.CheckConnectivity.calls == []
 
 
 async def test_load_unchanged_settings_skips_activation(
     coresys: CoreSys,
     network_manager_service: NetworkManagerService,
+    device_eth0_service: DeviceService,
 ):
-    """Test load does not re-activate connections when settings are unchanged."""
-    network_manager_service.ActivateConnection.calls.clear()
-
-    # First load updates the profiles to Supervisor defaults and re-activates
+    """Test load does not touch connections when settings are unchanged."""
+    # First load updates the profiles to Supervisor defaults and applies them
     await coresys.host.network.load()
-    assert len(network_manager_service.ActivateConnection.calls) == 2
 
     network_manager_service.ActivateConnection.calls.clear()
+    device_eth0_service.Reapply.calls.clear()
 
     # Profiles now match what Supervisor generates, nothing to apply
     await coresys.host.network.load()
     assert network_manager_service.ActivateConnection.calls == []
+    assert device_eth0_service.Reapply.calls == []
 
 
-async def test_load_outdated_settings_activates(
+async def test_load_outdated_settings_reapplies(
     coresys: CoreSys,
     network_manager_service: NetworkManagerService,
     connection_settings_service: ConnectionSettingsService,
+    device_eth0_service: DeviceService,
 ):
-    """Test load re-activates a connection when its profile is out of date."""
+    """Test load applies an out of date profile in place."""
+    await coresys.host.network.load()
+    network_manager_service.ActivateConnection.calls.clear()
+    device_eth0_service.Reapply.calls.clear()
+
+    # Simulate a profile predating a change of Supervisor defaults
+    connection_settings_service.settings["connection"]["id"] = Variant(
+        "s", "Wired connection 1"
+    )
+    await coresys.dbus.network.get("eth0").settings.reload()
+
+    await coresys.host.network.load()
+    assert device_eth0_service.Reapply.calls == [
+        ("/org/freedesktop/NetworkManager/Devices/1", {}, 0, 0)
+    ]
+    assert network_manager_service.ActivateConnection.calls == []
+
+
+async def test_load_reapply_fails_activates(
+    coresys: CoreSys,
+    network_manager_service: NetworkManagerService,
+    connection_settings_service: ConnectionSettingsService,
+    device_eth0_service: DeviceService,
+):
+    """Test load re-activates when changed settings can't be reapplied in place."""
     await coresys.host.network.load()
     network_manager_service.ActivateConnection.calls.clear()
 
@@ -141,6 +184,10 @@ async def test_load_outdated_settings_activates(
         "s", "Wired connection 1"
     )
     await coresys.dbus.network.get("eth0").settings.reload()
+    device_eth0_service.reapply_error = DBusError(
+        "org.freedesktop.NetworkManager.Device.IncompatibleConnection",
+        "Can't reapply any changes to '802-3-ethernet' setting",
+    )
 
     await coresys.host.network.load()
     assert (

--- a/tests/host/test_network.py
+++ b/tests/host/test_network.py
@@ -109,6 +109,47 @@ async def test_load(
     assert network_manager_service.CheckConnectivity.calls == []
 
 
+async def test_load_unchanged_settings_skips_activation(
+    coresys: CoreSys,
+    network_manager_service: NetworkManagerService,
+):
+    """Test load does not re-activate connections when settings are unchanged."""
+    network_manager_service.ActivateConnection.calls.clear()
+
+    # First load updates the profiles to Supervisor defaults and re-activates
+    await coresys.host.network.load()
+    assert len(network_manager_service.ActivateConnection.calls) == 2
+
+    network_manager_service.ActivateConnection.calls.clear()
+
+    # Profiles now match what Supervisor generates, nothing to apply
+    await coresys.host.network.load()
+    assert network_manager_service.ActivateConnection.calls == []
+
+
+async def test_load_outdated_settings_activates(
+    coresys: CoreSys,
+    network_manager_service: NetworkManagerService,
+    connection_settings_service: ConnectionSettingsService,
+):
+    """Test load re-activates a connection when its profile is out of date."""
+    await coresys.host.network.load()
+    network_manager_service.ActivateConnection.calls.clear()
+
+    # Simulate a profile predating a change of Supervisor defaults
+    connection_settings_service.settings["connection"]["id"] = Variant(
+        "s", "Wired connection 1"
+    )
+    await coresys.dbus.network.get("eth0").settings.reload()
+
+    await coresys.host.network.load()
+    assert (
+        "/org/freedesktop/NetworkManager/Settings/1",
+        "/org/freedesktop/NetworkManager/Devices/1",
+        "/",
+    ) in network_manager_service.ActivateConnection.calls
+
+
 async def test_load_with_disabled_methods(
     coresys: CoreSys,
     network_manager_service: NetworkManagerService,

--- a/tests/host/test_network.py
+++ b/tests/host/test_network.py
@@ -10,6 +10,11 @@ import pytest
 from supervisor.const import CoreState
 from supervisor.coresys import CoreSys
 from supervisor.dbus.const import InterfaceMethod
+from supervisor.dbus.network.setting import (
+    CONF_ATTR_802_WIRELESS_SECURITY,
+    CONF_ATTR_802_WIRELESS_SECURITY_PSK,
+)
+from supervisor.dbus.network.setting.generate import get_connection_from_interface
 from supervisor.exceptions import HostNotSupportedError
 from supervisor.homeassistant.const import WSEvent, WSType
 from supervisor.host.const import WifiMode
@@ -190,6 +195,77 @@ async def test_load_reapply_fails_activates(
     )
 
     await coresys.host.network.load()
+    assert (
+        "/org/freedesktop/NetworkManager/Settings/1",
+        "/org/freedesktop/NetworkManager/Devices/1",
+        "/",
+    ) in network_manager_service.ActivateConnection.calls
+
+
+async def test_apply_changes_reapplies_in_place(
+    coresys: CoreSys,
+    network_manager_service: NetworkManagerService,
+    device_eth0_service: DeviceService,
+):
+    """Test user-initiated apply of changed settings reapplies in place."""
+    await coresys.host.network.load()
+    network_manager_service.ActivateConnection.calls.clear()
+    device_eth0_service.Reapply.calls.clear()
+
+    interface = coresys.host.network.get("eth0")
+    interface.ipv4setting.nameservers = [IPv4Address("1.1.1.1")]
+    await coresys.host.network.apply_changes(interface)
+
+    assert device_eth0_service.Reapply.calls == [
+        ("/org/freedesktop/NetworkManager/Devices/1", {}, 0, 0)
+    ]
+    assert network_manager_service.ActivateConnection.calls == []
+
+
+async def test_apply_changes_unchanged_reactivates(
+    coresys: CoreSys,
+    network_manager_service: NetworkManagerService,
+    device_eth0_service: DeviceService,
+):
+    """Test user-initiated apply of unchanged settings re-activates."""
+    await coresys.host.network.load()
+    network_manager_service.ActivateConnection.calls.clear()
+    device_eth0_service.Reapply.calls.clear()
+
+    await coresys.host.network.apply_changes(coresys.host.network.get("eth0"))
+
+    assert device_eth0_service.Reapply.calls == []
+    assert (
+        "/org/freedesktop/NetworkManager/Settings/1",
+        "/org/freedesktop/NetworkManager/Devices/1",
+        "/",
+    ) in network_manager_service.ActivateConnection.calls
+
+
+async def test_apply_changes_with_psk_reactivates(
+    coresys: CoreSys,
+    network_manager_service: NetworkManagerService,
+    device_eth0_service: DeviceService,
+):
+    """Test apply with a Wi-Fi PSK in the payload re-activates."""
+    await coresys.host.network.load()
+    network_manager_service.ActivateConnection.calls.clear()
+    device_eth0_service.Reapply.calls.clear()
+
+    interface = coresys.host.network.get("eth0")
+    interface.ipv4setting.nameservers = [IPv4Address("1.1.1.1")]
+
+    def add_psk(*args, **kwargs):
+        conn = get_connection_from_interface(*args, **kwargs)
+        conn[CONF_ATTR_802_WIRELESS_SECURITY] = {
+            CONF_ATTR_802_WIRELESS_SECURITY_PSK: Variant("s", "supersecret")
+        }
+        return conn
+
+    with patch("supervisor.host.network.get_connection_from_interface", new=add_psk):
+        await coresys.host.network.apply_changes(interface)
+
+    assert device_eth0_service.Reapply.calls == []
     assert (
         "/org/freedesktop/NetworkManager/Settings/1",
         "/org/freedesktop/NetworkManager/Devices/1",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Since #3528, Supervisor re-applies its network defaults on every startup: it rewrites the NetworkManager connection profile of each enabled interface and re-activates the connection so the settings take effect. The re-activation runs unconditionally, so every Supervisor start causes a full connection cycle (routes torn down, DHCP re-negotiated, Wi-Fi reassociation) even when the profile did not change, which is the common case. The disruption is only a couple of seconds and for most use cases doesn't matter, but it is unnecessary, and in some cases it appears to trigger bugs which create a bigger disruption (see home-assistant/operating-system#4782). This PR avoids unnecessary full activation:

- `NetworkSetting.update()` now reports whether the profile actually changed by comparing NetworkManager's normalized view of the settings before and after the update call (NetworkManager omits properties at their default value from `GetSettings`, so comparing against Supervisor's generated payload would not work). On startup, if the profile is unchanged and the connection is active, activation is skipped entirely.
- When the profile did change (e.g. after a change of Supervisor's defaults), the settings are applied in place using NetworkManager's `Device.Reapply()` instead of a full re-activation. Not all settings can be reapplied (e.g. wireless security or `match` changes), in which case NetworkManager rejects the reapply and Supervisor falls back to the full re-activation as before. This keeps the startup apply working as the migration vehicle for new profile defaults (as last used by #6753).
- The in-place reapply is also used for user-initiated settings updates via the API, so changing e.g. IP or DNS configuration no longer drops connectivity. Payloads containing a Wi-Fi PSK always re-activate: secrets are excluded from `GetSettings` and ignored by NetworkManager's `Reapply` (the diff runs with `NM_SETTING_COMPARE_FLAG_IGNORE_SECRETS`), so an updated PSK would otherwise be written to the profile but never applied. Unchanged settings also still re-activate on the user path, which keeps resubmitting settings working as a way to force a reconnect and covers secret-only changes.
- Connection activation and in-place reapply are now logged at info level, so the Supervisor log shows when and why the host network configuration was touched.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/operating-system#4782
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
