### PR TITLE
Fix Core API proxy stripping the multipart boundary from Content-Type

### DIFF
--- a/supervisor/api/proxy.py
+++ b/supervisor/api/proxy.py
@@ -98,7 +98,7 @@ class APIProxy(CoreSysAttributes):
                     for name, value in request.headers.items()
                     if name in FORWARD_HEADERS
                 },
-                content_type=request.content_type,
+                content_type=request.headers.get(CONTENT_TYPE),
                 data=request.content,
                 timeout=timeout,
                 params=request.query,

--- a/tests/api/test_proxy.py
+++ b/tests/api/test_proxy.py
@@ -361,6 +361,49 @@ async def test_api_proxy_delete_request(
         assert response.content_type == "application/json"
 
 
+async def test_api_proxy_multipart_content_type_preserved(
+    api_client: TestClient,
+    install_app_example: App,
+):
+    """Test multipart Content-Type keeps its boundary parameter when proxied."""
+    install_app_example.persist[ATTR_ACCESS_TOKEN] = "abc123"
+    install_app_example.data["homeassistant_api"] = True
+
+    with patch.object(HomeAssistantAPI, "make_request") as make_request:
+        # Mock the response from make_request
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.content_type = "application/json"
+        mock_response.read.return_value = b'{"result": "ok"}'
+        make_request.return_value.__aenter__.return_value = mock_response
+
+        boundary = "d1b1a3a3f0a94a5c9e3a"
+        body = (
+            f"--{boundary}\r\n"
+            'Content-Disposition: form-data; name="file"; filename="test.png"\r\n'
+            "Content-Type: image/png\r\n\r\n"
+            "fakepng\r\n"
+            f"--{boundary}--\r\n"
+        ).encode()
+
+        response = await api_client.post(
+            "/core/api/media_source/local_source/upload",
+            headers={
+                "Authorization": "Bearer abc123",
+                "Content-Type": f"multipart/form-data; boundary={boundary}",
+            },
+            data=body,
+        )
+
+        # The boundary parameter must survive the proxy — without it Core
+        # cannot parse the multipart body ("boundary missed for Content-Type").
+        assert (
+            make_request.call_args[1]["content_type"]
+            == f"multipart/form-data; boundary={boundary}"
+        )
+        assert response.status == 200
+
+
 async def test_api_proxy_mcp_headers_forwarded(
     api_client: TestClient,
     install_app_example: App,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The Core API proxy (`/core/api/...`) forwards the request's Content-Type via aiohttp's parsed `request.content_type` property, which returns only the media type and **drops all header parameters — including the multipart `boundary`**. Core then cannot parse any multipart body proxied from an add-on and rejects the request with:

```
ValueError: boundary missed for Content-Type: multipart/form-data
```

This makes every multipart Core API endpoint (e.g. `POST /api/media_source/local_source/upload`, form-data webhooks) unreachable from add-ons, since the Supervisor proxy is the only route available to `SUPERVISOR_TOKEN`. First reported from the webhook angle in home-assistant/core#19588 (2018, closed stale).

This PR forwards the raw `Content-Type` header instead, preserving its parameters — the same thing the `stream()` proxy path already does (`request.headers.get(CONTENT_TYPE, "")`). Behavior note: when the incoming request has no Content-Type header, the proxy previously forwarded aiohttp's `application/octet-stream` fallback; it now omits the header and lets the client default apply — net effect is unchanged.

A regression test is included: it POSTs a multipart body through the proxy and asserts the boundary parameter survives into `make_request` (fails before the fix with `'multipart/form-data' != 'multipart/form-data; boundary=...'`, passes after).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #7049
- This PR is related to issue: home-assistant/core#19588
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
