### PR TITLE
Make app port-conflict repair always fixable

### DIFF
--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -1262,15 +1262,15 @@ class App(AppModel):
         """Create a port conflict issue for the given port.
 
         Source can only be "core" or None currently, may be extended in future.
-        If problematic port is explicitly mapped by user, suggest clearing port
-        config as a potential fix. Else we just note the issue.
+        If problematic port is explicitly mapped by user, suggest clearing the
+        mapping and then starting the app again. Otherwise suggest starting the
+        app again.
         """
-        ports = self.ports or {}
-        suggestions = (
-            [SuggestionType.CLEAR_PORT_CONFIG]
-            if any(public_port == port for public_port in ports.values())
-            else None
-        )
+        user_ports = self.user_ports()
+        suggestions = [SuggestionType.EXECUTE_START]
+        if any(public_port == port for public_port in user_ports.values()):
+            suggestions.insert(0, SuggestionType.CLEAR_PORT_CONFIG)
+
         self.sys_resolution.create_issue(
             IssueType.APP_PORT_CONFLICT,
             ContextType.ADDON,

--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -1262,13 +1262,13 @@ class App(AppModel):
         """Create a port conflict issue for the given port.
 
         Source can only be "core" or None currently, may be extended in future.
-        If problematic port is explicitly mapped by user, suggest clearing the
-        mapping and then starting the app again. Otherwise suggest starting the
-        app again.
+        If problematic port is mapped for this app (by user override or config
+        default), suggest clearing the mapping and then starting the app again.
+        Otherwise suggest starting the app again.
         """
-        user_ports = self.user_ports()
+        ports = self.ports or {}
         suggestions = [SuggestionType.EXECUTE_START]
-        if any(public_port == port for public_port in user_ports.values()):
+        if any(public_port == port for public_port in ports.values()):
             suggestions.insert(0, SuggestionType.CLEAR_PORT_CONFIG)
 
         self.sys_resolution.create_issue(

--- a/supervisor/resolution/fixups/app_clear_port_config.py
+++ b/supervisor/resolution/fixups/app_clear_port_config.py
@@ -3,6 +3,7 @@
 import logging
 
 from ...coresys import CoreSys
+from ...exceptions import AppsError
 from ..const import ContextType, IssueType, SuggestionType
 from ..data import Suggestion
 from .base import FixupBase
@@ -68,6 +69,15 @@ class FixupAppClearPortConfig(FixupBase):
             conflict_port,
             suggestion.reference,
         )
+
+        try:
+            await app.start()
+        except AppsError as err:
+            _LOGGER.error(
+                "Could not start app %s after clearing conflicting port config: %s",
+                suggestion.reference,
+                err,
+            )
 
     @property
     def suggestion(self) -> SuggestionType:

--- a/supervisor/resolution/fixups/app_execute_start.py
+++ b/supervisor/resolution/fixups/app_execute_start.py
@@ -57,7 +57,7 @@ class FixupAppExecuteStart(FixupBase):
     @property
     def issues(self) -> list[IssueType]:
         """Return a IssueType enum list."""
-        return [IssueType.BOOT_FAIL]
+        return [IssueType.BOOT_FAIL, IssueType.APP_PORT_CONFLICT]
 
     @property
     def auto(self) -> bool:

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -1319,7 +1319,7 @@ async def test_app_manual_only_boot(install_app_example: App):
                 reference=TEST_ADDON_SLUG,
                 reference_extra={"port": 2222},
             ),
-            [SuggestionType.CLEAR_PORT_CONFIG],
+            [SuggestionType.CLEAR_PORT_CONFIG, SuggestionType.EXECUTE_START],
         ),
     ],
 )
@@ -1419,6 +1419,13 @@ async def test_app_start_port_conflict_error(
         and suggestion.reference_extra == {"port": port}
         for suggestion in coresys.resolution.suggestions
     )
+    assert any(
+        suggestion.type == SuggestionType.EXECUTE_START
+        and suggestion.context == ContextType.ADDON
+        and suggestion.reference == install_app_ssh.slug
+        and suggestion.reference_extra == {"port": port}
+        for suggestion in coresys.resolution.suggestions
+    )
 
 
 @pytest.mark.usefixtures(
@@ -1464,6 +1471,45 @@ async def test_app_restart_port_conflict_creates_issue(
         and suggestion.context == ContextType.ADDON
         and suggestion.reference == install_app_ssh.slug
         and suggestion.reference_extra == {"port": port}
+        for suggestion in coresys.resolution.suggestions
+    )
+    assert any(
+        suggestion.type == SuggestionType.EXECUTE_START
+        and suggestion.context == ContextType.ADDON
+        and suggestion.reference == install_app_ssh.slug
+        and suggestion.reference_extra == {"port": port}
+        for suggestion in coresys.resolution.suggestions
+    )
+
+
+async def test_create_port_conflict_issue_non_user_port_suggestion(
+    coresys: CoreSys, install_app_ssh: App
+):
+    """Test port conflict on non-user-mapped port only suggests start."""
+    install_app_ssh.data[ATTR_PORTS] = {"80/tcp": 80, "22/tcp": None}
+    install_app_ssh.persist.pop("network", None)
+
+    install_app_ssh.create_port_conflict_issue(80)
+
+    assert any(
+        issue.type == IssueType.APP_PORT_CONFLICT
+        and issue.context == ContextType.ADDON
+        and issue.reference == install_app_ssh.slug
+        and issue.reference_extra == {"port": 80}
+        for issue in coresys.resolution.issues
+    )
+    assert any(
+        suggestion.type == SuggestionType.EXECUTE_START
+        and suggestion.context == ContextType.ADDON
+        and suggestion.reference == install_app_ssh.slug
+        and suggestion.reference_extra == {"port": 80}
+        for suggestion in coresys.resolution.suggestions
+    )
+    assert not any(
+        suggestion.type == SuggestionType.CLEAR_PORT_CONFIG
+        and suggestion.context == ContextType.ADDON
+        and suggestion.reference == install_app_ssh.slug
+        and suggestion.reference_extra == {"port": 80}
         for suggestion in coresys.resolution.suggestions
     )
 

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -1485,7 +1485,7 @@ async def test_app_restart_port_conflict_creates_issue(
 async def test_create_port_conflict_issue_non_user_port_suggestion(
     coresys: CoreSys, install_app_ssh: App
 ):
-    """Test port conflict on non-user-mapped port only suggests start."""
+    """Test port conflict on non-user-mapped default port suggests clear+start."""
     install_app_ssh.data[ATTR_PORTS] = {"80/tcp": 80, "22/tcp": None}
     install_app_ssh.persist.pop("network", None)
 
@@ -1505,7 +1505,7 @@ async def test_create_port_conflict_issue_non_user_port_suggestion(
         and suggestion.reference_extra == {"port": 80}
         for suggestion in coresys.resolution.suggestions
     )
-    assert not any(
+    assert any(
         suggestion.type == SuggestionType.CLEAR_PORT_CONFIG
         and suggestion.context == ContextType.ADDON
         and suggestion.reference == install_app_ssh.slug

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -1482,6 +1482,60 @@ async def test_app_restart_port_conflict_creates_issue(
     )
 
 
+@pytest.mark.usefixtures(
+    "container", "mock_amd64_arch_supported", "path_extern", "tmp_supervisor_data"
+)
+async def test_app_start_port_conflict_without_configured_ports(
+    coresys: CoreSys,
+    install_app_ssh: App,
+):
+    """Test port conflict during start with no configured ports suggests start only."""
+    port = 1234
+    docker_message = (
+        "failed to set up container networking: driver failed programming external "
+        "connectivity on endpoint app_local_ssh: failed to bind host port for "
+        "0.0.0.0:1234:172.30.33.4:1234/tcp: address already in use"
+    )
+    install_app_ssh.data["image"] = "test/amd64-addon-ssh"
+    install_app_ssh.data.pop(ATTR_PORTS, None)
+    install_app_ssh.persist.pop("network", None)
+    coresys.docker.containers.create.return_value.start.side_effect = (
+        aiodocker.DockerError(HTTPStatus.INTERNAL_SERVER_ERROR, docker_message)
+    )
+    await install_app_ssh.load()
+
+    with (
+        patch.object(App, "write_options"),
+        pytest.raises(
+            AppPortConflict,
+            check=lambda exc: exc.extra_fields == {"name": "local_ssh", "port": port},
+        ),
+    ):
+        await install_app_ssh.start()
+
+    assert any(
+        issue.type == IssueType.APP_PORT_CONFLICT
+        and issue.context == ContextType.ADDON
+        and issue.reference == install_app_ssh.slug
+        and issue.reference_extra == {"port": port}
+        for issue in coresys.resolution.issues
+    )
+    assert any(
+        suggestion.type == SuggestionType.EXECUTE_START
+        and suggestion.context == ContextType.ADDON
+        and suggestion.reference == install_app_ssh.slug
+        and suggestion.reference_extra == {"port": port}
+        for suggestion in coresys.resolution.suggestions
+    )
+    assert not any(
+        suggestion.type == SuggestionType.CLEAR_PORT_CONFIG
+        and suggestion.context == ContextType.ADDON
+        and suggestion.reference == install_app_ssh.slug
+        and suggestion.reference_extra == {"port": port}
+        for suggestion in coresys.resolution.suggestions
+    )
+
+
 async def test_create_port_conflict_issue_non_user_port_suggestion(
     coresys: CoreSys, install_app_ssh: App
 ):

--- a/tests/resolution/fixup/test_app_clear_port_config.py
+++ b/tests/resolution/fixup/test_app_clear_port_config.py
@@ -1,10 +1,13 @@
 """Test fixup clearing a conflicting app port mapping."""
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from supervisor.apps.app import App
 from supervisor.const import ATTR_PORTS
 from supervisor.coresys import CoreSys
+from supervisor.exceptions import AppUnknownError
 from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.data import Issue
 from supervisor.resolution.fixups.app_clear_port_config import FixupAppClearPortConfig
@@ -19,7 +22,7 @@ def _add_conflict_suggestion(coresys: CoreSys, slug: str, port: int) -> None:
             reference=slug,
             reference_extra={"port": port},
         ),
-        suggestions=[SuggestionType.CLEAR_PORT_CONFIG],
+        suggestions=[SuggestionType.CLEAR_PORT_CONFIG, SuggestionType.EXECUTE_START],
     )
 
 
@@ -34,7 +37,9 @@ async def test_fixup_clears_conflicting_port(coresys: CoreSys, install_app_ssh: 
     assert not fixup.auto
 
     _add_conflict_suggestion(coresys, app.slug, 2222)
-    await fixup()
+    with patch.object(App, "start", new=AsyncMock()) as start:
+        await fixup()
+        start.assert_awaited_once()
 
     # The conflicting mapping must be cleared in the persisted config, not just
     # in a throwaway copy returned by the getter.
@@ -56,12 +61,37 @@ async def test_fixup_persists_only_the_cleared_port(
     assert app.ports == {"22/tcp": 2222, "80/tcp": 80, "443/tcp": None}
 
     _add_conflict_suggestion(coresys, app.slug, 80)
-    await FixupAppClearPortConfig(coresys)()
+    with patch.object(App, "start", new=AsyncMock()) as start:
+        await FixupAppClearPortConfig(coresys)()
+        start.assert_awaited_once()
 
     # Only the existing user override and the cleared port are persisted; the
     # untouched config defaults stay out of the user config so future config
     # changes to them keep applying.
     assert app.persist["network"] == {"22/tcp": 2222, "80/tcp": None}
     assert app.ports == {"22/tcp": 2222, "80/tcp": None, "443/tcp": None}
+    assert coresys.resolution.issues == []
+    assert coresys.resolution.suggestions == []
+
+
+@pytest.mark.usefixtures("tmp_supervisor_data")
+async def test_fixup_resolves_issue_if_start_fails(
+    coresys: CoreSys, install_app_ssh: App
+):
+    """Test issue is resolved even if restart fails after clearing mapping."""
+    app = install_app_ssh
+    app.persist["network"] = {"22/tcp": 2222}
+
+    _add_conflict_suggestion(coresys, app.slug, 2222)
+
+    with patch.object(
+        App,
+        "start",
+        new=AsyncMock(side_effect=AppUnknownError(app=app.slug)),
+    ) as start:
+        await FixupAppClearPortConfig(coresys)()
+        start.assert_awaited_once()
+
+    assert app.persist["network"] == {"22/tcp": None}
     assert coresys.resolution.issues == []
     assert coresys.resolution.suggestions == []


### PR DESCRIPTION
## Proposed change

Adjust `APP_PORT_CONFLICT` repair suggestions so they are always actionable from Core:

- If the conflicting host port is explicitly user-mapped, create two suggestions:
  - `CLEAR_PORT_CONFIG`
  - `EXECUTE_START`
- If the conflicting host port is not user-mapped, create one suggestion:
  - `EXECUTE_START`

Also update the `CLEAR_PORT_CONFIG` fixup to attempt starting the app after clearing the mapping. If start fails, it now only logs and does not raise, so the conflict issue is still resolved because the conflicting mapping was removed.

Tests were updated to match the new suggestion behavior, assert that start is attempted, and verify the issue is resolved even when post-clear start fails.

This is intended to make the repair always fixable, as a sometimes-fixable repair does not work well with Core.
Related Core work: https://github.com/home-assistant/core/pull/177093

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/