### PR TITLE
Enter STOPPING state before Supervisor restart API response

### DIFF
--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -343,7 +343,13 @@ class Core(CoreSysAttributes):
             return
         self._stop_initiated = True
 
-        await self.begin_stop()
+        try:
+            await self.begin_stop()
+        except BaseException:
+            # Nothing has been torn down yet at this point, so let a later
+            # stop() retry if the transition failed or was cancelled
+            self._stop_initiated = False
+            raise
 
         # Stage 1
         try:

--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -44,6 +44,7 @@ class Core(CoreSysAttributes):
         self._state: CoreState = CoreState.INITIALIZE
         self.exit_code: int = 0
         self._shutdown_event: asyncio.Event = asyncio.Event()
+        self._stop_initiated: bool = False
 
     @property
     def state(self) -> CoreState:
@@ -315,16 +316,34 @@ class Core(CoreSysAttributes):
             )
             _LOGGER.info("Supervisor is up and running")
 
-    async def stop(self) -> None:
-        """Stop a running orchestration."""
-        # store new last boot / prevent time adjustments
-        if self.state in (CoreState.RUNNING, CoreState.SHUTDOWN):
-            await self._update_last_boot()
+    async def begin_stop(self) -> None:
+        """Transition into the STOPPING state ahead of stop().
+
+        In STOPPING state the system validation middleware rejects new API
+        requests. API handlers that trigger a Supervisor stop (e.g. restart)
+        await this before responding, so a request sent after the response
+        gets a clear error instead of being accepted and then killed
+        mid-request when stop() tears down the API server.
+        """
         if self.state in (CoreState.STOPPING, CoreState.CLOSE):
             return
 
+        # store new last boot / prevent time adjustments
+        if self.state in (CoreState.RUNNING, CoreState.SHUTDOWN):
+            await self._update_last_boot()
+
         # don't process scheduler anymore
         await self.set_state(CoreState.STOPPING)
+
+    async def stop(self) -> None:
+        """Stop a running orchestration."""
+        # The state alone cannot guard against re-entry here because callers
+        # may have entered STOPPING via begin_stop() already
+        if self._stop_initiated:
+            return
+        self._stop_initiated = True
+
+        await self.begin_stop()
 
         # Stage 1
         try:

--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -44,7 +44,6 @@ class Core(CoreSysAttributes):
         self._state: CoreState = CoreState.INITIALIZE
         self.exit_code: int = 0
         self._shutdown_event: asyncio.Event = asyncio.Event()
-        self._stop_initiated: bool = False
 
     @property
     def state(self) -> CoreState:
@@ -316,40 +315,28 @@ class Core(CoreSysAttributes):
             )
             _LOGGER.info("Supervisor is up and running")
 
-    async def begin_stop(self) -> None:
-        """Transition into the STOPPING state ahead of stop().
+    async def stop(self, *, stopping_complete: asyncio.Event | None = None) -> None:
+        """Stop a running orchestration.
 
-        In STOPPING state the system validation middleware rejects new API
-        requests. API handlers that trigger a Supervisor stop (e.g. restart)
-        await this before responding, so a request sent after the response
+        stopping_complete is set once the Supervisor is in STOPPING state,
+        in which the system validation middleware rejects new API requests.
+        API handlers that trigger a Supervisor stop (see Supervisor.restart)
+        wait for it before responding, so a request sent after the response
         gets a clear error instead of being accepted and then killed
-        mid-request when stop() tears down the API server.
+        mid-request when the API server is torn down.
         """
-        if self.state in (CoreState.STOPPING, CoreState.CLOSE):
-            return
-
         # store new last boot / prevent time adjustments
         if self.state in (CoreState.RUNNING, CoreState.SHUTDOWN):
             await self._update_last_boot()
+        if self.state in (CoreState.STOPPING, CoreState.CLOSE):
+            if stopping_complete:
+                stopping_complete.set()
+            return
 
         # don't process scheduler anymore
         await self.set_state(CoreState.STOPPING)
-
-    async def stop(self) -> None:
-        """Stop a running orchestration."""
-        # The state alone cannot guard against re-entry here because callers
-        # may have entered STOPPING via begin_stop() already
-        if self._stop_initiated:
-            return
-        self._stop_initiated = True
-
-        try:
-            await self.begin_stop()
-        except BaseException:
-            # Nothing has been torn down yet at this point, so let a later
-            # stop() retry if the transition failed or was cancelled
-            self._stop_initiated = False
-            raise
+        if stopping_complete:
+            stopping_complete.set()
 
         # Stage 1
         try:

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -250,6 +250,11 @@ class Supervisor(CoreSysAttributes):
     async def restart(self) -> None:
         """Restart Supervisor soft."""
         self.sys_core.exit_code = 100
+        # Enter STOPPING before the API response is sent, so a request that
+        # arrives after it is rejected by the system validation middleware
+        # instead of being accepted and then killed when stop() tears down
+        # the API server
+        await self.sys_core.begin_stop()
         self.sys_create_task(self.sys_core.stop())
 
     @property

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -250,12 +250,13 @@ class Supervisor(CoreSysAttributes):
     async def restart(self) -> None:
         """Restart Supervisor soft."""
         self.sys_core.exit_code = 100
-        # Enter STOPPING before the API response is sent, so a request that
-        # arrives after it is rejected by the system validation middleware
-        # instead of being accepted and then killed when stop() tears down
-        # the API server
-        await self.sys_core.begin_stop()
-        self.sys_create_task(self.sys_core.stop())
+        stopping = asyncio.Event()
+        self.sys_create_task(self.sys_core.stop(stopping_complete=stopping))
+
+        # Return only once STOPPING is entered and new API requests are
+        # rejected, so a request sent after the restart response can no
+        # longer be accepted and then killed by the API teardown
+        await stopping.wait()
 
     @property
     def in_progress(self) -> bool:

--- a/tests/api/middleware/test_security.py
+++ b/tests/api/middleware/test_security.py
@@ -299,3 +299,13 @@ async def test_blacklist_legacy_alias(
         "/homeassistant/api/hassio/app", headers={"Authorization": "Bearer abc123"}
     )
     assert resp.status == 403
+
+
+async def test_api_security_system_stopping(api_system: TestClient, coresys: CoreSys):
+    """Test API requests are rejected while the Supervisor is stopping."""
+    await coresys.core.set_state(CoreState.STOPPING)
+
+    resp = await api_system.get("/supervisor/ping")
+    result = await resp.json()
+    assert resp.status == 400
+    assert result["result"] == "error"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -365,3 +365,33 @@ async def test_shutdown_skipped_during_startup(
     assert (
         "Ignoring shutdown request, Supervisor has not finished starting" in caplog.text
     )
+
+
+async def test_stop_runs_teardown_after_begin_stop(coresys: CoreSys):
+    """Test stop() still runs the teardown when begin_stop() pre-set STOPPING."""
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    await coresys.core.begin_stop()
+    assert coresys.core.state == CoreState.STOPPING
+
+    coresys._websession = AsyncMock()
+    with (
+        patch.object(coresys.api, "stop", new=(api_stop := AsyncMock())),
+        patch.object(coresys.scheduler, "shutdown", new=AsyncMock()),
+        patch.object(coresys.docker, "unload", new=AsyncMock()),
+        patch.object(coresys.homeassistant.api, "close", new=AsyncMock()),
+        patch.object(coresys.ingress, "unload", new=AsyncMock()),
+        patch.object(coresys.hardware, "unload", new=AsyncMock()),
+        patch.object(coresys.dbus, "unload", new=AsyncMock()),
+        patch.object(coresys.loop, "stop") as loop_stop,
+    ):
+        await coresys.core.stop()
+
+        assert coresys.core.state == CoreState.CLOSE
+        api_stop.assert_called_once()
+        loop_stop.assert_called_once()
+
+        # A second stop() must not run the teardown again
+        await coresys.core.stop()
+        api_stop.assert_called_once()
+        loop_stop.assert_called_once()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -395,3 +395,33 @@ async def test_stop_runs_teardown_after_begin_stop(coresys: CoreSys):
         await coresys.core.stop()
         api_stop.assert_called_once()
         loop_stop.assert_called_once()
+
+
+async def test_stop_can_retry_after_begin_stop_failure(coresys: CoreSys):
+    """Test a failed begin_stop() does not permanently block stop()."""
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    with patch.object(
+        coresys.core, "begin_stop", side_effect=HassioError
+    ) as begin_stop:
+        with pytest.raises(HassioError):
+            await coresys.core.stop()
+        begin_stop.assert_called_once()
+
+    # The failed attempt tore nothing down, a retry must run the sequence
+    coresys._websession = AsyncMock()
+    with (
+        patch.object(coresys.api, "stop", new=(api_stop := AsyncMock())),
+        patch.object(coresys.scheduler, "shutdown", new=AsyncMock()),
+        patch.object(coresys.docker, "unload", new=AsyncMock()),
+        patch.object(coresys.homeassistant.api, "close", new=AsyncMock()),
+        patch.object(coresys.ingress, "unload", new=AsyncMock()),
+        patch.object(coresys.hardware, "unload", new=AsyncMock()),
+        patch.object(coresys.dbus, "unload", new=AsyncMock()),
+        patch.object(coresys.loop, "stop") as loop_stop,
+    ):
+        await coresys.core.stop()
+
+    assert coresys.core.state == CoreState.CLOSE
+    api_stop.assert_called_once()
+    loop_stop.assert_called_once()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -367,16 +367,19 @@ async def test_shutdown_skipped_during_startup(
     )
 
 
-async def test_stop_runs_teardown_after_begin_stop(coresys: CoreSys):
-    """Test stop() still runs the teardown when begin_stop() pre-set STOPPING."""
+async def test_stop_signals_stopping_complete(coresys: CoreSys):
+    """Test stop() sets stopping_complete before starting the teardown."""
     await coresys.core.set_state(CoreState.RUNNING)
 
-    await coresys.core.begin_stop()
-    assert coresys.core.state == CoreState.STOPPING
+    stopping = asyncio.Event()
+    seen_at_api_stop: list[tuple[CoreState, bool]] = []
+
+    async def api_stop():
+        seen_at_api_stop.append((coresys.core.state, stopping.is_set()))
 
     coresys._websession = AsyncMock()
     with (
-        patch.object(coresys.api, "stop", new=(api_stop := AsyncMock())),
+        patch.object(coresys.api, "stop", new=api_stop),
         patch.object(coresys.scheduler, "shutdown", new=AsyncMock()),
         patch.object(coresys.docker, "unload", new=AsyncMock()),
         patch.object(coresys.homeassistant.api, "close", new=AsyncMock()),
@@ -385,43 +388,28 @@ async def test_stop_runs_teardown_after_begin_stop(coresys: CoreSys):
         patch.object(coresys.dbus, "unload", new=AsyncMock()),
         patch.object(coresys.loop, "stop") as loop_stop,
     ):
-        await coresys.core.stop()
+        await coresys.core.stop(stopping_complete=stopping)
 
-        assert coresys.core.state == CoreState.CLOSE
-        api_stop.assert_called_once()
-        loop_stop.assert_called_once()
-
-        # A second stop() must not run the teardown again
-        await coresys.core.stop()
-        api_stop.assert_called_once()
-        loop_stop.assert_called_once()
-
-
-async def test_stop_can_retry_after_begin_stop_failure(coresys: CoreSys):
-    """Test a failed begin_stop() does not permanently block stop()."""
-    await coresys.core.set_state(CoreState.RUNNING)
-
-    with patch.object(
-        coresys.core, "begin_stop", side_effect=HassioError
-    ) as begin_stop:
-        with pytest.raises(HassioError):
-            await coresys.core.stop()
-        begin_stop.assert_called_once()
-
-    # The failed attempt tore nothing down, a retry must run the sequence
-    coresys._websession = AsyncMock()
-    with (
-        patch.object(coresys.api, "stop", new=(api_stop := AsyncMock())),
-        patch.object(coresys.scheduler, "shutdown", new=AsyncMock()),
-        patch.object(coresys.docker, "unload", new=AsyncMock()),
-        patch.object(coresys.homeassistant.api, "close", new=AsyncMock()),
-        patch.object(coresys.ingress, "unload", new=AsyncMock()),
-        patch.object(coresys.hardware, "unload", new=AsyncMock()),
-        patch.object(coresys.dbus, "unload", new=AsyncMock()),
-        patch.object(coresys.loop, "stop") as loop_stop,
-    ):
-        await coresys.core.stop()
-
+    assert stopping.is_set()
     assert coresys.core.state == CoreState.CLOSE
-    api_stop.assert_called_once()
+    # The event was set while STOPPING, before the API teardown began
+    assert seen_at_api_stop == [(CoreState.STOPPING, True)]
     loop_stop.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "state", [CoreState.STOPPING, CoreState.CLOSE], ids=["stopping", "close"]
+)
+async def test_stop_reentry_signals_event_without_teardown(
+    coresys: CoreSys, state: CoreState
+):
+    """Test stop() while already stopping sets the event and does nothing else."""
+    await coresys.core.set_state(state)
+
+    stopping = asyncio.Event()
+    with patch.object(coresys.api, "stop", new=(api_stop := AsyncMock())):
+        await coresys.core.stop(stopping_complete=stopping)
+
+    assert stopping.is_set()
+    api_stop.assert_not_called()
+    assert coresys.core.state == state

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -9,7 +9,8 @@ from aiohttp.client_exceptions import ClientError
 from awesomeversion import AwesomeVersion
 import pytest
 
-from supervisor.const import BusEvent, UpdateChannel
+from supervisor.const import BusEvent, CoreState, UpdateChannel
+from supervisor.core import Core
 from supervisor.coresys import CoreSys
 from supervisor.docker.supervisor import DockerSupervisor
 from supervisor.exceptions import (
@@ -266,3 +267,24 @@ async def test_update_apparmor_error(
         with pytest.raises(SupervisorAppArmorError):
             await coresys.supervisor.update_apparmor()
         assert coresys.core.healthy is False
+
+
+async def test_restart_enters_stopping_before_scheduling_stop(coresys: CoreSys):
+    """Test restart transitions to STOPPING before the stop task runs.
+
+    The API responds to /supervisor/restart once restart() returns. The state
+    must already be STOPPING at that point so the system validation middleware
+    rejects requests sent after the response instead of accepting work that
+    stop() would kill mid-request.
+    """
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    with patch.object(Core, "stop") as core_stop:
+        await coresys.supervisor.restart()
+
+        assert coresys.core.state == CoreState.STOPPING
+        assert coresys.core.exit_code == 100
+
+        # The stop sequence itself runs as a separate task
+        await asyncio.sleep(0)
+        core_stop.assert_called_once()

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -10,7 +10,6 @@ from awesomeversion import AwesomeVersion
 import pytest
 
 from supervisor.const import BusEvent, CoreState, UpdateChannel
-from supervisor.core import Core
 from supervisor.coresys import CoreSys
 from supervisor.docker.supervisor import DockerSupervisor
 from supervisor.exceptions import (
@@ -269,22 +268,40 @@ async def test_update_apparmor_error(
         assert coresys.core.healthy is False
 
 
-async def test_restart_enters_stopping_before_scheduling_stop(coresys: CoreSys):
-    """Test restart transitions to STOPPING before the stop task runs.
+async def test_restart_returns_once_requests_rejected(coresys: CoreSys):
+    """Test restart returns while stopping, after STOPPING state is entered.
 
     The API responds to /supervisor/restart once restart() returns. The state
     must already be STOPPING at that point so the system validation middleware
     rejects requests sent after the response instead of accepting work that
-    stop() would kill mid-request.
+    the stop sequence kills mid-request.
     """
     await coresys.core.set_state(CoreState.RUNNING)
 
-    with patch.object(Core, "stop") as core_stop:
+    teardown_release = asyncio.Event()
+
+    async def blocked_api_stop():
+        await teardown_release.wait()
+
+    coresys._websession = AsyncMock()  # pylint: disable=protected-access
+    with (
+        patch.object(coresys.api, "stop", new=blocked_api_stop),
+        patch.object(coresys.scheduler, "shutdown", new=AsyncMock()),
+        patch.object(coresys.docker, "unload", new=AsyncMock()),
+        patch.object(coresys.homeassistant.api, "close", new=AsyncMock()),
+        patch.object(coresys.ingress, "unload", new=AsyncMock()),
+        patch.object(coresys.hardware, "unload", new=AsyncMock()),
+        patch.object(coresys.dbus, "unload", new=AsyncMock()),
+        patch.object(coresys.loop, "stop"),
+    ):
         await coresys.supervisor.restart()
 
+        # Restart returned while the teardown is still in flight
         assert coresys.core.state == CoreState.STOPPING
         assert coresys.core.exit_code == 100
 
-        # The stop sequence itself runs as a separate task
-        await asyncio.sleep(0)
-        core_stop.assert_called_once()
+        # Let the stop sequence finish
+        teardown_release.set()
+        async with asyncio.timeout(1):
+            while coresys.core.state != CoreState.CLOSE:
+                await asyncio.sleep(0)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Supervisor accepts new API requests in the window after responding to `/supervisor/restart`: `Supervisor.restart()` schedules `Core.stop()` as a task and returns immediately, so the state only changes to `stopping` after the restart response has been sent. A request accepted in that window keeps running while the Supervisor shuts down, and when `Core.stop()` tears down the API server after the 10 second stage 1 timeout the connection is dropped without a response — the client sees EOF instead of an error. This is what made the CI restore step flaky in https://github.com/home-assistant/supervisor/actions/runs/30083369091 (see #7084 for a CI-side fix attempt): the restore request landed on the old, dying instance and got killed mid-request.

Make `Supervisor.restart()` transition the core state to `STOPPING` before returning, via a new `Core.begin_stop()` which contains the transition part previously at the start of `Core.stop()`. The system validation middleware already rejects all requests outside of `STARTUP`/`RUNNING`/`FREEZE`, so any request arriving after the restart response now deterministically gets a clear "System is not ready with state: stopping" error from the old instance instead of possibly being accepted and killed. Since the state can now already be `STOPPING` when `Core.stop()` runs, its re-entry guard is changed from a state check to an explicit flag.

`Supervisor.update()` schedules the same stop task but is deliberately left unchanged: entering `STOPPING` before `update()` returns would suppress the final job progress event to Home Assistant (WebSocket messages are dropped in `CLOSING_STATES`), regressing update progress reporting. Closing that window needs the final job event to be ordered before the state transition and is left for a follow-up.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
