### PR TITLE
Check for local data before adding or updating a mount

### DIFF
--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -1454,6 +1454,37 @@ class MountInvalidError(MountError):
     """Raise on invalid mount attempt."""
 
 
+class MountTargetNotDirectoryError(MountInvalidError):
+    """Raise when a mount target exists but is not a directory."""
+
+    error_key = "mount_target_not_directory_error"
+    message_template = "Cannot mount {name} at {path} as it is not a directory"
+
+    def __init__(
+        self, logger: Callable[..., None] | None = None, *, name: str, path: str
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"name": name, "path": path}
+        super().__init__(None, logger)
+
+
+class MountTargetNotEmptyError(MountInvalidError):
+    """Raise when a mount target directory contains existing data."""
+
+    error_key = "mount_target_not_empty_error"
+    message_template = (
+        "Cannot mount {name} because there is existing data at {path}. "
+        "Move it away first, then retry"
+    )
+
+    def __init__(
+        self, logger: Callable[..., None] | None = None, *, name: str, path: str
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"name": name, "path": path}
+        super().__init__(None, logger)
+
+
 class MountNotFound(MountError, APINotFound):
     """Raise on mount not found."""
 

--- a/supervisor/mounts/manager.py
+++ b/supervisor/mounts/manager.py
@@ -5,7 +5,7 @@ from collections.abc import Awaitable
 from contextlib import suppress
 from dataclasses import dataclass, replace
 import logging
-from pathlib import Path, PurePath
+from pathlib import PurePath
 from typing import Self
 
 from ..const import ATTR_NAME
@@ -15,6 +15,7 @@ from ..exceptions import (
     MountError,
     MountJobError,
     MountNotFound,
+    MountTargetNotDirectoryError,
     MountTargetNotEmptyError,
 )
 from ..host.const import HostFeature
@@ -248,23 +249,25 @@ class MountManager(FileConfiguration, CoreSysAttributes):
         elif mount.usage == MountUsage.SHARE:
             paths.append(self.sys_config.path_share / mount.name)
 
-        def find_conflict() -> Path | None:
+        def check_conflict() -> None:
             for path in paths:
                 try:
                     if path.is_mount() or not path.exists():
                         continue
-                    if not path.is_dir() or any(path.iterdir()):
-                        return path
+                    if not path.is_dir():
+                        raise MountTargetNotDirectoryError(
+                            _LOGGER.error, name=mount.name, path=path.as_posix()
+                        )
+                    if any(path.iterdir()):
+                        raise MountTargetNotEmptyError(
+                            _LOGGER.error, name=mount.name, path=path.as_posix()
+                        )
                 except OSError:
                     # Not inspectable (e.g. an unreachable network mount) —
                     # leave it to the mount-time check
                     continue
-            return None
 
-        if conflict := await self.sys_run_in_executor(find_conflict):
-            raise MountTargetNotEmptyError(
-                _LOGGER.error, name=mount.name, path=conflict.as_posix()
-            )
+        await self.sys_run_in_executor(check_conflict)
 
     @Job(
         name="mount_manager_remove_mount",

--- a/supervisor/mounts/manager.py
+++ b/supervisor/mounts/manager.py
@@ -11,7 +11,12 @@ from typing import Self
 from ..const import ATTR_NAME
 from ..coresys import CoreSys, CoreSysAttributes
 from ..dbus.const import UnitActiveState
-from ..exceptions import MountError, MountInvalidError, MountJobError, MountNotFound
+from ..exceptions import (
+    MountError,
+    MountJobError,
+    MountNotFound,
+    MountTargetNotEmptyError,
+)
 from ..host.const import HostFeature
 from ..jobs.const import JobCondition
 from ..jobs.decorator import Job
@@ -257,10 +262,8 @@ class MountManager(FileConfiguration, CoreSysAttributes):
             return None
 
         if conflict := await self.sys_run_in_executor(find_conflict):
-            raise MountInvalidError(
-                f"Cannot add mount {mount.name}: there is existing data at "
-                f"{conflict.as_posix()}. Move it away first, then retry",
-                _LOGGER.error,
+            raise MountTargetNotEmptyError(
+                _LOGGER.error, name=mount.name, path=conflict.as_posix()
             )
 
     @Job(

--- a/supervisor/mounts/manager.py
+++ b/supervisor/mounts/manager.py
@@ -2,15 +2,16 @@
 
 import asyncio
 from collections.abc import Awaitable
+from contextlib import suppress
 from dataclasses import dataclass, replace
 import logging
-from pathlib import PurePath
+from pathlib import Path, PurePath
 from typing import Self
 
 from ..const import ATTR_NAME
 from ..coresys import CoreSys, CoreSysAttributes
 from ..dbus.const import UnitActiveState
-from ..exceptions import MountActivationError, MountError, MountJobError, MountNotFound
+from ..exceptions import MountError, MountInvalidError, MountJobError, MountNotFound
 from ..host.const import HostFeature
 from ..jobs.const import JobCondition
 from ..jobs.decorator import Job
@@ -197,22 +198,70 @@ class MountManager(FileConfiguration, CoreSysAttributes):
         # Add mount name to job
         self.sys_jobs.current.reference = mount.name
 
+        await self._check_local_data_conflict(mount)
+
         if mount.name in self._mounts:
-            _LOGGER.debug("Mount '%s' exists, unmounting then mounting from new config")
+            _LOGGER.debug(
+                "Mount '%s' exists, unmounting then mounting from new config",
+                mount.name,
+            )
             await self.remove_mount(mount.name, retain_entry=True)
 
         _LOGGER.info("Creating or updating mount: %s", mount.name)
         try:
             await mount.load()
-        except MountActivationError as err:
-            await mount.unmount()
-            raise err
+            if mount.usage == MountUsage.MEDIA:
+                await self._bind_media(mount)
+            elif mount.usage == MountUsage.SHARE:
+                await self._bind_share(mount)
+        except MountError:
+            # Roll back so a failed add/update does not leave a half-created
+            # mount behind: data mount active and listed, but without bind
+            # mount and never persisted to the configuration.
+            if bound_mount := self._bound_mounts.pop(mount.name, None):
+                with suppress(MountError):
+                    await bound_mount.bind_mount.unmount()
+            with suppress(MountError):
+                await mount.unmount()
+            raise
 
         self._mounts[mount.name] = mount
+
+    async def _check_local_data_conflict(self, mount: Mount) -> None:
+        """Fail fast if a target directory of the mount contains local data.
+
+        The authoritative check happens when each unit is mounted, but by
+        then the data mount is already active. Checking upfront lets an
+        add/update whose target directory holds local data (e.g. written by
+        an add-on while no mount was in place) fail cleanly before anything
+        is touched. Paths that are already mount points are skipped — they
+        get unmounted before reuse.
+        """
+        paths = [mount.local_where]
         if mount.usage == MountUsage.MEDIA:
-            await self._bind_media(mount)
+            paths.append(self.sys_config.path_media / mount.name)
         elif mount.usage == MountUsage.SHARE:
-            await self._bind_share(mount)
+            paths.append(self.sys_config.path_share / mount.name)
+
+        def find_conflict() -> Path | None:
+            for path in paths:
+                try:
+                    if path.is_mount() or not path.exists():
+                        continue
+                    if not path.is_dir() or any(path.iterdir()):
+                        return path
+                except OSError:
+                    # Not inspectable (e.g. an unreachable network mount) —
+                    # leave it to the mount-time check
+                    continue
+            return None
+
+        if conflict := await self.sys_run_in_executor(find_conflict):
+            raise MountInvalidError(
+                f"Cannot add mount {mount.name}: there is existing data at "
+                f"{conflict.as_posix()}. Move it away first, then retry",
+                _LOGGER.error,
+            )
 
     @Job(
         name="mount_manager_remove_mount",

--- a/supervisor/mounts/mount.py
+++ b/supervisor/mounts/mount.py
@@ -31,7 +31,8 @@ from ..exceptions import (
     DBusSystemdNoSuchUnit,
     MountActivationError,
     MountError,
-    MountInvalidError,
+    MountTargetNotDirectoryError,
+    MountTargetNotEmptyError,
 )
 from ..resolution.const import ContextType, IssueType
 from ..resolution.data import Issue
@@ -346,14 +347,12 @@ class Mount(CoreSysAttributes, ABC):
                 )
                 self.local_where.mkdir(parents=True)
             elif not self.local_where.is_dir():
-                raise MountInvalidError(
-                    f"Cannot mount {self.name} at {self.local_where.as_posix()} as it is not a directory",
-                    _LOGGER.error,
+                raise MountTargetNotDirectoryError(
+                    _LOGGER.error, name=self.name, path=self.local_where.as_posix()
                 )
             elif any(self.local_where.iterdir()):
-                raise MountInvalidError(
-                    f"Cannot mount {self.name} at {self.local_where.as_posix()} because it is not empty",
-                    _LOGGER.error,
+                raise MountTargetNotEmptyError(
+                    _LOGGER.error, name=self.name, path=self.local_where.as_posix()
                 )
 
         await self.sys_run_in_executor(ensure_empty_folder)

--- a/tests/mounts/test_manager.py
+++ b/tests/mounts/test_manager.py
@@ -16,9 +16,10 @@ from supervisor.dbus.const import UnitActiveState
 from supervisor.exceptions import (
     MountActivationError,
     MountError,
-    MountInvalidError,
     MountJobError,
     MountNotFound,
+    MountTargetNotDirectoryError,
+    MountTargetNotEmptyError,
 )
 from supervisor.mounts.manager import MountManager
 from supervisor.mounts.mount import BindMount, Mount
@@ -613,7 +614,30 @@ async def test_create_mount_blocked_by_existing_local_data(
     media_dir.mkdir()
     (media_dir / "recording.mp4").touch()
 
-    with pytest.raises(MountInvalidError):
+    with pytest.raises(MountTargetNotEmptyError):
+        await coresys.mounts.create_mount(Mount.from_dict(coresys, MEDIA_TEST_DATA))
+
+    assert "media_test" not in coresys.mounts
+    assert systemd_service.StartTransientUnit.calls == []
+
+
+async def test_create_mount_blocked_by_non_directory_target(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock],
+    tmp_supervisor_data,
+    path_extern,
+    mount_propagation,
+    mock_is_mount,
+):
+    """Test creating a media mount fails fast if the media target is not a directory."""
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_service.StartTransientUnit.calls.clear()
+
+    await coresys.mounts.load()
+
+    (coresys.config.path_media / "media_test").touch()
+
+    with pytest.raises(MountTargetNotDirectoryError):
         await coresys.mounts.create_mount(Mount.from_dict(coresys, MEDIA_TEST_DATA))
 
     assert "media_test" not in coresys.mounts
@@ -638,7 +662,7 @@ async def test_update_mount_blocked_by_existing_local_data(
     media_dir.mkdir(exist_ok=True)
     (media_dir / "recording.mp4").touch()
 
-    with pytest.raises(MountInvalidError):
+    with pytest.raises(MountTargetNotEmptyError):
         await coresys.mounts.create_mount(Mount.from_dict(coresys, MEDIA_TEST_DATA))
 
     assert mount == coresys.mounts.get("media_test")

--- a/tests/mounts/test_manager.py
+++ b/tests/mounts/test_manager.py
@@ -16,11 +16,12 @@ from supervisor.dbus.const import UnitActiveState
 from supervisor.exceptions import (
     MountActivationError,
     MountError,
+    MountInvalidError,
     MountJobError,
     MountNotFound,
 )
 from supervisor.mounts.manager import MountManager
-from supervisor.mounts.mount import Mount
+from supervisor.mounts.mount import BindMount, Mount
 from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.data import Issue, Suggestion
 
@@ -592,6 +593,99 @@ async def test_save_data(
                 "read_only": False,
             }
         ]
+
+
+async def test_create_mount_blocked_by_existing_local_data(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock],
+    tmp_supervisor_data,
+    path_extern,
+    mount_propagation,
+    mock_is_mount,
+):
+    """Test creating a media mount fails fast if the media directory has local data."""
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_service.StartTransientUnit.calls.clear()
+
+    await coresys.mounts.load()
+
+    media_dir = coresys.config.path_media / "media_test"
+    media_dir.mkdir()
+    (media_dir / "recording.mp4").touch()
+
+    with pytest.raises(MountInvalidError):
+        await coresys.mounts.create_mount(Mount.from_dict(coresys, MEDIA_TEST_DATA))
+
+    assert "media_test" not in coresys.mounts
+    assert systemd_service.StartTransientUnit.calls == []
+
+
+async def test_update_mount_blocked_by_existing_local_data(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock],
+    mount: Mount,
+):
+    """Test updating a mount fails fast on local data without touching the mount.
+
+    Simulates the state after systemd tore down the bind mount and an add-on
+    wrote into the bare media directory: the update must not unmount the data
+    mount just to fail on the non-empty bind target afterwards.
+    """
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_service.StopUnit.calls.clear()
+
+    media_dir = coresys.config.path_media / "media_test"
+    media_dir.mkdir(exist_ok=True)
+    (media_dir / "recording.mp4").touch()
+
+    with pytest.raises(MountInvalidError):
+        await coresys.mounts.create_mount(Mount.from_dict(coresys, MEDIA_TEST_DATA))
+
+    assert mount == coresys.mounts.get("media_test")
+    assert mount.state == UnitActiveState.ACTIVE
+    assert systemd_service.StopUnit.calls == []
+
+
+async def test_create_mount_bind_failure_rolls_back(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock],
+    tmp_supervisor_data,
+    path_extern,
+    mount_propagation,
+    mock_is_mount,
+):
+    """Test a bind mount failure during create unmounts the new data mount."""
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_service.StartTransientUnit.calls.clear()
+    systemd_service.StopUnit.calls.clear()
+
+    await coresys.mounts.load()
+
+    systemd_service.response_get_unit = {
+        "mnt-data-supervisor-mounts-media_test.mount": [
+            ERROR_NO_UNIT,
+            "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
+            "/org/freedesktop/systemd1/unit/tmp_2dyellow_2emount",
+        ],
+        "mnt-data-supervisor-media-media_test.mount": [ERROR_NO_UNIT],
+    }
+
+    with (
+        patch.object(
+            BindMount, "load", side_effect=MountError("Test bind mount failure")
+        ),
+        pytest.raises(MountError),
+    ):
+        await coresys.mounts.create_mount(Mount.from_dict(coresys, MEDIA_TEST_DATA))
+
+    assert "media_test" not in coresys.mounts
+    assert coresys.mounts.bound_mounts == []
+    assert [call[0] for call in systemd_service.StartTransientUnit.calls] == [
+        "mnt-data-supervisor-mounts-media_test.mount"
+    ]
+    assert [call[0] for call in systemd_service.StopUnit.calls] == [
+        "mnt-data-supervisor-mounts-media_test.mount"
+    ]
 
 
 async def test_create_mount_start_unit_failure(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Adding or updating a mount whose target directory already contains local data only fails at the bind-mount step, via the non-empty check in `Mount.mount()`. This is a common situation: an add-on may have written into `/media/<name>` before network storage was set up (e.g. Frigate records to `/media/frigate` by default, and the mount created later per its network storage guide collides with the existing recordings — see the Frigate group of `MountInvalidError` events on Sentry), or data was written while no bind mount was in place after systemd tore it down together with a stopped/restarted data mount (#7013).

Failing that late leaves a half-created mount behind: the data mount unit is already mounted and the mount is registered in `MountManager._mounts`, but the config is never persisted, so the mount shows up in the API until the next Supervisor restart and then silently disappears while its transient unit lives on. Updating an existing mount in that state is worse: the working data mount is unmounted first (`remove_mount(retain_entry=True)`), only for the update to fail on the non-empty bind target afterwards.

This PR checks the mount's target directories (the data mount target, plus the media/share bind target where applicable) for local data upfront and fails the add/update with a clear message before anything is mounted or unmounted. Paths that are already mount points are skipped — they get unmounted before reuse — and paths that cannot be inspected (e.g. an unreachable network mount) are left to the authoritative mount-time check.

Should mounting still fail halfway (e.g. the bind mount unit fails to start), `create_mount()` now rolls back by unmounting the units it created instead of leaving the half-created mount in the list: registration in `_mounts` happens only after the data mount and bind mount both succeeded.

The target-directory errors are also made translatable following the established `error_key`/`message_template`/`extra_fields` pattern: `MountTargetNotEmptyError` (`mount_target_not_empty_error`) is raised by both the new upfront check and the mount-time non-empty check, and `MountTargetNotDirectoryError` (`mount_target_not_directory_error`) covers the target-is-not-a-directory case. Both remain subclasses of `MountInvalidError`, so existing exception handling is unaffected, and `extra_fields` carries `name` and `path` so the frontend can localize the message and display the user-facing path. Frontends without the translation strings fall back to the English message as before.

Also fixes the debug log statement in `create_mount()` which referenced `%s` without passing the mount name.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #7037, #6938
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
