### PR TITLE
Block supervisor/hassio WebSocket command types in the HA proxy

### DIFF
--- a/supervisor/api/proxy.py
+++ b/supervisor/api/proxy.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager
 import logging
 import re
 from typing import Final
@@ -44,12 +44,15 @@ CORE_API_DENY: Final = re.compile(r"^hassio(?:/|_)")
 DENIED_WS_TYPE_PREFIXES = ("supervisor/", "hassio/")
 
 
-def _denied_command_type(data: str) -> str | None:
+def _denied_command_type(data: str) -> tuple[str, str | None] | None:
     """Return the command type if it's one apps must never reach, else None."""
     try:
-        command_type = json_loads(data).get("type")
+        parsed = json_loads(data)
+        command_type = parsed.get("type")
         return (
-            command_type if command_type.startswith(DENIED_WS_TYPE_PREFIXES) else None
+            (command_type, parsed.get("id"))
+            if command_type and command_type.startswith(DENIED_WS_TYPE_PREFIXES)
+            else None
         )
     except ValueError, AttributeError:
         # ValueError: data wasn't valid JSON.
@@ -231,14 +234,12 @@ class APIProxy(CoreSysAttributes):
             msg = await source.receive()
             match msg.type:
                 case WSMsgType.TEXT if filter_app_commands and (
-                    denied_type := _denied_command_type(msg.data)
+                    denied_msg := _denied_command_type(msg.data)
                 ):
+                    denied_type, message_id = denied_msg
                     logger.warning(
                         "Blocked disallowed WebSocket command type %r", denied_type
                     )
-                    message_id = None
-                    with suppress(ValueError):
-                        message_id = json_loads(msg.data).get("id")
                     await source.send_json(
                         {
                             "id": message_id,

--- a/supervisor/api/proxy.py
+++ b/supervisor/api/proxy.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 import logging
 import re
 from typing import Final
@@ -16,7 +16,7 @@ from aiohttp.web_exceptions import HTTPBadGateway, HTTPForbidden, HTTPUnauthoriz
 
 from ..coresys import CoreSysAttributes
 from ..exceptions import APIError, HomeAssistantAPIError, HomeAssistantAuthError
-from ..utils.json import json_dumps
+from ..utils.json import json_dumps, json_loads
 from ..utils.logging import AppLoggerAdapter
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -36,6 +36,26 @@ HEADER_HA_ACCESS = "X-Ha-Access"
 # The security middleware blacklist already blocks them; this is a redundant
 # guard so the proxy can't become a confused deputy if that ever regresses.
 CORE_API_DENY: Final = re.compile(r"^hassio(?:/|_)")
+# Command types that only Home Assistant's own frontend may use, reserved for the
+# `hassio` integration in Core. Apps proxying to the Home Assistant WebSocket API
+# only ever need normal HA commands (e.g. call_service, subscribe_events) and must
+# never be able to reach these, since Core executes them by calling back into the
+# Supervisor with its own, fully privileged token.
+DENIED_WS_TYPE_PREFIXES = ("supervisor/", "hassio/")
+
+
+def _denied_command_type(data: str) -> str | None:
+    """Return the command type if it's one apps must never reach, else None."""
+    try:
+        command_type = json_loads(data).get("type")
+        return (
+            command_type if command_type.startswith(DENIED_WS_TYPE_PREFIXES) else None
+        )
+    except ValueError, AttributeError:
+        # ValueError: data wasn't valid JSON.
+        # AttributeError: decoded message wasn't a dict (no .get) or "type" wasn't
+        # a string (no .startswith) or missing entirely (.get returns None).
+        return None
 
 
 class APIProxy(CoreSysAttributes):
@@ -197,11 +217,40 @@ class APIProxy(CoreSysAttributes):
         source: web.WebSocketResponse | ClientWebSocketResponse,
         target: web.WebSocketResponse | ClientWebSocketResponse,
         logger: AppLoggerAdapter,
+        *,
+        filter_app_commands: bool = False,
     ) -> None:
-        """Proxy a message from client to server or vice versa."""
+        """Proxy a message from client to server or vice versa.
+
+        If filter_app_commands is set, TEXT messages whose command type is reserved
+        for Home Assistant's own frontend (see DENIED_WS_TYPE_PREFIXES) are rejected
+        instead of forwarded, to prevent apps from using this proxy to reach the
+        Supervisor API at full privilege through Home Assistant Core.
+        """
         while not source.closed and not target.closed:
             msg = await source.receive()
             match msg.type:
+                case WSMsgType.TEXT if filter_app_commands and (
+                    denied_type := _denied_command_type(msg.data)
+                ):
+                    logger.warning(
+                        "Blocked disallowed WebSocket command type %r", denied_type
+                    )
+                    message_id = None
+                    with suppress(ValueError):
+                        message_id = json_loads(msg.data).get("id")
+                    await source.send_json(
+                        {
+                            "id": message_id,
+                            "type": "result",
+                            "success": False,
+                            "error": {
+                                "code": "unauthorized",
+                                "message": "Unauthorized",
+                            },
+                        },
+                        dumps=json_dumps,
+                    )
                 case WSMsgType.TEXT:
                     await target.send_str(msg.data)
                 case WSMsgType.BINARY:
@@ -297,7 +346,9 @@ class APIProxy(CoreSysAttributes):
         logger.info("Home Assistant WebSocket API proxy running")
 
         client_task = self.sys_create_task(self._proxy_message(client, server, logger))
-        server_task = self.sys_create_task(self._proxy_message(server, client, logger))
+        server_task = self.sys_create_task(
+            self._proxy_message(server, client, logger, filter_app_commands=True)
+        )
 
         # Typically, this will return with an empty pending set. However, if one of
         # the directions has an exception, make sure to close both connections and

--- a/tests/api/test_proxy.py
+++ b/tests/api/test_proxy.py
@@ -169,6 +169,125 @@ async def test_proxy_binary_message(
     assert await client.close()
 
 
+async def test_proxy_blocks_supervisor_api_command(
+    proxy_ws_client: WebSocketGenerator,
+    ha_ws_server: MockHAServerWebSocket,
+    install_app_ssh: App,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test the proxy blocks a supervisor/api command instead of tunneling it to Core.
+
+    Regression test for the confused-deputy chain described in
+    ws-supervisor-api-disclosure.md: an app with only `homeassistant_api: true` could
+    reach the full, unrestricted Supervisor API by sending a `supervisor/api` command
+    through this proxy, since Core executes it by calling back into the Supervisor
+    with its own, fully privileged token.
+    """
+    install_app_ssh.persist[ATTR_ACCESS_TOKEN] = "abc123"
+    client: MockHAClientWebSocket = await proxy_ws_client(
+        install_app_ssh.supervisor_token
+    )
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        await client.send_json_auto_id(
+            {
+                "type": "supervisor/api",
+                "endpoint": "/addons/self/options",
+                "method": "post",
+                "data": {"boot": "auto"},
+            }
+        )
+        result = await client.receive_json()
+        assert (
+            "Blocked disallowed WebSocket command type 'supervisor/api'" in caplog.text
+        )
+
+    assert result == {
+        "id": 1,
+        "type": "result",
+        "success": False,
+        "error": {"code": "unauthorized", "message": "Unauthorized"},
+    }
+    # The command must never have reached Home Assistant Core
+    assert ha_ws_server.incoming.empty()
+
+    assert await client.close()
+
+
+@pytest.mark.parametrize(
+    "command_type",
+    [
+        "supervisor/api",
+        "supervisor/event",
+        "supervisor/subscribe",
+        "hassio/update/core",
+    ],
+)
+async def test_proxy_blocks_denied_command_types(
+    proxy_ws_client: WebSocketGenerator,
+    ha_ws_server: MockHAServerWebSocket,
+    install_app_ssh: App,
+    command_type: str,
+):
+    """Test every Supervisor/Core-only command namespace is blocked, not just supervisor/api."""
+    install_app_ssh.persist[ATTR_ACCESS_TOKEN] = "abc123"
+    client: MockHAClientWebSocket = await proxy_ws_client(
+        install_app_ssh.supervisor_token
+    )
+
+    await client.send_json_auto_id({"type": command_type})
+    result = await client.receive_json()
+
+    assert result["success"] is False
+    assert result["error"]["code"] == "unauthorized"
+    assert ha_ws_server.incoming.empty()
+
+    assert await client.close()
+
+
+async def test_proxy_allows_normal_commands_after_blocked_command(
+    proxy_ws_client: WebSocketGenerator,
+    ha_ws_server: MockHAServerWebSocket,
+    install_app_ssh: App,
+):
+    """Test the connection stays usable after a denied command is rejected."""
+    install_app_ssh.persist[ATTR_ACCESS_TOKEN] = "abc123"
+    client: MockHAClientWebSocket = await proxy_ws_client(
+        install_app_ssh.supervisor_token
+    )
+
+    await client.send_json_auto_id({"type": "supervisor/api", "endpoint": "/backups"})
+    denied = await client.receive_json()
+    assert denied["success"] is False
+
+    await client.send_json_auto_id({"type": "call_service", "domain": "light"})
+    proxied_msg = await ha_ws_server.incoming.get()
+    assert proxied_msg.type == WSMsgType.TEXT
+    assert '"type": "call_service"' in proxied_msg.data
+
+    assert await client.close()
+
+
+async def test_proxy_forwards_malformed_text_message(
+    proxy_ws_client: WebSocketGenerator,
+    ha_ws_server: MockHAServerWebSocket,
+    install_app_ssh: App,
+):
+    """Test non-JSON text frames are forwarded as-is (Core rejects them itself)."""
+    install_app_ssh.persist[ATTR_ACCESS_TOKEN] = "abc123"
+    client: MockHAClientWebSocket = await proxy_ws_client(
+        install_app_ssh.supervisor_token
+    )
+
+    await client.send_str("this is not JSON")
+    proxied_msg = await ha_ws_server.incoming.get()
+    assert proxied_msg.type == WSMsgType.TEXT
+    assert proxied_msg.data == "this is not JSON"
+
+    assert await client.close()
+
+
 async def test_proxy_large_message(
     proxy_ws_client: WebSocketGenerator,
     ha_ws_server: MockHAServerWebSocket,


### PR DESCRIPTION
## Proposed change

The Supervisor's Core WebSocket proxy (`/core/websocket`) accepts connections from any app with `homeassistant_api: true`. It authenticates the app with its own token but then opens the upstream connection to Core **as the Supervisor itself**. `_proxy_message` was forwarding frames verbatim with no content inspection.

An app could exploit this by sending a `supervisor/api` command (or other `supervisor/*`/`hassio/*` type) through the proxy. Core's `hassio` integration handles those commands by calling back into the Supervisor with Core's own token. That token bypasses all role checks in `security.py` — it is treated as the most privileged caller regardless of the app's declared `hassio_api` or `hassio_role`.

**Fix:** in `_proxy_message`, TEXT frames on the app-to-Core direction whose `type` field starts with `"supervisor/"` or `"hassio/"` are now rejected with a Core-shaped `result`/`unauthorized` response instead of being forwarded. The connection stays open so the app can continue making normal HA calls (e.g. `call_service`, `subscribe_events`). The Core-to-app direction is unfiltered. Fail-open on unparseable frames — Core's own validation already rejects those.

Tests cover: the exact `supervisor/api` attack vector, all denied command-type namespaces, continued usability of the connection after a rejection, and pass-through of non-JSON frames.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: <!-- no public issue — security fix -->
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/