### PR TITLE
Remove credentials from repository URLs in Sentry events

### DIFF
--- a/supervisor/misc/filter.py
+++ b/supervisor/misc/filter.py
@@ -18,6 +18,7 @@ from ..utils import check_exception_chain
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 RE_URL: re.Pattern = re.compile(r"(\w+:\/\/)(.*\.\w+)(.*)")
+RE_URL_CREDENTIALS: re.Pattern = re.compile(r"(?<=://)[^/@\s]+@")
 
 
 def sanitize_host(host: str) -> str:
@@ -45,6 +46,11 @@ def sanitize_url(url: str) -> str:
     return f"{match.group(1)}{host}{match.group(3)}"
 
 
+def sanitize_url_credentials(text: str) -> str:
+    """Return text with userinfo credentials removed from any URLs."""
+    return RE_URL_CREDENTIALS.sub("", text)
+
+
 def filter_data(coresys: CoreSys, event: Event, hint: Hint) -> Event | None:
     """Filter event data before sending to sentry."""
     # Ignore some exceptions. check_exception_chain walks __cause__ so
@@ -61,6 +67,27 @@ def filter_data(coresys: CoreSys, event: Event, hint: Hint) -> Event | None:
     # Ignore issue if system is not supported or diagnostics is disabled
     if not coresys.config.diagnostics or not coresys.core.supported or coresys.dev:
         return None
+
+    # Repository URLs can contain user-supplied credentials for private
+    # repositories. Remove credentials from event strings which can contain
+    # such URLs: exception messages (including git stderr in GitPython
+    # exceptions), log messages and breadcrumbs.
+    for exc_entry in cast(dict, event.get("exception", {})).get("values", []):
+        if exc_entry.get("value"):
+            exc_entry["value"] = sanitize_url_credentials(exc_entry["value"])
+
+    if logentry := cast(dict, event.get("logentry", {})):
+        if logentry.get("message"):
+            logentry["message"] = sanitize_url_credentials(logentry["message"])
+        if params := logentry.get("params"):
+            logentry["params"] = [
+                sanitize_url_credentials(param) if isinstance(param, str) else param
+                for param in params
+            ]
+
+    for crumb in cast(dict, event.get("breadcrumbs", {})).get("values", []):
+        if crumb.get("message"):
+            crumb["message"] = sanitize_url_credentials(crumb["message"])
 
     event.setdefault("extra", {}).update({"os.environ": dict(os.environ)})
     event.setdefault("user", {}).update({"id": coresys.machine_id})
@@ -134,7 +161,10 @@ def filter_data(coresys: CoreSys, event: Event, hint: Hint) -> Event | None:
                 "unhealthy": sorted(coresys.resolution.unhealthy),
             },
             "store": {
-                "repositories": coresys.store.repository_urls,
+                "repositories": [
+                    sanitize_url_credentials(url)
+                    for url in coresys.store.repository_urls
+                ],
             },
             "misc": {
                 "fallback_dns": coresys.plugins.dns.fallback,

--- a/tests/misc/test_filter_data.py
+++ b/tests/misc/test_filter_data.py
@@ -175,6 +175,50 @@ async def test_defaults(coresys):
     assert filtered["user"]["id"] == coresys.machine_id
 
 
+async def test_sanitize_url_credentials(coresys):
+    """Test that URL credentials are removed from event strings."""
+    coresys.config.diagnostics = True
+
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "type": "StoreGitCloneError",
+                    "value": "Can't clone https://x-access-token:github_pat_secret@github.com/example/repo repository",
+                }
+            ]
+        },
+        "logentry": {
+            "message": "Can't add repository %s due to %s",
+            "params": ["https://user:pass@example.com/repo", "error"],
+        },
+        "breadcrumbs": {
+            "values": [
+                {
+                    "message": "Cloning app repository from https://user:pass@example.com/repo"
+                }
+            ]
+        },
+    }
+
+    await coresys.core.set_state(CoreState.RUNNING)
+    with patch("shutil.disk_usage", return_value=(42, 42, 2 * (1024.0**3))):
+        filtered = filter_data(coresys, event, {})
+
+    assert (
+        filtered["exception"]["values"][0]["value"]
+        == "Can't clone https://github.com/example/repo repository"
+    )
+    assert filtered["logentry"]["params"] == [
+        "https://example.com/repo",
+        "error",
+    ]
+    assert (
+        filtered["breadcrumbs"]["values"][0]["message"]
+        == "Cloning app repository from https://example.com/repo"
+    )
+
+
 async def test_sanitize_user_hostname(coresys):
     """Test user hostname event sanitation."""
     event = SAMPLE_EVENT_AIOHTTP_EXTERNAL

--- a/tests/misc/test_sanitise_url.py
+++ b/tests/misc/test_sanitise_url.py
@@ -1,6 +1,6 @@
 """Test supervisor.utils.sanitize_url."""
 
-from supervisor.misc.filter import sanitize_host, sanitize_url
+from supervisor.misc.filter import sanitize_host, sanitize_url, sanitize_url_credentials
 
 
 def test_sanitize_host():
@@ -19,4 +19,29 @@ def test_sanitize_url():
     assert (
         sanitize_url("http://my.duckdns.org/test?test=123")
         == "http://sanitized-host.invalid/test?test=123"
+    )
+
+
+def test_sanitize_url_credentials():
+    """Test supervisor.misc.filter.sanitize_url_credentials."""
+    assert sanitize_url_credentials("test") == "test"
+    assert (
+        sanitize_url_credentials(
+            "https://x-access-token:github_pat_secret@github.com/example/repo"
+        )
+        == "https://github.com/example/repo"
+    )
+    assert (
+        sanitize_url_credentials("https://user@github.com/example/repo")
+        == "https://github.com/example/repo"
+    )
+    assert (
+        sanitize_url_credentials("https://github.com/example/repo")
+        == "https://github.com/example/repo"
+    )
+    assert (
+        sanitize_url_credentials(
+            "Can't clone https://user:pass@example.com/repo repository"
+        )
+        == "Can't clone https://example.com/repo repository"
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Store repository URLs may contain userinfo credentials (e.g. `https://x-access-token:<token>@github.com/...`) so Supervisor can clone private add-on repositories. These URLs currently end up verbatim in Sentry events: in captured exception messages, in log messages sent as breadcrumbs, and in the store repositories context that is attached to every event, leaking the embedded secrets. Sentry events from installations using such URLs show the GitHub personal access tokens in plain text (observed on SUPERVISOR-1JYE).

Add `sanitize_url_credentials()` alongside the existing `sanitize_url()` and use it in the `before_send` filter to remove credentials from exception values, log entries, breadcrumbs and the store repositories context. This also covers messages produced outside of Supervisor's own code, such as git's stderr embedded in GitPython exception messages (GitPython redacts the command line in exceptions, but not stderr).

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
