### PR TITLE
Respect user-overridden Core image for install and update

### DIFF
--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -221,6 +221,7 @@ class HomeAssistantCore(JobGroup):
                         _LOGGER.info("Home Assistant Core installation in progress")
 
         progress_task = self.sys_create_task(_periodic_progress_log())
+        install_image: str | None = None
         try:
             while True:
                 # read homeassistant tag and install it
@@ -262,10 +263,8 @@ class HomeAssistantCore(JobGroup):
                         )
 
                 try:
-                    await self.instance.update(
-                        to_version,
-                        image=self.sys_homeassistant.install_image,
-                    )
+                    install_image = self.sys_homeassistant.install_image
+                    await self.instance.update(to_version, image=install_image)
                     self.sys_homeassistant.version = self.instance.version or to_version
                     break
                 except DockerError, JobException:
@@ -283,7 +282,7 @@ class HomeAssistantCore(JobGroup):
             await progress_task
 
         _LOGGER.info("Home Assistant docker now installed")
-        self.sys_homeassistant.set_image(self.sys_homeassistant.install_image)
+        self.sys_homeassistant.set_image(install_image)
         await self.sys_homeassistant.save_data()
 
         # finishing
@@ -335,6 +334,7 @@ class HomeAssistantCore(JobGroup):
             )
 
         old_image = self.sys_homeassistant.image
+        install_image = self.sys_homeassistant.install_image
         rollback_version = (
             self.sys_homeassistant.version if not self.error_state else None
         )
@@ -362,9 +362,7 @@ class HomeAssistantCore(JobGroup):
             """Pull the Home Assistant image for the given version."""
             _LOGGER.info("Updating Home Assistant to version %s", to_version)
             try:
-                await self.instance.update(
-                    to_version, image=self.sys_homeassistant.install_image
-                )
+                await self.instance.update(to_version, image=install_image)
             except DockerError as err:
                 raise HomeAssistantUpdateImageError(
                     _LOGGER.warning, version=str(to_version)
@@ -373,7 +371,7 @@ class HomeAssistantCore(JobGroup):
         async def _start_update(to_version: AwesomeVersion) -> None:
             """Record the new version, (re)start Core and persist the change."""
             self.sys_homeassistant.version = self.instance.version or to_version
-            self.sys_homeassistant.set_image(self.sys_homeassistant.install_image)
+            self.sys_homeassistant.set_image(install_image)
 
             if running:
                 await self.start()

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -156,7 +156,7 @@ class HomeAssistantCore(JobGroup):
 
         _LOGGER.info("Setting up Home Assistant landingpage")
         while True:
-            if not self.sys_updater.image_homeassistant:
+            if not (install_image := self.sys_homeassistant.install_image):
                 _LOGGER.warning(
                     "Updater has no Home Assistant image information yet. Retrying in %ssec",
                     INSTALL_RETRY_WAIT_SECS,
@@ -166,9 +166,7 @@ class HomeAssistantCore(JobGroup):
                 continue
 
             try:
-                await self.instance.install(
-                    LANDINGPAGE, image=self.sys_updater.image_homeassistant
-                )
+                await self.instance.install(LANDINGPAGE, image=install_image)
                 break
             except DockerError, JobException:
                 pass
@@ -182,7 +180,7 @@ class HomeAssistantCore(JobGroup):
             await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
 
         self.sys_homeassistant.version = LANDINGPAGE
-        self.sys_homeassistant.set_image(self.sys_updater.image_homeassistant)
+        self.sys_homeassistant.set_image(install_image)
         await self.sys_homeassistant.save_data()
 
     @Job(
@@ -266,7 +264,7 @@ class HomeAssistantCore(JobGroup):
                 try:
                     await self.instance.update(
                         to_version,
-                        image=self.sys_updater.image_homeassistant,
+                        image=self.sys_homeassistant.install_image,
                     )
                     self.sys_homeassistant.version = self.instance.version or to_version
                     break
@@ -285,7 +283,7 @@ class HomeAssistantCore(JobGroup):
             await progress_task
 
         _LOGGER.info("Home Assistant docker now installed")
-        self.sys_homeassistant.set_image(self.sys_updater.image_homeassistant)
+        self.sys_homeassistant.set_image(self.sys_homeassistant.install_image)
         await self.sys_homeassistant.save_data()
 
         # finishing
@@ -365,7 +363,7 @@ class HomeAssistantCore(JobGroup):
             _LOGGER.info("Updating Home Assistant to version %s", to_version)
             try:
                 await self.instance.update(
-                    to_version, image=self.sys_updater.image_homeassistant
+                    to_version, image=self.sys_homeassistant.install_image
                 )
             except DockerError as err:
                 raise HomeAssistantUpdateImageError(
@@ -375,7 +373,7 @@ class HomeAssistantCore(JobGroup):
         async def _start_update(to_version: AwesomeVersion) -> None:
             """Record the new version, (re)start Core and persist the change."""
             self.sys_homeassistant.version = self.instance.version or to_version
-            self.sys_homeassistant.set_image(self.sys_updater.image_homeassistant)
+            self.sys_homeassistant.set_image(self.sys_homeassistant.install_image)
 
             if running:
                 await self.start()

--- a/supervisor/homeassistant/module.py
+++ b/supervisor/homeassistant/module.py
@@ -205,6 +205,17 @@ class HomeAssistant(FileConfiguration, CoreSysAttributes):
         self._data[ATTR_OVERRIDE_IMAGE] = value
 
     @property
+    def install_image(self) -> str | None:
+        """Return image to pull when installing or updating Home Assistant Core.
+
+        Uses the user-overridden image if set, otherwise the image from the
+        update information.
+        """
+        if self.override_image:
+            return self.image
+        return self.sys_updater.image_homeassistant
+
+    @property
     def version(self) -> AwesomeVersion | None:
         """Return version of local version."""
         return self._data.get(ATTR_VERSION)

--- a/supervisor/resolution/const.py
+++ b/supervisor/resolution/const.py
@@ -43,6 +43,7 @@ class UnsupportedReason(StrEnum):
     DNS_SERVER = "dns_server"
     DOCKER_CONFIGURATION = "docker_configuration"
     DOCKER_VERSION = "docker_version"
+    HOME_ASSISTANT_CORE_CUSTOM_IMAGE = "home_assistant_core_custom_image"
     HOME_ASSISTANT_CORE_VERSION = "home_assistant_core_version"
     JOB_CONDITIONS = "job_conditions"
     LXC = "lxc"

--- a/supervisor/resolution/evaluations/home_assistant_core_custom_image.py
+++ b/supervisor/resolution/evaluations/home_assistant_core_custom_image.py
@@ -1,0 +1,34 @@
+"""Evaluation class for Core image."""
+
+from ...const import CoreState
+from ...coresys import CoreSys
+from ..const import UnsupportedReason
+from .base import EvaluateBase
+
+
+def setup(coresys: CoreSys) -> EvaluateBase:
+    """Initialize evaluation-setup function."""
+    return EvaluateHomeAssistantCoreCustomImage(coresys)
+
+
+class EvaluateHomeAssistantCoreCustomImage(EvaluateBase):
+    """Evaluate the Home Assistant Core image."""
+
+    @property
+    def reason(self) -> UnsupportedReason:
+        """Return a UnsupportedReason enum."""
+        return UnsupportedReason.HOME_ASSISTANT_CORE_CUSTOM_IMAGE
+
+    @property
+    def on_failure(self) -> str:
+        """Return a string that is printed when self.evaluate is True."""
+        return f"Home Assistant Core is using the non-default image '{self.sys_homeassistant.image}'!"
+
+    @property
+    def states(self) -> list[CoreState]:
+        """Return a list of valid states when this evaluation can run."""
+        return [CoreState.RUNNING, CoreState.SETUP]
+
+    async def evaluate(self) -> bool:
+        """Run evaluation."""
+        return self.sys_homeassistant.image != self.sys_homeassistant.default_image

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -28,6 +28,7 @@ from supervisor.homeassistant.api import APIState
 from supervisor.homeassistant.const import LANDINGPAGE, WSEvent
 from supervisor.homeassistant.core import HomeAssistantCore
 from supervisor.homeassistant.module import HomeAssistant
+from supervisor.jobs.const import JobCondition
 from supervisor.resolution.const import ContextType, IssueType
 from supervisor.resolution.data import Issue
 from supervisor.updater import Updater
@@ -897,6 +898,71 @@ async def test_core_load_allows_image_override(
     assert (
         coresys.homeassistant.image == "ghcr.io/home-assistant/odroid-n2-homeassistant"
     )
+
+
+async def test_install_landingpage_uses_overridden_image(coresys: CoreSys):
+    """Test landingpage install pulls the user-overridden image."""
+    coresys.homeassistant.set_image("myorg/qemux86-64-homeassistant")
+    coresys.homeassistant.override_image = True
+
+    with (
+        patch.object(DockerHomeAssistant, "attach", side_effect=DockerError),
+        patch.object(DockerHomeAssistant, "install") as install,
+    ):
+        await coresys.homeassistant.core.install_landingpage()
+
+    install.assert_called_once_with(LANDINGPAGE, image="myorg/qemux86-64-homeassistant")
+    assert coresys.homeassistant.image == "myorg/qemux86-64-homeassistant"
+    assert coresys.homeassistant.version == LANDINGPAGE
+
+
+async def test_install_uses_overridden_image(coresys: CoreSys):
+    """Test Core install after landingpage pulls the user-overridden image."""
+    coresys.homeassistant.set_image("myorg/qemux86-64-homeassistant")
+    coresys.homeassistant.override_image = True
+
+    with (
+        patch.object(HomeAssistantCore, "start"),
+        patch.object(DockerHomeAssistant, "cleanup"),
+        patch.object(DockerHomeAssistant, "update") as update,
+        patch.object(
+            Updater,
+            "version_homeassistant",
+            new=PropertyMock(return_value=AwesomeVersion("2022.7.3")),
+        ),
+    ):
+        await coresys.homeassistant.core.install()
+
+    update.assert_called_once_with(
+        AwesomeVersion("2022.7.3"), image="myorg/qemux86-64-homeassistant"
+    )
+    assert coresys.homeassistant.image == "myorg/qemux86-64-homeassistant"
+
+
+async def test_update_uses_overridden_image(coresys: CoreSys):
+    """Test Core update pulls the user-overridden image."""
+    coresys.jobs.ignore_conditions = [
+        JobCondition.FREE_SPACE,
+        JobCondition.HEALTHY,
+        JobCondition.INTERNET_HOST,
+        JobCondition.PLUGINS_UPDATED,
+        JobCondition.SUPERVISOR_UPDATED,
+    ]
+    coresys.homeassistant.set_image("myorg/qemux86-64-homeassistant")
+    coresys.homeassistant.override_image = True
+    coresys.homeassistant.version = AwesomeVersion("2022.7.2")
+
+    with (
+        patch.object(DockerHomeAssistant, "update") as update,
+        patch.object(DockerHomeAssistant, "is_running", return_value=False),
+        patch.object(DockerHomeAssistant, "exists", return_value=False),
+    ):
+        await coresys.homeassistant.core.update(AwesomeVersion("2022.7.3"))
+
+    update.assert_called_once_with(
+        AwesomeVersion("2022.7.3"), image="myorg/qemux86-64-homeassistant"
+    )
+    assert coresys.homeassistant.image == "myorg/qemux86-64-homeassistant"
 
 
 async def test_core_loads_wrong_image_for_architecture(

--- a/tests/resolution/evaluation/test_evaluate_home_assistant_core_custom_image.py
+++ b/tests/resolution/evaluation/test_evaluate_home_assistant_core_custom_image.py
@@ -1,0 +1,73 @@
+"""Test Core image evaluation."""
+
+from unittest.mock import patch
+
+import pytest
+
+from supervisor.const import CoreState
+from supervisor.coresys import CoreSys
+from supervisor.resolution.evaluations.home_assistant_core_custom_image import (
+    EvaluateHomeAssistantCoreCustomImage,
+)
+
+
+@pytest.mark.parametrize(
+    ("image", "expected"),
+    [
+        (None, False),  # Unset, default image is used
+        ("ghcr.io/home-assistant/qemux86-64-homeassistant", False),  # Default image
+        ("myorg/qemux86-64-homeassistant", True),  # Fork on another registry
+        ("ghcr.io/myorg/qemux86-64-homeassistant", True),  # Fork on same registry
+    ],
+)
+async def test_core_image_evaluation(
+    coresys: CoreSys, image: str | None, expected: bool
+):
+    """Test evaluation logic on Core image."""
+    evaluation = EvaluateHomeAssistantCoreCustomImage(coresys)
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    coresys.homeassistant.set_image(image)
+
+    assert evaluation.reason not in coresys.resolution.unsupported
+    await evaluation()
+    assert (evaluation.reason in coresys.resolution.unsupported) is expected
+
+
+async def test_core_image_evaluation_resolves(coresys: CoreSys):
+    """Test the unsupported state is removed when the image is set back."""
+    evaluation = EvaluateHomeAssistantCoreCustomImage(coresys)
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    coresys.homeassistant.set_image("myorg/qemux86-64-homeassistant")
+    await evaluation()
+    assert evaluation.reason in coresys.resolution.unsupported
+
+    coresys.homeassistant.set_image(None)
+    await evaluation()
+    assert evaluation.reason not in coresys.resolution.unsupported
+
+
+async def test_did_run(coresys: CoreSys):
+    """Test that the evaluation ran as expected."""
+    evaluation = EvaluateHomeAssistantCoreCustomImage(coresys)
+    should_run = evaluation.states
+    should_not_run = [state for state in CoreState if state not in should_run]
+    assert len(should_run) != 0
+    assert len(should_not_run) != 0
+
+    with patch(
+        "supervisor.resolution.evaluations.home_assistant_core_custom_image.EvaluateHomeAssistantCoreCustomImage.evaluate",
+        return_value=None,
+    ) as evaluate:
+        for state in should_run:
+            await coresys.core.set_state(state)
+            await evaluation()
+            evaluate.assert_called_once()
+            evaluate.reset_mock()
+
+        for state in should_not_run:
+            await coresys.core.set_state(state)
+            await evaluation()
+            evaluate.assert_not_called()
+            evaluate.reset_mock()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `override_image` setting (set when a user configures a custom Core `image` via `/core/options`) was only honored by `load()`. The landingpage install, the initial Core install and Core updates always passed `image=self.sys_updater.image_homeassistant` to the Docker layer and wrote that image back to the Home Assistant config afterwards, discarding the user override on the next install or update.

This adds a `HomeAssistant.install_image` property that returns the user-overridden image when `override_image` is set, and the image from the update information otherwise. The landingpage install, Core install and Core update paths now use it for the image pull and persist that same image afterwards, so the override survives installs and updates. Version resolution is unchanged and still comes from the update information.

Behavior note: with an override set, a fresh install now pulls `<image>:landingpage` from the overridden image as well (previously the official landingpage image was used). An overridden image therefore needs a `landingpage` tag on the registry or a matching preinstalled local image for the fresh install flow. Since `override_image` is an explicit opt-in, the override is applied consistently to all image pulls.

As discussed in the PR, running a non-default Core image now marks the system as unsupported (`home_assistant_core_custom_image` reason). The evaluation compares the configured image against the default image for the machine rather than checking the `override_image` flag, so it also catches non-default images recorded through container adoption or manual configuration edits where the flag is not set.

Rollback note (raised in review): `update()` uses the currently configured install image for a rollback as well. If the image override is changed and a subsequent update fails, the rollback pulls the previous version on the newly configured image, not the image/version combination that was running before the update. Given this is a developer-focused feature, this behavior is accepted and documented here.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
