### PR TITLE
Gracefully handle lost systemd-journal-gatewayd connections

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -11,7 +11,11 @@ from aiohttp import hdrs, web
 from ..apps.app import App
 from ..const import SUPERVISOR_DOCKER_NAME, AppState, FeatureFlag
 from ..coresys import CoreSys, CoreSysAttributes
-from ..exceptions import APIAppNotInstalled, HostNotSupportedError, HostServiceError
+from ..exceptions import (
+    APIAppNotInstalled,
+    HostJournalGatewaydConnectionError,
+    HostNotSupportedError,
+)
 from ..utils.sentry import async_capture_exception
 from .apps import APIApps
 from .audio import APIAudio
@@ -506,7 +510,9 @@ class RestAPI(CoreSysAttributes):
             except Exception as err:  # pylint: disable=broad-exception-caught
                 # Supervisor logs are critical, so catch everything, log the exception
                 # and try to return Docker container logs as the fallback
-                if isinstance(err, (HostNotSupportedError, HostServiceError)):
+                if isinstance(
+                    err, (HostNotSupportedError, HostJournalGatewaydConnectionError)
+                ):
                     # No need for a traceback or capturing to Sentry, the cause
                     # is known and already logged at the source (e.g. missing or
                     # unreachable systemd-journal-gatewayd).

--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -11,7 +11,7 @@ from aiohttp import hdrs, web
 from ..apps.app import App
 from ..const import SUPERVISOR_DOCKER_NAME, AppState, FeatureFlag
 from ..coresys import CoreSys, CoreSysAttributes
-from ..exceptions import APIAppNotInstalled, HostNotSupportedError
+from ..exceptions import APIAppNotInstalled, HostNotSupportedError, HostServiceError
 from ..utils.sentry import async_capture_exception
 from .apps import APIApps
 from .audio import APIAudio
@@ -506,12 +506,17 @@ class RestAPI(CoreSysAttributes):
             except Exception as err:  # pylint: disable=broad-exception-caught
                 # Supervisor logs are critical, so catch everything, log the exception
                 # and try to return Docker container logs as the fallback
-                _LOGGER.exception(
-                    "Failed to get supervisor logs using advanced_logs API"
-                )
-                if not isinstance(err, HostNotSupportedError):
-                    # No need to capture HostNotSupportedError to Sentry, the cause
-                    # is known and reported to the user using the resolution center.
+                if isinstance(err, (HostNotSupportedError, HostServiceError)):
+                    # No need for a traceback or capturing to Sentry, the cause
+                    # is known and already logged at the source (e.g. missing or
+                    # unreachable systemd-journal-gatewayd).
+                    _LOGGER.warning(
+                        "Failed to get supervisor logs using advanced_logs API"
+                    )
+                else:
+                    _LOGGER.exception(
+                        "Failed to get supervisor logs using advanced_logs API"
+                    )
                     await async_capture_exception(err)
                 kwargs.pop("follow", None)  # Follow is not supported for Docker logs
                 kwargs.pop("latest", None)  # Latest is not supported for Docker logs

--- a/supervisor/api/host.py
+++ b/supervisor/api/host.py
@@ -297,10 +297,10 @@ class APIHost(CoreSysAttributes):
         async with self.sys_host.logs.journald_logs(
             params=params, range_header=range_header, accept=LogFormat.JOURNAL
         ) as resp:
+            response = web.StreamResponse()
+            response.content_type = CONTENT_TYPE_TEXT
+            headers_returned = False
             try:
-                response = web.StreamResponse()
-                response.content_type = CONTENT_TYPE_TEXT
-                headers_returned = False
                 async for cursor, line in journal_logs_reader(
                     resp, log_formatter, no_colors
                 ):
@@ -328,10 +328,19 @@ class APIHost(CoreSysAttributes):
                         )
                         break
             except (ConnectionResetError, ClientPayloadError) as ex:
-                # ClientPayloadError is most likely caused by the closing the connection
-                raise APIError(
-                    "Connection reset when trying to fetch data from systemd-journald."
-                ) from ex
+                # If the stream to the client already started, an error response
+                # can no longer be sent, so just end the stream. This happens
+                # e.g. when systemd-journal-gatewayd is stopped on host shutdown
+                # while a client is following the logs.
+                if not headers_returned:
+                    raise APIError(
+                        "Connection reset when trying to fetch data from systemd-journald."
+                    ) from ex
+                _LOGGER.debug(
+                    "%s raised when reading journal logs: %s",
+                    type(ex).__name__,
+                    ex,
+                )
             return response
 
     @api_process_raw(CONTENT_TYPE_TEXT, error_type=CONTENT_TYPE_TEXT)

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -791,8 +791,12 @@ class HostNotSupportedError(HassioNotSupportedError):
     """Host function is not supported."""
 
 
-class HostServiceError(HostError, APIError):
+class HostServiceError(HostError):
     """Host service functions failed."""
+
+
+class HostJournalGatewaydConnectionError(HostServiceError, APIError):
+    """Connection to systemd-journal-gatewayd failed."""
 
 
 class HostAppArmorError(HostError):

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -791,7 +791,7 @@ class HostNotSupportedError(HassioNotSupportedError):
     """Host function is not supported."""
 
 
-class HostServiceError(HostError):
+class HostServiceError(HostError, APIError):
     """Host service functions failed."""
 
 

--- a/supervisor/host/logs.py
+++ b/supervisor/host/logs.py
@@ -20,9 +20,9 @@ from aiohttp.hdrs import ACCEPT, RANGE
 from ..coresys import CoreSys, CoreSysAttributes
 from ..exceptions import (
     ConfigurationFileError,
+    HostJournalGatewaydConnectionError,
     HostLogError,
     HostNotSupportedError,
-    HostServiceError,
 )
 from ..utils.json import read_json_file
 from ..utils.systemd_journal import journal_boots_reader
@@ -247,6 +247,6 @@ class LogsControl(CoreSysAttributes):
                 ) as client_response:
                     yield client_response
         except UnixClientConnectorError as ex:
-            raise HostServiceError(
+            raise HostJournalGatewaydConnectionError(
                 "Unable to connect to systemd-journal-gatewayd", _LOGGER.error
             ) from ex

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -12,6 +12,7 @@ import time_machine
 
 from supervisor.coresys import CoreSys
 from supervisor.dbus.resolved import Resolved
+from supervisor.exceptions import HostServiceError
 from supervisor.homeassistant.api import APIState
 from supervisor.host.const import LogFormat, LogFormatter
 from supervisor.host.control import SystemControl
@@ -476,6 +477,27 @@ async def test_advanced_logs_gateway_reset_before_stream(
         await resp.text()
         == "Connection reset when trying to fetch data from systemd-journald."
     )
+
+
+async def test_advanced_logs_gateway_unavailable(
+    api_client_with_prefix: tuple[TestClient, str],
+    journald_logs: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test connection failure to journal gateway returns a plain API error."""
+    api_client, prefix = api_client_with_prefix
+
+    journald_logs.side_effect = HostServiceError(
+        "Unable to connect to systemd-journal-gatewayd"
+    )
+
+    with patch("supervisor.api.utils.async_capture_exception") as capture_exception:
+        resp = await api_client.get(f"{prefix}/host/logs")
+
+    assert resp.status == 400
+    assert await resp.text() == "Unable to connect to systemd-journal-gatewayd"
+    capture_exception.assert_not_called()
+    assert "Unexpected error during API call" not in caplog.text
 
 
 async def test_disk_usage_api(

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -12,7 +12,7 @@ import time_machine
 
 from supervisor.coresys import CoreSys
 from supervisor.dbus.resolved import Resolved
-from supervisor.exceptions import HostServiceError
+from supervisor.exceptions import HostJournalGatewaydConnectionError
 from supervisor.homeassistant.api import APIState
 from supervisor.host.const import LogFormat, LogFormatter
 from supervisor.host.control import SystemControl
@@ -487,7 +487,7 @@ async def test_advanced_logs_gateway_unavailable(
     """Test connection failure to journal gateway returns a plain API error."""
     api_client, prefix = api_client_with_prefix
 
-    journald_logs.side_effect = HostServiceError(
+    journald_logs.side_effect = HostJournalGatewaydConnectionError(
         "Unable to connect to systemd-journal-gatewayd"
     )
 

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
 from unittest.mock import ANY, MagicMock, patch
 
+from aiohttp import ClientPayloadError
 from aiohttp.test_utils import TestClient
 from dbus_fast import DBusError, ErrorType
 import pytest
@@ -434,6 +435,46 @@ async def test_advanced_logs_errors(
     assert (
         content
         == "Invalid content type requested. Only text/plain and text/x-log supported for now."
+    )
+
+
+async def test_advanced_logs_gateway_closed_mid_stream(
+    journald_gateway: MagicMock,
+    api_client_with_prefix: tuple[TestClient, str],
+):
+    """Test connection to journal gateway closed mid-stream ends the stream gracefully."""
+    api_client, prefix = api_client_with_prefix
+
+    journald_gateway.content.feed_data(b"__CURSOR=cursor1\nMESSAGE=Hello, world!\n\n")
+
+    resp = await api_client.get(f"{prefix}/host/logs/identifiers/test")
+    assert resp.status == 200
+
+    # Simulate connection to systemd-journal-gatewayd being closed mid-stream,
+    # e.g. because it was stopped on host shutdown.
+    journald_gateway.content.set_exception(
+        ClientPayloadError("Response payload is not completed")
+    )
+
+    assert await resp.text() == "Hello, world!\n"
+
+
+async def test_advanced_logs_gateway_reset_before_stream(
+    journald_gateway: MagicMock,
+    api_client_with_prefix: tuple[TestClient, str],
+):
+    """Test connection reset before the log stream started returns an API error."""
+    api_client, prefix = api_client_with_prefix
+
+    journald_gateway.content.set_exception(
+        ClientPayloadError("Response payload is not completed")
+    )
+
+    resp = await api_client.get(f"{prefix}/host/logs/identifiers/test")
+    assert resp.status == 400
+    assert (
+        await resp.text()
+        == "Connection reset when trying to fetch data from systemd-journald."
     )
 
 

--- a/tests/api/test_supervisor.py
+++ b/tests/api/test_supervisor.py
@@ -16,8 +16,8 @@ from supervisor.core import Core
 from supervisor.coresys import CoreSys
 from supervisor.exceptions import (
     HassioError,
+    HostJournalGatewaydConnectionError,
     HostNotSupportedError,
-    HostServiceError,
     StoreGitError,
 )
 from supervisor.homeassistant.const import WSEvent
@@ -257,7 +257,7 @@ async def test_api_supervisor_fallback_log_capture(
 
     journald_logs.reset_mock()
 
-    journald_logs.side_effect = HostServiceError(
+    journald_logs.side_effect = HostJournalGatewaydConnectionError(
         "Unable to connect to systemd-journal-gatewayd"
     )
 

--- a/tests/api/test_supervisor.py
+++ b/tests/api/test_supervisor.py
@@ -14,7 +14,12 @@ import pytest
 from supervisor.const import CoreState, FeatureFlag
 from supervisor.core import Core
 from supervisor.coresys import CoreSys
-from supervisor.exceptions import HassioError, HostNotSupportedError, StoreGitError
+from supervisor.exceptions import (
+    HassioError,
+    HostNotSupportedError,
+    HostServiceError,
+    StoreGitError,
+)
 from supervisor.homeassistant.const import WSEvent
 from supervisor.store.repository import Repository
 from supervisor.supervisor import Supervisor
@@ -244,6 +249,16 @@ async def test_api_supervisor_fallback_log_capture(
     api_client, prefix = api_client_with_prefix
     journald_logs.side_effect = HostNotSupportedError(
         "No systemd-journal-gatewayd Unix socket available!"
+    )
+
+    with patch("supervisor.api.async_capture_exception") as capture_exception:
+        await api_client.get(f"{prefix}/supervisor/logs")
+        capture_exception.assert_not_called()
+
+    journald_logs.reset_mock()
+
+    journald_logs.side_effect = HostServiceError(
+        "Unable to connect to systemd-journal-gatewayd"
     )
 
     with patch("supervisor.api.async_capture_exception") as capture_exception:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When systemd-journal-gatewayd is stopped while a client is following logs (e.g. on host reboot with the log viewer open), aiohttp raises `ClientPayloadError` and `advanced_logs_handler` converted it to an `APIError`. For the `/supervisor/logs` endpoints, the fallback wrapper then logged this as an unexpected error with a full traceback and captured it to Sentry on every occurrence (see #7103, [SUPERVISOR-1FHT](https://home-assistant-io.sentry.io/issues/SUPERVISOR-1FHT) with ~4.8k affected users).

Once the streaming response to the client has started, an error response can no longer be delivered anyway, so treat a lost connection to systemd-journal-gatewayd like the already-handled client-side disconnect and end the stream gracefully with a debug log. The `APIError` is still raised when the connection is lost before any data was sent to the client, in which case a proper error response (or the Docker container log fallback for the Supervisor's own logs) is still possible.

Manual testing (killing systemd-journal-gatewayd while Supervisor is running) surfaced a related noise source: every new log API request against the dead gateway raises `HostServiceError`, which the `api_process` decorators log as "Unexpected error during API call" with a traceback and capture to Sentry ([SUPERVISOR-K8C](https://home-assistant-io.sentry.io/issues/SUPERVISOR-K8C)) — redundant, since the error is already logged at the raise site. `HostServiceError` now also inherits from `APIError` (following the `HostContainerLogEpochError` precedent), so these requests get a plain 400 response instead. The supervisor logs fallback wrapper likewise treats it like `HostNotSupportedError` now: it falls back to Docker container logs with a warning instead of an exception log plus Sentry capture.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #7103
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
