### PR TITLE
Add websocket v2 jobs compatibility feature toggle

### DIFF
--- a/supervisor/api/jobs.py
+++ b/supervisor/api/jobs.py
@@ -6,6 +6,7 @@ from typing import Any
 from aiohttp import web
 import voluptuous as vol
 
+from ..const import FeatureFlag
 from ..coresys import CoreSysAttributes
 from ..exceptions import APIError, APINotFound, JobNotFound
 from ..jobs import SupervisorJob, process_job_dict_for_legacy_compatibility
@@ -38,6 +39,10 @@ class APIJobs(CoreSysAttributes):
         the order they occurred within the parent. For the list as a whole, sort from newest
         to oldest as its likely any client is most interested in the newer ones.
         """
+        websocket_v2_api_enabled = self.sys_config.feature_flags.get(
+            FeatureFlag.SUPERVISOR_WEBSOCKET_V2_API, False
+        )
+
         # Initially sort oldest to newest so all child lists end up in correct order
         jobs_by_parent: dict[str | None, list[SupervisorJob]] = {}
         for job in sorted(self.sys_jobs.jobs):
@@ -67,7 +72,11 @@ class APIJobs(CoreSysAttributes):
             # We remove parent_id and instead use that info to represent jobs as a tree
             job_dict = current_job.as_dict() | {"child_jobs": child_jobs}
             job_dict.pop("parent_id")
-            current_list.append(process_job_dict_for_legacy_compatibility(job_dict))
+            current_list.append(
+                job_dict
+                if websocket_v2_api_enabled
+                else process_job_dict_for_legacy_compatibility(job_dict)
+            )
 
             if current_job.uuid in jobs_by_parent:
                 queue.extend(

--- a/supervisor/const.py
+++ b/supervisor/const.py
@@ -572,6 +572,7 @@ class FeatureFlag(StrEnum):
     """Development features that can be toggled."""
 
     SUPERVISOR_V2_API = "supervisor_v2_api"
+    SUPERVISOR_WEBSOCKET_V2_API = "supervisor_websocket_v2_api"
 
 
 @dataclass

--- a/supervisor/jobs/__init__.py
+++ b/supervisor/jobs/__init__.py
@@ -17,7 +17,7 @@ from attrs import Attribute, define, field
 from attrs.setters import convert as attr_convert, frozen, validate as attr_validate
 from attrs.validators import ge, le
 
-from ..const import BusEvent
+from ..const import BusEvent, FeatureFlag
 from ..coresys import CoreSys, CoreSysAttributes
 from ..exceptions import HassioError, JobNotFound, JobStartException
 from ..homeassistant.const import WSEvent
@@ -299,9 +299,11 @@ class JobManager(FileConfiguration, CoreSysAttributes):
         # Job object will be before the change. Combine the change with current data
         if attribute.name == "errors":
             value = [err.as_dict() for err in value]
-        job_data = process_job_dict_for_legacy_compatibility(
-            job.as_dict() | {attribute.name: value}
-        )
+        job_data = job.as_dict() | {attribute.name: value}
+        if not self.sys_config.feature_flags.get(
+            FeatureFlag.SUPERVISOR_WEBSOCKET_V2_API, False
+        ):
+            job_data = process_job_dict_for_legacy_compatibility(job_data)
 
         # Notify Home Assistant of change if its not internal
         if not job.internal:

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, AsyncMock
 from aiohttp.test_utils import TestClient
 import pytest
 
+from supervisor.const import FeatureFlag
 from supervisor.coresys import CoreSys
 from supervisor.exceptions import SupervisorError
 from supervisor.jobs.const import ATTR_IGNORE_CONDITIONS, JobCondition
@@ -450,4 +451,35 @@ async def test_api_jobs_legacy_name_compatibility(
     assert any(job_event["name"] == "addon_manager_update" for job_event in job_events)
     assert not any(
         job_event["name"] == "app_manager_update" for job_event in job_events
+    )
+
+
+async def test_api_jobs_no_legacy_name_compatibility_when_websocket_v2_enabled(
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    ha_ws_client: AsyncMock,
+):
+    """Test legacy job name mapping is skipped when websocket v2 feature is enabled."""
+    api_client, prefix = api_client_with_prefix
+    coresys.config.set_feature_flag(FeatureFlag.SUPERVISOR_WEBSOCKET_V2_API, True)
+
+    job = coresys.jobs.new_job("app_manager_update", reference="local_example")
+    job.stage = "update"
+    job.progress = 50
+    with job.start():
+        pass
+
+    resp = await api_client.get(f"{prefix}/jobs/info")
+    assert resp.status == 200
+    result = await resp.json()
+    assert result["data"]["jobs"][0]["name"] == "app_manager_update"
+
+    job_events = [
+        evt.args[0]["data"]["data"]
+        for evt in ha_ws_client.async_send_command.call_args_list
+        if "data" in evt.args[0] and evt.args[0]["data"]["event"] == "job"
+    ]
+    assert any(job_event["name"] == "app_manager_update" for job_event in job_events)
+    assert not any(
+        job_event["name"] == "addon_manager_update" for job_event in job_events
     )


### PR DESCRIPTION
## Proposed change

Add a dedicated websocket v2 feature flag and use it to bypass legacy job-name compatibility mapping (`app_manager_update` -> `addon_manager_update`) for websocket/job payloads and jobs API responses.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6698
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
