### PR TITLE
Add websocket addon-to-app compatibility shim

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -391,6 +391,9 @@ split-on-trailing-comma = false
 
 [tool.ruff.lint.per-file-ignores]
 
+# Pytest tests often accept many fixture parameters by design.
+"tests/**/*.py" = ["PLR0917"]
+
 # DBus Service Mocks must use typing and names understood by dbus-fast
 "tests/dbus_service_mocks/*.py" = ["F722", "F821", "N815", "UP037"]
 

--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -258,7 +258,7 @@ class App(AppModel):
             self.sys_resolution.dismiss_issue(access_issue)
 
         self.sys_homeassistant.websocket.supervisor_event_custom(
-            WSEvent.ADDON,
+            WSEvent.APP,
             {
                 ATTR_SLUG: self.slug,
                 ATTR_STATE: new_state,

--- a/supervisor/homeassistant/const.py
+++ b/supervisor/homeassistant/const.py
@@ -33,13 +33,13 @@ class WSType(StrEnum):
     SUPERVISOR_EVENT = "supervisor/event"
     BACKUP_START = "backup/start"
     BACKUP_END = "backup/end"
-    HASSIO_UPDATE_ADDON = "hassio/update/addon"
+    HASSIO_UPDATE_APP = "hassio/update/app"
 
 
 class WSEvent(StrEnum):
     """Websocket events."""
 
-    ADDON = "addon"
+    APP = "app"
     HEALTH_CHANGED = "health_changed"
     ISSUE_CHANGED = "issue_changed"
     ISSUE_REMOVED = "issue_removed"

--- a/supervisor/homeassistant/websocket.py
+++ b/supervisor/homeassistant/websocket.py
@@ -19,6 +19,7 @@ from ..const import (
     STARTING_STATES,
     BusEvent,
     CoreState,
+    FeatureFlag,
 )
 from ..coresys import CoreSys, CoreSysAttributes
 from ..exceptions import (
@@ -250,6 +251,27 @@ class HomeAssistantWebSocket(CoreSysAttributes):
         self._lock: asyncio.Lock = asyncio.Lock()
         self._queue: list[dict[str, Any]] = []
 
+    def _apply_legacy_v1_websocket_compatibility(
+        self, message: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Map new WS metadata back to legacy names for v1 compatibility."""
+        if self.sys_config.feature_flags.get(
+            FeatureFlag.SUPERVISOR_WEBSOCKET_V2_API, False
+        ):
+            return message
+
+        if message.get(ATTR_TYPE) == WSType.HASSIO_UPDATE_APP:
+            return message.copy() | {ATTR_TYPE: "hassio/update/addon"}
+
+        if (
+            message.get(ATTR_TYPE) == WSType.SUPERVISOR_EVENT
+            and (data := message.get(ATTR_DATA))
+            and data.get(ATTR_EVENT) == WSEvent.APP
+        ):
+            return message.copy() | {ATTR_DATA: data.copy() | {ATTR_EVENT: "addon"}}
+
+        return message
+
     async def _process_queue(self, reference: CoreState) -> None:
         """Process queue once supervisor is running."""
         if reference == CoreState.RUNNING:
@@ -317,7 +339,9 @@ class HomeAssistantWebSocket(CoreSysAttributes):
         assert self.client
 
         try:
-            await self.client.async_send_command(message)
+            await self.client.async_send_command(
+                self._apply_legacy_v1_websocket_compatibility(message)
+            )
         except HomeAssistantWSConnectionError as err:
             _LOGGER.debug("Fire-and-forget WebSocket command failed: %s", err)
             if self.client:
@@ -333,7 +357,9 @@ class HomeAssistantWebSocket(CoreSysAttributes):
         # _ensure_connected guarantees self.client is set
         assert self.client
         try:
-            return await self.client.async_send_command(message)
+            return await self.client.async_send_command(
+                self._apply_legacy_v1_websocket_compatibility(message)
+            )
         except HomeAssistantWSConnectionError:
             if self.client:
                 await self.client.close()

--- a/supervisor/homeassistant/websocket.py
+++ b/supervisor/homeassistant/websocket.py
@@ -12,6 +12,8 @@ from awesomeversion import AwesomeVersion
 
 from ..const import (
     ATTR_ACCESS_TOKEN,
+    ATTR_APP,
+    ATTR_BACKUP,
     ATTR_DATA,
     ATTR_EVENT,
     ATTR_TYPE,
@@ -261,14 +263,20 @@ class HomeAssistantWebSocket(CoreSysAttributes):
             return message
 
         if message.get(ATTR_TYPE) == WSType.HASSIO_UPDATE_APP:
-            return message.copy() | {ATTR_TYPE: "hassio/update/addon"}
+            # Although this will omit any fields added in future they won't be understood
+            # by legacy versions of core anyway
+            return {
+                ATTR_TYPE: "hassio/update/addon",
+                "addon": message[ATTR_APP],
+                ATTR_BACKUP: message[ATTR_BACKUP],
+            }
 
         if (
             message.get(ATTR_TYPE) == WSType.SUPERVISOR_EVENT
-            and (data := message.get(ATTR_DATA))
+            and (data := message[ATTR_DATA])
             and data.get(ATTR_EVENT) == WSEvent.APP
         ):
-            return message.copy() | {ATTR_DATA: data.copy() | {ATTR_EVENT: "addon"}}
+            return message | {ATTR_DATA: data | {ATTR_EVENT: "addon"}}
 
         return message
 

--- a/supervisor/misc/tasks.py
+++ b/supervisor/misc/tasks.py
@@ -145,7 +145,7 @@ class Tasks(CoreSysAttributes):
             # Ultimately auto updates should be handled by Home Assistant Core itself
             # through a update entity feature.
             message = {
-                ATTR_TYPE: WSType.HASSIO_UPDATE_ADDON,
+                ATTR_TYPE: WSType.HASSIO_UPDATE_APP,
                 "addon": app.slug,
                 "backup": True,
             }

--- a/supervisor/misc/tasks.py
+++ b/supervisor/misc/tasks.py
@@ -7,7 +7,7 @@ from typing import cast
 
 from ..apps.const import APP_UPDATE_CONDITIONS
 from ..backups.const import LOCATION_CLOUD_BACKUP, LOCATION_TYPE
-from ..const import ATTR_TYPE, AppState
+from ..const import ATTR_APP, ATTR_BACKUP, ATTR_TYPE, AppState
 from ..coresys import CoreSysAttributes
 from ..exceptions import (
     AppsError,
@@ -146,8 +146,8 @@ class Tasks(CoreSysAttributes):
             # through a update entity feature.
             message = {
                 ATTR_TYPE: WSType.HASSIO_UPDATE_APP,
-                "addon": app.slug,
-                "backup": True,
+                ATTR_APP: app.slug,
+                ATTR_BACKUP: True,
             }
             _LOGGER.debug(
                 "Sending update app WebSocket command to Home Assistant Core: %s",

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -25,6 +25,7 @@ from supervisor.const import (
     AppBoot,
     AppState,
     BusEvent,
+    FeatureFlag,
 )
 from supervisor.coresys import CoreSys
 from supervisor.docker.app import DockerApp
@@ -42,6 +43,7 @@ from supervisor.exceptions import (
     HassioError,
 )
 from supervisor.hardware.helper import HwHelper
+from supervisor.homeassistant.const import WSType
 from supervisor.ingress import Ingress
 from supervisor.resolution.const import (
     ContextType,
@@ -165,6 +167,46 @@ async def test_app_state_listener(coresys: CoreSys, install_app_ssh: App) -> Non
             coresys, "app_local_non_installed", ContainerState.RUNNING
         )
         assert install_app_ssh.state == AppState.ERROR
+
+
+@pytest.mark.parametrize(
+    ("websocket_v2_enabled", "expected_event"),
+    [(False, "addon"), (True, "app")],
+)
+async def test_app_state_event_name_compatibility(
+    install_app_ssh: App,
+    ha_ws_client: AsyncMock,
+    websocket_v2_enabled: bool,
+    expected_event: str,
+) -> None:
+    """Test app state event uses legacy/new metadata based on WS v2 feature flag."""
+    install_app_ssh.sys_config.set_feature_flag(
+        FeatureFlag.SUPERVISOR_WEBSOCKET_V2_API, websocket_v2_enabled
+    )
+
+    with (
+        patch.object(DockerApp, "attach"),
+        patch.object(DockerApp, "current_state", return_value=ContainerState.UNKNOWN),
+        patch.object(App, "watchdog_container"),
+    ):
+        await install_app_ssh.load()
+        ha_ws_client.async_send_command.reset_mock()
+
+        await _fire_test_event(
+            install_app_ssh.coresys, f"app_{TEST_ADDON_SLUG}", ContainerState.RUNNING
+        )
+        await asyncio.sleep(0)
+
+    ha_ws_client.async_send_command.assert_any_call(
+        {
+            "type": WSType.SUPERVISOR_EVENT,
+            "data": {
+                "event": expected_event,
+                "slug": TEST_ADDON_SLUG,
+                "state": AppState.STARTED,
+            },
+        }
+    )
 
 
 async def test_app_failed_logs_exit_code(

--- a/tests/misc/test_tasks.py
+++ b/tests/misc/test_tasks.py
@@ -10,7 +10,7 @@ from awesomeversion import AwesomeVersion
 import pytest
 
 from supervisor.apps.app import App
-from supervisor.const import ATTR_VERSION_TIMESTAMP, CoreState
+from supervisor.const import ATTR_VERSION_TIMESTAMP, CoreState, FeatureFlag
 from supervisor.coresys import CoreSys
 from supervisor.exceptions import HomeAssistantError
 from supervisor.homeassistant.api import HomeAssistantAPI
@@ -300,14 +300,22 @@ async def test_scheduled_reload_updater_triggers_one_supervisor_update(
 
 
 @pytest.mark.usefixtures("tmp_supervisor_data")
+@pytest.mark.parametrize(
+    ("websocket_v2_enabled", "expected_message_type"),
+    [(False, "hassio/update/addon"), (True, "hassio/update/app")],
+)
 async def test_update_apps_auto_update_success(
     tasks: Tasks,
-    coresys: CoreSys,
     ha_ws_client: AsyncMock,
     install_app_example: App,
+    websocket_v2_enabled: bool,
+    expected_message_type: str,
 ):
     """Test that an eligible app is auto-updated via websocket command."""
-    await coresys.core.set_state(CoreState.RUNNING)
+    await tasks.sys_core.set_state(CoreState.RUNNING)
+    tasks.sys_config.set_feature_flag(
+        FeatureFlag.SUPERVISOR_WEBSOCKET_V2_API, websocket_v2_enabled
+    )
 
     # Set up the app as eligible for auto-update
     install_app_example.auto_update = True
@@ -326,7 +334,7 @@ async def test_update_apps_auto_update_success(
 
         ha_ws_client.async_send_command.assert_any_call(
             {
-                "type": "hassio/update/addon",
+                "type": expected_message_type,
                 "addon": install_app_example.slug,
                 "backup": True,
             }

--- a/tests/misc/test_tasks.py
+++ b/tests/misc/test_tasks.py
@@ -301,8 +301,8 @@ async def test_scheduled_reload_updater_triggers_one_supervisor_update(
 
 @pytest.mark.usefixtures("tmp_supervisor_data")
 @pytest.mark.parametrize(
-    ("websocket_v2_enabled", "expected_message_type"),
-    [(False, "hassio/update/addon"), (True, "hassio/update/app")],
+    ("websocket_v2_enabled", "expected_message_type", "expected_slug_key"),
+    [(False, "hassio/update/addon", "addon"), (True, "hassio/update/app", "app")],
 )
 async def test_update_apps_auto_update_success(
     tasks: Tasks,
@@ -310,6 +310,7 @@ async def test_update_apps_auto_update_success(
     install_app_example: App,
     websocket_v2_enabled: bool,
     expected_message_type: str,
+    expected_slug_key: str,
 ):
     """Test that an eligible app is auto-updated via websocket command."""
     await tasks.sys_core.set_state(CoreState.RUNNING)
@@ -335,7 +336,7 @@ async def test_update_apps_auto_update_success(
         ha_ws_client.async_send_command.assert_any_call(
             {
                 "type": expected_message_type,
-                "addon": install_app_example.slug,
+                expected_slug_key: install_app_example.slug,
                 "backup": True,
             }
         )


### PR DESCRIPTION
## Proposed change

This PR updates websocket metadata and app update command terminology from `addon` to `app`, while keeping V1 clients compatible through a single send-time shim in `HomeAssistantWebSocket`.

The compatibility layer is applied at the shared websocket send point, so:
- **V1** continues to receive legacy addon metadata
- **V2** receives the new app terminology unchanged

This also adds a tests-only Ruff override for `PLR0917` so pytest-style test functions with many fixtures are not flagged as lint errors.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #7031
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/