### PR TITLE
Return a proper API error when adding a duplicate store repository

### DIFF
--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -1285,6 +1285,18 @@ class StoreAppNotFoundError(StoreError, APINotFound):
         super().__init__(None, logger)
 
 
+class StoreRepositoryAlreadyAddedError(StoreError, APIConflict):
+    """Raise when a repository is already added to the store."""
+
+    error_key = "store_repository_already_added_error"
+    message_template = "Can't add {url}, already in the store"
+
+    def __init__(self, logger: Callable[..., None] | None = None, *, url: str) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"url": url}
+        super().__init__(None, logger)
+
+
 class StoreRepositoryLocalCannotReset(StoreError, APIError):
     """Raise if user requests a reset on the local app repository."""
 

--- a/supervisor/store/__init__.py
+++ b/supervisor/store/__init__.py
@@ -13,6 +13,7 @@ from ..exceptions import (
     StoreInvalidAppRepo,
     StoreJobError,
     StoreNotFound,
+    StoreRepositoryAlreadyAddedError,
 )
 from ..homeassistant.const import WSEvent
 from ..jobs.decorator import Job, JobCondition
@@ -147,7 +148,7 @@ class StoreManager(CoreSysAttributes, FileConfiguration):
         repository = Repository.create(self.coresys, url)
 
         if repository.slug in self.repositories:
-            raise StoreError(f"Can't add {url}, already in the store", _LOGGER.error)
+            raise StoreRepositoryAlreadyAddedError(_LOGGER.error, url=url)
 
         # Load the repository
         try:

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -113,6 +113,22 @@ async def test_api_store_add_repository(
     assert REPO_URL in coresys.store.repository_urls
 
 
+@pytest.mark.usefixtures("test_repository")
+async def test_api_store_add_repository_duplicate(
+    api_client: TestClient, supervisor_internet: AsyncMock
+) -> None:
+    """Test POST /store/repositories REST API with an already added repository."""
+    response = await api_client.post(
+        "/store/repositories", json={"repository": REPO_URL}
+    )
+
+    assert response.status == 409
+    result = await response.json()
+    assert result["error_key"] == "store_repository_already_added_error"
+    assert result["extra_fields"] == {"url": REPO_URL}
+    assert result["message"] == f"Can't add {REPO_URL}, already in the store"
+
+
 async def test_api_store_remove_repository(
     api_client: TestClient, coresys: CoreSys, test_repository: Repository
 ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adding a store repository that is already in the store raises a plain `StoreError`. Since that is not an `APIError`, the `api_process` decorator logs it as "Unexpected error during API call" and reports it to Sentry, where it is one of the most frequent issues (SUPERVISOR-1JYE, ~8100 affected installations in the last 90 days). The events are ordinary client actions: add-on setup flows and documentation "add repository" links re-submitting a repository the user already has, plus third-party automation re-adding its repositories on every add-on start without checking the response.

Introduce `StoreRepositoryAlreadyAddedError`, which is both a `StoreError` and an `APIConflict` with an error key and message template, following the `ServiceAlreadyProvidedError` precedent. The request now fails with HTTP 409 Conflict (previously 400) and the response carries the structured error key and extra fields, and the error is no longer logged as unexpected or reported to Sentry.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: [SUPERVISOR-1JYE](https://home-assistant-io.sentry.io/issues/SUPERVISOR-1JYE) (auto-resolved by the commit message reference)
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
