### PR TITLE
Pull Core HTTP server config over the Unix socket

### DIFF
--- a/supervisor/homeassistant/api.py
+++ b/supervisor/homeassistant/api.py
@@ -384,11 +384,14 @@ class HomeAssistantAPI(CoreSysAttributes):
         Replaces relying on Core pushing port/SSL via the Supervisor options
         API, which races with Supervisor's own startup checks.
         """
-        if not (config := await self.get_http_config()):
+        config = await self.get_http_config()
+        homeassistant = self.sys_homeassistant
+        # Reset to unknown when the config cannot be fetched (older Core, TCP
+        # fallback), so reachability decisions never use another Core's binds.
+        homeassistant.http_server_host = config.server_host if config else None
+        if not config:
             return
 
-        homeassistant = self.sys_homeassistant
-        homeassistant.http_server_host = config.server_host
         if (config.port, config.ssl) == (
             homeassistant.api_port,
             homeassistant.api_ssl,

--- a/supervisor/homeassistant/api.py
+++ b/supervisor/homeassistant/api.py
@@ -28,6 +28,10 @@ CORE_UNIX_SOCKET_MIN_VERSION: AwesomeVersion = AwesomeVersion(
     "2026.4.0.dev202603250907"
 )
 GET_CORE_STATE_MIN_VERSION: AwesomeVersion = AwesomeVersion("2023.8.0.dev20230720")
+# First nightly after https://github.com/home-assistant/core/pull/176976
+# added the endpoint. Requesting it from a dev build without the endpoint
+# fails gracefully (404 -> None).
+HTTP_CONFIG_MIN_VERSION: AwesomeVersion = AwesomeVersion("2026.8.0.dev202607280000")
 
 
 @dataclass(frozen=True)
@@ -36,6 +40,16 @@ class APIState:
 
     core_state: str
     offline_db_migration: bool
+
+
+@dataclass(frozen=True)
+class CoreHTTPConfig:
+    """Live HTTP server configuration reported by Core."""
+
+    port: int
+    ssl: bool
+    ssl_peer_certificate: bool
+    server_host: list[str]
 
 
 class HomeAssistantAPI(CoreSysAttributes):
@@ -334,6 +348,62 @@ class HomeAssistantAPI(CoreSysAttributes):
             raise HomeAssistantAPIError("No state received from Home Assistant API")
         return state
 
+    async def get_http_config(self) -> CoreHTTPConfig | None:
+        """Return the live HTTP server configuration pulled from Core.
+
+        Only available over the Unix socket on Core versions that provide the
+        endpoint. Returns None when it cannot be fetched, in which case the
+        values pushed by Core via the Supervisor options API remain in effect.
+        """
+        try:
+            if not self.use_unix_socket:
+                return None
+            if not version_is_new_enough(
+                self.sys_homeassistant.version, HTTP_CONFIG_MIN_VERSION
+            ):
+                return None
+            data = await self._get_json("api/core/http_config")
+        except HomeAssistantAPIError as err:
+            _LOGGER.debug("Can't fetch Core HTTP config: %s", err)
+            return None
+
+        try:
+            return CoreHTTPConfig(
+                port=int(data["port"]),
+                ssl=bool(data["ssl"]),
+                ssl_peer_certificate=bool(data["ssl_peer_certificate"]),
+                server_host=[str(host) for host in data["server_host"]],
+            )
+        except (KeyError, TypeError, ValueError) as err:
+            _LOGGER.warning("Malformed Core HTTP config response: %s", err)
+            return None
+
+    async def _update_http_config(self) -> None:
+        """Refresh the connection parameters from Core's HTTP config.
+
+        Replaces relying on Core pushing port/SSL via the Supervisor options
+        API, which races with Supervisor's own startup checks.
+        """
+        if not (config := await self.get_http_config()):
+            return
+
+        homeassistant = self.sys_homeassistant
+        homeassistant.http_server_host = config.server_host
+        if (config.port, config.ssl) == (
+            homeassistant.api_port,
+            homeassistant.api_ssl,
+        ):
+            return
+
+        _LOGGER.info(
+            "Updating Core connection parameters from its HTTP config: port %s, ssl %s",
+            config.port,
+            config.ssl,
+        )
+        homeassistant.api_port = config.port
+        homeassistant.api_ssl = config.ssl
+        await homeassistant.save_data()
+
     async def get_api_state(self) -> APIState | None:
         """Return state of Home Assistant Core or None."""
         # Skip check on landingpage
@@ -363,6 +433,7 @@ class HomeAssistantAPI(CoreSysAttributes):
                     else f"TCP {self.sys_homeassistant.api_url}"
                 )
                 _LOGGER.info("Connected to Core via %s", transport)
+                await self._update_http_config()
 
             state = data.get("state", "RUNNING")
             # Recorder state was added in HA Core 2024.8

--- a/supervisor/homeassistant/frontend_check.py
+++ b/supervisor/homeassistant/frontend_check.py
@@ -149,6 +149,23 @@ async def check_api_reachable(coresys: CoreSys) -> bool:
     return True
 
 
+def bind_reachable(coresys: CoreSys) -> bool:
+    """Return True if Supervisor can reach the address Core's HTTP server binds to.
+
+    Core reports its `server_host` binds via its HTTP config endpoint; when
+    that is unknown (older Core), assume reachable, matching previous
+    behavior. Supervisor connects over IPv4 to the container IP, so the bind
+    is reachable when it includes the IPv4 all-interfaces address or the
+    container IP itself. An IPv6 all-interfaces bind ("::") does not count:
+    Core's HTTP server sockets are v6-only (asyncio sets IPV6_V6ONLY), so
+    they do not accept IPv4 connections.
+    """
+    hosts = coresys.homeassistant.http_server_host
+    if hosts is None:
+        return True
+    return "0.0.0.0" in hosts or str(coresys.homeassistant.ip_address) in hosts
+
+
 async def verify_frontend(coresys: CoreSys) -> bool:
     """Verify the frontend is available after an update.
 
@@ -159,6 +176,14 @@ async def verify_frontend(coresys: CoreSys) -> bool:
     connection, so we fall back to a plain TCP reachability check instead of
     forcing a rollback, relying on the component check done by the caller.
     """
+    if not bind_reachable(coresys):
+        _LOGGER.info(
+            "Core binds its HTTP server to %s which Supervisor cannot reach, "
+            "skipping frontend verification",
+            coresys.homeassistant.http_server_host,
+        )
+        return True
+
     frontend = await check_frontend(coresys)
     websocket = await check_websocket(coresys)
 

--- a/supervisor/homeassistant/module.py
+++ b/supervisor/homeassistant/module.py
@@ -90,6 +90,7 @@ class HomeAssistant(FileConfiguration, CoreSysAttributes):
         self._websocket: HomeAssistantWebSocket = HomeAssistantWebSocket(coresys)
         self._core: HomeAssistantCore = HomeAssistantCore(coresys)
         self._secrets: HomeAssistantSecrets = HomeAssistantSecrets(coresys)
+        self._http_server_host: list[str] | None = None
 
     @property
     def api(self) -> HomeAssistantAPI:
@@ -150,6 +151,20 @@ class HomeAssistant(FileConfiguration, CoreSysAttributes):
     def api_ssl(self, value: bool):
         """Set SSL for Home Assistant instance."""
         self._data[ATTR_SSL] = value
+
+    @property
+    def http_server_host(self) -> list[str] | None:
+        """Return the hosts Core's HTTP server binds to, if known.
+
+        Pulled from Core's HTTP config over the Unix socket; None when unknown
+        (older Core). Not persisted, refreshed whenever Supervisor connects.
+        """
+        return self._http_server_host
+
+    @http_server_host.setter
+    def http_server_host(self, value: list[str] | None) -> None:
+        """Set the hosts Core's HTTP server binds to."""
+        self._http_server_host = value
 
     @property
     def api_url(self) -> str:

--- a/tests/homeassistant/test_api.py
+++ b/tests/homeassistant/test_api.py
@@ -10,7 +10,7 @@ from supervisor.coresys import CoreSys
 from supervisor.docker.const import ContainerState
 from supervisor.docker.monitor import DockerContainerStateEvent
 from supervisor.exceptions import DockerError, HomeAssistantAPIError
-from supervisor.homeassistant.api import APIState, HomeAssistantAPI
+from supervisor.homeassistant.api import APIState, CoreHTTPConfig, HomeAssistantAPI
 from supervisor.homeassistant.const import LANDINGPAGE
 
 from tests.common import MockResponse
@@ -283,6 +283,137 @@ async def test_get_api_state(
     with patch.object(type(coresys.homeassistant.api), "use_unix_socket", False):
         assert await coresys.homeassistant.api.get_api_state() == expected_state
         assert await coresys.homeassistant.api.check_api_state() is expected_check
+
+
+# --- get_http_config ---
+
+TEST_HTTP_CONFIG = {
+    "port": 80,
+    "ssl": False,
+    "ssl_peer_certificate": False,
+    "server_host": ["0.0.0.0", "::"],
+}
+
+
+async def test_get_http_config(coresys: CoreSys):
+    """Test get_http_config parses the endpoint response."""
+    coresys.homeassistant.version = AwesomeVersion("2026.8.0")
+    api = coresys.homeassistant.api
+    with (
+        patch.object(type(api), "use_unix_socket", True),
+        patch.object(api, "_get_json", return_value=TEST_HTTP_CONFIG),
+    ):
+        assert await api.get_http_config() == CoreHTTPConfig(
+            port=80,
+            ssl=False,
+            ssl_peer_certificate=False,
+            server_host=["0.0.0.0", "::"],
+        )
+
+
+@pytest.mark.parametrize(
+    ("use_unix_socket", "version", "response"),
+    [
+        # TCP fallback: the endpoint is socket-only.
+        (False, "2026.8.0", TEST_HTTP_CONFIG),
+        # Core version without the endpoint.
+        (True, "2026.7.0", TEST_HTTP_CONFIG),
+        # Endpoint request fails.
+        (True, "2026.8.0", HomeAssistantAPIError("Core API return 404")),
+        # Malformed responses.
+        (True, "2026.8.0", {"port": 80}),
+        (True, "2026.8.0", {**TEST_HTTP_CONFIG, "port": "no-number"}),
+        (True, "2026.8.0", {**TEST_HTTP_CONFIG, "server_host": 42}),
+    ],
+)
+async def test_get_http_config_unavailable(
+    coresys: CoreSys,
+    use_unix_socket: bool,
+    version: str,
+    response: dict | Exception,
+):
+    """Test get_http_config returns None when the config cannot be fetched."""
+    coresys.homeassistant.version = AwesomeVersion(version)
+    api = coresys.homeassistant.api
+    get_json = (
+        AsyncMock(side_effect=response)
+        if isinstance(response, Exception)
+        else AsyncMock(return_value=response)
+    )
+    with (
+        patch.object(type(api), "use_unix_socket", use_unix_socket),
+        patch.object(api, "_get_json", get_json),
+    ):
+        assert await api.get_http_config() is None
+
+
+async def test_http_config_pulled_on_connect(
+    coresys: CoreSys, real_get_api_state: HomeAssistantAPI
+):
+    """Test connection parameters refresh from Core's HTTP config on connect."""
+    api = coresys.homeassistant.api
+    coresys.homeassistant.version = AwesomeVersion("2026.8.0")
+    api.get_core_state = AsyncMock(
+        return_value={"state": "RUNNING", "recorder_state": {}}
+    )
+    coresys.homeassistant.save_data = AsyncMock()
+
+    assert coresys.homeassistant.api_port == 8123
+    assert coresys.homeassistant.http_server_host is None
+
+    with (
+        patch.object(type(api), "use_unix_socket", True),
+        patch.object(api, "_get_json", return_value=TEST_HTTP_CONFIG) as get_json,
+    ):
+        await api.get_api_state()
+        assert coresys.homeassistant.api_port == 80
+        assert coresys.homeassistant.api_ssl is False
+        assert coresys.homeassistant.http_server_host == ["0.0.0.0", "::"]
+        coresys.homeassistant.save_data.assert_awaited_once()
+
+        # Already connected: no pull on subsequent checks.
+        get_json.reset_mock()
+        await api.get_api_state()
+        get_json.assert_not_awaited()
+
+    # Container restart resets the connection; the config is pulled again.
+    await api.container_state_changed(
+        DockerContainerStateEvent(
+            name="homeassistant",
+            state=ContainerState.STOPPED,
+            id="abc123",
+            time=1234567890,
+        )
+    )
+    with (
+        patch.object(type(api), "use_unix_socket", True),
+        patch.object(api, "_get_json", return_value=TEST_HTTP_CONFIG) as get_json,
+    ):
+        await api.get_api_state()
+        get_json.assert_awaited_once_with("api/core/http_config")
+
+
+async def test_http_config_unchanged_not_saved(
+    coresys: CoreSys, real_get_api_state: HomeAssistantAPI
+):
+    """Test unchanged connection parameters are not saved to disk."""
+    api = coresys.homeassistant.api
+    coresys.homeassistant.version = AwesomeVersion("2026.8.0")
+    api.get_core_state = AsyncMock(
+        return_value={"state": "RUNNING", "recorder_state": {}}
+    )
+    coresys.homeassistant.save_data = AsyncMock()
+
+    config = {**TEST_HTTP_CONFIG, "port": 8123, "server_host": ["172.30.32.1"]}
+    with (
+        patch.object(type(api), "use_unix_socket", True),
+        patch.object(api, "_get_json", return_value=config),
+    ):
+        await api.get_api_state()
+
+    coresys.homeassistant.save_data.assert_not_awaited()
+    # The bind hosts are still updated for the frontend reachability check.
+    assert coresys.homeassistant.http_server_host == ["172.30.32.1"]
 
 
 # --- make_request ---

--- a/tests/homeassistant/test_api.py
+++ b/tests/homeassistant/test_api.py
@@ -416,6 +416,27 @@ async def test_http_config_unchanged_not_saved(
     assert coresys.homeassistant.http_server_host == ["172.30.32.1"]
 
 
+async def test_http_config_reset_when_unavailable(
+    coresys: CoreSys, real_get_api_state: HomeAssistantAPI
+):
+    """Test bind hosts reset when the HTTP config cannot be fetched.
+
+    After a downgrade to a Core without the endpoint, reachability decisions
+    must not use the previous Core's binds.
+    """
+    api = coresys.homeassistant.api
+    coresys.homeassistant.version = AwesomeVersion("2026.8.0")
+    api.get_core_state = AsyncMock(
+        return_value={"state": "RUNNING", "recorder_state": {}}
+    )
+    coresys.homeassistant.http_server_host = ["172.30.32.1"]
+
+    with patch.object(type(api), "use_unix_socket", False):
+        await api.get_api_state()
+
+    assert coresys.homeassistant.http_server_host is None
+
+
 # --- make_request ---
 
 

--- a/tests/homeassistant/test_frontend_check.py
+++ b/tests/homeassistant/test_frontend_check.py
@@ -222,3 +222,53 @@ async def test_verify_frontend_ssl_no_response_uses_tcp_check(
     ):
         assert await verify_frontend(coresys) is reachable
     check.assert_awaited_once_with(coresys)
+
+
+# --- bind reachability ---
+
+
+@pytest.mark.parametrize(
+    ("server_host", "reachable"),
+    [
+        # Unknown (older Core without the HTTP config endpoint): assume reachable.
+        (None, True),
+        # Default all-interfaces bind.
+        (["0.0.0.0", "::"], True),
+        (["0.0.0.0"], True),
+        # v6-only sockets (IPV6_V6ONLY) do not accept Supervisor's IPv4 connection.
+        (["::"], False),
+        # Bound specifically to the container IP Supervisor connects to.
+        (["172.30.32.1"], True),
+        # Bound to an address unreachable from outside the Core container.
+        (["127.0.0.1"], False),
+    ],
+)
+async def test_verify_frontend_bind_reachability(
+    coresys: CoreSys,
+    server_host: list[str] | None,
+    reachable: bool,
+    caplog: pytest.LogCaptureFixture,
+):
+    """verify_frontend skips the probes when Core's bind is unreachable."""
+    coresys.homeassistant.http_server_host = server_host
+    with (
+        patch(
+            "supervisor.homeassistant.frontend_check.check_frontend",
+            AsyncMock(return_value=ProbeResult.BAD_RESPONSE),
+        ) as frontend,
+        patch(
+            "supervisor.homeassistant.frontend_check.check_websocket",
+            AsyncMock(return_value=ProbeResult.BAD_RESPONSE),
+        ),
+    ):
+        result = await verify_frontend(coresys)
+
+    if reachable:
+        # Probes ran; the bad responses fail the verification as usual.
+        assert result is False
+        frontend.assert_awaited_once()
+    else:
+        # Probes skipped; the frontend cannot be verified, so it is trusted.
+        assert result is True
+        frontend.assert_not_awaited()
+        assert "skipping frontend verification" in caplog.text


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Supervisor currently learns the port and SSL state of Core's HTTP server only when the hassio integration pushes them via the Supervisor options API during its setup. Supervisor's own startup API and frontend checks can run before that push lands, so they probe Core with stale or default connection parameters.

This makes Supervisor pull the connection parameters instead: whenever a connection to Core is established, fetch Core's live HTTP server configuration from the new socket-only `/api/core/http_config` endpoint (home-assistant/core#176976) and update the stored port and SSL settings from it. On older Core versions without the endpoint (gated on `2026.8.0.dev202607280000`) the pushed options remain in effect, so behavior there is unchanged.

Core also reports the addresses its HTTP server binds to (the `http` integration's `server_host`), kept in a new runtime-only `http_server_host` attribute (not persisted, refreshed on every reconnect). The frontend verification after a Core update is now skipped when Supervisor cannot reach that bind, instead of failing the probes and rolling back an update that may be perfectly fine. Supervisor connects over IPv4 to the container IP, so the bind counts as reachable when it includes `0.0.0.0` or the container IP itself. An IPv6 all-interfaces bind (`::`) does not count: Core's HTTP server sockets are v6-only (asyncio sets `IPV6_V6ONLY`), so they do not accept IPv4 connections — verified empirically. This covers the reverse-proxy setup discussed in the Core PR review, where Core binds specifically to `172.30.32.1`: that is the address Supervisor already uses, so the frontend check still runs there.

Port and SSL are persisted (as with the pushed options), but only written to disk when they actually changed.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

Companion Core PR that added the endpoint: home-assistant/core#176976 (merged, ships in 2026.8).

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
