### PR TITLE
Fix length validation of str and password options with bounds

### DIFF
--- a/supervisor/apps/options.py
+++ b/supervisor/apps/options.py
@@ -150,7 +150,7 @@ class AppOptions(CoreSysAttributes):
         if typ.startswith(_STR) or typ.startswith(_PASSWORD):
             if typ.startswith(_PASSWORD) and value:
                 self.pwned.add(hashlib.sha1(str(value).encode()).hexdigest())
-            return vol.All(str(value), vol.Range(**range_args))(value)
+            return vol.All(str, vol.Length(**range_args))(value)
         if typ.startswith(_INT):
             return vol.All(vol.Coerce(int), vol.Range(**range_args))(value)
         if typ.startswith(_FLOAT):

--- a/tests/api/test_apps.py
+++ b/tests/api/test_apps.py
@@ -665,12 +665,12 @@ async def test_app_set_options_error(api_client: TestClient):
     body = await resp.json()
     assert (
         body["message"]
-        == "App local_example has invalid options: not a valid value. Got {'message': True}"
+        == "App local_example has invalid options: expected str. Got {'message': True}"
     )
     assert body["error_key"] == "addon_configuration_invalid_error"
     assert body["extra_fields"] == {
         "addon": "local_example",
-        "validation_error": "not a valid value. Got {'message': True}",
+        "validation_error": "expected str. Got {'message': True}",
     }
 
 

--- a/tests/apps/test_options.py
+++ b/tests/apps/test_options.py
@@ -45,6 +45,40 @@ def test_simple_schema(coresys):
         )({"name": "Pascal", "fires": True})
 
 
+def test_simple_schema_string_length(coresys):
+    """Test string length limits."""
+    assert AppOptions(
+        coresys,
+        {"name": "str(1,32)", "password": "password(8,)"},
+        MOCK_ADDON_NAME,
+        MOCK_ADDON_SLUG,
+    )({"name": "Pascal", "password": "12345678"})
+
+    with pytest.raises(vol.error.Invalid):
+        AppOptions(
+            coresys,
+            {"name": "str(1,32)", "password": "password(8,)"},
+            MOCK_ADDON_NAME,
+            MOCK_ADDON_SLUG,
+        )({"name": "", "password": "12345678"})
+
+    with pytest.raises(vol.error.Invalid):
+        AppOptions(
+            coresys,
+            {"name": "str(1,32)", "password": "password(8,)"},
+            MOCK_ADDON_NAME,
+            MOCK_ADDON_SLUG,
+        )({"name": "x" * 33, "password": "12345678"})
+
+    with pytest.raises(vol.error.Invalid):
+        AppOptions(
+            coresys,
+            {"name": "str(1,32)", "password": "password(8,)"},
+            MOCK_ADDON_NAME,
+            MOCK_ADDON_SLUG,
+        )({"name": "Pascal", "password": "1234"})
+
+
 def test_simple_schema_integers(coresys):
     """Test integer limits."""
     assert AppOptions(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

App option schemas with string length bounds such as `str(1,32)` or `password(8,)` currently fail validation for every value: the value is validated with `vol.Range`, which compares the string itself against the numeric bounds. Comparing a `str` with a `float` raises `TypeError`, which voluptuous reports as `invalid value or type (must have a partial ordering)`, so saving options always fails for any app using a bounded `str` or `password` schema. Unbounded `str`/`password` is unaffected since `vol.Range` without bounds performs no comparison.

Use `vol.Length` to check the string length against the bounds, which is the [documented meaning](https://developers.home-assistant.io/docs/apps/configuration/#options--schema) of `str(min,max)`. Also replace the `str(value)` literal passed to `vol.All` (a self-equality check) with the `str` type, so non-string values still fail validation but now with a clearer error message.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
