### PR TITLE
Refactor v2 API contracts to remove deprecated supervisor/apps/backups fields

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -509,15 +509,26 @@ class RestAPI(CoreSysAttributes):
         api_supervisor = APISupervisor()
         api_supervisor.coresys = self.coresys
 
+        info_handler = (
+            api_supervisor.info_v1
+            if app is self.versions[AppVersion.V1]
+            else api_supervisor.info
+        )
+        options_handler = (
+            api_supervisor.options_v1
+            if app is self.versions[AppVersion.V1]
+            else api_supervisor.options
+        )
+
         app.add_routes(
             [
                 web.get("/supervisor/ping", api_supervisor.ping),
-                web.get("/supervisor/info", api_supervisor.info),
+                web.get("/supervisor/info", info_handler),
                 web.get("/supervisor/stats", api_supervisor.stats),
                 web.post("/supervisor/update", api_supervisor.update),
                 web.post("/supervisor/reload", api_supervisor.reload),
                 web.post("/supervisor/restart", api_supervisor.restart),
-                web.post("/supervisor/options", api_supervisor.options),
+                web.post("/supervisor/options", options_handler),
                 web.post("/supervisor/repair", api_supervisor.repair),
             ]
         )
@@ -664,7 +675,7 @@ class RestAPI(CoreSysAttributes):
                 """Route to store if info requested for not installed app."""
                 try:
                     addon: App = api_apps.get_app_for_request(request)
-                    return await api_apps.info_data(addon, request)
+                    return await api_apps.info_data_v1(addon, request)
                 except APIAppNotInstalled:
                     # Route to store/{app}/info but add missing fields
                     return dict(

--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -513,15 +513,26 @@ class RestAPI(CoreSysAttributes):
         api_supervisor = APISupervisor()
         api_supervisor.coresys = self.coresys
 
+        info_handler = (
+            api_supervisor.info_v1
+            if app is self.versions[AppVersion.V1]
+            else api_supervisor.info
+        )
+        options_handler = (
+            api_supervisor.options_v1
+            if app is self.versions[AppVersion.V1]
+            else api_supervisor.options
+        )
+
         app.add_routes(
             [
                 web.get("/supervisor/ping", api_supervisor.ping),
-                web.get("/supervisor/info", api_supervisor.info),
+                web.get("/supervisor/info", info_handler),
                 web.get("/supervisor/stats", api_supervisor.stats),
                 web.post("/supervisor/update", api_supervisor.update),
                 web.post("/supervisor/reload", api_supervisor.reload),
                 web.post("/supervisor/restart", api_supervisor.restart),
-                web.post("/supervisor/options", api_supervisor.options),
+                web.post("/supervisor/options", options_handler),
                 web.post("/supervisor/repair", api_supervisor.repair),
             ]
         )
@@ -668,7 +679,7 @@ class RestAPI(CoreSysAttributes):
                 """Route to store if info requested for not installed app."""
                 try:
                     addon: App = api_apps.get_app_for_request(request)
-                    return await api_apps.info_data(addon, request)
+                    return await api_apps.info_data_v1(addon, request)
                 except APIAppNotInstalled:
                     # Route to store/{app}/info but add missing fields
                     return dict(

--- a/supervisor/api/apps.py
+++ b/supervisor/api/apps.py
@@ -189,7 +189,6 @@ class APIApps(CoreSysAttributes):
                 ATTR_NAME: app.name,
                 ATTR_SLUG: app.slug,
                 ATTR_DESCRIPTON: app.description,
-                ATTR_ADVANCED: app.advanced,  # Deprecated 2026.03
                 ATTR_STAGE: app.stage,
                 ATTR_VERSION: app.version,
                 ATTR_VERSION_LATEST: app.latest_version,
@@ -216,7 +215,10 @@ class APIApps(CoreSysAttributes):
     @api_process
     async def list_apps_v1(self, request: web.Request) -> dict[str, Any]:
         """Return all installed apps (v1: uses "addons" key)."""
-        return {ATTR_ADDONS: self._list_apps_data()}
+        data = self._list_apps_data()
+        for idx, app in enumerate(self.sys_apps.installed):
+            data[idx][ATTR_ADVANCED] = app.advanced  # Deprecated 2026.03
+        return {ATTR_ADDONS: data}
 
     @api_process
     async def reload(self, request: web.Request) -> None:
@@ -243,7 +245,6 @@ class APIApps(CoreSysAttributes):
             ATTR_DNS: app.dns,
             ATTR_DESCRIPTON: app.description,
             ATTR_LONG_DESCRIPTION: await app.long_description(),
-            ATTR_ADVANCED: app.advanced,  # Deprecated 2026.03
             ATTR_STAGE: app.stage,
             ATTR_REPOSITORY: app.repository,
             ATTR_VERSION_LATEST: app.latest_version,
@@ -311,6 +312,12 @@ class APIApps(CoreSysAttributes):
             ATTR_SYSTEM_MANAGED: app.system_managed,
             ATTR_SYSTEM_MANAGED_CONFIG_ENTRY: app.system_managed_config_entry,
         }
+
+    async def info_data_v1(self, app: App, request: web.Request) -> dict[str, Any]:
+        """Build and return v1 app information dict."""
+        data = await self.info_data(app, request)
+        data[ATTR_ADVANCED] = app.advanced  # Deprecated 2026.03
+        return data
 
     @api_process
     async def info(self, request: web.Request) -> dict[str, Any]:

--- a/supervisor/api/backups.py
+++ b/supervisor/api/backups.py
@@ -88,7 +88,8 @@ def _convert_local_location(item: str | None) -> str | None:
 
 
 # pylint: disable=no-value-for-parameter
-SCHEMA_FOLDERS = vol.All([vol.In(_ALL_FOLDERS)], vol.Unique())
+SCHEMA_FOLDERS_V2 = vol.All([vol.In(ALL_FOLDERS)], vol.Unique())
+SCHEMA_FOLDERS_V1 = vol.All([vol.In(_ALL_FOLDERS)], vol.Unique())
 SCHEMA_LOCATION = vol.All(vol.Maybe(str), _convert_local_location)
 SCHEMA_LOCATION_LIST = vol.All(_ensure_list, [SCHEMA_LOCATION], vol.Unique())
 
@@ -105,7 +106,7 @@ SCHEMA_RESTORE_PARTIAL_V1 = SCHEMA_RESTORE_FULL.extend(
     {
         vol.Optional(ATTR_HOMEASSISTANT): vol.Boolean(),
         vol.Optional(ATTR_ADDONS): vol.All([str], vol.Unique()),
-        vol.Optional(ATTR_FOLDERS): SCHEMA_FOLDERS,
+        vol.Optional(ATTR_FOLDERS): SCHEMA_FOLDERS_V1,
     }
 )
 
@@ -114,7 +115,7 @@ SCHEMA_RESTORE_PARTIAL = SCHEMA_RESTORE_FULL.extend(
     {
         vol.Optional(ATTR_HOMEASSISTANT): vol.Boolean(),
         vol.Optional(ATTR_APPS): vol.All([str], vol.Unique()),
-        vol.Optional(ATTR_FOLDERS): SCHEMA_FOLDERS,
+        vol.Optional(ATTR_FOLDERS): SCHEMA_FOLDERS_V2,
     }
 )
 
@@ -135,7 +136,7 @@ SCHEMA_BACKUP_FULL = vol.Schema(
 SCHEMA_BACKUP_PARTIAL_V1 = SCHEMA_BACKUP_FULL.extend(
     {
         vol.Optional(ATTR_ADDONS): vol.Or(ALL_APPS_FLAG, vol.All([str], vol.Unique())),
-        vol.Optional(ATTR_FOLDERS): SCHEMA_FOLDERS,
+        vol.Optional(ATTR_FOLDERS): SCHEMA_FOLDERS_V1,
         vol.Optional(ATTR_HOMEASSISTANT): vol.Boolean(),
     }
 )
@@ -144,7 +145,7 @@ SCHEMA_BACKUP_PARTIAL_V1 = SCHEMA_BACKUP_FULL.extend(
 SCHEMA_BACKUP_PARTIAL = SCHEMA_BACKUP_FULL.extend(
     {
         vol.Optional(ATTR_APPS): vol.Or(ALL_APPS_FLAG, vol.All([str], vol.Unique())),
-        vol.Optional(ATTR_FOLDERS): SCHEMA_FOLDERS,
+        vol.Optional(ATTR_FOLDERS): SCHEMA_FOLDERS_V2,
         vol.Optional(ATTR_HOMEASSISTANT): vol.Boolean(),
     }
 )

--- a/supervisor/api/supervisor.py
+++ b/supervisor/api/supervisor.py
@@ -62,9 +62,7 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 SCHEMA_OPTIONS = vol.Schema(
     {
         vol.Optional(ATTR_CHANNEL): vol.Coerce(UpdateChannel),
-        vol.Optional(ATTR_APPS_REPOSITORIES): repositories,
         vol.Optional(ATTR_TIMEZONE): str,
-        vol.Optional(ATTR_WAIT_BOOT): wait_boot,
         vol.Optional(ATTR_LOGGING): vol.Coerce(LogLevel),
         vol.Optional(ATTR_DEBUG): vol.Boolean(),
         vol.Optional(ATTR_DEBUG_BLOCK): vol.Boolean(),
@@ -78,20 +76,21 @@ SCHEMA_OPTIONS = vol.Schema(
     }
 )
 
+SCHEMA_OPTIONS_V1 = SCHEMA_OPTIONS.extend(
+    {
+        vol.Optional(ATTR_APPS_REPOSITORIES): repositories,
+        vol.Optional(ATTR_WAIT_BOOT): wait_boot,
+    }
+)
+
 SCHEMA_VERSION = vol.Schema({vol.Optional(ATTR_VERSION): version_tag})
 
 
 class APISupervisor(CoreSysAttributes):
     """Handle RESTful API for Supervisor functions."""
 
-    @api_process
-    async def ping(self, request: web.Request) -> bool:
-        """Return ok for signal that the API is ready."""
-        return True
-
-    @api_process
-    async def info(self, request: web.Request) -> dict[str, Any]:
-        """Return host information."""
+    def _info_data(self) -> dict[str, Any]:
+        """Build supervisor info response."""
         return {
             ATTR_VERSION: self.sys_supervisor.version,
             ATTR_VERSION_LATEST: self.sys_supervisor.latest_version,
@@ -113,31 +112,78 @@ class APISupervisor(CoreSysAttributes):
                 feature.value: self.sys_config.feature_flags.get(feature, False)
                 for feature in FeatureFlag
             },
-            # Deprecated
-            ATTR_WAIT_BOOT: self.sys_config.wait_boot,
-            ATTR_ADDONS: [
-                {
-                    ATTR_NAME: app.name,
-                    ATTR_SLUG: app.slug,
-                    ATTR_VERSION: app.version,
-                    ATTR_VERSION_LATEST: app.latest_version,
-                    ATTR_UPDATE_AVAILABLE: app.need_update,
-                    ATTR_STATE: app.state,
-                    ATTR_REPOSITORY: app.repository,
-                    ATTR_ICON: app.with_icon,
-                }
-                for app in self.sys_apps.local.values()
-            ],
-            ATTR_APPS_REPOSITORIES: [
-                {ATTR_NAME: store.name, ATTR_SLUG: store.slug}
-                for store in self.sys_store.all
-            ],
         }
 
     @api_process
+    async def ping(self, request: web.Request) -> bool:
+        """Return ok for signal that the API is ready."""
+        return True
+
+    @api_process
+    async def info(self, request: web.Request) -> dict[str, Any]:
+        """Return host information for v2 contract."""
+        return self._info_data()
+
+    @api_process
+    async def info_v1(self, request: web.Request) -> dict[str, Any]:
+        """Return host information."""
+        data = self._info_data()
+        # Deprecated
+        data[ATTR_WAIT_BOOT] = self.sys_config.wait_boot
+        data[ATTR_ADDONS] = [
+            {
+                ATTR_NAME: app.name,
+                ATTR_SLUG: app.slug,
+                ATTR_VERSION: app.version,
+                ATTR_VERSION_LATEST: app.latest_version,
+                ATTR_UPDATE_AVAILABLE: app.need_update,
+                ATTR_STATE: app.state,
+                ATTR_REPOSITORY: app.repository,
+                ATTR_ICON: app.with_icon,
+            }
+            for app in self.sys_apps.local.values()
+        ]
+        data[ATTR_APPS_REPOSITORIES] = [
+            {ATTR_NAME: store.name, ATTR_SLUG: store.slug}
+            for store in self.sys_store.all
+        ]
+        return data
+
+    @api_process
     async def options(self, request: web.Request) -> None:
-        """Set Supervisor options."""
+        """Set Supervisor options for v2 contract."""
         body = await api_validate(SCHEMA_OPTIONS, request)
+        await self._options(body)
+
+        # Save changes before processing apps in case of errors
+        await self.sys_updater.save_data()
+        await self.sys_config.save_data()
+
+        await self.sys_resolution.evaluate.evaluate_system()
+
+    @api_process
+    async def options_v1(self, request: web.Request) -> None:
+        """Set Supervisor options."""
+        body = await api_validate(SCHEMA_OPTIONS_V1, request)
+        if ATTR_WAIT_BOOT in body:
+            # Deprecated
+            self.sys_config.wait_boot = body[ATTR_WAIT_BOOT]
+        await self._options(body)
+
+        # Save changes before processing apps in case of errors
+        await self.sys_updater.save_data()
+        await self.sys_config.save_data()
+
+        # Remove: 2022.9
+        if ATTR_APPS_REPOSITORIES in body:
+            await asyncio.shield(
+                self.sys_store.update_repositories(set(body[ATTR_APPS_REPOSITORIES]))
+            )
+
+        await self.sys_resolution.evaluate.evaluate_system()
+
+    async def _options(self, body: dict[str, Any]) -> None:
+        """Apply supervisor options."""
 
         # Timezone must be first as validation is incomplete
         # If a timezone is present we do that validation after in the executor
@@ -187,25 +233,9 @@ class APISupervisor(CoreSysAttributes):
                 self.sys_config.detect_blocking_io = False
                 BlockBusterManager.deactivate()
 
-        # Deprecated
-        if ATTR_WAIT_BOOT in body:
-            self.sys_config.wait_boot = body[ATTR_WAIT_BOOT]
-
         if ATTR_FEATURE_FLAGS in body:
             for feature, enabled in body[ATTR_FEATURE_FLAGS].items():
                 self.sys_config.set_feature_flag(feature, enabled)
-
-        # Save changes before processing apps in case of errors
-        await self.sys_updater.save_data()
-        await self.sys_config.save_data()
-
-        # Remove: 2022.9
-        if ATTR_APPS_REPOSITORIES in body:
-            await asyncio.shield(
-                self.sys_store.update_repositories(set(body[ATTR_APPS_REPOSITORIES]))
-            )
-
-        await self.sys_resolution.evaluate.evaluate_system()
 
     @api_process
     async def stats(self, request: web.Request) -> dict[str, Any]:

--- a/supervisor/api/supervisor.py
+++ b/supervisor/api/supervisor.py
@@ -165,10 +165,11 @@ class APISupervisor(CoreSysAttributes):
     async def options_v1(self, request: web.Request) -> None:
         """Set Supervisor options."""
         body = await api_validate(SCHEMA_OPTIONS_V1, request)
+        await self._options(body)
+
         if ATTR_WAIT_BOOT in body:
             # Deprecated
             self.sys_config.wait_boot = body[ATTR_WAIT_BOOT]
-        await self._options(body)
 
         # Save changes before processing apps in case of errors
         await self.sys_updater.save_data()

--- a/supervisor/api/supervisor.py
+++ b/supervisor/api/supervisor.py
@@ -155,7 +155,6 @@ class APISupervisor(CoreSysAttributes):
         body = await api_validate(SCHEMA_OPTIONS, request)
         await self._options(body)
 
-        # Save changes before processing apps in case of errors
         await self.sys_updater.save_data()
         await self.sys_config.save_data()
 

--- a/tests/api/test_apps.py
+++ b/tests/api/test_apps.py
@@ -793,3 +793,40 @@ async def test_v2_list_apps_uses_apps_key(api_client_v2: TestClient):
     assert "apps" in body["data"]
     assert "addons" not in body["data"]
     assert body["data"]["apps"][0]["slug"] == "local_ssh"
+
+
+@pytest.mark.usefixtures("install_app_ssh")
+async def test_v1_list_apps_includes_deprecated_advanced(api_client: TestClient):
+    """V1 GET /addons keeps deprecated advanced field."""
+    resp = await api_client.get("/addons")
+    assert resp.status == 200
+
+    body = await resp.json()
+    assert "advanced" in body["data"]["addons"][0]
+
+
+@pytest.mark.usefixtures("install_app_ssh")
+async def test_v2_list_apps_excludes_deprecated_advanced(api_client_v2: TestClient):
+    """V2 GET /v2/apps drops deprecated advanced field."""
+    resp = await api_client_v2.get("/v2/apps")
+    assert resp.status == 200
+
+    body = await resp.json()
+    assert "advanced" not in body["data"]["apps"][0]
+
+
+@pytest.mark.usefixtures("install_app_ssh")
+async def test_apps_info_versioned_advanced_field(
+    app_api_client_with_root: tuple[TestClient, str],
+):
+    """V1 app info keeps advanced, v2 app info drops it."""
+    client, root = app_api_client_with_root
+
+    resp = await client.get(f"{root}/{TEST_ADDON_SLUG}/info")
+    assert resp.status == 200
+
+    data = (await resp.json())["data"]
+    if root == "/addons":
+        assert "advanced" in data
+    else:
+        assert "advanced" not in data

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -1629,6 +1629,50 @@ async def test_restore_partial_with_addons_key(
     assert "addons" not in call_kwargs
 
 
+async def test_v1_partial_backup_accepts_homeassistant_folder(
+    api_client: TestClient,
+    coresys: CoreSys,
+    mock_partial_backup: Backup,
+):
+    """V1 partial backup accepts legacy 'homeassistant' folder value."""
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    with patch.object(
+        BackupManager, "do_backup_partial", return_value=mock_partial_backup
+    ) as mock_backup:
+        resp = await api_client.post(
+            "/backups/new/partial",
+            json={"folders": ["homeassistant"]},
+        )
+
+    assert resp.status == 200
+    mock_backup.assert_called_once()
+    _, call_kwargs = mock_backup.call_args
+    assert call_kwargs["folders"] == ["homeassistant"]
+
+
+async def test_v1_partial_restore_accepts_homeassistant_folder(
+    api_client: TestClient,
+    coresys: CoreSys,
+    mock_partial_backup: Backup,
+):
+    """V1 partial restore accepts legacy 'homeassistant' folder value."""
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    with patch.object(
+        BackupManager, "do_restore_partial", return_value=True
+    ) as mock_restore:
+        resp = await api_client.post(
+            f"/backups/{mock_partial_backup.slug}/restore/partial",
+            json={"folders": ["homeassistant"]},
+        )
+
+    assert resp.status == 200
+    mock_restore.assert_called_once()
+    _, call_kwargs = mock_restore.call_args
+    assert call_kwargs["folders"] == ["homeassistant"]
+
+
 # ── V2 API tests ──────────────────────────────────────────────────────────────
 
 
@@ -1758,3 +1802,40 @@ async def test_v2_restore_partial_accepts_apps_key(
     assert "apps" in call_kwargs
     assert call_kwargs["apps"] == ["local_ssh"]
     assert "addons" not in call_kwargs
+
+
+async def test_v2_partial_backup_rejects_homeassistant_folder(
+    api_client_v2: TestClient,
+    coresys: CoreSys,
+):
+    """V2 partial backup rejects legacy 'homeassistant' folder value."""
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    resp = await api_client_v2.post(
+        "/v2/backups/new/partial",
+        json={"folders": ["homeassistant"]},
+    )
+
+    assert resp.status == 400
+    result = await resp.json()
+    assert result["result"] == "error"
+    assert "homeassistant" in result["message"]
+
+
+async def test_v2_partial_restore_rejects_homeassistant_folder(
+    api_client_v2: TestClient,
+    coresys: CoreSys,
+    mock_partial_backup: Backup,
+):
+    """V2 partial restore rejects legacy 'homeassistant' folder value."""
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    resp = await api_client_v2.post(
+        f"/v2/backups/{mock_partial_backup.slug}/restore/partial",
+        json={"folders": ["homeassistant"]},
+    )
+
+    assert resp.status == 400
+    result = await resp.json()
+    assert result["result"] == "error"
+    assert "homeassistant" in result["message"]

--- a/tests/api/test_supervisor.py
+++ b/tests/api/test_supervisor.py
@@ -44,13 +44,38 @@ async def test_api_supervisor_options_debug(
     assert coresys.config.debug
 
 
+async def test_api_supervisor_info_v1_includes_deprecated_fields(
+    api_client: TestClient,
+):
+    """Test v1 /supervisor/info includes deprecated contract fields."""
+    resp = await api_client.get("/supervisor/info")
+    assert resp.status == 200
+
+    data = (await resp.json())["data"]
+    assert "wait_boot" in data
+    assert "addons" in data
+    assert "addons_repositories" in data
+
+
+async def test_api_supervisor_info_v2_excludes_deprecated_fields(
+    api_client_v2: TestClient,
+):
+    """Test v2 /supervisor/info excludes deprecated contract fields."""
+    resp = await api_client_v2.get("/v2/supervisor/info")
+    assert resp.status == 200
+
+    data = (await resp.json())["data"]
+    assert "wait_boot" not in data
+    assert "addons" not in data
+    assert "addons_repositories" not in data
+
+
 async def test_api_supervisor_options_add_repository(
-    api_client_with_prefix: tuple[TestClient, str],
+    api_client: TestClient,
     coresys: CoreSys,
     supervisor_internet: AsyncMock,
 ):
     """Test add a repository via POST /supervisor/options REST API."""
-    api_client, prefix = api_client_with_prefix
     assert REPO_URL not in coresys.store.repository_urls
 
     with (
@@ -58,7 +83,7 @@ async def test_api_supervisor_options_add_repository(
         patch("supervisor.store.repository.RepositoryGit.validate", return_value=True),
     ):
         response = await api_client.post(
-            f"{prefix}/supervisor/options", json={"addons_repositories": [REPO_URL]}
+            "/supervisor/options", json={"addons_repositories": [REPO_URL]}
         )
 
     assert response.status == 200
@@ -66,22 +91,50 @@ async def test_api_supervisor_options_add_repository(
 
 
 async def test_api_supervisor_options_remove_repository(
-    api_client_with_prefix: tuple[TestClient, str],
+    api_client: TestClient,
     coresys: CoreSys,
     test_repository: Repository,
 ):
     """Test remove a repository via POST /supervisor/options REST API."""
-    api_client, prefix = api_client_with_prefix
     assert test_repository.source in coresys.store.repository_urls
     assert test_repository.slug in coresys.store.repositories
 
     response = await api_client.post(
-        f"{prefix}/supervisor/options", json={"addons_repositories": []}
+        "/supervisor/options", json={"addons_repositories": []}
     )
 
     assert response.status == 200
     assert test_repository.source not in coresys.store.repository_urls
     assert test_repository.slug not in coresys.store.repositories
+
+
+async def test_api_supervisor_options_v1_accepts_deprecated_fields(
+    api_client: TestClient,
+    coresys: CoreSys,
+):
+    """Test v1 /supervisor/options accepts deprecated request fields."""
+    with patch.object(coresys.store, "update_repositories", new=AsyncMock()) as update:
+        response = await api_client.post(
+            "/supervisor/options",
+            json={"wait_boot": 42, "addons_repositories": []},
+        )
+
+    assert response.status == 200
+    assert coresys.config.wait_boot == 42
+    update.assert_awaited_once_with(set())
+
+
+async def test_api_supervisor_options_v2_rejects_deprecated_fields(
+    api_client_v2: TestClient,
+):
+    """Test v2 /supervisor/options rejects deprecated request fields."""
+    response = await api_client_v2.post("/v2/supervisor/options", json={"wait_boot": 7})
+    assert response.status == 400
+
+    response = await api_client_v2.post(
+        "/v2/supervisor/options", json={"addons_repositories": []}
+    )
+    assert response.status == 400
 
 
 @pytest.mark.parametrize("git_error", [None, StoreGitError()])
@@ -107,17 +160,16 @@ async def test_api_supervisor_options_repositories_skipped_on_error(
 
 
 async def test_api_supervisor_options_repo_error_with_config_change(
-    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+    api_client: TestClient, coresys: CoreSys
 ):
     """Test config change with add repository error via POST /supervisor/options REST API."""
-    api_client, prefix = api_client_with_prefix
     assert not coresys.config.debug
 
     with patch(
         "supervisor.store.repository.RepositoryGit.load", side_effect=StoreGitError()
     ):
         response = await api_client.post(
-            f"{prefix}/supervisor/options",
+            "/supervisor/options",
             json={"debug": True, "addons_repositories": [REPO_URL]},
         )
 

--- a/tests/api/test_supervisor.py
+++ b/tests/api/test_supervisor.py
@@ -139,19 +139,16 @@ async def test_api_supervisor_options_v2_rejects_deprecated_fields(
 
 @pytest.mark.parametrize("git_error", [None, StoreGitError()])
 async def test_api_supervisor_options_repositories_skipped_on_error(
-    api_client_with_prefix: tuple[TestClient, str],
-    coresys: CoreSys,
-    git_error: StoreGitError,
+    api_client: TestClient, coresys: CoreSys, git_error: StoreGitError
 ):
     """Test repositories skipped on error via POST /supervisor/options REST API."""
-    api_client, prefix = api_client_with_prefix
     with (
         patch("supervisor.store.repository.RepositoryGit.load", side_effect=git_error),
         patch("supervisor.store.repository.RepositoryGit.validate", return_value=False),
         patch("supervisor.store.repository.RepositoryCustom.remove"),
     ):
         response = await api_client.post(
-            f"{prefix}/supervisor/options", json={"addons_repositories": [REPO_URL]}
+            "/supervisor/options", json={"addons_repositories": [REPO_URL]}
         )
 
     assert response.status == 400


### PR DESCRIPTION
## Proposed change

This PR refactors the v2 API contract to remove deprecated fields and request options while preserving v1 behavior.

It keeps legacy support only on v1 endpoints and keeps v2 endpoints strict/clean.

Changes include:
- Apps API: remove deprecated `advanced` from v2 responses; keep it on v1 responses.
- Supervisor API: remove deprecated `wait_boot`, `addons`, and `addons_repositories` from v2 info/options; keep them on v1 handlers.
- Backups API: accept legacy `folders: ["homeassistant"]` only on v1 partial backup/restore; reject it on v2.
- Route wiring updated where needed so v1 uses legacy shims and v2 uses clean handlers.
- Tests expanded to lock v1/v2 contract behavior.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #6808
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [x] [CLI][cli-repository] updated (if necessary)
- [x] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/