### PR TITLE
Fix CI race between Supervisor restart and backup restore

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -419,10 +419,29 @@ jobs:
 
       - name: Restart supervisor
         run: |
+          started_at=$(docker inspect --format='{{.State.StartedAt}}' hassio_supervisor)
+
           test=$(docker exec hassio_cli ha supervisor restart --no-progress --raw-json | jq -r '.result')
           if [ "$test" != "ok" ]; then
             exit 1
           fi
+
+          # The restart API call returns before the Supervisor actually shuts
+          # down. Wait for the container to restart so the API check below
+          # doesn't accidentally probe the old, still-running instance.
+          echo "Waiting for the Supervisor container to restart..."
+          timeout=120
+          elapsed=0
+          while [ "$(docker inspect --format='{{.State.StartedAt}}' hassio_supervisor)" == "$started_at" ]; do
+            if [ $elapsed -ge $timeout ]; then
+              echo "ERROR: Supervisor container did not restart within ${timeout}s"
+              docker logs --tail 50 hassio_supervisor
+              exit 1
+            fi
+            sleep 1
+            elapsed=$((elapsed + 1))
+          done
+          echo "Supervisor container restarted (took ${elapsed}s)"
 
       - *wait_for_supervisor
 

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -419,7 +419,7 @@ jobs:
 
       - name: Restart supervisor
         run: |
-          started_at=$(docker inspect --format='{{.State.StartedAt}}' hassio_supervisor)
+          pid_before=$(docker exec hassio_supervisor pgrep -f "python3 -m supervisor")
 
           test=$(docker exec hassio_cli ha supervisor restart --no-progress --raw-json | jq -r '.result')
           if [ "$test" != "ok" ]; then
@@ -427,21 +427,27 @@ jobs:
           fi
 
           # The restart API call returns before the Supervisor actually shuts
-          # down. Wait for the container to restart so the API check below
-          # doesn't accidentally probe the old, still-running instance.
-          echo "Waiting for the Supervisor container to restart..."
+          # down. On restart s6 starts a new Supervisor process inside the
+          # running container (the container itself does not restart), so wait
+          # for a new process before probing the API again - otherwise the
+          # check below may hit the old, still-running instance.
+          echo "Waiting for the Supervisor process to restart..."
           timeout=120
           elapsed=0
-          while [ "$(docker inspect --format='{{.State.StartedAt}}' hassio_supervisor)" == "$started_at" ]; do
+          while true; do
+            pid_now=$(docker exec hassio_supervisor pgrep -f "python3 -m supervisor" || true)
+            if [ -n "$pid_now" ] && [ "$pid_now" != "$pid_before" ]; then
+              break
+            fi
             if [ $elapsed -ge $timeout ]; then
-              echo "ERROR: Supervisor container did not restart within ${timeout}s"
+              echo "ERROR: Supervisor process did not restart within ${timeout}s"
               docker logs --tail 50 hassio_supervisor
               exit 1
             fi
             sleep 1
             elapsed=$((elapsed + 1))
           done
-          echo "Supervisor container restarted (took ${elapsed}s)"
+          echo "Supervisor process restarted (took ${elapsed}s, PID ${pid_before} -> ${pid_now})"
 
       - *wait_for_supervisor
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The "Restore SSH app from backup" step in the build workflow occasionally fails with an empty CLI response, e.g. in https://github.com/home-assistant/supervisor/actions/runs/30083369091.

The restore request is in fact always sent to the old Supervisor instance: `ha supervisor restart` returns before the Supervisor actually shuts down, and the subsequent "Wait for Supervisor to come up" step polls `/supervisor/ping`, which the old instance still answers. The workflow therefore proceeds immediately without ever observing the restart. Whenever the restore (including waiting for the SSH add-on to start) does not complete within Core's 10 second stage 1 shutdown window, the API server is torn down mid-request and the CLI sees EOF, making the step flaky.

Fix this by recording the Supervisor container's `StartedAt` timestamp before issuing the restart and waiting until it changes, so the reused "Wait for Supervisor to come up" step (and everything after it) is guaranteed to talk to the new Supervisor instance.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
