### PR TITLE
Fix parsing for image name with port in registry name

### DIFF
--- a/supervisor/resolution/evaluations/container.py
+++ b/supervisor/resolution/evaluations/container.py
@@ -96,6 +96,7 @@ class EvaluateContainer(EvaluateBase):
         for image in images:
             self.sys_resolution.evaluate.cached_images.add(image)
 
+            # This assumes that the image has the format <name>:<tag>
             image_name = image.rpartition(":")[0]
             if image_name not in IGNORE_IMAGES and image_name not in self.known_images:
                 self._images.add(image_name)

--- a/supervisor/resolution/evaluations/container.py
+++ b/supervisor/resolution/evaluations/container.py
@@ -96,7 +96,7 @@ class EvaluateContainer(EvaluateBase):
         for image in images:
             self.sys_resolution.evaluate.cached_images.add(image)
 
-            image_name = image.partition(":")[0]
+            image_name = image.rpartition(":")[0]
             if image_name not in IGNORE_IMAGES and image_name not in self.known_images:
                 self._images.add(image_name)
                 if any(

--- a/tests/resolution/evaluation/test_evaluate_container.py
+++ b/tests/resolution/evaluation/test_evaluate_container.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import aiodocker
 from aiodocker.containers import DockerContainer
 
+from supervisor.apps.app import App
 from supervisor.const import CoreState
 from supervisor.coresys import CoreSys
 from supervisor.resolution.const import ContextType, IssueType, UnhealthyReason
@@ -20,6 +21,12 @@ def _make_image_attr(image: str) -> DockerContainer:
             "Image": image,
         },
     }
+    return out
+
+
+def _make_app_attr(image: str) -> App:
+    out = MagicMock(spec=App)
+    out.image = image
     return out
 
 
@@ -53,6 +60,24 @@ async def test_evaluation(coresys: CoreSys):
     assert container.reason not in coresys.resolution.unsupported
 
     assert coresys.resolution.evaluate.cached_images == set()
+
+
+async def test_registry_with_port(coresys: CoreSys):
+    coresys._apps = MagicMock()
+    coresys._apps.installed = [_make_app_attr("ghcr.io:443/home-assistant/supervisor")]
+
+    container = EvaluateContainer(coresys)
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    coresys.docker.containers.list.return_value = [
+        _make_image_attr("ghcr.io:443/home-assistant/supervisor:latest"),
+    ]
+    await container()
+    assert container.reason not in coresys.resolution.unsupported
+
+    assert coresys.resolution.evaluate.cached_images == {
+        "ghcr.io:443/home-assistant/supervisor:latest"
+    }
 
 
 async def test_corrupt_docker(coresys: CoreSys):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Docker image names normally look like this: 
```
ghcr.io/home-assistant/green-homeassistant:2026.8.1
```

But the registry can also contain a port like this:

```
gitlab.informatik.uni-bremen.de:5005/home-assistant/addon-uhb-mqtt-connector/aarch64:0.3.3-dev1
```

To check if there are any docker containers not managed by supervisor running on the host, these image names need to be parsed. The current implementation assumes there is only ever one colon (`:`) in the image name, and splits on the first one.

This results in images, where a port for the registry is specified, to be parsed incorrectly. Supervisor thinks the the tag for my second example is:
```
5005/home-assistant/addon-uhb-mqtt-connector/aarch64:0.3.3-dev1
```
with the name without tag just being:
```
gitlab.informatik.uni-bremen.de
```

The correct way to parse all image names, regardless of whether a port is specified or not, is to split on the last colon (`:`). 

This pull request implements this correct parsing.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #7125

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
