### PR TITLE
Fix flaky test_adjust_system_datetime_if_time_behind

### DIFF
--- a/tests/dbus_service_mocks/systemd_unit.py
+++ b/tests/dbus_service_mocks/systemd_unit.py
@@ -1,5 +1,7 @@
 """Mock of systemd unit dbus service."""
 
+import asyncio
+
 from dbus_fast.service import PropertyAccess, dbus_property
 
 from .base import DBusServiceMock
@@ -26,6 +28,11 @@ class SystemdUnit(DBusServiceMock):
         """Initialize object."""
         super().__init__()
         self.object_path = object_path
+        # Set whenever ActiveState is queried. Tests that drive
+        # wait_for_active_state can await this to be sure the client has
+        # installed its PropertiesChanged subscription before emitting a
+        # signal, avoiding a lost-signal race.
+        self.active_state_read = asyncio.Event()
 
     @dbus_property(access=PropertyAccess.READ)
     def Id(self) -> "s":
@@ -218,6 +225,7 @@ class SystemdUnit(DBusServiceMock):
     @dbus_property(access=PropertyAccess.READ)
     def ActiveState(self) -> "s":
         """Get ActiveState."""
+        self.active_state_read.set()
         if isinstance(self.active_state, list):
             return self.active_state.pop(0)
         return self.active_state

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -86,6 +86,7 @@ async def test_adjust_system_datetime_if_time_behind(
     systemd_service.StopUnit.calls.clear()
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
     systemd_unit_service.active_state = "active"
+    systemd_unit_service.active_state_read.clear()
 
     utc_ts = datetime.datetime.now().replace(tzinfo=datetime.UTC) + datetime.timedelta(
         hours=1, minutes=1
@@ -108,7 +109,10 @@ async def test_adjust_system_datetime_if_time_behind(
     ):
         # Start the time adjustment which will wait for timesyncd to stop
         task = asyncio.create_task(coresys.core._adjust_system_datetime())
-        await asyncio.sleep(0.1)
+        # wait_for_active_state installs the PropertiesChanged subscription and
+        # then reads ActiveState. Waiting for that read guarantees the client is
+        # subscribed before we emit, so the signal cannot be lost to a race.
+        await systemd_unit_service.active_state_read.wait()
         # Simulate timesyncd stopping via D-Bus signal
         systemd_unit_service.emit_properties_changed({"ActiveState": "inactive"})
         await task


### PR DESCRIPTION
## Proposed change

`tests/test_core.py::test_adjust_system_datetime_if_time_behind` was flaky in CI, occasionally failing with `Failed: Timeout (>10.0s) from pytest-timeout`.

The test starts `_adjust_system_datetime()` as a background task and then emits the `systemd-timesyncd` `PropertiesChanged` signal that `wait_for_active_state()` blocks on. It used a fixed `await asyncio.sleep(0.1)` to give the task time to install its D-Bus signal subscription before emitting. On a busy CI runner (heavily parallel under pytest-xdist), 0.1 s was not always enough for the task to traverse `retrieve_whoami → set_timezone → stop_unit` and reach the `AddMatch` round-trip inside `wait_for_active_state()`. When the signal was emitted before the subscription was installed, it was broadcast to no subscriber and dropped; `wait_for_signal()` then blocked forever until pytest-timeout killed the test at 10 s.

This replaces the timing-based sleep with a deterministic handshake. The `SystemdUnit` D-Bus mock now exposes an `active_state_read` `asyncio.Event`, set whenever its `ActiveState` property is queried. Inside `wait_for_active_state()`, `ActiveState` is read only after the `PropertiesChanged` subscription has been installed, so awaiting that event before emitting guarantees the client is subscribed and the signal cannot be lost to a race. The event is a reusable synchronization primitive for any test that drives `wait_for_active_state()` this way.

Verified under full CPU load: the old sleep-based sync point timed out 10/10 runs, while the event-based version passed 30/30.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
