### PR TITLE
Migrate addon error metadata to app/apps with v1 compatibility shim

### DIFF
--- a/supervisor/api/middleware/security.py
+++ b/supervisor/api/middleware/security.py
@@ -294,7 +294,7 @@ class SecurityMiddleware(CoreSysAttributes):
         """Check if core is ready to response."""
         if self.sys_core.state not in VALID_API_STATES:
             return api_return_error(
-                message=f"System is not ready with state: {self.sys_core.state}"
+                message=f"System is not ready with state: {self.sys_core.state}",
             )
 
         return await handler(request)

--- a/supervisor/api/utils.py
+++ b/supervisor/api/utils.py
@@ -36,6 +36,42 @@ from . import const
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
+# V1 compatibility shim for three AppNotSupported* errors whose legacy
+# addon_* keys are still consumed by the Supervisor client library.
+_V1_LEGACY_ERROR_KEY_MAP: dict[str, str] = {
+    "app_not_supported_architecture_error": "addon_not_supported_architecture_error",
+    "app_not_supported_machine_type_error": "addon_not_supported_machine_type_error",
+    "app_not_supported_home_assistant_version_error": "addon_not_supported_home_assistant_version_error",
+}
+
+
+def _request_from_handler_args(args: tuple[Any, ...]) -> Request | None:
+    """Extract aiohttp Request from handler args.
+
+    aiohttp invokes route handlers as handler(request). For bound methods,
+    Python binds self first, so args are (self, request).
+    """
+    if args and isinstance(args[0], Request):
+        return args[0]
+
+    if len(args) > 1:
+        return cast(Request, args[1])
+
+    return None
+
+
+def _is_v2_request(request: Request | None) -> bool:
+    """Return True when request targets the v2 sub-app."""
+    return bool(request and request.path.startswith("/v2/"))
+
+
+def _response_error_key(error_key: str, request: Request | None) -> str:
+    """Return mapped error key for the request API version."""
+    if _is_v2_request(request):
+        return error_key
+
+    return _V1_LEGACY_ERROR_KEY_MAP.get(error_key, error_key)
+
 
 def extract_supervisor_token(request: web.Request) -> str | None:
     """Extract Supervisor token from request."""
@@ -71,13 +107,19 @@ def api_process(method):
         try:
             answer = await method(*args, **kwargs)
         except APIError as err:
+            request = _request_from_handler_args(args)
             return api_return_error(
-                err, status=err.status, job_id=err.job_id, headers=err.headers
+                err,
+                status=err.status,
+                job_id=err.job_id,
+                headers=err.headers,
+                request=request,
             )
         except HassioError as err:
             _LOGGER.exception("Unexpected error during API call: %s", err)
             await async_capture_exception(err)
-            return api_return_error(err)
+            request = _request_from_handler_args(args)
+            return api_return_error(err, request=request)
 
         if isinstance(answer, (dict, list)):
             return api_return_ok(data=answer)
@@ -117,17 +159,22 @@ def api_process_raw(content, *, error_type=None):
             try:
                 msg_data = await method(*args, **kwargs)
             except APIError as err:
+                request = _request_from_handler_args(args)
                 return api_return_error(
                     err,
                     error_type=error_type or const.CONTENT_TYPE_BINARY,
                     status=err.status,
                     job_id=err.job_id,
+                    request=request,
                 )
             except HassioError as err:
                 _LOGGER.exception("Unexpected error during API call: %s", err)
                 await async_capture_exception(err)
+                request = _request_from_handler_args(args)
                 return api_return_error(
-                    err, error_type=error_type or const.CONTENT_TYPE_BINARY
+                    err,
+                    error_type=error_type or const.CONTENT_TYPE_BINARY,
+                    request=request,
                 )
 
             if isinstance(msg_data, (web.Response, web.StreamResponse)):
@@ -148,6 +195,7 @@ def api_return_error(
     *,
     headers: Mapping[str, str] | None = None,
     job_id: str | None = None,
+    request: Request | None = None,
 ) -> web.Response:
     """Return an API error message."""
     if error and not message:
@@ -175,7 +223,7 @@ def api_return_error(
             if job_id:
                 result[JSON_JOB_ID] = job_id
             if error and error.error_key:
-                result[JSON_ERROR_KEY] = error.error_key
+                result[JSON_ERROR_KEY] = _response_error_key(error.error_key, request)
             if error and error.extra_fields:
                 result[JSON_EXTRA_FIELDS] = error.extra_fields
 

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -395,7 +395,7 @@ class AppsError(HassioError):
 class AppAPIError(AppsError, APIError):
     """Base class for App-related API errors that have an app for context.
 
-    Owns the shape of extra_fields so subclasses uniformly expose addon
+    Owns the shape of extra_fields so subclasses uniformly expose app
     (display name) and slug. Pass an app-like object (anything with .name
     and .slug attributes — App, AppModel, AppStore). Errors raised without
     an app object available (e.g., unknown or not-installed app lookups)
@@ -411,7 +411,7 @@ class AppAPIError(AppsError, APIError):
     ) -> None:
         """Initialize exception."""
         self.extra_fields = {
-            "addon": app.name,
+            "app": app.name,
             "slug": app.slug,
             **extra_fields,
         }
@@ -421,8 +421,8 @@ class AppAPIError(AppsError, APIError):
 class AppAlreadyInstalledError(AppAPIError):
     """Raise when attempting to install an app that is already installed."""
 
-    error_key = "addon_already_installed_error"
-    message_template = "App {addon} is already installed"
+    error_key = "app_already_installed_error"
+    message_template = "App {app} is already installed"
 
 
 class AppNotFoundError(AppsError, APIError):
@@ -431,7 +431,7 @@ class AppNotFoundError(AppsError, APIError):
     No app object exists at this point, so this is not an AppAPIError.
     """
 
-    error_key = "addon_not_found_error"
+    error_key = "app_not_found_error"
     message_template = "App {slug} does not exist"
 
     def __init__(self, logger: Callable[..., None] | None = None, *, slug: str) -> None:
@@ -446,7 +446,7 @@ class AppNotInstalledError(AppsError, APIError):
     No app object exists at this point, so this is not an AppAPIError.
     """
 
-    error_key = "addon_not_installed_error"
+    error_key = "app_not_installed_error"
     message_template = "App {slug} is not installed"
 
     def __init__(self, logger: Callable[..., None] | None = None, *, slug: str) -> None:
@@ -458,23 +458,23 @@ class AppNotInstalledError(AppsError, APIError):
 class AppNotInStoreError(AppAPIError):
     """Raise when an installed app is no longer available in its store."""
 
-    error_key = "addon_not_in_store_error"
-    message_template = "App {addon} is not available inside store"
+    error_key = "app_not_in_store_error"
+    message_template = "App {app} is not available inside store"
 
 
 class AppNoUpdateAvailableError(AppAPIError):
     """Raise when an update is requested but local matches store version."""
 
-    error_key = "addon_no_update_available_error"
-    message_template = "No update available for app {addon}"
+    error_key = "app_no_update_available_error"
+    message_template = "No update available for app {app}"
 
 
 class AppRebuildVersionChangedError(AppAPIError):
     """Raise when rebuild is requested but local and store versions differ."""
 
-    error_key = "addon_rebuild_version_changed_error"
+    error_key = "app_rebuild_version_changed_error"
     message_template = (
-        "Local and store versions of app {addon} differ, use Update instead of Rebuild"
+        "Local and store versions of app {app} differ, use Update instead of Rebuild"
     )
 
 
@@ -485,8 +485,8 @@ class AppConfigurationError(AppsError):
 class AppConfigurationInvalidError(AppConfigurationError, APIError):
     """Raise if invalid configuration provided for app."""
 
-    error_key = "addon_configuration_invalid_error"
-    message_template = "App {addon} has invalid options: {validation_error}"
+    error_key = "app_configuration_invalid_error"
+    message_template = "App {app} has invalid options: {validation_error}"
 
     def __init__(
         self,
@@ -496,42 +496,42 @@ class AppConfigurationInvalidError(AppConfigurationError, APIError):
         validation_error: str,
     ) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": app, "validation_error": validation_error}
+        self.extra_fields = {"app": app, "validation_error": validation_error}
         super().__init__(None, logger)
 
 
 class AppBootConfigCannotChangeError(AppsError, APIError):
     """Raise if user attempts to change app boot config when it can't be changed."""
 
-    error_key = "addon_boot_config_cannot_change_error"
+    error_key = "app_boot_config_cannot_change_error"
     message_template = (
-        "App {addon} boot option is set to {boot_config} so it cannot be changed"
+        "App {app} boot option is set to {boot_config} so it cannot be changed"
     )
 
     def __init__(
         self, logger: Callable[..., None] | None = None, *, app: str, boot_config: str
     ) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": app, "boot_config": boot_config}
+        self.extra_fields = {"app": app, "boot_config": boot_config}
         super().__init__(None, logger)
 
 
 class AppNotRunningError(AppsError, APIError):
     """Raise when an app is not running."""
 
-    error_key = "addon_not_running_error"
-    message_template = "App {addon} is not running"
+    error_key = "app_not_running_error"
+    message_template = "App {app} is not running"
 
     def __init__(self, logger: Callable[..., None] | None = None, *, app: str) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": app}
+        self.extra_fields = {"app": app}
         super().__init__(None, logger)
 
 
 class AppPortConflict(AppsError, APIError):
     """Raise if app cannot start due to a port conflict."""
 
-    error_key = "addon_port_conflict"
+    error_key = "app_port_conflict"
     message_template = "Cannot start app {name} because port {port} is already in use"
 
     def __init__(
@@ -549,8 +549,8 @@ class AppNotSupportedError(HassioNotSupportedError):
 class AppNotSupportedArchitectureError(AppNotSupportedError, AppAPIError):
     """App does not support system due to architecture."""
 
-    error_key = "addon_not_supported_architecture_error"
-    message_template = "App {addon} not supported on this platform, supported architectures: {architectures}"
+    error_key = "app_not_supported_architecture_error"
+    message_template = "App {app} not supported on this platform, supported architectures: {architectures}"
 
     def __init__(  # pylint: disable=useless-parent-delegation
         self,
@@ -566,8 +566,8 @@ class AppNotSupportedArchitectureError(AppNotSupportedError, AppAPIError):
 class AppNotSupportedMachineTypeError(AppNotSupportedError, AppAPIError):
     """App does not support system due to machine type."""
 
-    error_key = "addon_not_supported_machine_type_error"
-    message_template = "App {addon} not supported on this machine, supported machine types: {machine_types}"
+    error_key = "app_not_supported_machine_type_error"
+    message_template = "App {app} not supported on this machine, supported machine types: {machine_types}"
 
     def __init__(  # pylint: disable=useless-parent-delegation
         self,
@@ -583,8 +583,8 @@ class AppNotSupportedMachineTypeError(AppNotSupportedError, AppAPIError):
 class AppNotSupportedHomeAssistantVersionError(AppNotSupportedError, AppAPIError):
     """App does not support system due to Home Assistant version."""
 
-    error_key = "addon_not_supported_home_assistant_version_error"
-    message_template = "App {addon} not supported on this system, requires Home Assistant version {version} or greater"
+    error_key = "app_not_supported_home_assistant_version_error"
+    message_template = "App {app} not supported on this system, requires Home Assistant version {version} or greater"
 
     def __init__(  # pylint: disable=useless-parent-delegation
         self,
@@ -600,45 +600,45 @@ class AppNotSupportedHomeAssistantVersionError(AppNotSupportedError, AppAPIError
 class AppRebuildImageBasedError(AppNotSupportedError, AppAPIError):
     """Raise when rebuild is requested for an image-based app."""
 
-    error_key = "addon_rebuild_image_based_error"
-    message_template = "Cannot rebuild app {addon}, it is image-based"
+    error_key = "app_rebuild_image_based_error"
+    message_template = "Cannot rebuild app {app}, it is image-based"
 
 
 class AppNotSupportedWriteStdinError(AppNotSupportedError, APIError):
     """App does not support writing to stdin."""
 
-    error_key = "addon_not_supported_write_stdin_error"
-    message_template = "App {addon} does not support writing to stdin"
+    error_key = "app_not_supported_write_stdin_error"
+    message_template = "App {app} does not support writing to stdin"
 
     def __init__(self, logger: Callable[..., None] | None = None, *, app: str) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": app}
+        self.extra_fields = {"app": app}
         super().__init__(None, logger)
 
 
 class AppBuildDockerfileMissingError(AppNotSupportedError, APIError):
     """Raise when app build invalid because dockerfile is missing."""
 
-    error_key = "addon_build_dockerfile_missing_error"
+    error_key = "app_build_dockerfile_missing_error"
     message_template = (
-        "Cannot build app '{addon}' because dockerfile is missing. A repair "
+        "Cannot build app '{app}' because dockerfile is missing. A repair "
         "using '{repair_command}' will fix this if the cause is data "
         "corruption. Otherwise please report this to the app developer."
     )
 
     def __init__(self, logger: Callable[..., None] | None = None, *, app: str) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": app, "repair_command": "ha supervisor repair"}
+        self.extra_fields = {"app": app, "repair_command": "ha supervisor repair"}
         super().__init__(None, logger)
 
 
 class AppBuildArchitectureNotSupportedError(AppNotSupportedError, APIError):
     """Raise when app cannot be built on system because it doesn't support its architecture."""
 
-    error_key = "addon_build_architecture_not_supported_error"
+    error_key = "app_build_architecture_not_supported_error"
     message_template = (
-        "Cannot build app '{addon}' because its supported architectures "
-        "({addon_arches}) do not match the system supported architectures ({system_arches})"
+        "Cannot build app '{app}' because its supported architectures "
+        "({app_arches}) do not match the system supported architectures ({system_arches})"
     )
 
     def __init__(
@@ -651,8 +651,8 @@ class AppBuildArchitectureNotSupportedError(AppNotSupportedError, APIError):
     ) -> None:
         """Initialize exception."""
         self.extra_fields = {
-            "addon": app,
-            "addon_arches": ", ".join(app_arch_list),
+            "app": app,
+            "app_arches": ", ".join(app_arch_list),
             "system_arches": ", ".join(system_arch_list),
         }
         super().__init__(None, logger)
@@ -661,35 +661,35 @@ class AppBuildArchitectureNotSupportedError(AppNotSupportedError, APIError):
 class AppUnknownError(AppsError, APIUnknownSupervisorError):
     """Raise when unknown error occurs taking an action for an app."""
 
-    error_key = "addon_unknown_error"
-    message_template = "An unknown error occurred with app {addon}"
+    error_key = "app_unknown_error"
+    message_template = "An unknown error occurred with app {app}"
 
     def __init__(self, logger: Callable[..., None] | None = None, *, app: str) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": app}
+        self.extra_fields = {"app": app}
         super().__init__(logger)
 
 
 class AppBuildFailedUnknownError(AppsError, APIUnknownSupervisorError):
     """Raise when the build failed for an app due to an unknown error."""
 
-    error_key = "addon_build_failed_unknown_error"
+    error_key = "app_build_failed_unknown_error"
     message_template = (
-        "An unknown error occurred while trying to build the image for app {addon}"
+        "An unknown error occurred while trying to build the image for app {app}"
     )
 
     def __init__(self, logger: Callable[..., None] | None = None, *, app: str) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": app}
+        self.extra_fields = {"app": app}
         super().__init__(logger)
 
 
 class AppFileReadError(AppsError, APIError):
     """Raise when an app metadata file cannot be read due to a filesystem error."""
 
-    error_key = "addon_file_read_error"
+    error_key = "app_file_read_error"
     message_template = (
-        "Could not read metadata for app {addon} due to a filesystem error: {error}"
+        "Could not read metadata for app {app} due to a filesystem error: {error}"
     )
 
     def __init__(
@@ -700,7 +700,7 @@ class AppFileReadError(AppsError, APIError):
         error: str,
     ) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": app, "error": error}
+        self.extra_fields = {"app": app, "error": error}
         super().__init__(None, logger)
 
 
@@ -1276,12 +1276,12 @@ class StoreNotFound(StoreError):
 class StoreAppNotFoundError(StoreError, APINotFound):
     """Raise if a requested app is not in the store."""
 
-    error_key = "store_addon_not_found_error"
-    message_template = "App {addon} does not exist in the store"
+    error_key = "store_app_not_found_error"
+    message_template = "App {app} does not exist in the store"
 
     def __init__(self, logger: Callable[..., None] | None = None, *, app: str) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": app}
+        self.extra_fields = {"app": app}
         super().__init__(None, logger)
 
 
@@ -1376,9 +1376,9 @@ class BackupFatalIOError(BackupError):
 class AppBackupMetadataInvalidError(BackupError, APIError):
     """Raise if invalid metadata file provided for app in backup."""
 
-    error_key = "addon_backup_metadata_invalid_error"
+    error_key = "app_backup_metadata_invalid_error"
     message_template = (
-        "Metadata file for app {addon} in backup is invalid: {validation_error}"
+        "Metadata file for app {app} in backup is invalid: {validation_error}"
     )
 
     def __init__(
@@ -1389,16 +1389,16 @@ class AppBackupMetadataInvalidError(BackupError, APIError):
         validation_error: str,
     ) -> None:
         """Initialize exception."""
-        self.extra_fields = {"addon": app, "validation_error": validation_error}
+        self.extra_fields = {"app": app, "validation_error": validation_error}
         super().__init__(None, logger)
 
 
 class AppPrePostBackupCommandReturnedError(BackupError, APIError):
     """Raise when app's pre/post backup command returns an error."""
 
-    error_key = "addon_pre_post_backup_command_returned_error"
+    error_key = "app_pre_post_backup_command_returned_error"
     message_template = (
-        "Pre-/Post backup command for app {addon} returned error code: "
+        "Pre-/Post backup command for app {app} returned error code: "
         "{exit_code}. Please report this to the app developer. Enable debug "
         "logging to capture complete command output using {debug_logging_command}"
     )
@@ -1408,7 +1408,7 @@ class AppPrePostBackupCommandReturnedError(BackupError, APIError):
     ) -> None:
         """Initialize exception."""
         self.extra_fields = {
-            "addon": app,
+            "app": app,
             "exit_code": exit_code,
             "debug_logging_command": "ha supervisor options --logging debug",
         }

--- a/tests/api/test_apps.py
+++ b/tests/api/test_apps.py
@@ -540,9 +540,9 @@ async def test_app_options_boot_mode_manual_only_invalid(
         body["message"]
         == "App local_example boot option is set to manual_only so it cannot be changed"
     )
-    assert body["error_key"] == "addon_boot_config_cannot_change_error"
+    assert body["error_key"] == "app_boot_config_cannot_change_error"
     assert body["extra_fields"] == {
-        "addon": "local_example",
+        "app": "local_example",
         "boot_config": "manual_only",
     }
 
@@ -667,9 +667,9 @@ async def test_app_set_options_error(api_client: TestClient):
         body["message"]
         == "App local_example has invalid options: expected str. Got {'message': True}"
     )
-    assert body["error_key"] == "addon_configuration_invalid_error"
+    assert body["error_key"] == "app_configuration_invalid_error"
     assert body["extra_fields"] == {
-        "addon": "local_example",
+        "app": "local_example",
         "validation_error": "expected str. Got {'message': True}",
     }
 
@@ -691,9 +691,9 @@ async def test_app_start_options_error(
             body["message"]
             == "An unknown error occurred with app local_example. Check Supervisor logs for details"
         )
-        assert body["error_key"] == "addon_unknown_error"
+        assert body["error_key"] == "app_unknown_error"
         assert body["extra_fields"] == {
-            "addon": "local_example",
+            "app": "local_example",
         }
         assert "App local_example can't write options" in caplog.text
 
@@ -707,9 +707,9 @@ async def test_app_start_options_error(
         body["message"]
         == "App local_example has invalid options: expected boolean. Got {'message': 'hello'}"
     )
-    assert body["error_key"] == "addon_configuration_invalid_error"
+    assert body["error_key"] == "app_configuration_invalid_error"
     assert body["extra_fields"] == {
-        "addon": "local_example",
+        "app": "local_example",
         "validation_error": "expected boolean. Got {'message': 'hello'}",
     }
     assert (
@@ -731,8 +731,8 @@ async def test_app_not_running_error(
     assert resp.status == 400
     body = await resp.json()
     assert body["message"] == "App local_example is not running"
-    assert body["error_key"] == "addon_not_running_error"
-    assert body["extra_fields"] == {"addon": "local_example"}
+    assert body["error_key"] == "app_not_running_error"
+    assert body["extra_fields"] == {"app": "local_example"}
 
 
 @pytest.mark.usefixtures("install_app_example")
@@ -745,8 +745,8 @@ async def test_app_write_stdin_not_supported_error(
     assert resp.status == 400
     body = await resp.json()
     assert body["message"] == "App local_example does not support writing to stdin"
-    assert body["error_key"] == "addon_not_supported_write_stdin_error"
-    assert body["extra_fields"] == {"addon": "local_example"}
+    assert body["error_key"] == "app_not_supported_write_stdin_error"
+    assert body["extra_fields"] == {"app": "local_example"}
 
 
 @pytest.mark.usefixtures("install_app_ssh")
@@ -775,9 +775,9 @@ async def test_app_rebuild_fails_error(api_client: TestClient, coresys: CoreSys)
         body["message"]
         == "An unknown error occurred while trying to build the image for app local_ssh. Check Supervisor logs for details"
     )
-    assert body["error_key"] == "addon_build_failed_unknown_error"
+    assert body["error_key"] == "app_build_failed_unknown_error"
     assert body["extra_fields"] == {
-        "addon": "local_ssh",
+        "app": "local_ssh",
     }
 
 

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -1596,9 +1596,9 @@ async def test_pre_post_backup_command_error(
         "1. Please report this to the app developer. Enable debug "
         "logging to capture complete command output using ha supervisor options --logging debug"
     )
-    assert job.errors[0].error_key == "addon_pre_post_backup_command_returned_error"
+    assert job.errors[0].error_key == "app_pre_post_backup_command_returned_error"
     assert job.errors[0].extra_fields == {
-        "addon": "local_example",
+        "app": "local_example",
         "exit_code": 1,
         "debug_logging_command": "ha supervisor options --logging debug",
     }

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -466,8 +466,8 @@ async def test_store_app_not_found(
     if json_expected:
         body = await resp.json()
         assert body["message"] == "App bad does not exist in the store"
-        assert body["error_key"] == "store_addon_not_found_error"
-        assert body["extra_fields"] == {"addon": "bad"}
+        assert body["error_key"] == "store_app_not_found_error"
+        assert body["extra_fields"] == {"app": "bad"}
     else:
         assert await resp.text() == "App bad does not exist in the store"
 
@@ -490,8 +490,8 @@ async def test_store_app_not_found_legacy_paths(
     if json_expected:
         body = await resp.json()
         assert body["message"] == "App bad does not exist in the store"
-        assert body["error_key"] == "store_addon_not_found_error"
-        assert body["extra_fields"] == {"addon": "bad"}
+        assert body["error_key"] == "store_app_not_found_error"
+        assert body["extra_fields"] == {"app": "bad"}
     else:
         assert await resp.text() == "App bad does not exist in the store"
 
@@ -688,7 +688,7 @@ async def test_api_store_apps_app_availability_success(
     ],
 )
 async def test_api_store_apps_app_availability_arch_not_supported(
-    api_client: TestClient,
+    store_app_api_client_with_root: tuple[TestClient, str],
     coresys: CoreSys,
     supported_architectures: list[str],
     api_action: str,
@@ -696,6 +696,7 @@ async def test_api_store_apps_app_availability_arch_not_supported(
     installed: bool,
 ):
     """Test availability errors for /store/apps/{app}/* REST APIs - architecture not supported."""
+    client, root = store_app_api_client_with_root
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     # Create an app with unsupported architecture
     app_obj = AppStore(coresys, "test_arch_addon")
@@ -721,14 +722,17 @@ async def test_api_store_apps_app_availability_arch_not_supported(
     with patch.object(
         CpuArchManager, "supported", new=PropertyMock(return_value=["amd64"])
     ):
-        resp = await api_client.request(
-            api_method, f"/store/addons/{app_obj.slug}/{api_action}"
-        )
+        resp = await client.request(api_method, f"/{root}/{app_obj.slug}/{api_action}")
         assert resp.status == 400
         result = await resp.json()
-        assert result["error_key"] == "addon_not_supported_architecture_error"
+        expected_error_key = (
+            "app_not_supported_architecture_error"
+            if root.startswith("v2/")
+            else "addon_not_supported_architecture_error"
+        )
+        assert result["error_key"] == expected_error_key
         assert result["extra_fields"] == {
-            "addon": "Test Arch Add-on",
+            "app": "Test Arch Add-on",
             "slug": "test_arch_addon",
             "architectures": (architectures := ", ".join(supported_architectures)),
         }
@@ -753,7 +757,7 @@ async def test_api_store_apps_app_availability_arch_not_supported(
     ],
 )
 async def test_api_store_apps_app_availability_machine_not_supported(
-    api_client: TestClient,
+    store_app_api_client_with_root: tuple[TestClient, str],
     coresys: CoreSys,
     supported_machines: list[str],
     api_action: str,
@@ -761,6 +765,7 @@ async def test_api_store_apps_app_availability_machine_not_supported(
     installed: bool,
 ):
     """Test availability errors for /store/apps/{app}/* REST APIs - machine not supported."""
+    client, root = store_app_api_client_with_root
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     # Create an app with unsupported machine type
     app_obj = AppStore(coresys, "test_machine_addon")
@@ -785,14 +790,17 @@ async def test_api_store_apps_app_availability_machine_not_supported(
 
     # Mock the system machine to be different
     with patch.object(CoreSys, "machine", new=PropertyMock(return_value="qemux86-64")):
-        resp = await api_client.request(
-            api_method, f"/store/addons/{app_obj.slug}/{api_action}"
-        )
+        resp = await client.request(api_method, f"/{root}/{app_obj.slug}/{api_action}")
         assert resp.status == 400
         result = await resp.json()
-        assert result["error_key"] == "addon_not_supported_machine_type_error"
+        expected_error_key = (
+            "app_not_supported_machine_type_error"
+            if root.startswith("v2/")
+            else "addon_not_supported_machine_type_error"
+        )
+        assert result["error_key"] == expected_error_key
         assert result["extra_fields"] == {
-            "addon": "Test Machine Add-on",
+            "app": "Test Machine Add-on",
             "slug": "test_machine_addon",
             "machine_types": (machine_types := ", ".join(supported_machines)),
         }
@@ -811,13 +819,14 @@ async def test_api_store_apps_app_availability_machine_not_supported(
     ],
 )
 async def test_api_store_apps_app_availability_homeassistant_version_too_old(
-    api_client: TestClient,
+    store_app_api_client_with_root: tuple[TestClient, str],
     coresys: CoreSys,
     api_action: str,
     api_method: str,
     installed: bool,
 ):
     """Test availability errors for /store/apps/{app}/* REST APIs - Home Assistant version too old."""
+    client, root = store_app_api_client_with_root
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     # Create an app that requires newer Home Assistant version
     app_obj = AppStore(coresys, "test_version_addon")
@@ -846,14 +855,17 @@ async def test_api_store_apps_app_availability_homeassistant_version_too_old(
         "version",
         new=PropertyMock(return_value=AwesomeVersion("2022.1.1")),
     ):
-        resp = await api_client.request(
-            api_method, f"/store/addons/{app_obj.slug}/{api_action}"
-        )
+        resp = await client.request(api_method, f"/{root}/{app_obj.slug}/{api_action}")
         assert resp.status == 400
         result = await resp.json()
-        assert result["error_key"] == "addon_not_supported_home_assistant_version_error"
+        expected_error_key = (
+            "app_not_supported_home_assistant_version_error"
+            if root.startswith("v2/")
+            else "addon_not_supported_home_assistant_version_error"
+        )
+        assert result["error_key"] == expected_error_key
         assert result["extra_fields"] == {
-            "addon": "Test Version Add-on",
+            "app": "Test Version Add-on",
             "slug": "test_version_addon",
             "version": "2023.1.1",
         }


### PR DESCRIPTION
## Proposed change

This PR completes the exception/error metadata migration from `addon`/`addons` terminology to `app`/`apps` terminology for API errors, including:

- renamed `error_key` values in `supervisor/exceptions.py`
- renamed `extra_fields` keys (for example `addon` -> `app`)
- renamed message template placeholders from `{addon}` to `{app}`
- updated API tests to assert the new naming

For backward compatibility with the current Supervisor client library, V1 responses map the following three new keys back to their legacy values, while V2 returns the new keys:

- `app_not_supported_architecture_error`
- `app_not_supported_machine_type_error`
- `app_not_supported_home_assistant_version_error`

This mapping is centralized in `api_return_error` via a small helper in `supervisor/api/utils.py`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #7027
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/