### PR TITLE
Replace preloaded jemalloc with PYTHONMALLOC=mimalloc

### DIFF
--- a/rootfs/etc/services.d/supervisor/run
+++ b/rootfs/etc/services.d/supervisor/run
@@ -2,7 +2,10 @@
 # ==============================================================================
 # Start Supervisor service
 # ==============================================================================
-export LD_PRELOAD="/usr/local/lib/libjemalloc.so.2"
-export MALLOC_CONF="background_thread:true,metadata_thp:auto"
+# Use mimalloc as Python's object allocator by default. It is bundled in CPython
+# (3.13+), so no LD_PRELOAD or extra library is required, and it uses noticeably
+# less memory than the previously preloaded jemalloc. Override or disable via
+# PYTHONMALLOC, e.g. `PYTHONMALLOC=pymalloc` for the default allocator.
+export PYTHONMALLOC="${PYTHONMALLOC:-mimalloc}"
 
 exec python3 -m supervisor


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Switch the Supervisor container from preloading jemalloc process-wide to selecting mimalloc as CPython's object allocator via `PYTHONMALLOC=mimalloc`. This is the Supervisor counterpart of home-assistant/core#175604, which makes the same change for Home Assistant Core and contains the full motivation and benchmark results.

In short: mimalloc is bundled in CPython 3.13+ (`--with-mimalloc`, enabled by default), so no `LD_PRELOAD` and no external allocator library are needed. Benchmarks on the Core image (same Python 3.14/musl/Alpine base as Supervisor) showed jemalloc has no measurable CPU advantage over the default allocator while retaining substantially more memory; `PYTHONMALLOC=mimalloc` gave the best combined result (~27% lower peak RSS than jemalloc at CPU parity or slightly better). jemalloc also bakes the page size in at build time and aborts with `Unsupported system page size` on aarch64 kernels using 16 KB/64 KB pages, whereas mimalloc queries the page size at runtime.

`PYTHONMALLOC` is only defaulted, not forced (`${PYTHONMALLOC:-mimalloc}`), so the allocator remains user-overridable, e.g. `PYTHONMALLOC=pymalloc` for CPython's default allocator. Unlike Core, Supervisor preloaded jemalloc unconditionally (no `DISABLE_JEMALLOC` escape hatch), so there is no legacy opt-out variable to handle.

Verified against the current base image (`base-python:3.14-alpine3.22-2026.05.0`): its CPython 3.14.5 is built with `WITH_MIMALLOC=1` and starts cleanly under `PYTHONMALLOC=mimalloc`, the default expansion picks mimalloc when the variable is unset, and a user-supplied value wins over the default.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/core#175604 (same change for Home Assistant Core, with full motivation and benchmarks)
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
