### PR TITLE
Emit store_reloaded event when a store reload updates repositories

### DIFF
--- a/supervisor/homeassistant/const.py
+++ b/supervisor/homeassistant/const.py
@@ -44,5 +44,6 @@ class WSEvent(StrEnum):
     ISSUE_CHANGED = "issue_changed"
     ISSUE_REMOVED = "issue_removed"
     JOB = "job"
+    STORE_RELOADED = "store_reloaded"
     SUPERVISOR_UPDATE = "supervisor_update"
     SUPPORTED_CHANGED = "supported_changed"

--- a/supervisor/store/__init__.py
+++ b/supervisor/store/__init__.py
@@ -14,6 +14,7 @@ from ..exceptions import (
     StoreJobError,
     StoreNotFound,
 )
+from ..homeassistant.const import WSEvent
 from ..jobs.decorator import Job, JobCondition
 from ..resolution.const import ContextType, IssueType, SuggestionType
 from ..utils.common import FileConfiguration
@@ -114,6 +115,13 @@ class StoreManager(CoreSysAttributes, FileConfiguration):
             # read data from repositories
             await self.data.update()
             await self._read_apps()
+
+            # Notify Home Assistant so add-on update entities pick up the newly
+            # loaded store data instead of waiting for the next scheduled poll.
+            self.sys_homeassistant.websocket.supervisor_event(
+                WSEvent.STORE_RELOADED,
+                {ATTR_REPOSITORIES: sorted(updated_repos)},
+            )
 
     @Job(
         name="store_manager_add_repository",

--- a/tests/store/test_store_manager.py
+++ b/tests/store/test_store_manager.py
@@ -1,9 +1,10 @@
 """Test store manager."""
 
+import asyncio
 from datetime import datetime
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import PropertyMock, patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 from awesomeversion import AwesomeVersion
 import pytest
@@ -13,11 +14,12 @@ from supervisor.arch import CpuArchManager
 from supervisor.backups.manager import BackupManager
 from supervisor.coresys import CoreSys
 from supervisor.exceptions import AppNotSupportedError, StoreJobError
+from supervisor.homeassistant.const import WSEvent
 from supervisor.homeassistant.module import HomeAssistant
 from supervisor.store import StoreManager
 from supervisor.store.app import AppStore
 from supervisor.store.git import GitRepo
-from supervisor.store.repository import Repository
+from supervisor.store.repository import Repository, RepositoryGit
 
 from tests.common import load_yaml_fixture
 
@@ -244,6 +246,37 @@ async def test_reload(coresys: CoreSys, supervisor_internet):
         await coresys.store.reload()
 
         assert git_pull.call_count == 4
+
+
+async def test_reload_fires_store_reloaded_event(
+    coresys: CoreSys, supervisor_internet, ha_ws_client: AsyncMock
+) -> None:
+    """Test reload fires a store_reloaded event for the updated repositories."""
+    await coresys.store.load()
+
+    def _store_reloaded_events() -> list[dict[str, Any]]:
+        return [
+            call.args[0]["data"]["data"]
+            for call in ha_ws_client.async_send_command.call_args_list
+            if call.args[0].get("data", {}).get("event") == WSEvent.STORE_RELOADED
+        ]
+
+    # No repository reports an update, so no event is fired
+    with patch.object(RepositoryGit, "update", return_value=False):
+        await coresys.store.reload()
+        await asyncio.sleep(0)
+    assert _store_reloaded_events() == []
+
+    # A repository update fires exactly one event listing the updated repos
+    with patch.object(RepositoryGit, "update", return_value=True):
+        await coresys.store.reload()
+        await asyncio.sleep(0)
+
+    events = _store_reloaded_events()
+    assert len(events) == 1
+    assert set(events[0]["repositories"]) == {
+        repo.slug for repo in coresys.store.all if isinstance(repo, RepositoryGit)
+    }
 
 
 async def test_app_version_timestamp(coresys: CoreSys, install_app_example: App):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

When a user clicks "Check for updates" on the apps dashboard, the frontend reloads the add-on store through the `supervisor/api` websocket proxy (`/store/reload`). A reload pulls fresh repository data, which can change add-on update availability. Home Assistant Core, however, learns about this only through its periodic add-on coordinator poll (`RUN_RELOAD_APPS`, up to three hours). Until that poll runs, the add-on `update` entities stay stale: the more info dialog opened from an app page can disagree with the dashboard, reporting the add-on as up to date with a disabled update button.

This adds a `store_reloaded` `supervisor/event`, emitted after a store reload actually updates one or more repositories. Core can subscribe to it and refresh the affected add-on update entities immediately, using the same event-driven mechanism already in place for `supervisor_update`, `job`, `issue_changed`, and friends.

Details:

- The event fires only when `StoreManager.reload()` updated at least one repository. Whichever reload pulls a change first — the periodic reload task or a proxied `/store/reload` — fires it, so a no-op reload does not wake Core unnecessarily.
- It carries the updated repository slugs under `data.repositories`.

This is the Supervisor half of a two-part change. The companion Core change subscribes to the event and refreshes the add-on update coordinator, replacing the current approach of inspecting `/store/reload` traffic inside the websocket API proxy handler. Version skew is harmless in both directions: an older Core simply ignores the unknown event and keeps polling, and a newer Core against an older Supervisor just never receives it.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/core#176584
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
