### PR TITLE
Add v1/v2 terminology shim for host disk usage response

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -258,7 +258,12 @@ class RestAPI(CoreSysAttributes):
                 web.post("/host/reload", api_host.reload),
                 web.post("/host/options", api_host.options),
                 web.get("/host/services", api_host.services),
-                web.get("/host/disks/default/usage", api_host.disk_usage),
+                web.get(
+                    "/host/disks/default/usage",
+                    api_host.disk_usage_v1
+                    if app is self.versions[AppVersion.V1]
+                    else api_host.disk_usage,
+                ),
             ]
         )
 

--- a/supervisor/api/host.py
+++ b/supervisor/api/host.py
@@ -93,6 +93,21 @@ SCHEMA_SHUTDOWN = vol.Schema(
 class APIHost(CoreSysAttributes):
     """Handle RESTful API for host functions."""
 
+    @staticmethod
+    def _legacy_disk_usage_ids_for_v1(data: dict[str, Any]) -> dict[str, Any]:
+        """Translate app terminology IDs to legacy addon IDs for v1 responses."""
+        legacy_id_map = {
+            "apps_data": "addons_data",
+            "apps_config": "addons_config",
+        }
+
+        children = data.get("children", [])
+        for child in children:
+            if (child_id := child.get("id")) in legacy_id_map:
+                child["id"] = legacy_id_map[child_id]
+
+        return data
+
     async def _check_ha_offline_migration(self, force: bool) -> None:
         """Check if HA has an offline migration in progress and raise if not forced."""
         if (
@@ -337,6 +352,10 @@ class APIHost(CoreSysAttributes):
     @api_process
     async def disk_usage(self, request: web.Request) -> dict[str, Any]:
         """Return a breakdown of storage usage for the system."""
+        return await self._disk_usage_data(request)
+
+    async def _disk_usage_data(self, request: web.Request) -> dict[str, Any]:
+        """Build disk usage response data."""
 
         max_depth = request.query.get(ATTR_MAX_DEPTH, 1)
         try:
@@ -357,8 +376,8 @@ class APIHost(CoreSysAttributes):
         known_paths = await self.sys_run_in_executor(
             disk.get_dir_sizes,
             {
-                "addons_data": self.sys_config.path_apps_data,
-                "addons_config": self.sys_config.path_app_configs,
+                "apps_data": self.sys_config.path_apps_data,
+                "apps_config": self.sys_config.path_app_configs,
                 "media": self.sys_config.path_media,
                 "share": self.sys_config.path_share,
                 "backup": self.sys_config.path_backup,
@@ -383,6 +402,11 @@ class APIHost(CoreSysAttributes):
                 *known_paths,
             ],
         }
+
+    @api_process
+    async def disk_usage_v1(self, request: web.Request) -> dict[str, Any]:
+        """Return disk usage with legacy addon IDs for v1 compatibility."""
+        return self._legacy_disk_usage_ids_for_v1(await self._disk_usage_data(request))
 
     async def _get_container_last_epoch(self, identifier: str | list[str]) -> str:
         """Get Docker's internal log epoch of the latest log entry for given identifier(s)."""

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -457,7 +457,7 @@ async def test_disk_usage_api(
         # Mock the directory structure sizes for each path
         mock_dir_sizes.return_value = [
             {
-                "id": "addons_data",
+                "id": "apps_data",
                 "label": "Apps Data",
                 "used_bytes": 100000000,
                 "children": [
@@ -465,7 +465,7 @@ async def test_disk_usage_api(
                 ],
             },
             {
-                "id": "addons_config",
+                "id": "apps_config",
                 "label": "Apps Config",
                 "used_bytes": 200000000,
                 "children": [
@@ -537,8 +537,10 @@ async def test_disk_usage_api(
         assert children[0]["label"] == "System"
 
         # Verify all expected directories are present in the remaining children
-        assert children[1]["id"] == "addons_data"
-        assert children[2]["id"] == "addons_config"
+        expected_data_id = "addons_data" if prefix == "" else "apps_data"
+        expected_config_id = "addons_config" if prefix == "" else "apps_config"
+        assert children[1]["id"] == expected_data_id
+        assert children[2]["id"] == expected_config_id
         assert children[3]["id"] == "media"
         assert children[4]["id"] == "share"
         assert children[5]["id"] == "backup"
@@ -575,8 +577,8 @@ async def test_disk_usage_api(
         call_args = mock_dir_sizes.call_args
         assert call_args[0][1] == 1  # max_depth parameter
         paths_dict = call_args[0][0]  # paths dictionary
-        assert paths_dict["addons_data"] == coresys.config.path_apps_data
-        assert paths_dict["addons_config"] == coresys.config.path_app_configs
+        assert paths_dict["apps_data"] == coresys.config.path_apps_data
+        assert paths_dict["apps_config"] == coresys.config.path_app_configs
         assert paths_dict["media"] == coresys.config.path_media
         assert paths_dict["share"] == coresys.config.path_share
         assert paths_dict["backup"] == coresys.config.path_backup
@@ -598,7 +600,7 @@ async def test_disk_usage_api_with_custom_depth(
         # Mock deeper directory structure
         mock_dir_sizes.return_value = [
             {
-                "id": "addons_data",
+                "id": "apps_data",
                 "label": "Apps Data",
                 "used_bytes": 100000000,
                 "children": [
@@ -617,7 +619,7 @@ async def test_disk_usage_api_with_custom_depth(
                 ],
             },
             {
-                "id": "addons_config",
+                "id": "apps_config",
                 "label": "Apps Config",
                 "used_bytes": 100000000,
                 "children": [
@@ -757,12 +759,12 @@ async def test_disk_usage_api_invalid_depth(
         mock_disk_usage.return_value = (1000000000, 500000000, 500000000)
         mock_dir_sizes.return_value = [
             {
-                "id": "addons_data",
+                "id": "apps_data",
                 "label": "Apps Data",
                 "used_bytes": 100000000,
             },
             {
-                "id": "addons_config",
+                "id": "apps_config",
                 "label": "Apps Config",
                 "used_bytes": 100000000,
             },
@@ -822,12 +824,12 @@ async def test_disk_usage_api_empty_directories(
         # Mock empty directory structures (no children)
         mock_dir_sizes.return_value = [
             {
-                "id": "addons_data",
+                "id": "apps_data",
                 "label": "Apps Data",
                 "used_bytes": 0,
             },
             {
-                "id": "addons_config",
+                "id": "apps_config",
                 "label": "Apps Config",
                 "used_bytes": 0,
             },
@@ -872,6 +874,44 @@ async def test_disk_usage_api_empty_directories(
         # All other directories should have size 0
         for i in range(1, len(children)):
             assert children[i]["used_bytes"] == 0
+
+
+async def test_disk_usage_api_v1_uses_legacy_addon_ids(
+    api_client: TestClient, coresys: CoreSys
+):
+    """Test v1 disk usage response uses legacy addon IDs."""
+    with (
+        patch.object(coresys.hardware.disk, "disk_usage") as mock_disk_usage,
+        patch.object(coresys.hardware.disk, "get_dir_sizes") as mock_dir_sizes,
+    ):
+        mock_disk_usage.return_value = (1000000000, 500000000, 500000000)
+        mock_dir_sizes.return_value = [
+            {"id": "apps_data", "label": "Apps Data", "used_bytes": 100000000},
+            {
+                "id": "apps_config",
+                "label": "Apps Config",
+                "used_bytes": 200000000,
+            },
+            {"id": "media", "label": "Media", "used_bytes": 50000000},
+            {"id": "share", "label": "Share", "used_bytes": 300000000},
+            {"id": "backup", "label": "Backup", "used_bytes": 10000000},
+            {"id": "ssl", "label": "SSL", "used_bytes": 40000000},
+            {
+                "id": "homeassistant",
+                "label": "Home Assistant",
+                "used_bytes": 40000000,
+            },
+        ]
+
+        resp = await api_client.get("/host/disks/default/usage")
+        assert resp.status == 200
+        result = await resp.json()
+
+        child_ids = [child["id"] for child in result["data"]["children"]]
+        assert "addons_data" in child_ids
+        assert "addons_config" in child_ids
+        assert "apps_data" not in child_ids
+        assert "apps_config" not in child_ids
 
 
 @pytest.mark.parametrize("action", ["reboot", "shutdown"])


### PR DESCRIPTION
## Proposed change

Adds version-aware terminology handling for `GET /host/disks/default/usage`:

- **V2** returns response IDs using app terminology (`apps_data`, `apps_config`)
- **V1** applies a compatibility shim and returns legacy addon terminology (`addons_data`, `addons_config`)

This preserves backward compatibility for existing v1 consumers while aligning v2 output with app terminology.

The implementation also keeps the response-building logic shared and applies the shim only in the v1 handler.

Tests were updated/added to verify:
- v1 response still uses legacy addon IDs
- v2 response uses app IDs
- disk usage behavior remains correct with default/invalid/custom `max_depth`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #7030
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/