### PR TITLE
Rename backup and restore job stages from addon(s) to app(s)

### DIFF
--- a/supervisor/backups/const.py
+++ b/supervisor/backups/const.py
@@ -27,24 +27,24 @@ class BackupType(StrEnum):
 class BackupJobStage(StrEnum):
     """Backup job stage enum."""
 
-    ADDON_REPOSITORIES = "addon_repositories"
-    ADDONS = "addons"
+    APP_REPOSITORIES = "app_repositories"
+    APPS = "apps"
     FINISHING_FILE = "finishing_file"
     FOLDERS = "folders"
     HOME_ASSISTANT = "home_assistant"
     SUPERVISOR_CONFIG = "supervisor_config"
     COPY_ADDITONAL_LOCATIONS = "copy_additional_locations"
-    AWAIT_ADDON_RESTARTS = "await_addon_restarts"
+    AWAIT_APP_RESTARTS = "await_app_restarts"
 
 
 class RestoreJobStage(StrEnum):
     """Restore job stage enum."""
 
-    ADDON_REPOSITORIES = "addon_repositories"
-    ADDONS = "addons"
-    AWAIT_ADDON_RESTARTS = "await_addon_restarts"
+    APP_REPOSITORIES = "app_repositories"
+    APPS = "apps"
+    AWAIT_APP_RESTARTS = "await_app_restarts"
     AWAIT_HOME_ASSISTANT_RESTART = "await_home_assistant_restart"
     FOLDERS = "folders"
     HOME_ASSISTANT = "home_assistant"
     SUPERVISOR_CONFIG = "supervisor_config"
-    REMOVE_DELTA_ADDONS = "remove_delta_addons"
+    REMOVE_DELTA_APPS = "remove_delta_apps"

--- a/supervisor/backups/const.py
+++ b/supervisor/backups/const.py
@@ -33,7 +33,7 @@ class BackupJobStage(StrEnum):
     FOLDERS = "folders"
     HOME_ASSISTANT = "home_assistant"
     SUPERVISOR_CONFIG = "supervisor_config"
-    COPY_ADDITONAL_LOCATIONS = "copy_additional_locations"
+    COPY_ADDITIONAL_LOCATIONS = "copy_additional_locations"
     AWAIT_APP_RESTARTS = "await_app_restarts"
 
 

--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -245,7 +245,7 @@ class BackupManager(FileConfiguration, JobGroup):
         # Add backup ID to job
         self.sys_jobs.current.reference = backup.slug
 
-        self._change_stage(BackupJobStage.ADDON_REPOSITORIES, backup)
+        self._change_stage(BackupJobStage.APP_REPOSITORIES, backup)
         backup.store_repositories()
 
         return backup
@@ -544,7 +544,7 @@ class BackupManager(FileConfiguration, JobGroup):
 
                 # Backup apps
                 if app_list:
-                    self._change_stage(BackupJobStage.ADDONS, backup)
+                    self._change_stage(BackupJobStage.APPS, backup)
                     app_start_tasks = await backup.store_apps(app_list)
 
                 # Backup folders
@@ -579,7 +579,7 @@ class BackupManager(FileConfiguration, JobGroup):
                 await self._copy_to_additional_locations(backup, additional_locations)
 
             if app_start_tasks:
-                self._change_stage(BackupJobStage.AWAIT_ADDON_RESTARTS, backup)
+                self._change_stage(BackupJobStage.AWAIT_APP_RESTARTS, backup)
                 # Ignore exceptions from waiting for app startup, app errors handled elsewhere
                 await asyncio.gather(*app_start_tasks, return_exceptions=True)
 
@@ -744,14 +744,14 @@ class BackupManager(FileConfiguration, JobGroup):
 
                 # Delete delta apps
                 if replace:
-                    self._change_stage(RestoreJobStage.REMOVE_DELTA_ADDONS, backup)
+                    self._change_stage(RestoreJobStage.REMOVE_DELTA_APPS, backup)
                     success = success and await backup.remove_delta_apps()
 
                 if app_list:
-                    self._change_stage(RestoreJobStage.ADDON_REPOSITORIES, backup)
+                    self._change_stage(RestoreJobStage.APP_REPOSITORIES, backup)
                     await backup.restore_repositories(replace)
 
-                    self._change_stage(RestoreJobStage.ADDONS, backup)
+                    self._change_stage(RestoreJobStage.APPS, backup)
                     restore_success, app_start_tasks = await backup.restore_apps(
                         app_list
                     )
@@ -778,7 +778,7 @@ class BackupManager(FileConfiguration, JobGroup):
             ) from err
         else:
             if app_start_tasks:
-                self._change_stage(RestoreJobStage.AWAIT_ADDON_RESTARTS, backup)
+                self._change_stage(RestoreJobStage.AWAIT_APP_RESTARTS, backup)
                 # Failure to resume apps post restore is still a restore failure
                 if any(await asyncio.gather(*app_start_tasks, return_exceptions=True)):
                     return False
@@ -999,7 +999,7 @@ class BackupManager(FileConfiguration, JobGroup):
         await self.sys_homeassistant.begin_backup()
 
         # Run all pre-backup tasks for apps
-        self._change_stage(BackupJobStage.ADDONS)
+        self._change_stage(BackupJobStage.APPS)
         await asyncio.gather(*[app.begin_backup() for app in running_apps])
 
     @Job(
@@ -1022,7 +1022,7 @@ class BackupManager(FileConfiguration, JobGroup):
             self._change_stage(BackupJobStage.HOME_ASSISTANT)
             await self.sys_homeassistant.end_backup()
 
-            self._change_stage(BackupJobStage.ADDONS)
+            self._change_stage(BackupJobStage.APPS)
             app_start_tasks: list[asyncio.Task] = [
                 task
                 for task in await asyncio.gather(
@@ -1036,7 +1036,7 @@ class BackupManager(FileConfiguration, JobGroup):
             self._thaw_task = None
 
         if app_start_tasks:
-            self._change_stage(BackupJobStage.AWAIT_ADDON_RESTARTS)
+            self._change_stage(BackupJobStage.AWAIT_APP_RESTARTS)
             await asyncio.gather(*app_start_tasks, return_exceptions=True)
 
     @Job(

--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -575,7 +575,7 @@ class BackupManager(FileConfiguration, JobGroup):
             self._backups[backup.slug] = backup
 
             if additional_locations:
-                self._change_stage(BackupJobStage.COPY_ADDITONAL_LOCATIONS, backup)
+                self._change_stage(BackupJobStage.COPY_ADDITIONAL_LOCATIONS, backup)
                 await self._copy_to_additional_locations(backup, additional_locations)
 
             if app_start_tasks:

--- a/supervisor/jobs/__init__.py
+++ b/supervisor/jobs/__init__.py
@@ -35,6 +35,20 @@ _CURRENT_JOB: ContextVar[str | None] = ContextVar("current_job", default=None)
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
+LEGACY_BACKUP_RESTORE_STAGE_MAP: dict[str, str] = {
+    "app_repositories": "addon_repositories",
+    "apps": "addons",
+    "await_app_restarts": "await_addon_restarts",
+    "remove_delta_apps": "remove_delta_addons",
+}
+
+BACKUP_RESTORE_JOB_NAMES: set[str] = {
+    "backup_manager_full_restore",
+    "backup_manager_partial_restore",
+    "backup_manager_full_backup",
+    "backup_manager_partial_backup",
+}
+
 
 def process_job_dict_for_legacy_compatibility(
     job_data: dict[str, Any],
@@ -45,6 +59,17 @@ def process_job_dict_for_legacy_compatibility(
     # compatibility can be removed when Core v2026.7 is no longer supported.
     if job_data.get("name") == "app_manager_update":
         return job_data | {"name": "addon_manager_update"}
+
+    # Home Assistant Core expects legacy backup/restore stage names on websocket
+    # v1 and REST v1. Map only backup manager jobs to avoid changing unrelated
+    # stage names.
+    if (
+        job_data.get("name") in BACKUP_RESTORE_JOB_NAMES
+        and (stage := cast(str | None, job_data.get("stage")))
+        in LEGACY_BACKUP_RESTORE_STAGE_MAP
+    ):
+        return job_data | {"stage": LEGACY_BACKUP_RESTORE_STAGE_MAP[stage]}
+
     return job_data
 
 

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -483,3 +483,119 @@ async def test_api_jobs_no_legacy_name_compatibility_when_websocket_v2_enabled(
     assert not any(
         job_event["name"] == "addon_manager_update" for job_event in job_events
     )
+
+
+@pytest.mark.parametrize(
+    ("job_name", "new_stage", "legacy_stage"),
+    [
+        ("backup_manager_full_backup", "app_repositories", "addon_repositories"),
+        ("backup_manager_full_backup", "apps", "addons"),
+        ("backup_manager_full_backup", "await_app_restarts", "await_addon_restarts"),
+        ("backup_manager_full_restore", "remove_delta_apps", "remove_delta_addons"),
+        ("backup_manager_full_restore", "app_repositories", "addon_repositories"),
+        ("backup_manager_full_restore", "apps", "addons"),
+        (
+            "backup_manager_full_restore",
+            "await_app_restarts",
+            "await_addon_restarts",
+        ),
+    ],
+)
+async def test_api_jobs_legacy_stage_compatibility(
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    ha_ws_client: AsyncMock,
+    job_name: str,
+    new_stage: str,
+    legacy_stage: str,
+):
+    """Test backup/restore stage names are mapped in REST+websocket v1 outputs."""
+    api_client, prefix = api_client_with_prefix
+    job = coresys.jobs.new_job(job_name, reference="test")
+    job.stage = new_stage
+    job.progress = 50
+    with job.start():
+        pass
+
+    resp = await api_client.get(f"{prefix}/jobs/info")
+    assert resp.status == 200
+    result = await resp.json()
+    assert result["data"]["jobs"][0]["stage"] == legacy_stage
+
+    resp = await api_client.get(f"{prefix}/jobs/{job.uuid}")
+    assert resp.status == 200
+    result = await resp.json()
+    assert result["data"]["stage"] == legacy_stage
+
+    job_events = [
+        evt.args[0]["data"]["data"]
+        for evt in ha_ws_client.async_send_command.call_args_list
+        if "data" in evt.args[0] and evt.args[0]["data"]["event"] == "job"
+    ]
+    assert any(
+        job_event["uuid"] == job.uuid and job_event["stage"] == legacy_stage
+        for job_event in job_events
+    )
+    assert not any(
+        job_event["uuid"] == job.uuid and job_event["stage"] == new_stage
+        for job_event in job_events
+    )
+
+
+@pytest.mark.parametrize(
+    ("job_name", "new_stage", "legacy_stage"),
+    [
+        ("backup_manager_full_backup", "app_repositories", "addon_repositories"),
+        ("backup_manager_full_backup", "apps", "addons"),
+        ("backup_manager_full_backup", "await_app_restarts", "await_addon_restarts"),
+        ("backup_manager_full_restore", "remove_delta_apps", "remove_delta_addons"),
+        ("backup_manager_full_restore", "app_repositories", "addon_repositories"),
+        ("backup_manager_full_restore", "apps", "addons"),
+        (
+            "backup_manager_full_restore",
+            "await_app_restarts",
+            "await_addon_restarts",
+        ),
+    ],
+)
+async def test_api_jobs_no_legacy_stage_compatibility_when_websocket_v2_enabled(
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    ha_ws_client: AsyncMock,
+    job_name: str,
+    new_stage: str,
+    legacy_stage: str,
+):
+    """Test backup/restore stage names are not mapped in REST+websocket v2 outputs."""
+    api_client, prefix = api_client_with_prefix
+    coresys.config.set_feature_flag(FeatureFlag.SUPERVISOR_WEBSOCKET_V2_API, True)
+
+    job = coresys.jobs.new_job(job_name, reference="test")
+    job.stage = new_stage
+    job.progress = 50
+    with job.start():
+        pass
+
+    resp = await api_client.get(f"{prefix}/jobs/info")
+    assert resp.status == 200
+    result = await resp.json()
+    assert result["data"]["jobs"][0]["stage"] == new_stage
+
+    resp = await api_client.get(f"{prefix}/jobs/{job.uuid}")
+    assert resp.status == 200
+    result = await resp.json()
+    assert result["data"]["stage"] == new_stage
+
+    job_events = [
+        evt.args[0]["data"]["data"]
+        for evt in ha_ws_client.async_send_command.call_args_list
+        if "data" in evt.args[0] and evt.args[0]["data"]["event"] == "job"
+    ]
+    assert any(
+        job_event["uuid"] == job.uuid and job_event["stage"] == new_stage
+        for job_event in job_events
+    )
+    assert not any(
+        job_event["uuid"] == job.uuid and job_event["stage"] == legacy_stage
+        for job_event in job_events
+    )

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -1169,12 +1169,12 @@ async def test_backup_progress(
         _make_backup_message_for_assert(reference=None, stage=None),
         _make_backup_message_for_assert(reference=full_backup.slug, stage=None),
         _make_backup_message_for_assert(
-            reference=full_backup.slug, stage="addon_repositories"
+            reference=full_backup.slug, stage="app_repositories"
         ),
         _make_backup_message_for_assert(
             reference=full_backup.slug, stage="home_assistant"
         ),
-        _make_backup_message_for_assert(reference=full_backup.slug, stage="addons"),
+        _make_backup_message_for_assert(reference=full_backup.slug, stage="apps"),
         _make_backup_message_for_assert(reference=full_backup.slug, stage="folders"),
         _make_backup_message_for_assert(
             reference=full_backup.slug, stage="supervisor_config"
@@ -1183,11 +1183,11 @@ async def test_backup_progress(
             reference=full_backup.slug, stage="finishing_file"
         ),
         _make_backup_message_for_assert(
-            reference=full_backup.slug, stage="await_addon_restarts"
+            reference=full_backup.slug, stage="await_app_restarts"
         ),
         _make_backup_message_for_assert(
             reference=full_backup.slug,
-            stage="await_addon_restarts",
+            stage="await_app_restarts",
             done=True,
             progress=100,
         ),
@@ -1216,10 +1216,10 @@ async def test_backup_progress(
         _make_backup_message_for_assert(
             action="partial_backup",
             reference=partial_backup.slug,
-            stage="addon_repositories",
+            stage="app_repositories",
         ),
         _make_backup_message_for_assert(
-            action="partial_backup", reference=partial_backup.slug, stage="addons"
+            action="partial_backup", reference=partial_backup.slug, stage="apps"
         ),
         _make_backup_message_for_assert(
             action="partial_backup", reference=partial_backup.slug, stage="folders"
@@ -1307,15 +1307,15 @@ async def test_restore_progress(
         _make_backup_message_for_assert(
             action="full_restore",
             reference=full_backup.slug,
-            stage="remove_delta_addons",
+            stage="remove_delta_apps",
         ),
         _make_backup_message_for_assert(
             action="full_restore",
             reference=full_backup.slug,
-            stage="addon_repositories",
+            stage="app_repositories",
         ),
         _make_backup_message_for_assert(
-            action="full_restore", reference=full_backup.slug, stage="addons"
+            action="full_restore", reference=full_backup.slug, stage="apps"
         ),
         _make_backup_message_for_assert(
             action="full_restore",
@@ -1325,7 +1325,7 @@ async def test_restore_progress(
         _make_backup_message_for_assert(
             action="full_restore",
             reference=full_backup.slug,
-            stage="await_addon_restarts",
+            stage="await_app_restarts",
         ),
         _make_backup_message_for_assert(
             action="full_restore",
@@ -1417,12 +1417,12 @@ async def test_restore_progress(
         _make_backup_message_for_assert(
             action="partial_restore",
             reference=app_backup.slug,
-            stage="addon_repositories",
+            stage="app_repositories",
         ),
         _make_backup_message_for_assert(
             action="partial_restore",
             reference=app_backup.slug,
-            stage="addons",
+            stage="apps",
         ),
         _make_backup_message_for_assert(
             action="partial_restore",
@@ -1484,7 +1484,7 @@ async def test_freeze_thaw(
                 action="freeze_all", reference=None, stage="home_assistant"
             ),
             _make_backup_message_for_assert(
-                action="freeze_all", reference=None, stage="addons"
+                action="freeze_all", reference=None, stage="apps"
             ),
             _make_backup_message_for_assert(
                 action="thaw_all", reference=None, stage=None
@@ -1492,7 +1492,7 @@ async def test_freeze_thaw(
             _make_backup_message_for_assert(
                 action="freeze_all",
                 reference=None,
-                stage="addons",
+                stage="apps",
                 done=True,
                 progress=100,
             ),
@@ -1519,12 +1519,12 @@ async def test_freeze_thaw(
                 action="thaw_all", reference=None, stage="home_assistant"
             ),
             _make_backup_message_for_assert(
-                action="thaw_all", reference=None, stage="addons"
+                action="thaw_all", reference=None, stage="apps"
             ),
             _make_backup_message_for_assert(
                 action="thaw_all",
                 reference=None,
-                stage="addons",
+                stage="apps",
                 done=True,
                 progress=100,
             ),

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -1169,12 +1169,12 @@ async def test_backup_progress(
         _make_backup_message_for_assert(reference=None, stage=None),
         _make_backup_message_for_assert(reference=full_backup.slug, stage=None),
         _make_backup_message_for_assert(
-            reference=full_backup.slug, stage="app_repositories"
+            reference=full_backup.slug, stage="addon_repositories"
         ),
         _make_backup_message_for_assert(
             reference=full_backup.slug, stage="home_assistant"
         ),
-        _make_backup_message_for_assert(reference=full_backup.slug, stage="apps"),
+        _make_backup_message_for_assert(reference=full_backup.slug, stage="addons"),
         _make_backup_message_for_assert(reference=full_backup.slug, stage="folders"),
         _make_backup_message_for_assert(
             reference=full_backup.slug, stage="supervisor_config"
@@ -1183,11 +1183,11 @@ async def test_backup_progress(
             reference=full_backup.slug, stage="finishing_file"
         ),
         _make_backup_message_for_assert(
-            reference=full_backup.slug, stage="await_app_restarts"
+            reference=full_backup.slug, stage="await_addon_restarts"
         ),
         _make_backup_message_for_assert(
             reference=full_backup.slug,
-            stage="await_app_restarts",
+            stage="await_addon_restarts",
             done=True,
             progress=100,
         ),
@@ -1216,10 +1216,10 @@ async def test_backup_progress(
         _make_backup_message_for_assert(
             action="partial_backup",
             reference=partial_backup.slug,
-            stage="app_repositories",
+            stage="addon_repositories",
         ),
         _make_backup_message_for_assert(
-            action="partial_backup", reference=partial_backup.slug, stage="apps"
+            action="partial_backup", reference=partial_backup.slug, stage="addons"
         ),
         _make_backup_message_for_assert(
             action="partial_backup", reference=partial_backup.slug, stage="folders"
@@ -1307,15 +1307,15 @@ async def test_restore_progress(
         _make_backup_message_for_assert(
             action="full_restore",
             reference=full_backup.slug,
-            stage="remove_delta_apps",
+            stage="remove_delta_addons",
         ),
         _make_backup_message_for_assert(
             action="full_restore",
             reference=full_backup.slug,
-            stage="app_repositories",
+            stage="addon_repositories",
         ),
         _make_backup_message_for_assert(
-            action="full_restore", reference=full_backup.slug, stage="apps"
+            action="full_restore", reference=full_backup.slug, stage="addons"
         ),
         _make_backup_message_for_assert(
             action="full_restore",
@@ -1325,7 +1325,7 @@ async def test_restore_progress(
         _make_backup_message_for_assert(
             action="full_restore",
             reference=full_backup.slug,
-            stage="await_app_restarts",
+            stage="await_addon_restarts",
         ),
         _make_backup_message_for_assert(
             action="full_restore",
@@ -1417,12 +1417,12 @@ async def test_restore_progress(
         _make_backup_message_for_assert(
             action="partial_restore",
             reference=app_backup.slug,
-            stage="app_repositories",
+            stage="addon_repositories",
         ),
         _make_backup_message_for_assert(
             action="partial_restore",
             reference=app_backup.slug,
-            stage="apps",
+            stage="addons",
         ),
         _make_backup_message_for_assert(
             action="partial_restore",


### PR DESCRIPTION
_Note: Description updated by @agners to reflect the backwards compatibility layer added in later commits._

## Proposed change

As part of the ongoing addon -> app refactor, this changes backup and restore job stage identifiers that still used addon/addons terminology to app/apps terminology.

This updates both enum members and emitted stage string values, then adjusts backup manager stage transitions and the related progress-event tests. It also fixes the `COPY_ADDITONAL_LOCATIONS` -> `COPY_ADDITIONAL_LOCATIONS` typo in the enum member name (string value unchanged).

Home Assistant Core parses these stage values in its `hassio` backup integration to report backup/restore progress, so the legacy stage names are preserved on REST v1 and WebSocket v1 output via the existing legacy compatibility mapping in the jobs module. The new `app` stage names are only emitted once a client opts into the v2 API via the `supervisor_websocket_v2_api` feature flag, so this is only a breaking change for clients opting into the v2 API.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #7028
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
