### PR TITLE
Rename resolution addon issue types and check slugs to app-based naming

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -438,13 +438,33 @@ class RestAPI(CoreSysAttributes):
         api_resolution = APIResolution()
         api_resolution.coresys = self.coresys
 
+        if app is self.versions[AppVersion.V1]:
+            app.add_routes(
+                [
+                    web.get("/resolution/info", api_resolution.info_v1),
+                    web.post(
+                        "/resolution/check/{check}/options",
+                        api_resolution.options_check_v1,
+                    ),
+                    web.post(
+                        "/resolution/check/{check}/run", api_resolution.run_check_v1
+                    ),
+                ]
+            )
+        else:
+            app.add_routes(
+                [
+                    web.get("/resolution/info", api_resolution.info),
+                    web.post(
+                        "/resolution/check/{check}/options",
+                        api_resolution.options_check,
+                    ),
+                    web.post("/resolution/check/{check}/run", api_resolution.run_check),
+                ]
+            )
+
         app.add_routes(
             [
-                web.get("/resolution/info", api_resolution.info),
-                web.post(
-                    "/resolution/check/{check}/options", api_resolution.options_check
-                ),
-                web.post("/resolution/check/{check}/run", api_resolution.run_check),
                 web.post(
                     "/resolution/suggestion/{suggestion}",
                     api_resolution.apply_suggestion,

--- a/supervisor/api/resolution.py
+++ b/supervisor/api/resolution.py
@@ -20,7 +20,12 @@ from ..const import (
 )
 from ..coresys import CoreSysAttributes
 from ..resolution.checks.base import CheckBase
+from ..resolution.const import LEGACY_CHECK_SLUG_MAP
 from ..resolution.data import Issue, Suggestion
+from ..resolution.module import (
+    process_check_dict_for_legacy_compatibility,
+    process_issue_dict_for_legacy_compatibility,
+)
 from .utils import api_process, api_validate
 
 SCHEMA_CHECK_OPTIONS = vol.Schema({vol.Optional(ATTR_ENABLED): bool})
@@ -43,6 +48,13 @@ class APIResolution(CoreSysAttributes):
         """Extract check from request or raise."""
         return self.sys_resolution.check.get(request.match_info["check"])
 
+    def _extract_check_v1(self, request: web.Request) -> CheckBase:
+        """Extract check from request using legacy slug mapping or raise (v1)."""
+        slug = request.match_info["check"]
+        # Translate legacy (old) slug to new slug if needed
+        new_slug = LEGACY_CHECK_SLUG_MAP.get(slug, slug)
+        return self.sys_resolution.check.get(new_slug)
+
     def _generate_suggestion_information(self, suggestion: Suggestion):
         """Generate suggestion information for response."""
         resp = asdict(suggestion)
@@ -55,9 +67,8 @@ class APIResolution(CoreSysAttributes):
         )
         return resp
 
-    @api_process
-    async def info(self, request: web.Request) -> dict[str, Any]:
-        """Return resolution information."""
+    def _build_info_response(self) -> dict[str, Any]:
+        """Build the resolution info response with current (v2) names."""
         return {
             ATTR_UNSUPPORTED: sorted(self.sys_resolution.unsupported),
             ATTR_UNHEALTHY: sorted(self.sys_resolution.unhealthy),
@@ -69,6 +80,26 @@ class APIResolution(CoreSysAttributes):
             ATTR_CHECKS: [
                 {ATTR_ENABLED: check.enabled, ATTR_SLUG: check.slug}
                 for check in self.sys_resolution.check.all_checks
+            ],
+        }
+
+    @api_process
+    async def info(self, request: web.Request) -> dict[str, Any]:
+        """Return resolution information."""
+        return self._build_info_response()
+
+    @api_process
+    async def info_v1(self, request: web.Request) -> dict[str, Any]:
+        """Return resolution info (v1: uses legacy issue types and check slugs)."""
+        data = self._build_info_response()
+        return data | {
+            ATTR_ISSUES: [
+                process_issue_dict_for_legacy_compatibility(issue)
+                for issue in data[ATTR_ISSUES]
+            ],
+            ATTR_CHECKS: [
+                process_check_dict_for_legacy_compatibility(check)
+                for check in data[ATTR_CHECKS]
             ],
         }
 
@@ -119,7 +150,26 @@ class APIResolution(CoreSysAttributes):
         await self.sys_resolution.save_data()
 
     @api_process
+    @api_process
+    async def options_check_v1(self, request: web.Request) -> None:
+        """Set options for check (v1: accepts legacy check slug in URL)."""
+        body = await api_validate(SCHEMA_CHECK_OPTIONS, request)
+        check = self._extract_check_v1(request)
+
+        # Apply options
+        if ATTR_ENABLED in body:
+            check.enabled = body[ATTR_ENABLED]
+
+        await self.sys_resolution.save_data()
+
+    @api_process
     async def run_check(self, request: web.Request) -> None:
         """Execute a backend check."""
         check = self._extract_check(request)
+        await check()
+
+    @api_process
+    async def run_check_v1(self, request: web.Request) -> None:
+        """Execute a backend check (v1: accepts legacy check slug in URL)."""
+        check = self._extract_check_v1(request)
         await check()

--- a/supervisor/api/resolution.py
+++ b/supervisor/api/resolution.py
@@ -150,7 +150,6 @@ class APIResolution(CoreSysAttributes):
         await self.sys_resolution.save_data()
 
     @api_process
-    @api_process
     async def options_check_v1(self, request: web.Request) -> None:
         """Set options for check (v1: accepts legacy check slug in URL)."""
         body = await api_validate(SCHEMA_CHECK_OPTIONS, request)

--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -293,7 +293,7 @@ class App(AppModel):
             self.has_deprecated_machine and not self.has_supported_machine
         ):
             self.sys_resolution.create_issue(
-                IssueType.DEPRECATED_ARCH_ADDON,
+                IssueType.DEPRECATED_ARCH_APP,
                 ContextType.ADDON,
                 reference=self.slug,
                 suggestions=[SuggestionType.EXECUTE_REMOVE],

--- a/supervisor/resolution/checks/app_pwned.py
+++ b/supervisor/resolution/checks/app_pwned.py
@@ -26,7 +26,7 @@ class CheckAppPwned(CheckBase):
     @property
     def slug(self) -> str:
         """Return the check slug."""
-        return "addon_pwned"
+        return "app_pwned"
 
     @Job(
         name="check_app_pwned_run",

--- a/supervisor/resolution/checks/deprecated_app.py
+++ b/supervisor/resolution/checks/deprecated_app.py
@@ -18,14 +18,14 @@ class CheckDeprecatedApp(CheckBase):
     @property
     def slug(self) -> str:
         """Return the check slug."""
-        return "deprecated_addon"
+        return "deprecated_app"
 
     async def run_check(self) -> None:
         """Run check if not affected by issue."""
         for app in self.sys_apps.installed:
             if app.stage == AppStage.DEPRECATED:
                 self.sys_resolution.create_issue(
-                    IssueType.DEPRECATED_ADDON,
+                    IssueType.DEPRECATED_APP,
                     ContextType.ADDON,
                     reference=app.slug,
                     suggestions=[SuggestionType.EXECUTE_REMOVE],
@@ -42,7 +42,7 @@ class CheckDeprecatedApp(CheckBase):
     @property
     def issue(self) -> IssueType:
         """Return a IssueType enum."""
-        return IssueType.DEPRECATED_ADDON
+        return IssueType.DEPRECATED_APP
 
     @property
     def context(self) -> ContextType:

--- a/supervisor/resolution/checks/deprecated_arch_app.py
+++ b/supervisor/resolution/checks/deprecated_arch_app.py
@@ -18,7 +18,7 @@ class CheckDeprecatedArchApp(CheckBase):
     @property
     def slug(self) -> str:
         """Return the check slug."""
-        return "deprecated_arch_addon"
+        return "deprecated_arch_app"
 
     async def run_check(self) -> None:
         """Run check if not affected by issue."""
@@ -30,7 +30,7 @@ class CheckDeprecatedArchApp(CheckBase):
                 app.has_deprecated_machine and not app.has_supported_machine
             ):
                 self.sys_resolution.create_issue(
-                    IssueType.DEPRECATED_ARCH_ADDON,
+                    IssueType.DEPRECATED_ARCH_APP,
                     ContextType.ADDON,
                     reference=app.slug,
                     suggestions=[SuggestionType.EXECUTE_REMOVE],
@@ -54,7 +54,7 @@ class CheckDeprecatedArchApp(CheckBase):
     @property
     def issue(self) -> IssueType:
         """Return a IssueType enum."""
-        return IssueType.DEPRECATED_ARCH_ADDON
+        return IssueType.DEPRECATED_ARCH_APP
 
     @property
     def context(self) -> ContextType:

--- a/supervisor/resolution/checks/detached_app_missing.py
+++ b/supervisor/resolution/checks/detached_app_missing.py
@@ -18,14 +18,14 @@ class CheckDetachedAppMissing(CheckBase):
     @property
     def slug(self) -> str:
         """Return the check slug."""
-        return "detached_addon_missing"
+        return "detached_app_missing"
 
     async def run_check(self) -> None:
         """Run check if not affected by issue."""
         for app in self.sys_apps.installed:
             if app.is_detached and app.repository not in self.sys_store.repositories:
                 self.sys_resolution.create_issue(
-                    IssueType.DETACHED_ADDON_MISSING,
+                    IssueType.DETACHED_APP_MISSING,
                     ContextType.ADDON,
                     reference=app.slug,
                 )
@@ -41,7 +41,7 @@ class CheckDetachedAppMissing(CheckBase):
     @property
     def issue(self) -> IssueType:
         """Return a IssueType enum."""
-        return IssueType.DETACHED_ADDON_MISSING
+        return IssueType.DETACHED_APP_MISSING
 
     @property
     def context(self) -> ContextType:

--- a/supervisor/resolution/checks/detached_app_removed.py
+++ b/supervisor/resolution/checks/detached_app_removed.py
@@ -18,14 +18,14 @@ class CheckDetachedAppRemoved(CheckBase):
     @property
     def slug(self) -> str:
         """Return the check slug."""
-        return "detached_addon_removed"
+        return "detached_app_removed"
 
     async def run_check(self) -> None:
         """Run check if not affected by issue."""
         for app in self.sys_apps.installed:
             if app.is_detached and app.repository in self.sys_store.repositories:
                 self.sys_resolution.create_issue(
-                    IssueType.DETACHED_ADDON_REMOVED,
+                    IssueType.DETACHED_APP_REMOVED,
                     ContextType.ADDON,
                     reference=app.slug,
                     suggestions=[SuggestionType.EXECUTE_REMOVE],
@@ -42,7 +42,7 @@ class CheckDetachedAppRemoved(CheckBase):
     @property
     def issue(self) -> IssueType:
         """Return a IssueType enum."""
-        return IssueType.DETACHED_ADDON_REMOVED
+        return IssueType.DETACHED_APP_REMOVED
 
     @property
     def context(self) -> ContextType:

--- a/supervisor/resolution/const.py
+++ b/supervisor/resolution/const.py
@@ -149,7 +149,7 @@ LEGACY_CHECK_SLUG_MAP: dict[str, str] = {
     "detached_addon_removed": "detached_app_removed",
 }
 
-# Reverse map for translating legacy check slugs in incoming V1 API requests.
+# Reverse map for translating current check slugs to legacy slugs for backward compatibility.
 INCOMING_LEGACY_CHECK_SLUG_MAP: dict[str, str] = {
     v: k for k, v in LEGACY_CHECK_SLUG_MAP.items()
 }

--- a/supervisor/resolution/const.py
+++ b/supervisor/resolution/const.py
@@ -84,10 +84,10 @@ class IssueType(StrEnum):
     CORRUPT_DOCKER = "corrupt_docker"
     CORRUPT_REPOSITORY = "corrupt_repository"
     CORRUPT_FILESYSTEM = "corrupt_filesystem"
-    DEPRECATED_ADDON = "deprecated_addon"
-    DEPRECATED_ARCH_ADDON = "deprecated_arch_addon"
-    DETACHED_ADDON_MISSING = "detached_addon_missing"
-    DETACHED_ADDON_REMOVED = "detached_addon_removed"
+    DEPRECATED_APP = "deprecated_app"
+    DEPRECATED_ARCH_APP = "deprecated_arch_app"
+    DETACHED_APP_MISSING = "detached_app_missing"
+    DETACHED_APP_REMOVED = "detached_app_removed"
     DEVICE_ACCESS_MISSING = "device_access_missing"
     DISABLED_DATA_DISK = "disabled_data_disk"
     DISK_LIFETIME = "disk_lifetime"
@@ -135,3 +135,31 @@ class SuggestionType(StrEnum):
     EXECUTE_UPDATE = "execute_update"
     REGISTRY_LOGIN = "registry_login"
     RENAME_DATA_DISK = "rename_data_disk"
+
+
+# Maps legacy check slugs to current slugs.
+# Legacy slugs are stored in old resolution.json or in incoming REST API.
+# Used to migrate persisted metadata on load and translate incoming V1 API
+# requests.
+LEGACY_CHECK_SLUG_MAP: dict[str, str] = {
+    "addon_pwned": "app_pwned",
+    "deprecated_addon": "deprecated_app",
+    "deprecated_arch_addon": "deprecated_arch_app",
+    "detached_addon_missing": "detached_app_missing",
+    "detached_addon_removed": "detached_app_removed",
+}
+
+# Reverse map for translating legacy check slugs in incoming V1 API requests.
+INCOMING_LEGACY_CHECK_SLUG_MAP: dict[str, str] = {
+    v: k for k, v in LEGACY_CHECK_SLUG_MAP.items()
+}
+
+# Maps new issue type values to legacy values for backward compatibility.
+# Used for WS API (when SUPERVISOR_WEBSOCKET_V2_API is disabled) and V1 REST API.
+# Can be removed when Core v2026.7 is no longer supported.
+LEGACY_ISSUE_TYPE_MAP: dict[str, str] = {
+    "deprecated_app": "deprecated_addon",
+    "deprecated_arch_app": "deprecated_arch_addon",
+    "detached_app_missing": "detached_addon_missing",
+    "detached_app_removed": "detached_addon_removed",
+}

--- a/supervisor/resolution/const.py
+++ b/supervisor/resolution/const.py
@@ -149,13 +149,15 @@ LEGACY_CHECK_SLUG_MAP: dict[str, str] = {
     "detached_addon_removed": "detached_app_removed",
 }
 
-# Reverse map for translating current check slugs to legacy slugs for backward compatibility.
-INCOMING_LEGACY_CHECK_SLUG_MAP: dict[str, str] = {
+# Reverse map for translating current check slugs to legacy slugs for outgoing
+# v1-compatible responses.
+OUTGOING_LEGACY_CHECK_SLUG_MAP: dict[str, str] = {
     v: k for k, v in LEGACY_CHECK_SLUG_MAP.items()
 }
 
 # Maps new issue type values to legacy values for backward compatibility.
-# Used for WS API (when SUPERVISOR_WEBSOCKET_V2_API is disabled) and V1 REST API.
+# Used for outgoing WS API compatibility (when SUPERVISOR_WEBSOCKET_V2_API is
+# disabled) and V1 REST API responses.
 # Can be removed when Core v2026.7 is no longer supported.
 LEGACY_ISSUE_TYPE_MAP: dict[str, str] = {
     "deprecated_app": "deprecated_addon",

--- a/supervisor/resolution/const.py
+++ b/supervisor/resolution/const.py
@@ -158,7 +158,6 @@ OUTGOING_LEGACY_CHECK_SLUG_MAP: dict[str, str] = {
 # Maps new issue type values to legacy values for backward compatibility.
 # Used for outgoing WS API compatibility (when SUPERVISOR_WEBSOCKET_V2_API is
 # disabled) and V1 REST API responses.
-# Can be removed when Core v2026.7 is no longer supported.
 LEGACY_ISSUE_TYPE_MAP: dict[str, str] = {
     "deprecated_app": "deprecated_addon",
     "deprecated_arch_app": "deprecated_arch_addon",

--- a/supervisor/resolution/fixups/app_execute_remove.py
+++ b/supervisor/resolution/fixups/app_execute_remove.py
@@ -49,7 +49,7 @@ class FixupAppExecuteRemove(FixupBase):
     @property
     def issues(self) -> list[IssueType]:
         """Return a IssueType enum list."""
-        return [IssueType.DETACHED_ADDON_REMOVED, IssueType.DEPRECATED_ARCH_ADDON]
+        return [IssueType.DETACHED_APP_REMOVED, IssueType.DEPRECATED_ARCH_APP]
 
     @property
     def auto(self) -> bool:

--- a/supervisor/resolution/module.py
+++ b/supervisor/resolution/module.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 
 from ..bus import EventListener
+from ..const import FeatureFlag
 from ..coresys import CoreSys, CoreSysAttributes
 from ..exceptions import (
     ResolutionError,
@@ -17,6 +18,8 @@ from ..utils.common import FileConfiguration
 from .check import ResolutionCheck
 from .const import (
     FILE_CONFIG_RESOLUTION,
+    INCOMING_LEGACY_CHECK_SLUG_MAP,
+    LEGACY_ISSUE_TYPE_MAP,
     SCHEDULED_HEALTHCHECK,
     ContextType,
     IssueType,
@@ -30,6 +33,24 @@ from .fixup import ResolutionFixup
 from .validate import SCHEMA_RESOLUTION_CONFIG
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+def process_issue_dict_for_legacy_compatibility(
+    issue_data: dict[str, Any],
+) -> dict[str, Any]:
+    """Map new issue type values to legacy values for API compatibility."""
+    if (issue_type := issue_data.get("type")) in LEGACY_ISSUE_TYPE_MAP:
+        return issue_data | {"type": LEGACY_ISSUE_TYPE_MAP[issue_type]}
+    return issue_data
+
+
+def process_check_dict_for_legacy_compatibility(
+    check_data: dict[str, Any],
+) -> dict[str, Any]:
+    """Map new check slug values to legacy values for API compatibility."""
+    if (slug := check_data.get("slug")) in INCOMING_LEGACY_CHECK_SLUG_MAP:
+        return check_data | {"slug": INCOMING_LEGACY_CHECK_SLUG_MAP[slug]}
+    return check_data
 
 
 class ResolutionManager(FileConfiguration, CoreSysAttributes):
@@ -169,12 +190,22 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
             self.add_unhealthy_reason(self._OSERROR_UNHEALTHY_REASONS[err.errno])
 
     def _make_issue_message(self, issue: Issue) -> dict[str, Any]:
-        """Make issue into message for core."""
-        return asdict(issue) | {
+        """Make issue into message for core.
+
+        Applies legacy compatibility shim when SUPERVISOR_WEBSOCKET_V2_API is
+        disabled (backward compatible with Home Assistant Core v2026.7 and
+        earlier).
+        """
+        data = asdict(issue) | {
             "suggestions": [
                 asdict(suggestion) for suggestion in self.suggestions_for_issue(issue)
             ]
         }
+        if not self.sys_config.feature_flags.get(
+            FeatureFlag.SUPERVISOR_WEBSOCKET_V2_API, False
+        ):
+            data = process_issue_dict_for_legacy_compatibility(data)
+        return data
 
     def get_suggestion_by_id(self, uuid: str) -> Suggestion:
         """Return suggestion with uuid."""
@@ -290,8 +321,13 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
         self._issues.remove(issue)
 
         # Event on issue removal
+        issue_data = asdict(issue)
+        if not self.sys_config.feature_flags.get(
+            FeatureFlag.SUPERVISOR_WEBSOCKET_V2_API, False
+        ):
+            issue_data = process_issue_dict_for_legacy_compatibility(issue_data)
         self.sys_homeassistant.websocket.supervisor_event(
-            WSEvent.ISSUE_REMOVED, asdict(issue)
+            WSEvent.ISSUE_REMOVED, issue_data
         )
 
         # Clean up any orphaned suggestions

--- a/supervisor/resolution/module.py
+++ b/supervisor/resolution/module.py
@@ -18,8 +18,8 @@ from ..utils.common import FileConfiguration
 from .check import ResolutionCheck
 from .const import (
     FILE_CONFIG_RESOLUTION,
-    INCOMING_LEGACY_CHECK_SLUG_MAP,
     LEGACY_ISSUE_TYPE_MAP,
+    OUTGOING_LEGACY_CHECK_SLUG_MAP,
     SCHEDULED_HEALTHCHECK,
     ContextType,
     IssueType,
@@ -48,8 +48,8 @@ def process_check_dict_for_legacy_compatibility(
     check_data: dict[str, Any],
 ) -> dict[str, Any]:
     """Map new check slug values to legacy values for API compatibility."""
-    if (slug := check_data.get("slug")) in INCOMING_LEGACY_CHECK_SLUG_MAP:
-        return check_data | {"slug": INCOMING_LEGACY_CHECK_SLUG_MAP[slug]}
+    if (slug := check_data.get("slug")) in OUTGOING_LEGACY_CHECK_SLUG_MAP:
+        return check_data | {"slug": OUTGOING_LEGACY_CHECK_SLUG_MAP[slug]}
     return check_data
 
 
@@ -196,11 +196,24 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
         disabled (backward compatible with Home Assistant Core v2026.7 and
         earlier).
         """
-        data = asdict(issue) | {
-            "suggestions": [
-                asdict(suggestion) for suggestion in self.suggestions_for_issue(issue)
-            ]
-        }
+        return self._issue_event_data(issue, with_suggestions=True)
+
+    def _issue_event_data(
+        self, issue: Issue, *, with_suggestions: bool = False
+    ) -> dict[str, Any]:
+        """Build issue payload and apply legacy compatibility if needed."""
+        data = (
+            asdict(issue)
+            | {
+                "suggestions": [
+                    asdict(suggestion)
+                    for suggestion in self.suggestions_for_issue(issue)
+                ]
+            }
+            if with_suggestions
+            else asdict(issue)
+        )
+
         if not self.sys_config.feature_flags.get(
             FeatureFlag.SUPERVISOR_WEBSOCKET_V2_API, False
         ):
@@ -321,13 +334,8 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
         self._issues.remove(issue)
 
         # Event on issue removal
-        issue_data = asdict(issue)
-        if not self.sys_config.feature_flags.get(
-            FeatureFlag.SUPERVISOR_WEBSOCKET_V2_API, False
-        ):
-            issue_data = process_issue_dict_for_legacy_compatibility(issue_data)
         self.sys_homeassistant.websocket.supervisor_event(
-            WSEvent.ISSUE_REMOVED, issue_data
+            WSEvent.ISSUE_REMOVED, self._issue_event_data(issue)
         )
 
         # Clean up any orphaned suggestions

--- a/supervisor/resolution/validate.py
+++ b/supervisor/resolution/validate.py
@@ -32,6 +32,8 @@ def _get_check_slug(module_name: str) -> str:
 
 def _migrate_checks_config(data: dict) -> dict:
     """Migrate legacy check slug keys to current slug keys."""
+    if not isinstance(data, dict):
+        raise vol.Invalid("Expected a dictionary for checks configuration")
     return {LEGACY_CHECK_SLUG_MAP.get(key, key): value for key, value in data.items()}
 
 

--- a/supervisor/resolution/validate.py
+++ b/supervisor/resolution/validate.py
@@ -5,16 +5,11 @@ from pathlib import Path
 import voluptuous as vol
 
 from ..const import ATTR_CHECKS, ATTR_ENABLED
+from .const import LEGACY_CHECK_SLUG_MAP
 
 # Maps check module filename stem -> public API slug for checks whose slug
 # differs from their module name (i.e., slug overrides for backward compat).
-_CHECK_SLUG_OVERRIDES: dict[str, str] = {
-    "app_pwned": "addon_pwned",
-    "deprecated_app": "deprecated_addon",
-    "deprecated_arch_app": "deprecated_arch_addon",
-    "detached_app_missing": "detached_addon_missing",
-    "detached_app_removed": "detached_addon_removed",
-}
+_CHECK_SLUG_OVERRIDES: dict[str, str] = {}
 
 
 def get_valid_modules(folder, *, base=__file__) -> list[str]:
@@ -33,6 +28,11 @@ def get_valid_modules(folder, *, base=__file__) -> list[str]:
 def _get_check_slug(module_name: str) -> str:
     """Return the public slug for a check module (may differ from module name)."""
     return _CHECK_SLUG_OVERRIDES.get(module_name, module_name)
+
+
+def _migrate_checks_config(data: dict) -> dict:
+    """Migrate legacy check slug keys to current slug keys."""
+    return {LEGACY_CHECK_SLUG_MAP.get(key, key): value for key, value in data.items()}
 
 
 SCHEMA_CHECK_CONFIG = vol.Schema(
@@ -54,9 +54,9 @@ SCHEMA_CHECKS_CONFIG = vol.Schema(
 
 SCHEMA_RESOLUTION_CONFIG = vol.Schema(
     {
-        vol.Required(
-            ATTR_CHECKS, default=SCHEMA_CHECKS_CONFIG({})
-        ): SCHEMA_CHECKS_CONFIG,
+        vol.Required(ATTR_CHECKS, default=SCHEMA_CHECKS_CONFIG({})): vol.All(
+            _migrate_checks_config, SCHEMA_CHECKS_CONFIG
+        ),
     },
     extra=vol.REMOVE_EXTRA,
 )

--- a/tests/api/test_resolution.py
+++ b/tests/api/test_resolution.py
@@ -1,5 +1,6 @@
 """Test Resolution API."""
 
+import asyncio
 from http import HTTPStatus
 from unittest.mock import AsyncMock
 
@@ -12,9 +13,11 @@ from supervisor.const import (
     ATTR_UNHEALTHY,
     ATTR_UNSUPPORTED,
     CoreState,
+    FeatureFlag,
 )
 from supervisor.coresys import CoreSys
 from supervisor.exceptions import ResolutionError
+from supervisor.homeassistant.const import WSType
 from supervisor.resolution.const import (
     ContextType,
     IssueType,
@@ -245,3 +248,275 @@ async def test_check_not_found(
     assert body["message"] == "Check 'bad' does not exist"
     assert body["error_key"] == "resolution_check_not_found_error"
     assert body["extra_fields"] == {"check": "bad"}
+
+
+@pytest.mark.parametrize(
+    ("issue_type", "legacy_issue_type"),
+    [
+        (IssueType.DEPRECATED_APP, "deprecated_addon"),
+        (IssueType.DEPRECATED_ARCH_APP, "deprecated_arch_addon"),
+        (IssueType.DETACHED_APP_MISSING, "detached_addon_missing"),
+        (IssueType.DETACHED_APP_REMOVED, "detached_addon_removed"),
+    ],
+)
+async def test_api_resolution_info_v1_uses_legacy_names(
+    coresys: CoreSys, api_client: TestClient, issue_type: str, legacy_issue_type: str
+):
+    """Test v1 resolution info uses legacy issue type and check slug names."""
+    coresys.resolution.add_issue(Issue(issue_type, ContextType.ADDON, reference="test"))
+
+    resp = await api_client.get("/resolution/info")
+    result = await resp.json()
+
+    # V1 should return legacy issue type name
+    issue_types = [issue["type"] for issue in result["data"][ATTR_ISSUES]]
+    assert legacy_issue_type in issue_types
+    assert issue_type not in issue_types
+
+    # V1 should return legacy check slugs
+    check_slugs = [check["slug"] for check in result["data"]["checks"]]
+    assert "addon_pwned" in check_slugs
+    assert "deprecated_addon" in check_slugs
+    assert "deprecated_arch_addon" in check_slugs
+    assert "detached_addon_missing" in check_slugs
+    assert "detached_addon_removed" in check_slugs
+    # Should NOT have new names
+    assert "app_pwned" not in check_slugs
+    assert "deprecated_app" not in check_slugs
+    assert "deprecated_arch_app" not in check_slugs
+    assert "detached_app_missing" not in check_slugs
+    assert "detached_app_removed" not in check_slugs
+
+
+@pytest.mark.parametrize(
+    "issue_type",
+    [
+        IssueType.DEPRECATED_APP,
+        IssueType.DEPRECATED_ARCH_APP,
+        IssueType.DETACHED_APP_MISSING,
+        IssueType.DETACHED_APP_REMOVED,
+    ],
+)
+async def test_api_resolution_info_v2_uses_new_names(
+    coresys: CoreSys, api_client_v2: TestClient, issue_type: str
+):
+    """Test v2 resolution info uses new issue type and check slug names."""
+    coresys.resolution.add_issue(Issue(issue_type, ContextType.ADDON, reference="test"))
+
+    resp = await api_client_v2.get("/v2/resolution/info")
+    result = await resp.json()
+
+    # V2 should return new issue type name
+    issue_types = [issue["type"] for issue in result["data"][ATTR_ISSUES]]
+    assert issue_type in issue_types
+
+    # V2 should return new check slugs
+    check_slugs = [check["slug"] for check in result["data"]["checks"]]
+    assert "app_pwned" in check_slugs
+    assert "deprecated_app" in check_slugs
+    assert "deprecated_arch_app" in check_slugs
+    assert "detached_app_missing" in check_slugs
+    assert "detached_app_removed" in check_slugs
+    # Should NOT have legacy names
+    assert "addon_pwned" not in check_slugs
+    assert "deprecated_addon" not in check_slugs
+    assert "deprecated_arch_addon" not in check_slugs
+    assert "detached_addon_missing" not in check_slugs
+    assert "detached_addon_removed" not in check_slugs
+
+
+@pytest.mark.parametrize(
+    ("issue_type", "legacy_issue_type"),
+    [
+        (IssueType.DEPRECATED_APP, "deprecated_addon"),
+        (IssueType.DEPRECATED_ARCH_APP, "deprecated_arch_addon"),
+        (IssueType.DETACHED_APP_MISSING, "detached_addon_missing"),
+        (IssueType.DETACHED_APP_REMOVED, "detached_addon_removed"),
+    ],
+)
+async def test_ws_resolution_issue_events_legacy_compat(
+    coresys: CoreSys,
+    ha_ws_client: AsyncMock,
+    issue_type: str,
+    legacy_issue_type: str,
+):
+    """Test WS issue events use legacy names when SUPERVISOR_WEBSOCKET_V2_API is disabled."""
+    # Default: SUPERVISOR_WEBSOCKET_V2_API is disabled
+    coresys.resolution.add_issue(Issue(issue_type, ContextType.ADDON, reference="test"))
+    await asyncio.sleep(0)
+
+    ws_events = [
+        call.args[0]
+        for call in ha_ws_client.async_send_command.call_args_list
+        if call.args[0].get("type") == WSType.SUPERVISOR_EVENT
+        and call.args[0].get("data", {}).get("event") == "issue_changed"
+    ]
+    assert len(ws_events) == 1
+    assert ws_events[0]["data"]["data"]["type"] == legacy_issue_type
+
+    # After dismissing, the issue_removed event should also use legacy name
+    ha_ws_client.async_send_command.reset_mock()
+    issue = coresys.resolution.issues[0]
+    coresys.resolution.dismiss_issue(issue)
+    await asyncio.sleep(0)
+
+    ws_events = [
+        call.args[0]
+        for call in ha_ws_client.async_send_command.call_args_list
+        if call.args[0].get("type") == WSType.SUPERVISOR_EVENT
+        and call.args[0].get("data", {}).get("event") == "issue_removed"
+    ]
+    assert len(ws_events) == 1
+    assert ws_events[0]["data"]["data"]["type"] == legacy_issue_type
+
+
+@pytest.mark.parametrize(
+    "issue_type",
+    [
+        IssueType.DEPRECATED_APP,
+        IssueType.DEPRECATED_ARCH_APP,
+        IssueType.DETACHED_APP_MISSING,
+        IssueType.DETACHED_APP_REMOVED,
+    ],
+)
+async def test_ws_resolution_issue_events_v2(
+    coresys: CoreSys, ha_ws_client: AsyncMock, issue_type: str
+):
+    """Test WS issue events use new names when SUPERVISOR_WEBSOCKET_V2_API is enabled."""
+    coresys.config.set_feature_flag(FeatureFlag.SUPERVISOR_WEBSOCKET_V2_API, True)
+
+    coresys.resolution.add_issue(Issue(issue_type, ContextType.ADDON, reference="test"))
+    await asyncio.sleep(0)
+
+    ws_events = [
+        call.args[0]
+        for call in ha_ws_client.async_send_command.call_args_list
+        if call.args[0].get("type") == WSType.SUPERVISOR_EVENT
+        and call.args[0].get("data", {}).get("event") == "issue_changed"
+    ]
+    assert len(ws_events) == 1
+    assert ws_events[0]["data"]["data"]["type"] == issue_type
+
+    # After dismissing, the issue_removed event should also use new name
+    ha_ws_client.async_send_command.reset_mock()
+    issue = coresys.resolution.issues[0]
+    coresys.resolution.dismiss_issue(issue)
+    await asyncio.sleep(0)
+
+    ws_events = [
+        call.args[0]
+        for call in ha_ws_client.async_send_command.call_args_list
+        if call.args[0].get("type") == WSType.SUPERVISOR_EVENT
+        and call.args[0].get("data", {}).get("event") == "issue_removed"
+    ]
+    assert len(ws_events) == 1
+    assert ws_events[0]["data"]["data"]["type"] == issue_type
+
+
+@pytest.mark.parametrize(
+    ("check_slug", "legacy_slug"),
+    [
+        ("app_pwned", "addon_pwned"),
+        ("deprecated_app", "deprecated_addon"),
+        ("deprecated_arch_app", "deprecated_arch_addon"),
+        ("detached_app_missing", "detached_addon_missing"),
+        ("detached_app_removed", "detached_addon_removed"),
+    ],
+)
+async def test_api_resolution_check_run_v1_accepts_legacy_names(
+    api_client: TestClient,
+    check_slug: str,
+    legacy_slug: str,
+):
+    """Test v1 check run endpoint translates legacy check slugs to new ones."""
+    # V1 should accept legacy slug and translate it to new slug
+    resp = await api_client.post(f"/resolution/check/{legacy_slug}/run")
+    assert resp.status == 200
+
+    # V1 should also accept new slug directly
+    resp = await api_client.post(f"/resolution/check/{check_slug}/run")
+    assert resp.status == 200
+
+
+@pytest.mark.parametrize(
+    ("check_slug", "legacy_slug"),
+    [
+        ("app_pwned", "addon_pwned"),
+        ("deprecated_app", "deprecated_addon"),
+        ("deprecated_arch_app", "deprecated_arch_addon"),
+        ("detached_app_missing", "detached_addon_missing"),
+        ("detached_app_removed", "detached_addon_removed"),
+    ],
+)
+async def test_api_resolution_check_run_v2_accepts_new_names(
+    api_client_v2: TestClient, check_slug: str, legacy_slug: str
+):
+    """Test v2 check run endpoint accepts new check slugs and rejects legacy ones."""
+    # V2 should accept new slug
+    resp = await api_client_v2.post(f"/v2/resolution/check/{check_slug}/run")
+    assert resp.status == 200
+
+    # V2 should NOT accept legacy slug
+    resp = await api_client_v2.post(f"/v2/resolution/check/{legacy_slug}/run")
+    assert resp.status == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.parametrize(
+    ("check_slug", "legacy_slug"),
+    [
+        ("app_pwned", "addon_pwned"),
+        ("deprecated_app", "deprecated_addon"),
+        ("deprecated_arch_app", "deprecated_arch_addon"),
+        ("detached_app_missing", "detached_addon_missing"),
+        ("detached_app_removed", "detached_addon_removed"),
+    ],
+)
+async def test_api_resolution_check_options_v1_accepts_legacy_names(
+    api_client: TestClient,
+    check_slug: str,
+    legacy_slug: str,
+):
+    """Test v1 check options endpoint translates legacy check slugs to new ones."""
+    # V1 should accept legacy slug and translate it to new slug
+    resp = await api_client.post(
+        f"/resolution/check/{legacy_slug}/options", json={"enabled": False}
+    )
+    assert resp.status == 200
+
+    # V1 should also accept new slug directly
+    resp = await api_client.post(
+        f"/resolution/check/{check_slug}/options", json={"enabled": True}
+    )
+    assert resp.status == 200
+
+
+@pytest.mark.parametrize(
+    ("check_slug", "legacy_slug"),
+    [
+        ("app_pwned", "addon_pwned"),
+        ("deprecated_app", "deprecated_addon"),
+        ("deprecated_arch_app", "deprecated_arch_addon"),
+        ("detached_app_missing", "detached_addon_missing"),
+        ("detached_app_removed", "detached_addon_removed"),
+    ],
+)
+async def test_api_resolution_check_options_v2_accepts_new_names(
+    api_client_v2: TestClient, check_slug: str, legacy_slug: str
+):
+    """Test v2 check options endpoint accepts new check slugs and rejects legacy ones."""
+    # V2 should accept new slug
+    resp = await api_client_v2.post(
+        f"/v2/resolution/check/{check_slug}/options", json={"enabled": False}
+    )
+    assert resp.status == 200
+
+    resp = await api_client_v2.post(
+        f"/v2/resolution/check/{check_slug}/options", json={"enabled": True}
+    )
+    assert resp.status == 200
+
+    # V2 should NOT accept legacy slug
+    resp = await api_client_v2.post(
+        f"/v2/resolution/check/{legacy_slug}/options", json={"enabled": False}
+    )
+    assert resp.status == HTTPStatus.NOT_FOUND

--- a/tests/resolution/check/test_check_app_pwned.py
+++ b/tests/resolution/check/test_check_app_pwned.py
@@ -23,7 +23,7 @@ class FakeApp:
 async def test_base(coresys: CoreSys):
     """Test check basics."""
     app_pwned = CheckAppPwned(coresys)
-    assert app_pwned.slug == "addon_pwned"
+    assert app_pwned.slug == "app_pwned"
     assert app_pwned.enabled
 
 
@@ -92,7 +92,7 @@ async def test_with_global_disable(coresys: CoreSys, caplog):
     coresys.security.verify_secret = AsyncMock(side_effect=PwnedSecret)
     await app_pwned.run_check.__wrapped__(app_pwned)
     assert not coresys.security.verify_secret.called
-    assert "Skipping addon_pwned, pwned is globally disabled" in caplog.text
+    assert "Skipping app_pwned, pwned is globally disabled" in caplog.text
 
 
 async def test_did_run(coresys: CoreSys):

--- a/tests/resolution/check/test_check_deprecated_app.py
+++ b/tests/resolution/check/test_check_deprecated_app.py
@@ -13,7 +13,7 @@ from supervisor.resolution.data import Issue
 async def test_base(coresys: CoreSys):
     """Test check basics."""
     deprecated_app = CheckDeprecatedApp(coresys)
-    assert deprecated_app.slug == "deprecated_addon"
+    assert deprecated_app.slug == "deprecated_app"
     assert deprecated_app.enabled
 
 
@@ -31,7 +31,7 @@ async def test_check(coresys: CoreSys, install_app_ssh: App):
     await deprecated_app()
 
     assert len(coresys.resolution.issues) == 1
-    assert coresys.resolution.issues[0].type is IssueType.DEPRECATED_ADDON
+    assert coresys.resolution.issues[0].type is IssueType.DEPRECATED_APP
     assert coresys.resolution.issues[0].context is ContextType.ADDON
     assert coresys.resolution.issues[0].reference == install_app_ssh.slug
     assert len(coresys.resolution.suggestions) == 1
@@ -45,7 +45,7 @@ async def test_approve(coresys: CoreSys, install_app_ssh: App):
     assert (
         await deprecated_app.approve_check(
             Issue(
-                IssueType.DEPRECATED_ADDON,
+                IssueType.DEPRECATED_APP,
                 ContextType.ADDON,
                 reference=install_app_ssh.slug,
             )
@@ -59,7 +59,7 @@ async def test_approve(coresys: CoreSys, install_app_ssh: App):
     assert (
         await deprecated_app.approve_check(
             Issue(
-                IssueType.DEPRECATED_ADDON,
+                IssueType.DEPRECATED_APP,
                 ContextType.ADDON,
                 reference=install_app_ssh.slug,
             )

--- a/tests/resolution/check/test_check_deprecated_arch_app.py
+++ b/tests/resolution/check/test_check_deprecated_arch_app.py
@@ -13,7 +13,7 @@ from supervisor.resolution.data import Issue
 async def test_base(coresys: CoreSys):
     """Test check basics."""
     deprecated_arch_app = CheckDeprecatedArchApp(coresys)
-    assert deprecated_arch_app.slug == "deprecated_arch_addon"
+    assert deprecated_arch_app.slug == "deprecated_arch_app"
     assert deprecated_arch_app.enabled
 
 
@@ -30,7 +30,7 @@ async def test_check(coresys: CoreSys, install_app_ssh: App):
     await deprecated_arch_app()
 
     assert len(coresys.resolution.issues) == 1
-    assert coresys.resolution.issues[0].type is IssueType.DEPRECATED_ARCH_ADDON
+    assert coresys.resolution.issues[0].type is IssueType.DEPRECATED_ARCH_APP
     assert coresys.resolution.issues[0].context is ContextType.ADDON
     assert coresys.resolution.issues[0].reference == install_app_ssh.slug
     assert len(coresys.resolution.suggestions) == 1
@@ -61,7 +61,7 @@ async def test_check_deprecated_machine(coresys: CoreSys, install_app_ssh: App):
     await deprecated_arch_app()
 
     assert len(coresys.resolution.issues) == 1
-    assert coresys.resolution.issues[0].type is IssueType.DEPRECATED_ARCH_ADDON
+    assert coresys.resolution.issues[0].type is IssueType.DEPRECATED_ARCH_APP
     assert coresys.resolution.suggestions[0].type is SuggestionType.EXECUTE_REMOVE
 
 
@@ -100,7 +100,7 @@ async def test_approve(coresys: CoreSys, install_app_ssh: App):
     assert (
         await deprecated_arch_app.approve_check(
             Issue(
-                IssueType.DEPRECATED_ARCH_ADDON,
+                IssueType.DEPRECATED_ARCH_APP,
                 ContextType.ADDON,
                 reference=install_app_ssh.slug,
             )
@@ -113,7 +113,7 @@ async def test_approve(coresys: CoreSys, install_app_ssh: App):
     assert (
         await deprecated_arch_app.approve_check(
             Issue(
-                IssueType.DEPRECATED_ARCH_ADDON,
+                IssueType.DEPRECATED_ARCH_APP,
                 ContextType.ADDON,
                 reference=install_app_ssh.slug,
             )
@@ -126,7 +126,7 @@ async def test_approve(coresys: CoreSys, install_app_ssh: App):
     assert (
         await deprecated_arch_app.approve_check(
             Issue(
-                IssueType.DEPRECATED_ARCH_ADDON,
+                IssueType.DEPRECATED_ARCH_APP,
                 ContextType.ADDON,
                 reference=install_app_ssh.slug,
             )
@@ -140,7 +140,7 @@ async def test_approve(coresys: CoreSys, install_app_ssh: App):
     assert (
         await deprecated_arch_app.approve_check(
             Issue(
-                IssueType.DEPRECATED_ARCH_ADDON,
+                IssueType.DEPRECATED_ARCH_APP,
                 ContextType.ADDON,
                 reference=install_app_ssh.slug,
             )
@@ -153,7 +153,7 @@ async def test_approve(coresys: CoreSys, install_app_ssh: App):
     assert (
         await deprecated_arch_app.approve_check(
             Issue(
-                IssueType.DEPRECATED_ARCH_ADDON,
+                IssueType.DEPRECATED_ARCH_APP,
                 ContextType.ADDON,
                 reference=install_app_ssh.slug,
             )
@@ -166,7 +166,7 @@ async def test_approve(coresys: CoreSys, install_app_ssh: App):
     assert (
         await deprecated_arch_app.approve_check(
             Issue(
-                IssueType.DEPRECATED_ARCH_ADDON,
+                IssueType.DEPRECATED_ARCH_APP,
                 ContextType.ADDON,
                 reference=install_app_ssh.slug,
             )

--- a/tests/resolution/check/test_check_detached_app_missing.py
+++ b/tests/resolution/check/test_check_detached_app_missing.py
@@ -13,7 +13,7 @@ from supervisor.resolution.data import Issue
 async def test_base(coresys: CoreSys):
     """Test check basics."""
     detached_app_missing = CheckDetachedAppMissing(coresys)
-    assert detached_app_missing.slug == "detached_addon_missing"
+    assert detached_app_missing.slug == "detached_app_missing"
     assert detached_app_missing.enabled
 
 
@@ -34,7 +34,7 @@ async def test_check(coresys: CoreSys, install_app_ssh: App):
     await detached_app_missing()
 
     assert len(coresys.resolution.issues) == 1
-    assert coresys.resolution.issues[0].type is IssueType.DETACHED_ADDON_MISSING
+    assert coresys.resolution.issues[0].type is IssueType.DETACHED_APP_MISSING
     assert coresys.resolution.issues[0].context is ContextType.ADDON
     assert coresys.resolution.issues[0].reference == install_app_ssh.slug
     assert len(coresys.resolution.suggestions) == 0
@@ -48,7 +48,7 @@ async def test_approve(coresys: CoreSys, install_app_ssh: App):
     assert (
         await detached_app_missing.approve_check(
             Issue(
-                IssueType.DETACHED_ADDON_MISSING,
+                IssueType.DETACHED_APP_MISSING,
                 ContextType.ADDON,
                 reference=install_app_ssh.slug,
             )
@@ -65,7 +65,7 @@ async def test_approve(coresys: CoreSys, install_app_ssh: App):
     assert (
         await detached_app_missing.approve_check(
             Issue(
-                IssueType.DETACHED_ADDON_MISSING,
+                IssueType.DETACHED_APP_MISSING,
                 ContextType.ADDON,
                 reference=install_app_ssh.slug,
             )

--- a/tests/resolution/check/test_check_detached_app_removed.py
+++ b/tests/resolution/check/test_check_detached_app_removed.py
@@ -15,7 +15,7 @@ from supervisor.resolution.data import Issue
 async def test_base(coresys: CoreSys):
     """Test check basics."""
     detached_app_removed = CheckDetachedAppRemoved(coresys)
-    assert detached_app_removed.slug == "detached_addon_removed"
+    assert detached_app_removed.slug == "detached_app_removed"
     assert detached_app_removed.enabled
 
 
@@ -37,7 +37,7 @@ async def test_check(coresys: CoreSys, install_app_ssh: App, tmp_supervisor_data
     await detached_app_removed()
 
     assert len(coresys.resolution.issues) == 1
-    assert coresys.resolution.issues[0].type is IssueType.DETACHED_ADDON_REMOVED
+    assert coresys.resolution.issues[0].type is IssueType.DETACHED_APP_REMOVED
     assert coresys.resolution.issues[0].context is ContextType.ADDON
     assert coresys.resolution.issues[0].reference == install_app_ssh.slug
 
@@ -57,7 +57,7 @@ async def test_approve(
     assert (
         await detached_app_removed.approve_check(
             Issue(
-                IssueType.DETACHED_ADDON_REMOVED,
+                IssueType.DETACHED_APP_REMOVED,
                 ContextType.ADDON,
                 reference=install_app_ssh.slug,
             )
@@ -74,7 +74,7 @@ async def test_approve(
     assert (
         await detached_app_removed.approve_check(
             Issue(
-                IssueType.DETACHED_ADDON_REMOVED,
+                IssueType.DETACHED_APP_REMOVED,
                 ContextType.ADDON,
                 reference=install_app_ssh.slug,
             )

--- a/tests/resolution/fixup/test_app_execute_remove.py
+++ b/tests/resolution/fixup/test_app_execute_remove.py
@@ -24,7 +24,7 @@ async def test_fixup(coresys: CoreSys, install_app_ssh: App):
     )
     coresys.resolution.add_issue(
         Issue(
-            IssueType.DETACHED_ADDON_REMOVED,
+            IssueType.DETACHED_APP_REMOVED,
             ContextType.ADDON,
             reference=install_app_ssh.slug,
         )
@@ -52,7 +52,7 @@ async def test_fixup_deprecated_arch_app(coresys: CoreSys, install_app_ssh: App)
     )
     coresys.resolution.add_issue(
         Issue(
-            IssueType.DEPRECATED_ARCH_ADDON,
+            IssueType.DEPRECATED_ARCH_APP,
             ContextType.ADDON,
             reference=install_app_ssh.slug,
         )

--- a/tests/resolution/test_resolution_manager.py
+++ b/tests/resolution/test_resolution_manager.py
@@ -16,6 +16,7 @@ from supervisor.resolution.const import (
     UnsupportedReason,
 )
 from supervisor.resolution.data import Issue, Suggestion
+from supervisor.resolution.validate import _migrate_checks_config
 
 
 def test_properies_unsupported(coresys: CoreSys):
@@ -454,3 +455,27 @@ async def test_dismiss_issue_removes_orphaned_suggestions(coresys: CoreSys):
                 },
             )
         )
+
+
+@pytest.mark.parametrize(
+    ("legacy_slug", "new_slug"),
+    [
+        ("addon_pwned", "app_pwned"),
+        ("deprecated_addon", "deprecated_app"),
+        ("deprecated_arch_addon", "deprecated_arch_app"),
+        ("detached_addon_missing", "detached_app_missing"),
+        ("detached_addon_removed", "detached_app_removed"),
+    ],
+)
+def test_resolution_file_migration_legacy_check_slugs(legacy_slug: str, new_slug: str):
+    """Test that resolution.json with legacy check slugs is migrated to new names."""
+    # Create a checks config with legacy slug
+    legacy_config = {legacy_slug: {"enabled": False}}
+
+    # Migrate it using the same function used in schema validation
+    migrated_config = _migrate_checks_config(legacy_config)
+
+    # Verify the legacy slug was migrated to the new slug
+    assert new_slug in migrated_config
+    assert legacy_slug not in migrated_config
+    assert migrated_config[new_slug]["enabled"] is False


### PR DESCRIPTION
## Proposed change

Renames resolution system issue types and check slugs from addon-based naming to app-based naming, for consistency with the newer "apps" terminology introduced in the Supervisor.

The following renames are applied:

**Issue types:**
- `deprecated_addon` → `deprecated_app`
- `deprecated_arch_addon` → `deprecated_arch_app`
- `detached_addon_missing` → `detached_app_missing`
- `detached_addon_removed` → `detached_app_removed`

**Check slugs:**
- `addon_pwned` → `app_pwned`
- `deprecated_addon` → `deprecated_app`
- `deprecated_arch_addon` → `deprecated_arch_app`
- `detached_addon_missing` → `detached_app_missing`
- `detached_addon_removed` → `detached_app_removed`

Full backward compatibility is maintained:
- **REST API V1** (root `/`) returns legacy names and accepts legacy check slugs
- **REST API V2** (`/v2`) returns and accepts new names only
- **WebSocket events** use legacy names unless the `SUPERVISOR_WEBSOCKET_V2_API` feature flag is enabled
- **`resolution.json`** files with legacy check slugs are automatically migrated to new names on load

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #6907, #7029
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/