### PR TITLE
Fix restart test cleanup race around loop.stop

### DIFF
--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -279,9 +279,13 @@ async def test_restart_returns_once_requests_rejected(coresys: CoreSys):
     await coresys.core.set_state(CoreState.RUNNING)
 
     teardown_release = asyncio.Event()
+    loop_stop_called = asyncio.Event()
 
     async def blocked_api_stop():
         await teardown_release.wait()
+
+    def blocked_loop_stop() -> None:
+        loop_stop_called.set()
 
     coresys._websession = AsyncMock()  # pylint: disable=protected-access
     with (
@@ -292,7 +296,7 @@ async def test_restart_returns_once_requests_rejected(coresys: CoreSys):
         patch.object(coresys.ingress, "unload", new=AsyncMock()),
         patch.object(coresys.hardware, "unload", new=AsyncMock()),
         patch.object(coresys.dbus, "unload", new=AsyncMock()),
-        patch.object(coresys.loop, "stop"),
+        patch.object(coresys.loop, "stop", side_effect=blocked_loop_stop),
     ):
         await coresys.supervisor.restart()
 
@@ -305,3 +309,8 @@ async def test_restart_returns_once_requests_rejected(coresys: CoreSys):
         async with asyncio.timeout(1):
             while coresys.core.state != CoreState.CLOSE:
                 await asyncio.sleep(0)
+
+        # Ensure the stop task reaches loop.stop while it is still patched,
+        # otherwise the real loop.stop can run after this context exits.
+        async with asyncio.timeout(1):
+            await loop_stop_called.wait()


### PR DESCRIPTION
## Proposed change

This PR fixes a teardown race in `test_restart_returns_once_requests_rejected`.

The test patches `coresys.loop.stop` while triggering `Supervisor.restart()`. The stop flow runs in a background task, and the previous test could leave a narrow window where the patch context exited before the background task actually reached `loop.stop`. In that case, the real loop stop could fire during cleanup and surface as:

`RuntimeError: Event loop stopped before Future completed.`

The test now waits for a dedicated `loop_stop_called` event, set by the patched `loop.stop`, before leaving the patch context.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/