### PR TITLE
Report real OS version to Core versions consuming version_pending

### DIFF
--- a/supervisor/api/os.py
+++ b/supervisor/api/os.py
@@ -37,8 +37,10 @@ from ..const import (
 )
 from ..coresys import CoreSysAttributes
 from ..exceptions import APIError, APINotFound, BoardInvalidError
+from ..homeassistant.const import LANDINGPAGE
 from ..resolution.const import ContextType, IssueType, SuggestionType
 from ..resolution.data import Issue
+from ..utils import version_is_new_enough
 from ..validate import version_tag
 from .const import (
     ATTR_BOOT_SLOT,
@@ -60,6 +62,12 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 # Raspberry Pi firmware management requires the io.hass.os.Boards.RaspberryPi
 # .Firmware D-Bus interface first shipped in this OS Agent release.
 RPI_FIRMWARE_MIN_OS_AGENT_VERSION: AwesomeVersion = AwesomeVersion("1.9.0")
+
+# First Core nightly whose update entity consumes version_pending to finalize
+# the OS update state (home-assistant/core#177155).
+CORE_VERSION_PENDING_MIN_VERSION: AwesomeVersion = AwesomeVersion(
+    "2026.8.0.dev202607250000"
+)
 
 # pylint: disable=no-value-for-parameter
 SCHEMA_VERSION = vol.Schema({vol.Optional(ATTR_VERSION): version_tag})
@@ -95,16 +103,28 @@ SCHEMA_SWAP_OPTIONS = vol.Schema(
 class APIOS(CoreSysAttributes):
     """Handle RESTful API for OS functions."""
 
+    @property
+    def _core_handles_version_pending(self) -> bool:
+        """Return True if the installed Core consumes version_pending."""
+        return (
+            self.sys_homeassistant.version is not None
+            and self.sys_homeassistant.version != LANDINGPAGE
+            and version_is_new_enough(
+                self.sys_homeassistant.version, CORE_VERSION_PENDING_MIN_VERSION
+            )
+        )
+
     @api_process
     async def info(self, request: web.Request) -> dict[str, Any]:
         """Return OS information."""
         return {
-            # Report an installed update pending activation as the current
-            # version: the Core update entity compares version with
-            # version_latest, so it would offer the update again otherwise.
-            # Once Core consumes version_pending, this can be limited to Core
-            # versions predating that support.
-            ATTR_VERSION: self.sys_os.version_pending or self.sys_os.version,
+            # For Core versions unaware of version_pending, report an installed
+            # update pending activation as the current version: the Core update
+            # entity compares version with version_latest, so it would offer
+            # the update again otherwise.
+            ATTR_VERSION: self.sys_os.version
+            if self._core_handles_version_pending
+            else self.sys_os.version_pending or self.sys_os.version,
             ATTR_VERSION_LATEST: self.sys_os.latest_version,
             ATTR_VERSION_PENDING: self.sys_os.version_pending,
             ATTR_UPDATE_AVAILABLE: self.sys_os.need_update,

--- a/supervisor/api/os.py
+++ b/supervisor/api/os.py
@@ -66,7 +66,7 @@ RPI_FIRMWARE_MIN_OS_AGENT_VERSION: AwesomeVersion = AwesomeVersion("1.9.0")
 # First Core nightly whose update entity consumes version_pending to finalize
 # the OS update state (home-assistant/core#177155).
 CORE_VERSION_PENDING_MIN_VERSION: AwesomeVersion = AwesomeVersion(
-    "2026.8.0.dev202607250000"
+    "2026.8.0.dev202607250310"
 )
 
 # pylint: disable=no-value-for-parameter

--- a/tests/api/test_os.py
+++ b/tests/api/test_os.py
@@ -289,6 +289,20 @@ async def test_api_os_update_no_auto_reboot_creates_issue(
     # unaware of version_pending don't offer the update again
     assert result["data"]["version"] == "13.0"
 
+    # Same for Core versions predating version_pending support
+    coresys.homeassistant.version = AwesomeVersion("2026.7.3")
+    resp = await api_client.get(f"{prefix}/os/info")
+    result = await resp.json()
+    assert result["data"]["version_pending"] == "13.0"
+    assert result["data"]["version"] == "13.0"
+
+    # Core versions consuming version_pending get the real current version
+    coresys.homeassistant.version = AwesomeVersion("2026.8.0.dev202607250200")
+    resp = await api_client.get(f"{prefix}/os/info")
+    result = await resp.json()
+    assert result["data"]["version_pending"] == "13.0"
+    assert result["data"]["version"] == "16.2"
+
 
 async def test_api_os_update_failure_no_reboot_no_issue(
     api_client_with_prefix: tuple[TestClient, str],

--- a/tests/api/test_os.py
+++ b/tests/api/test_os.py
@@ -297,7 +297,7 @@ async def test_api_os_update_no_auto_reboot_creates_issue(
     assert result["data"]["version"] == "13.0"
 
     # Core versions consuming version_pending get the real current version
-    coresys.homeassistant.version = AwesomeVersion("2026.8.0.dev202607250200")
+    coresys.homeassistant.version = AwesomeVersion("2026.8.0.dev202607250310")
     resp = await api_client.get(f"{prefix}/os/info")
     result = await resp.json()
     assert result["data"]["version_pending"] == "13.0"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `/os/info` endpoint reports an installed update pending activation as the current `version` so that Core update entities unaware of `version_pending` don't offer the update again. Since home-assistant/core#177155 Core uses `version_pending` to determine the OS update state, so such Core versions should get the real current version again.

This limits the compat shim to Core versions predating that support, following the same version gating pattern as `CORE_UNIX_SOCKET_MIN_VERSION` (minimum version check with landing page exclusion).

The first nightly with the change included is `2026.8.0.dev202607250310`.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
