### PR TITLE
Reserve Core's host port before booting pre-Core apps

### DIFF
--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -7,8 +7,7 @@ from datetime import timedelta
 import logging
 from typing import Final, Self
 
-import aiodocker
-from aiodocker.containers import DockerContainer
+from dbus_fast import Variant
 
 from .const import (
     ATTR_STARTUP,
@@ -19,9 +18,10 @@ from .const import (
     CoreState,
 )
 from .coresys import CoreSys, CoreSysAttributes
-from .dbus.const import StopUnitMode, UnitActiveState
+from .dbus.const import StartUnitMode, StopUnitMode, UnitActiveState
 from .exceptions import (
     AppFileReadError,
+    DBusError,
     HassioError,
     HomeAssistantCrashError,
     HomeAssistantError,
@@ -37,8 +37,10 @@ from .utils.whoami import retrieve_whoami
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
-# Name of the short-lived container used to hold Core's host port during boot.
-_PORT_RESERVE_CONTAINER: Final = "hassio_port_reserve"
+# Name of the transient systemd unit used to hold Core's host port during boot.
+_PORT_RESERVE_UNIT: Final = "hassio-port-reserve.socket"
+_PORT_RESERVE_TIMEOUT: Final = 10
+_TERMINAL_STATES: Final = {UnitActiveState.INACTIVE, UnitActiveState.FAILED}
 
 
 class Core(CoreSysAttributes):
@@ -252,18 +254,19 @@ class Core(CoreSysAttributes):
                     await self.sys_supervisor.update()
                     return
 
-        # Start a temporary host-network container to hold Core's TCP port before
-        # booting any apps. Core runs with --network=host, so it competes in the
-        # host network namespace. Supervisor itself is on the hassio bridge and
-        # cannot bind there directly, so we use a container that can.
+        # Reserve Core's TCP port before booting any apps. Core runs with
+        # --network=host, so it competes with apps in the host network
+        # namespace. Supervisor itself is on the hassio bridge and cannot bind
+        # there directly, so a transient systemd socket unit is used instead
+        # (systemd performs the bind itself as part of activating the unit).
         # Released just before Core starts so Core can claim the port.
-        core_port_container: DockerContainer | None = None
+        core_port_reserved = False
         try:
             if not await self.sys_homeassistant.core.is_running():
                 hosts = self.sys_homeassistant.http_server_host
                 host = hosts[0] if hosts else "0.0.0.0"
                 port = self.sys_homeassistant.api_port
-                core_port_container = await self._reserve_core_port(host, port)
+                core_port_reserved = await self._reserve_core_port(host, port)
 
             # Start app mark as initialize
             await self.sys_apps.boot(AppStartup.INITIALIZE)
@@ -283,9 +286,9 @@ class Core(CoreSysAttributes):
             await self.sys_apps.boot(AppStartup.SERVICES)
 
             # Release the port reservation so Core can bind it
-            if core_port_container is not None:
-                await self._release_core_port(core_port_container)
-                core_port_container = None
+            if core_port_reserved:
+                await self._release_core_port()
+                core_port_reserved = False
 
             # run HomeAssistant
             if (
@@ -321,9 +324,9 @@ class Core(CoreSysAttributes):
             await self._update_last_boot()
 
         finally:
-            # Ensure the port reservation container is always removed
-            if core_port_container is not None:
-                await self._release_core_port(core_port_container)
+            # Ensure the port reservation is always released
+            if core_port_reserved:
+                await self._release_core_port()
 
             # Add core tasks into scheduler
             await self.sys_tasks.load()
@@ -471,89 +474,112 @@ class Core(CoreSysAttributes):
         self.sys_config.last_boot = last_boot
         await self.sys_config.save_data()
 
-    async def _reserve_core_port(self, host: str, port: int) -> DockerContainer | None:
-        """Start a temporary host-network container that holds Core's TCP port.
+    async def _reserve_core_port(self, host: str, port: int) -> bool:
+        """Reserve Core's host TCP port using a transient systemd socket unit.
 
         Core runs with --network=host, meaning it binds directly in the host
         network namespace. Supervisor lives on the hassio bridge and cannot
-        bind in the host namespace itself. We therefore start a minimal
-        container (using the Supervisor's own image, which is always present)
-        on --network=host so that Docker's host-network plumbing is used. The
-        container runs a Python one-liner that binds the socket and then blocks
-        on signal.pause(); killing the container releases the port.
+        bind there itself. Instead of starting a process, we ask the host's
+        systemd (over D-Bus, already a hard Supervisor dependency) to create
+        a transient ``.socket`` unit listening on Core's port. Systemd binds
+        the socket itself as part of activating the unit — no executable or
+        container is involved, and waiting for the unit to become active
+        guarantees the bind has already happened, closing the race window a
+        subprocess/container based approach would have.
 
-        Returns the running container, or None if reservation failed (non-fatal
-        — boot continues without the protection).
-
-        Known limitations
-        -----------------
-        * There is a small race window between ``container.start()`` returning
-          and the Python process inside actually calling ``s.bind()``. In
-          practice the SYSTEM/SERVICES boot sequence takes long enough that
-          this has never been observed to matter, but it is not zero.
-        * Starting a full Supervisor-image container adds a few hundred
-          milliseconds of latency to the boot sequence.
+        Returns True if the port was reserved (the caller must then call
+        ``_release_core_port`` before Core starts), or False if the
+        reservation could not be made (non-fatal — boot continues without
+        the protection).
         """
-        image = self.sys_supervisor.image
-        tag = str(self.sys_supervisor.version) if self.sys_supervisor.version else None
-        if not image or not tag:
+        if not self.sys_dbus.systemd.is_connected:
             _LOGGER.warning(
-                "Cannot reserve Core port %s:%d: Supervisor image/version unknown",
+                "Cannot reserve Core port %s:%d: systemd D-Bus not connected",
                 host,
                 port,
             )
-            return None
+            return False
 
-        # Remove any stale reservation container from a previous crashed boot
-        with suppress(Exception):
-            stale = await self.sys_docker.docker.containers.get(_PORT_RESERVE_CONTAINER)
-            await stale.delete(force=True)
+        # Clean up a unit left behind by a previous crashed Supervisor boot.
+        # Unlike a oneshot unit, our socket unit never exits on its own, so a
+        # unit left active by a crash would otherwise hold Core's port forever,
+        # and systemd refuses to redefine a transient unit that's still loaded
+        # (in any state) under the same name even with mode=replace.
+        await self._release_core_port()
 
-        bind_cmd = (
-            "import socket, signal; "
-            "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); "
-            "s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1); "
-            f"s.bind(('{host}', {port})); "
-            "signal.pause()"
-        )
+        properties: list[tuple[str, Variant]] = [
+            ("Description", Variant("s", "Home Assistant Core port reservation")),
+            ("Listen", Variant("a(ss)", [("Stream", f"{host}:{port}")])),
+        ]
+
         try:
-            container = await self.sys_docker.docker.containers.create(
-                {
-                    "Image": f"{image}:{tag}",
-                    "Cmd": ["python3", "-c", bind_cmd],
-                    "HostConfig": {"NetworkMode": "host"},
-                },
-                name=_PORT_RESERVE_CONTAINER,
+            await self.sys_dbus.systemd.start_transient_unit(
+                _PORT_RESERVE_UNIT, StartUnitMode.REPLACE, properties
             )
-            await container.start()
-            _LOGGER.debug(
-                "Reserved Home Assistant Core port %s:%d during app startup",
-                host,
-                port,
-            )
-            return container
-        except (aiodocker.DockerError, TimeoutError) as err:
+            unit = await self.sys_dbus.systemd.get_unit(_PORT_RESERVE_UNIT)
+            async with asyncio.timeout(_PORT_RESERVE_TIMEOUT):
+                state = await unit.wait_for_active_state(
+                    {UnitActiveState.ACTIVE, UnitActiveState.FAILED}
+                )
+            if state != UnitActiveState.ACTIVE:
+                raise DBusError(f"unit entered state {state}")
+        except (DBusError, TimeoutError) as err:
             _LOGGER.warning(
                 "Could not reserve Home Assistant Core port %s:%d: %s",
                 host,
                 port,
                 err,
             )
-            # Clean up any partially-created container
-            with suppress(Exception):
-                stale = await self.sys_docker.docker.containers.get(
-                    _PORT_RESERVE_CONTAINER
-                )
-                await stale.delete(force=True)
-            return None
+            await self._release_core_port()
+            return False
 
-    async def _release_core_port(self, container: DockerContainer) -> None:
-        """Stop and remove the Core port reservation container."""
-        with suppress(Exception):
-            await container.kill()
-        with suppress(Exception):
-            await container.delete(force=True)
-        _LOGGER.debug("Released Home Assistant Core port reservation")
+        _LOGGER.debug(
+            "Reserved Home Assistant Core port %s:%d during app startup",
+            host,
+            port,
+        )
+        return True
+
+    async def _release_core_port(self) -> None:
+        """Stop the port reservation unit if it exists, releasing the held port.
+
+        Waits for the unit to actually leave a running state before returning:
+        systemd refuses to redefine a transient unit that's still loaded (in
+        any state) even with mode=replace, so callers about to (re)create the
+        unit rely on this to avoid a "unit already exists" race. Safe to call
+        even when no unit exists (e.g. on a fresh boot, or if
+        start_transient_unit itself never got to create one) -- this is then
+        a cheap no-op. Used both to release a successful reservation and to
+        clean up a stale/failed one before (re)creating it.
+        """
+        if not self.sys_dbus.systemd.is_connected:
+            return
+
+        with suppress(DBusError):
+            unit = await self.sys_dbus.systemd.get_unit(_PORT_RESERVE_UNIT)
+
+            # A DBusError here (e.g. a timeout waiting for the reply) doesn't
+            # necessarily mean the stop didn't happen on the systemd side, so
+            # don't give up: wait_for_active_state below is the authoritative
+            # check of the real state, not this call's return value.
+            with suppress(DBusError):
+                await self.sys_dbus.systemd.stop_unit(
+                    _PORT_RESERVE_UNIT, StopUnitMode.REPLACE
+                )
+
+            state = UnitActiveState.FAILED
+            with suppress(TimeoutError):
+                async with asyncio.timeout(_PORT_RESERVE_TIMEOUT):
+                    state = await unit.wait_for_active_state(_TERMINAL_STATES)
+
+            # Only a FAILED unit needs resetting -- systemd keeps those around
+            # until reset, but garbage collects a cleanly INACTIVE one on its
+            # own. A timeout above leaves state at FAILED so we still try.
+            if state != UnitActiveState.INACTIVE:
+                with suppress(DBusError):
+                    await self.sys_dbus.systemd.reset_failed_unit(_PORT_RESERVE_UNIT)
+
+            _LOGGER.debug("Stopped Home Assistant Core port reservation unit")
 
     async def _adjust_system_datetime(self) -> None:
         """Adjust system time/date on startup."""

--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -19,9 +19,9 @@ from .const import (
 )
 from .coresys import CoreSys, CoreSysAttributes
 from .dbus.const import StartUnitMode, StopUnitMode, UnitActiveState
+from .dbus.systemd import ExecStartEntry
 from .exceptions import (
     AppFileReadError,
-    DBusError,
     HassioError,
     HomeAssistantCrashError,
     HomeAssistantError,
@@ -37,10 +37,23 @@ from .utils.whoami import retrieve_whoami
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
-# Name of the transient systemd unit used to hold Core's host port during boot.
+# Transient systemd units used to hold Core's host port(s) during boot. The
+# socket is paired with a no-op oneshot service (RemainAfterExit) so systemd
+# always has a valid activation target -- otherwise it would tear the socket
+# down on the first connection attempt before Core is ready.
 _PORT_RESERVE_UNIT: Final = "hassio-port-reserve.socket"
+_PORT_RESERVE_SERVICE: Final = "hassio-port-reserve.service"
 _PORT_RESERVE_TIMEOUT: Final = 10
 _TERMINAL_STATES: Final = {UnitActiveState.INACTIVE, UnitActiveState.FAILED}
+
+
+def _format_bind_address(host: str, port: int) -> str:
+    """Format a host/port pair for a systemd ``Listen`` directive.
+
+    IPv6 addresses must be bracketed (e.g. ``[::]:8123``) or systemd rejects
+    them; plain ``host:port`` is used for IPv4 addresses/hostnames.
+    """
+    return f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
 
 
 class Core(CoreSysAttributes):
@@ -254,19 +267,15 @@ class Core(CoreSysAttributes):
                     await self.sys_supervisor.update()
                     return
 
-        # Reserve Core's TCP port before booting any apps. Core runs with
-        # --network=host, so it competes with apps in the host network
-        # namespace. Supervisor itself is on the hassio bridge and cannot bind
-        # there directly, so a transient systemd socket unit is used instead
-        # (systemd performs the bind itself as part of activating the unit).
-        # Released just before Core starts so Core can claim the port.
+        # Reserve Core's TCP port before booting other apps, since Core runs
+        # with --network=host and competes with them for it. Released again
+        # just before Core starts so it can claim the port itself.
         core_port_reserved = False
         try:
             if not await self.sys_homeassistant.core.is_running():
-                hosts = self.sys_homeassistant.http_server_host
-                host = hosts[0] if hosts else "0.0.0.0"
+                hosts = self.sys_homeassistant.http_server_host or ["0.0.0.0", "::"]
                 port = self.sys_homeassistant.api_port
-                core_port_reserved = await self._reserve_core_port(host, port)
+                core_port_reserved = await self._reserve_core_port(hosts, port)
 
             # Start app mark as initialize
             await self.sys_apps.boot(AppStartup.INITIALIZE)
@@ -285,10 +294,12 @@ class Core(CoreSysAttributes):
             # start app mark as services
             await self.sys_apps.boot(AppStartup.SERVICES)
 
-            # Release the port reservation so Core can bind it
+            # Release the reservation so Core can bind its own port. This is
+            # best-effort only: Core's port is just its API/frontend bind, so
+            # Core must be started regardless -- if it can't bind yet it just
+            # logs and keeps retrying, which beats not starting Core at all.
             if core_port_reserved:
-                await self._release_core_port()
-                core_port_reserved = False
+                core_port_reserved = not await self._release_core_port()
 
             # run HomeAssistant
             if (
@@ -474,47 +485,71 @@ class Core(CoreSysAttributes):
         self.sys_config.last_boot = last_boot
         await self.sys_config.save_data()
 
-    async def _reserve_core_port(self, host: str, port: int) -> bool:
-        """Reserve Core's host TCP port using a transient systemd socket unit.
+    async def _reserve_core_port(self, hosts: list[str], port: int) -> bool:
+        """Reserve Core's host TCP port(s) using a transient systemd socket.
 
-        Core runs with --network=host, meaning it binds directly in the host
-        network namespace. Supervisor lives on the hassio bridge and cannot
-        bind there itself. Instead of starting a process, we ask the host's
-        systemd (over D-Bus, already a hard Supervisor dependency) to create
-        a transient ``.socket`` unit listening on Core's port. Systemd binds
-        the socket itself as part of activating the unit — no executable or
-        container is involved, and waiting for the unit to become active
-        guarantees the bind has already happened, closing the race window a
-        subprocess/container based approach would have.
+        Core runs with --network=host, so Supervisor (on the hassio bridge)
+        can't bind the port itself -- instead systemd is asked to bind a
+        transient ``.socket`` unit for each host, paired atomically (via
+        ``aux``) with a no-op oneshot service so it has a valid activation
+        target.
 
-        Returns True if the port was reserved (the caller must then call
-        ``_release_core_port`` before Core starts), or False if the
-        reservation could not be made (non-fatal — boot continues without
-        the protection).
+        Returns True if reserved (caller must later call
+        ``_release_core_port``), or False if it couldn't be reserved
+        (non-fatal, boot continues without the protection).
         """
         if not self.sys_dbus.systemd.is_connected:
             _LOGGER.warning(
-                "Cannot reserve Core port %s:%d: systemd D-Bus not connected",
-                host,
+                "Cannot reserve Core port(s) %s:%d: systemd D-Bus not connected",
+                hosts,
                 port,
             )
             return False
 
-        # Clean up a unit left behind by a previous crashed Supervisor boot.
-        # Unlike a oneshot unit, our socket unit never exits on its own, so a
-        # unit left active by a crash would otherwise hold Core's port forever,
-        # and systemd refuses to redefine a transient unit that's still loaded
-        # (in any state) under the same name even with mode=replace.
-        await self._release_core_port()
+        # Clean up any unit left behind by a crashed Supervisor boot -- systemd
+        # refuses to redefine a transient unit that's still loaded under the
+        # same name, even with mode=replace.
+        if not await self._release_core_port():
+            _LOGGER.warning(
+                "Cannot reserve Core port(s) %s:%d: a previous reservation "
+                "could not be confirmed released",
+                hosts,
+                port,
+            )
+            return False
 
-        properties: list[tuple[str, Variant]] = [
+        service_properties: list[tuple[str, Variant]] = [
+            (
+                "Description",
+                Variant("s", "Home Assistant Core port reservation holder"),
+            ),
+            ("Type", Variant("s", "oneshot")),
+            ("RemainAfterExit", Variant("b", True)),
+            (
+                "ExecStart",
+                Variant(
+                    "a(sasb)",
+                    [ExecStartEntry("/bin/sh", ["/bin/sh", "-c", ":"], False)],
+                ),
+            ),
+        ]
+        socket_properties: list[tuple[str, Variant]] = [
             ("Description", Variant("s", "Home Assistant Core port reservation")),
-            ("Listen", Variant("a(ss)", [("Stream", f"{host}:{port}")])),
+            (
+                "Listen",
+                Variant(
+                    "a(ss)",
+                    [("Stream", _format_bind_address(host, port)) for host in hosts],
+                ),
+            ),
         ]
 
         try:
             await self.sys_dbus.systemd.start_transient_unit(
-                _PORT_RESERVE_UNIT, StartUnitMode.REPLACE, properties
+                _PORT_RESERVE_UNIT,
+                StartUnitMode.REPLACE,
+                socket_properties,
+                aux=[(_PORT_RESERVE_SERVICE, service_properties)],
             )
             unit = await self.sys_dbus.systemd.get_unit(_PORT_RESERVE_UNIT)
             async with asyncio.timeout(_PORT_RESERVE_TIMEOUT):
@@ -522,11 +557,11 @@ class Core(CoreSysAttributes):
                     {UnitActiveState.ACTIVE, UnitActiveState.FAILED}
                 )
             if state != UnitActiveState.ACTIVE:
-                raise DBusError(f"unit entered state {state}")
-        except (DBusError, TimeoutError) as err:
+                raise HassioError(f"unit entered state {state}")
+        except (HassioError, TimeoutError) as err:
             _LOGGER.warning(
-                "Could not reserve Home Assistant Core port %s:%d: %s",
-                host,
+                "Could not reserve Home Assistant Core port(s) %s:%d: %s",
+                hosts,
                 port,
                 err,
             )
@@ -534,52 +569,75 @@ class Core(CoreSysAttributes):
             return False
 
         _LOGGER.debug(
-            "Reserved Home Assistant Core port %s:%d during app startup",
-            host,
+            "Reserved Home Assistant Core port(s) %s:%d during app startup",
+            hosts,
             port,
         )
         return True
 
-    async def _release_core_port(self) -> None:
-        """Stop the port reservation unit if it exists, releasing the held port.
+    async def _stop_unit_confirmed(self, unit_name: str) -> bool:
+        """Stop a transient unit and confirm it actually reached INACTIVE.
 
-        Waits for the unit to actually leave a running state before returning:
-        systemd refuses to redefine a transient unit that's still loaded (in
-        any state) even with mode=replace, so callers about to (re)create the
-        unit rely on this to avoid a "unit already exists" race. Safe to call
-        even when no unit exists (e.g. on a fresh boot, or if
-        start_transient_unit itself never got to create one) -- this is then
-        a cheap no-op. Used both to release a successful reservation and to
-        clean up a stale/failed one before (re)creating it.
+        Retries once. Returns False if this can't be confirmed, meaning
+        systemd may still be holding whatever resource the unit represents.
         """
-        if not self.sys_dbus.systemd.is_connected:
-            return
+        try:
+            unit = await self.sys_dbus.systemd.get_unit(unit_name)
+        except HassioError:
+            # No such unit (or couldn't even ask) -- nothing to release.
+            return True
 
-        with suppress(DBusError):
-            unit = await self.sys_dbus.systemd.get_unit(_PORT_RESERVE_UNIT)
+        for _attempt in range(2):
+            # A stop error doesn't necessarily mean it didn't happen on the
+            # systemd side -- always re-check the real state below instead.
+            with suppress(HassioError):
+                await self.sys_dbus.systemd.stop_unit(unit_name, StopUnitMode.REPLACE)
 
-            # A DBusError here (e.g. a timeout waiting for the reply) doesn't
-            # necessarily mean the stop didn't happen on the systemd side, so
-            # don't give up: wait_for_active_state below is the authoritative
-            # check of the real state, not this call's return value.
-            with suppress(DBusError):
-                await self.sys_dbus.systemd.stop_unit(
-                    _PORT_RESERVE_UNIT, StopUnitMode.REPLACE
-                )
-
-            state = UnitActiveState.FAILED
             with suppress(TimeoutError):
                 async with asyncio.timeout(_PORT_RESERVE_TIMEOUT):
-                    state = await unit.wait_for_active_state(_TERMINAL_STATES)
+                    await unit.wait_for_active_state(_TERMINAL_STATES)
 
-            # Only a FAILED unit needs resetting -- systemd keeps those around
-            # until reset, but garbage collects a cleanly INACTIVE one on its
-            # own. A timeout above leaves state at FAILED so we still try.
-            if state != UnitActiveState.INACTIVE:
-                with suppress(DBusError):
-                    await self.sys_dbus.systemd.reset_failed_unit(_PORT_RESERVE_UNIT)
+            try:
+                state = await unit.get_active_state()
+            except HassioError:
+                return True  # unit disappeared -- nothing left to hold it
 
+            if state == UnitActiveState.INACTIVE:
+                return True
+
+            if state == UnitActiveState.FAILED:
+                # FAILED units stick around until explicitly reset.
+                with suppress(HassioError):
+                    await self.sys_dbus.systemd.reset_failed_unit(unit_name)
+                with suppress(HassioError):
+                    if await unit.get_active_state() == UnitActiveState.INACTIVE:
+                        return True
+
+        _LOGGER.error(
+            "Could not confirm systemd unit %s was released; it may still be "
+            "holding Home Assistant Core's port",
+            unit_name,
+        )
+        return False
+
+    async def _release_core_port(self) -> bool:
+        """Stop the port reservation units if they exist, releasing the port.
+
+        Safe to call as a no-op when nothing exists yet. Returns True once
+        both units are confirmed gone/INACTIVE, or False otherwise.
+        """
+        if not self.sys_dbus.systemd.is_connected:
+            return True
+
+        # Stop both units -- leaving either loaded would make systemd refuse
+        # to redefine it under the same name next time.
+        socket_released = await self._stop_unit_confirmed(_PORT_RESERVE_UNIT)
+        service_released = await self._stop_unit_confirmed(_PORT_RESERVE_SERVICE)
+
+        if socket_released and service_released:
             _LOGGER.debug("Stopped Home Assistant Core port reservation unit")
+
+        return socket_released and service_released
 
     async def _adjust_system_datetime(self) -> None:
         """Adjust system time/date on startup."""

--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -5,7 +5,10 @@ from collections.abc import Awaitable
 from contextlib import suppress
 from datetime import timedelta
 import logging
-from typing import Self
+from typing import Final, Self
+
+import aiodocker
+from aiodocker.containers import DockerContainer
 
 from .const import (
     ATTR_STARTUP,
@@ -33,6 +36,9 @@ from .utils.sentry import async_capture_exception
 from .utils.whoami import retrieve_whoami
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+# Name of the short-lived container used to hold Core's host port during boot.
+_PORT_RESERVE_CONTAINER: Final = "hassio_port_reserve"
 
 
 class Core(CoreSysAttributes):
@@ -246,7 +252,19 @@ class Core(CoreSysAttributes):
                     await self.sys_supervisor.update()
                     return
 
+        # Start a temporary host-network container to hold Core's TCP port before
+        # booting any apps. Core runs with --network=host, so it competes in the
+        # host network namespace. Supervisor itself is on the hassio bridge and
+        # cannot bind there directly, so we use a container that can.
+        # Released just before Core starts so Core can claim the port.
+        core_port_container: DockerContainer | None = None
         try:
+            if not await self.sys_homeassistant.core.is_running():
+                hosts = self.sys_homeassistant.http_server_host
+                host = hosts[0] if hosts else "0.0.0.0"
+                port = self.sys_homeassistant.api_port
+                core_port_container = await self._reserve_core_port(host, port)
+
             # Start app mark as initialize
             await self.sys_apps.boot(AppStartup.INITIALIZE)
 
@@ -263,6 +281,11 @@ class Core(CoreSysAttributes):
 
             # start app mark as services
             await self.sys_apps.boot(AppStartup.SERVICES)
+
+            # Release the port reservation so Core can bind it
+            if core_port_container is not None:
+                await self._release_core_port(core_port_container)
+                core_port_container = None
 
             # run HomeAssistant
             if (
@@ -298,6 +321,10 @@ class Core(CoreSysAttributes):
             await self._update_last_boot()
 
         finally:
+            # Ensure the port reservation container is always removed
+            if core_port_container is not None:
+                await self._release_core_port(core_port_container)
+
             # Add core tasks into scheduler
             await self.sys_tasks.load()
 
@@ -443,6 +470,90 @@ class Core(CoreSysAttributes):
             return
         self.sys_config.last_boot = last_boot
         await self.sys_config.save_data()
+
+    async def _reserve_core_port(self, host: str, port: int) -> DockerContainer | None:
+        """Start a temporary host-network container that holds Core's TCP port.
+
+        Core runs with --network=host, meaning it binds directly in the host
+        network namespace. Supervisor lives on the hassio bridge and cannot
+        bind in the host namespace itself. We therefore start a minimal
+        container (using the Supervisor's own image, which is always present)
+        on --network=host so that Docker's host-network plumbing is used. The
+        container runs a Python one-liner that binds the socket and then blocks
+        on signal.pause(); killing the container releases the port.
+
+        Returns the running container, or None if reservation failed (non-fatal
+        — boot continues without the protection).
+
+        Known limitations
+        -----------------
+        * There is a small race window between ``container.start()`` returning
+          and the Python process inside actually calling ``s.bind()``. In
+          practice the SYSTEM/SERVICES boot sequence takes long enough that
+          this has never been observed to matter, but it is not zero.
+        * Starting a full Supervisor-image container adds a few hundred
+          milliseconds of latency to the boot sequence.
+        """
+        image = self.sys_supervisor.image
+        tag = str(self.sys_supervisor.version) if self.sys_supervisor.version else None
+        if not image or not tag:
+            _LOGGER.warning(
+                "Cannot reserve Core port %s:%d: Supervisor image/version unknown",
+                host,
+                port,
+            )
+            return None
+
+        # Remove any stale reservation container from a previous crashed boot
+        with suppress(Exception):
+            stale = await self.sys_docker.docker.containers.get(_PORT_RESERVE_CONTAINER)
+            await stale.delete(force=True)
+
+        bind_cmd = (
+            "import socket, signal; "
+            "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); "
+            "s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1); "
+            f"s.bind(('{host}', {port})); "
+            "signal.pause()"
+        )
+        try:
+            container = await self.sys_docker.docker.containers.create(
+                {
+                    "Image": f"{image}:{tag}",
+                    "Cmd": ["python3", "-c", bind_cmd],
+                    "HostConfig": {"NetworkMode": "host"},
+                },
+                name=_PORT_RESERVE_CONTAINER,
+            )
+            await container.start()
+            _LOGGER.debug(
+                "Reserved Home Assistant Core port %s:%d during app startup",
+                host,
+                port,
+            )
+            return container
+        except (aiodocker.DockerError, TimeoutError) as err:
+            _LOGGER.warning(
+                "Could not reserve Home Assistant Core port %s:%d: %s",
+                host,
+                port,
+                err,
+            )
+            # Clean up any partially-created container
+            with suppress(Exception):
+                stale = await self.sys_docker.docker.containers.get(
+                    _PORT_RESERVE_CONTAINER
+                )
+                await stale.delete(force=True)
+            return None
+
+    async def _release_core_port(self, container: DockerContainer) -> None:
+        """Stop and remove the Core port reservation container."""
+        with suppress(Exception):
+            await container.kill()
+        with suppress(Exception):
+            await container.delete(force=True)
+        _LOGGER.debug("Released Home Assistant Core port reservation")
 
     async def _adjust_system_datetime(self) -> None:
         """Adjust system time/date on startup."""

--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -542,6 +542,7 @@ class Core(CoreSysAttributes):
                     [("Stream", _format_bind_address(host, port)) for host in hosts],
                 ),
             ),
+            ("BindIPv6Only", Variant("s", "ipv6-only")),
         ]
 
         try:
@@ -593,11 +594,11 @@ class Core(CoreSysAttributes):
             with suppress(HassioError):
                 await self.sys_dbus.systemd.stop_unit(unit_name, StopUnitMode.REPLACE)
 
-            with suppress(TimeoutError):
-                async with asyncio.timeout(_PORT_RESERVE_TIMEOUT):
-                    await unit.wait_for_active_state(_TERMINAL_STATES)
-
             try:
+                with suppress(TimeoutError):
+                    async with asyncio.timeout(_PORT_RESERVE_TIMEOUT):
+                        await unit.wait_for_active_state(_TERMINAL_STATES)
+
                 state = await unit.get_active_state()
             except HassioError:
                 return True  # unit disappeared -- nothing left to hold it

--- a/supervisor/dbus/systemd.py
+++ b/supervisor/dbus/systemd.py
@@ -249,11 +249,20 @@ class Systemd(DBusInterfaceProxy):
 
     @dbus_connected
     async def start_transient_unit(
-        self, unit: str, mode: StartUnitMode, properties: list[tuple[str, Variant]]
+        self,
+        unit: str,
+        mode: StartUnitMode,
+        properties: list[tuple[str, Variant]],
+        aux: list[tuple[str, list[tuple[str, Variant]]]] | None = None,
     ) -> str:
-        """Start a transient unit which is released when stopped or on reboot. Returns object path of job."""
+        """Start a transient unit which is released when stopped or on reboot.
+
+        ``aux`` allows auxiliary transient units (e.g. a paired ``.service``
+        for a ``.socket`` unit) to be defined atomically in the same
+        transaction as the primary unit. Returns object path of job.
+        """
         return await self.connected_dbus.Manager.call(
-            "start_transient_unit", unit, mode, properties, []
+            "start_transient_unit", unit, mode, properties, aux or []
         )
 
     @dbus_connected

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,12 +7,14 @@ import datetime
 import errno
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
-import aiodocker
 from awesomeversion import AwesomeVersion
+from dbus_fast import DBusError, ErrorType, Variant
 import pytest
 
 from supervisor.const import AppStartup, CoreState
+from supervisor.core import _PORT_RESERVE_UNIT
 from supervisor.coresys import CoreSys
+from supervisor.dbus.const import DBUS_ERR_SYSTEMD_NO_SUCH_UNIT
 from supervisor.exceptions import AppFileReadError, HassioError, WhoamiSSLError
 from supervisor.hardware.helper import HwHelper
 from supervisor.homeassistant.core import HomeAssistantCore
@@ -425,10 +427,29 @@ async def test_stop_reentry_signals_event_without_teardown(
 
 
 @pytest.fixture
-def core_start_base_mocks(coresys: CoreSys):
+def core_start_base_mocks(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+):
     """Set up boilerplate mocks for Core.start() that are not under test."""
     # Default config.last_boot is epoch (1970); HwHelper.last_boot returns now →
     # the two differ, so the supervisor-restart early-return is not triggered.
+
+    # By default simulate a fresh boot with no leftover port reservation unit:
+    # the first GetUnit call (stale-unit cleanup check) raises NoSuchUnit, and
+    # every later GetUnit call (waiting for the freshly-started unit, then the
+    # real release before Core starts) succeeds. Sized generously since a
+    # single reservation cycle makes 3 GetUnit calls.
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
+    systemd_service.response_get_unit = [
+        DBusError(DBUS_ERR_SYSTEMD_NO_SUCH_UNIT, "no such unit"),
+    ] + [SystemdService.response_get_unit] * 10
+    # Link the unit mock so Start/StopUnit calls flip its ActiveState the
+    # same way real systemd would, letting wait_for_active_state resolve
+    # immediately instead of waiting on a signal that never comes.
+    systemd_service.mock_systemd_unit = systemd_unit_service
+
     with (
         patch.object(coresys.os, "mark_healthy", new=AsyncMock()),
         patch.object(coresys.updater, "reload", new=AsyncMock()),
@@ -462,29 +483,6 @@ def core_start_base_mocks(coresys: CoreSys):
         yield
 
 
-def _make_docker_containers_mock(mock_container: MagicMock) -> MagicMock:
-    """Return a mock for sys_docker.docker.containers.
-
-    get() raises DockerError(404) to indicate no stale container;
-    create() returns mock_container.
-    """
-    mock_containers = MagicMock()
-    mock_containers.get = AsyncMock(
-        side_effect=aiodocker.DockerError(404, {"message": "no such container"})
-    )
-    mock_containers.create = AsyncMock(return_value=mock_container)
-    return mock_containers
-
-
-def _make_reservation_container() -> MagicMock:
-    """Return a mock Docker container used as the port reservation container."""
-    mock_container = MagicMock()
-    mock_container.start = AsyncMock()
-    mock_container.kill = AsyncMock()
-    mock_container.delete = AsyncMock()
-    return mock_container
-
-
 @pytest.mark.usefixtures("core_start_base_mocks")
 @pytest.mark.parametrize(
     ("http_server_host", "expected_bind_host"),
@@ -496,6 +494,7 @@ def _make_reservation_container() -> MagicMock:
 )
 async def test_start_reserves_core_port(
     coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
     http_server_host: list[str] | None,
     expected_bind_host: str,
 ):
@@ -507,52 +506,54 @@ async def test_start_reserves_core_port(
     coresys.homeassistant.http_server_host = http_server_host
     assert coresys.homeassistant.api_port == 8123
 
-    mock_container = _make_reservation_container()
-    coresys.docker.docker = MagicMock()
-    coresys.docker.docker.containers = _make_docker_containers_mock(mock_container)
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_service.StartTransientUnit.calls.clear()
+    systemd_service.StopUnit.calls.clear()
 
     await coresys.core.start()
 
-    # Container must be created with host networking and the right bind address
-    coresys.docker.docker.containers.create.assert_awaited_once()
-    create_config = coresys.docker.docker.containers.create.call_args[0][0]
-    assert create_config["HostConfig"]["NetworkMode"] == "host"
-    assert expected_bind_host in create_config["Cmd"][-1]
-    assert "8123" in create_config["Cmd"][-1]
+    # A transient socket unit must be created listening on the right address
+    assert len(systemd_service.StartTransientUnit.calls) == 1
+    unit_name, mode, properties, _aux = systemd_service.StartTransientUnit.calls[0]
+    assert unit_name == _PORT_RESERVE_UNIT
+    assert mode == "replace"
+    assert ("Listen", Variant("a(ss)", [("Stream", f"{expected_bind_host}:8123")])) in (
+        properties
+    )
 
-    # Container must be started then cleaned up before Core starts
-    mock_container.start.assert_awaited_once()
-    mock_container.kill.assert_awaited_once()
-    mock_container.delete.assert_awaited_once()
+    # Reservation must be released before Core starts
+    assert (_PORT_RESERVE_UNIT, "replace") in systemd_service.StopUnit.calls
 
     # Core must have started
-    coresys.homeassistant.core.start.assert_awaited_once()
-
-    mock_container.kill.assert_awaited_once()
-    mock_container.delete.assert_awaited_once()
     coresys.homeassistant.core.start.assert_awaited_once()
 
 
 @pytest.mark.usefixtures("core_start_base_mocks")
 async def test_start_port_held_during_app_boot_released_before_core_start(
     coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ):
-    """Port reservation container exists during SYSTEM/SERVICES boot and is removed before Core starts.
+    """Port reservation unit exists during SYSTEM/SERVICES boot and is stopped before Core starts.
 
     This verifies that an app attempting to bind Core's port during SYSTEM or
-    SERVICES boot would be blocked by the reservation container, and that the
-    container is removed in time for Core to bind its own port.
+    SERVICES boot would be blocked by the reservation unit, and that the unit
+    is stopped in time for Core to bind its own port.
     """
     coresys.homeassistant.http_server_host = None
 
     call_sequence: list[str] = []
 
-    mock_container = _make_reservation_container()
-    mock_container.start.side_effect = lambda: call_sequence.append("container_start")
-    mock_container.kill.side_effect = lambda: call_sequence.append("container_kill")
+    orig_reserve = coresys.core._reserve_core_port
+    orig_release = coresys.core._release_core_port
 
-    coresys.docker.docker = MagicMock()
-    coresys.docker.docker.containers = _make_docker_containers_mock(mock_container)
+    async def tracking_reserve(host: str, port: int) -> bool:
+        result = await orig_reserve(host, port)
+        call_sequence.append("port_reserved")
+        return result
+
+    async def tracking_release() -> None:
+        await orig_release()
+        call_sequence.append("port_released")
 
     async def tracking_boot(stage: AppStartup) -> None:
         call_sequence.append(f"boot:{stage}")
@@ -561,6 +562,8 @@ async def test_start_port_held_during_app_boot_released_before_core_start(
         call_sequence.append("core_start")
 
     with (
+        patch.object(coresys.core, "_reserve_core_port", side_effect=tracking_reserve),
+        patch.object(coresys.core, "_release_core_port", side_effect=tracking_release),
         patch.object(coresys.apps, "boot", side_effect=tracking_boot),
         patch.object(
             coresys.homeassistant.core, "start", side_effect=tracking_core_start
@@ -568,30 +571,33 @@ async def test_start_port_held_during_app_boot_released_before_core_start(
     ):
         await coresys.core.start()
 
-    assert "container_start" in call_sequence
+    assert "port_reserved" in call_sequence
     assert f"boot:{AppStartup.SYSTEM}" in call_sequence
     assert f"boot:{AppStartup.SERVICES}" in call_sequence
-    assert "container_kill" in call_sequence
+    assert "port_released" in call_sequence
     assert "core_start" in call_sequence
 
-    container_start_idx = call_sequence.index("container_start")
+    reserved_idx = call_sequence.index("port_reserved")
     system_boot_idx = call_sequence.index(f"boot:{AppStartup.SYSTEM}")
     services_boot_idx = call_sequence.index(f"boot:{AppStartup.SERVICES}")
-    container_kill_idx = call_sequence.index("container_kill")
+    released_idx = call_sequence.index("port_released")
     core_start_idx = call_sequence.index("core_start")
 
-    # Reservation container must be running before any pre-Core app stage boots
-    assert container_start_idx < system_boot_idx
-    assert container_start_idx < services_boot_idx
-    # Container must be stopped before Core starts
-    assert container_kill_idx < core_start_idx
+    # Reservation unit must be active before any pre-Core app stage boots
+    assert reserved_idx < system_boot_idx
+    assert reserved_idx < services_boot_idx
+    # Unit must be stopped before Core starts
+    assert released_idx < core_start_idx
 
 
 @pytest.mark.usefixtures("core_start_base_mocks")
-async def test_start_skips_port_reservation_when_core_already_running(coresys: CoreSys):
-    """When Core is already running (Supervisor restart), no reservation container is created."""
-    coresys.docker.docker = MagicMock()
-    coresys.docker.docker.containers = MagicMock()
+async def test_start_skips_port_reservation_when_core_already_running(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+):
+    """When Core is already running (Supervisor restart), no reservation unit is created."""
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_service.StartTransientUnit.calls.clear()
 
     with patch.object(
         coresys.homeassistant.core,
@@ -600,4 +606,138 @@ async def test_start_skips_port_reservation_when_core_already_running(coresys: C
     ):
         await coresys.core.start()
 
-    coresys.docker.docker.containers.create.assert_not_called()
+    assert systemd_service.StartTransientUnit.calls == []
+
+
+@pytest.mark.usefixtures("core_start_base_mocks")
+async def test_start_continues_when_port_reservation_fails(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+):
+    """Core boot continues even if the port reservation could not be made."""
+    coresys.homeassistant.http_server_host = None
+
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_service.response_start_transient_unit = DBusError(
+        ErrorType.FAILED, "unit already exists"
+    )
+
+    await coresys.core.start()
+
+    coresys.homeassistant.core.start.assert_awaited_once()
+
+
+@pytest.mark.usefixtures("core_start_base_mocks")
+async def test_start_cleans_up_stale_active_unit_before_reserving(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+):
+    """A reservation unit left active by a previous crashed boot is stopped first.
+
+    Systemd refuses to redefine a transient unit that is still loaded (in any
+    state), even with mode=replace, so a unit left active by a Supervisor
+    crash must be stopped -- and that stop waited out -- before a new
+    reservation can be started under the same name.
+    """
+    coresys.homeassistant.http_server_host = None
+
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
+
+    # Simulate a leftover unit from a previous crashed boot: GetUnit finds it
+    # and it is still active (mock_systemd_unit is already linked by the base
+    # fixture so StopUnit/StartTransientUnit flip its ActiveState like real
+    # systemd would).
+    systemd_service.response_get_unit = SystemdService.response_get_unit
+    systemd_unit_service.active_state = "active"
+    systemd_service.StopUnit.calls.clear()
+    systemd_service.StartTransientUnit.calls.clear()
+    systemd_service.ResetFailedUnit.calls.clear()
+
+    await coresys.core.start()
+
+    # The stale unit must have been stopped before the new one was started
+    assert (_PORT_RESERVE_UNIT, "replace") in systemd_service.StopUnit.calls
+    assert len(systemd_service.StartTransientUnit.calls) == 1
+    # It cleanly reached INACTIVE, so there was nothing to reset
+    assert systemd_service.ResetFailedUnit.calls == []
+    coresys.homeassistant.core.start.assert_awaited_once()
+
+
+async def test_release_core_port_resets_failed_unit(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+):
+    """Releasing a unit that ended up FAILED (not cleanly INACTIVE) resets it.
+
+    Systemd keeps a FAILED unit around until it is explicitly reset, unlike a
+    unit that cleanly stops to INACTIVE and is garbage collected on its own.
+    """
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
+
+    # Simulate a unit that is FAILED and stays that way: StopUnit's mock
+    # unconditionally flips a *linked* unit to INACTIVE, so leave it unlinked
+    # and set the state directly instead, matching a real FAILED unit that
+    # ignores a stop request.
+    systemd_service.response_get_unit = SystemdService.response_get_unit
+    systemd_unit_service.active_state = "failed"
+
+    await coresys.core._release_core_port()
+
+    assert (_PORT_RESERVE_UNIT, "replace") in systemd_service.StopUnit.calls
+    assert (_PORT_RESERVE_UNIT,) in systemd_service.ResetFailedUnit.calls
+
+
+async def test_reserve_core_port_skips_when_dbus_not_connected(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+):
+    """No reservation is attempted if systemd D-Bus is not connected."""
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_service.StartTransientUnit.calls.clear()
+
+    with patch.object(coresys.dbus.systemd, "dbus", None):
+        result = await coresys.core._reserve_core_port("0.0.0.0", 8123)
+
+    assert result is False
+    assert systemd_service.StartTransientUnit.calls == []
+
+
+async def test_release_core_port_skips_when_dbus_not_connected(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+):
+    """Releasing is a no-op if systemd D-Bus is not connected."""
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_service.StopUnit.calls.clear()
+
+    with patch.object(coresys.dbus.systemd, "dbus", None):
+        await coresys.core._release_core_port()
+
+    assert systemd_service.StopUnit.calls == []
+
+
+async def test_reserve_core_port_returns_false_when_unit_ends_up_failed(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+):
+    """If the unit is created but ends up FAILED rather than ACTIVE, fail cleanly.
+
+    This can happen if the port turns out to already be bound by something
+    else outside Supervisor's knowledge: systemd creates the unit but it
+    immediately fails to actually claim the socket.
+    """
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
+
+    # Leave mock_systemd_unit unlinked so StartTransientUnit's mock doesn't
+    # overwrite ActiveState back to "active" after we set it.
+    systemd_service.response_get_unit = SystemdService.response_get_unit
+    systemd_unit_service.active_state = "failed"
+    systemd_service.StartTransientUnit.calls.clear()
+
+    result = await coresys.core._reserve_core_port("0.0.0.0", 8123)
+
+    assert result is False
+    assert len(systemd_service.StartTransientUnit.calls) == 1

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,15 +7,20 @@ import datetime
 import errno
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
+import aiodocker
+from awesomeversion import AwesomeVersion
 import pytest
 
-from supervisor.const import CoreState
+from supervisor.const import AppStartup, CoreState
 from supervisor.coresys import CoreSys
 from supervisor.exceptions import AppFileReadError, HassioError, WhoamiSSLError
+from supervisor.hardware.helper import HwHelper
+from supervisor.homeassistant.core import HomeAssistantCore
 from supervisor.host.control import SystemControl
 from supervisor.host.info import InfoCenter
 from supervisor.resolution.const import IssueType, SuggestionType, UnhealthyReason
 from supervisor.supervisor import Supervisor
+from supervisor.utils.dt import utcnow
 from supervisor.utils.whoami import WhoamiData
 
 from tests.dbus_service_mocks.base import DBusServiceMock
@@ -417,3 +422,182 @@ async def test_stop_reentry_signals_event_without_teardown(
     assert stopping.is_set()
     api_stop.assert_not_called()
     assert coresys.core.state == state
+
+
+@pytest.fixture
+def core_start_base_mocks(coresys: CoreSys):
+    """Set up boilerplate mocks for Core.start() that are not under test."""
+    # Default config.last_boot is epoch (1970); HwHelper.last_boot returns now →
+    # the two differ, so the supervisor-restart early-return is not triggered.
+    with (
+        patch.object(coresys.os, "mark_healthy", new=AsyncMock()),
+        patch.object(coresys.updater, "reload", new=AsyncMock()),
+        patch.object(Supervisor, "need_update", new=PropertyMock(return_value=False)),
+        patch.object(
+            Supervisor,
+            "image",
+            new=PropertyMock(
+                return_value="ghcr.io/home-assistant/amd64-hassio-supervisor"
+            ),
+        ),
+        patch.object(HwHelper, "last_boot", return_value=utcnow()),
+        patch.object(coresys.services, "reset", new=AsyncMock()),
+        patch.object(coresys.tasks, "load", new=AsyncMock()),
+        patch.object(coresys.host, "reload", new=AsyncMock()),
+        patch.object(coresys.resolution, "healthcheck", new=AsyncMock()),
+        patch.object(
+            HomeAssistantCore,
+            "error_state",
+            new=PropertyMock(return_value=False),
+        ),
+        patch.object(coresys.core, "_update_last_boot", new=AsyncMock()),
+        patch.object(coresys.homeassistant.websocket, "supervisor_update_event"),
+        patch.object(coresys.apps, "boot", new=AsyncMock()),
+        patch.object(
+            coresys.homeassistant.core, "is_running", new=AsyncMock(return_value=False)
+        ),
+        patch.object(coresys.homeassistant.core, "start", new=AsyncMock()),
+    ):
+        coresys.homeassistant.version = AwesomeVersion("2023.8.1")
+        yield
+
+
+def _make_docker_containers_mock(mock_container: MagicMock) -> MagicMock:
+    """Return a mock for sys_docker.docker.containers.
+
+    get() raises DockerError(404) to indicate no stale container;
+    create() returns mock_container.
+    """
+    mock_containers = MagicMock()
+    mock_containers.get = AsyncMock(
+        side_effect=aiodocker.DockerError(404, {"message": "no such container"})
+    )
+    mock_containers.create = AsyncMock(return_value=mock_container)
+    return mock_containers
+
+
+def _make_reservation_container() -> MagicMock:
+    """Return a mock Docker container used as the port reservation container."""
+    mock_container = MagicMock()
+    mock_container.start = AsyncMock()
+    mock_container.kill = AsyncMock()
+    mock_container.delete = AsyncMock()
+    return mock_container
+
+
+@pytest.mark.usefixtures("core_start_base_mocks")
+@pytest.mark.parametrize(
+    ("http_server_host", "expected_bind_host"),
+    [
+        (None, "0.0.0.0"),
+        (["192.0.2.1", "0.0.0.0"], "192.0.2.1"),
+    ],
+    ids=["no_server_host", "with_server_host"],
+)
+async def test_start_reserves_core_port(
+    coresys: CoreSys,
+    http_server_host: list[str] | None,
+    expected_bind_host: str,
+):
+    """On fresh boot, Core's port is reserved using the correct bind address.
+
+    When http_server_host is None the reservation falls back to 0.0.0.0;
+    when it is set the first listed host is used.
+    """
+    coresys.homeassistant.http_server_host = http_server_host
+    assert coresys.homeassistant.api_port == 8123
+
+    mock_container = _make_reservation_container()
+    coresys.docker.docker = MagicMock()
+    coresys.docker.docker.containers = _make_docker_containers_mock(mock_container)
+
+    await coresys.core.start()
+
+    # Container must be created with host networking and the right bind address
+    coresys.docker.docker.containers.create.assert_awaited_once()
+    create_config = coresys.docker.docker.containers.create.call_args[0][0]
+    assert create_config["HostConfig"]["NetworkMode"] == "host"
+    assert expected_bind_host in create_config["Cmd"][-1]
+    assert "8123" in create_config["Cmd"][-1]
+
+    # Container must be started then cleaned up before Core starts
+    mock_container.start.assert_awaited_once()
+    mock_container.kill.assert_awaited_once()
+    mock_container.delete.assert_awaited_once()
+
+    # Core must have started
+    coresys.homeassistant.core.start.assert_awaited_once()
+
+    mock_container.kill.assert_awaited_once()
+    mock_container.delete.assert_awaited_once()
+    coresys.homeassistant.core.start.assert_awaited_once()
+
+
+@pytest.mark.usefixtures("core_start_base_mocks")
+async def test_start_port_held_during_app_boot_released_before_core_start(
+    coresys: CoreSys,
+):
+    """Port reservation container exists during SYSTEM/SERVICES boot and is removed before Core starts.
+
+    This verifies that an app attempting to bind Core's port during SYSTEM or
+    SERVICES boot would be blocked by the reservation container, and that the
+    container is removed in time for Core to bind its own port.
+    """
+    coresys.homeassistant.http_server_host = None
+
+    call_sequence: list[str] = []
+
+    mock_container = _make_reservation_container()
+    mock_container.start.side_effect = lambda: call_sequence.append("container_start")
+    mock_container.kill.side_effect = lambda: call_sequence.append("container_kill")
+
+    coresys.docker.docker = MagicMock()
+    coresys.docker.docker.containers = _make_docker_containers_mock(mock_container)
+
+    async def tracking_boot(stage: AppStartup) -> None:
+        call_sequence.append(f"boot:{stage}")
+
+    async def tracking_core_start() -> None:
+        call_sequence.append("core_start")
+
+    with (
+        patch.object(coresys.apps, "boot", side_effect=tracking_boot),
+        patch.object(
+            coresys.homeassistant.core, "start", side_effect=tracking_core_start
+        ),
+    ):
+        await coresys.core.start()
+
+    assert "container_start" in call_sequence
+    assert f"boot:{AppStartup.SYSTEM}" in call_sequence
+    assert f"boot:{AppStartup.SERVICES}" in call_sequence
+    assert "container_kill" in call_sequence
+    assert "core_start" in call_sequence
+
+    container_start_idx = call_sequence.index("container_start")
+    system_boot_idx = call_sequence.index(f"boot:{AppStartup.SYSTEM}")
+    services_boot_idx = call_sequence.index(f"boot:{AppStartup.SERVICES}")
+    container_kill_idx = call_sequence.index("container_kill")
+    core_start_idx = call_sequence.index("core_start")
+
+    # Reservation container must be running before any pre-Core app stage boots
+    assert container_start_idx < system_boot_idx
+    assert container_start_idx < services_boot_idx
+    # Container must be stopped before Core starts
+    assert container_kill_idx < core_start_idx
+
+
+@pytest.mark.usefixtures("core_start_base_mocks")
+async def test_start_skips_port_reservation_when_core_already_running(coresys: CoreSys):
+    """When Core is already running (Supervisor restart), no reservation container is created."""
+    coresys.docker.docker = MagicMock()
+    coresys.docker.docker.containers = MagicMock()
+
+    with patch.object(
+        coresys.homeassistant.core,
+        "is_running",
+        new=AsyncMock(return_value=True),
+    ):
+        await coresys.core.start()
+
+    coresys.docker.docker.containers.create.assert_not_called()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,10 +12,19 @@ from dbus_fast import DBusError, ErrorType, Variant
 import pytest
 
 from supervisor.const import AppStartup, CoreState
-from supervisor.core import _PORT_RESERVE_UNIT
+from supervisor.core import (
+    _PORT_RESERVE_SERVICE,
+    _PORT_RESERVE_UNIT,
+    _format_bind_address,
+)
 from supervisor.coresys import CoreSys
 from supervisor.dbus.const import DBUS_ERR_SYSTEMD_NO_SUCH_UNIT
-from supervisor.exceptions import AppFileReadError, HassioError, WhoamiSSLError
+from supervisor.exceptions import (
+    AppFileReadError,
+    DBusNotConnectedError,
+    HassioError,
+    WhoamiSSLError,
+)
 from supervisor.hardware.helper import HwHelper
 from supervisor.homeassistant.core import HomeAssistantCore
 from supervisor.host.control import SystemControl
@@ -435,16 +444,19 @@ def core_start_base_mocks(
     # Default config.last_boot is epoch (1970); HwHelper.last_boot returns now →
     # the two differ, so the supervisor-restart early-return is not triggered.
 
-    # By default simulate a fresh boot with no leftover port reservation unit:
-    # the first GetUnit call (stale-unit cleanup check) raises NoSuchUnit, and
-    # every later GetUnit call (waiting for the freshly-started unit, then the
-    # real release before Core starts) succeeds. Sized generously since a
-    # single reservation cycle makes 3 GetUnit calls.
+    # By default simulate a fresh boot with no leftover port reservation
+    # units: the socket and paired service unit are each checked once during
+    # stale-unit cleanup (both raise NoSuchUnit), then the socket unit is
+    # checked again while waiting for it to come up, then both units are
+    # checked again during the real release before Core starts. Sized
+    # generously since a single reservation cycle makes several GetUnit
+    # calls across both units.
     systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
     systemd_service.response_get_unit = [
         DBusError(DBUS_ERR_SYSTEMD_NO_SUCH_UNIT, "no such unit"),
-    ] + [SystemdService.response_get_unit] * 10
+        DBusError(DBUS_ERR_SYSTEMD_NO_SUCH_UNIT, "no such unit"),
+    ] + [SystemdService.response_get_unit] * 20
     # Link the unit mock so Start/StopUnit calls flip its ActiveState the
     # same way real systemd would, letting wait_for_active_state resolve
     # immediately instead of waiting on a signal that never comes.
@@ -483,25 +495,41 @@ def core_start_base_mocks(
         yield
 
 
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("0.0.0.0", "0.0.0.0:8123"),
+        ("192.0.2.1", "192.0.2.1:8123"),
+        ("::", "[::]:8123"),
+        ("2001:db8::1", "[2001:db8::1]:8123"),
+    ],
+)
+def test_format_bind_address(host: str, expected: str) -> None:
+    """IPv6 addresses must be bracketed for systemd's Listen directive."""
+    assert _format_bind_address(host, 8123) == expected
+
+
 @pytest.mark.usefixtures("core_start_base_mocks")
 @pytest.mark.parametrize(
-    ("http_server_host", "expected_bind_host"),
+    ("http_server_host", "expected_listen"),
     [
-        (None, "0.0.0.0"),
-        (["192.0.2.1", "0.0.0.0"], "192.0.2.1"),
+        (None, ["0.0.0.0:8123", "[::]:8123"]),
+        (["192.0.2.1", "0.0.0.0"], ["192.0.2.1:8123", "0.0.0.0:8123"]),
+        (["::"], ["[::]:8123"]),
     ],
-    ids=["no_server_host", "with_server_host"],
+    ids=["no_server_host", "with_server_host", "ipv6_only"],
 )
 async def test_start_reserves_core_port(
     coresys: CoreSys,
     all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
     http_server_host: list[str] | None,
-    expected_bind_host: str,
+    expected_listen: list[str],
 ):
-    """On fresh boot, Core's port is reserved using the correct bind address.
+    """On fresh boot, Core's port is reserved on every configured bind address.
 
-    When http_server_host is None the reservation falls back to 0.0.0.0;
-    when it is set the first listed host is used.
+    When http_server_host is None the reservation falls back to protecting
+    both 0.0.0.0 and :: (both address families); when it is set, every listed
+    host is reserved, not just the first one.
     """
     coresys.homeassistant.http_server_host = http_server_host
     assert coresys.homeassistant.api_port == 8123
@@ -512,17 +540,28 @@ async def test_start_reserves_core_port(
 
     await coresys.core.start()
 
-    # A transient socket unit must be created listening on the right address
+    # A transient socket unit must be created listening on every address
     assert len(systemd_service.StartTransientUnit.calls) == 1
-    unit_name, mode, properties, _aux = systemd_service.StartTransientUnit.calls[0]
+    unit_name, mode, properties, aux = systemd_service.StartTransientUnit.calls[0]
     assert unit_name == _PORT_RESERVE_UNIT
     assert mode == "replace"
-    assert ("Listen", Variant("a(ss)", [("Stream", f"{expected_bind_host}:8123")])) in (
-        properties
+    listen_property = next(value for key, value in properties if key == "Listen")
+    assert listen_property == Variant(
+        "a(ss)", [("Stream", entry) for entry in expected_listen]
     )
+
+    # The socket must be paired atomically with a holder service, or the
+    # first incoming connection during boot would tear the reservation down
+    assert len(aux) == 1
+    service_name, service_properties = aux[0]
+    assert service_name == _PORT_RESERVE_SERVICE
+    service_properties_dict = dict(service_properties)
+    assert service_properties_dict["Type"] == Variant("s", "oneshot")
+    assert service_properties_dict["RemainAfterExit"] == Variant("b", True)
 
     # Reservation must be released before Core starts
     assert (_PORT_RESERVE_UNIT, "replace") in systemd_service.StopUnit.calls
+    assert (_PORT_RESERVE_SERVICE, "replace") in systemd_service.StopUnit.calls
 
     # Core must have started
     coresys.homeassistant.core.start.assert_awaited_once()
@@ -546,14 +585,15 @@ async def test_start_port_held_during_app_boot_released_before_core_start(
     orig_reserve = coresys.core._reserve_core_port
     orig_release = coresys.core._release_core_port
 
-    async def tracking_reserve(host: str, port: int) -> bool:
-        result = await orig_reserve(host, port)
+    async def tracking_reserve(hosts: list[str], port: int) -> bool:
+        result = await orig_reserve(hosts, port)
         call_sequence.append("port_reserved")
         return result
 
-    async def tracking_release() -> None:
-        await orig_release()
+    async def tracking_release() -> bool:
+        result = await orig_release()
         call_sequence.append("port_released")
+        return result
 
     async def tracking_boot(stage: AppStartup) -> None:
         call_sequence.append(f"boot:{stage}")
@@ -628,6 +668,37 @@ async def test_start_continues_when_port_reservation_fails(
 
 
 @pytest.mark.usefixtures("core_start_base_mocks")
+async def test_start_still_starts_core_when_release_not_confirmed(
+    coresys: CoreSys,
+):
+    """Core is still started even if the reservation release can't be confirmed.
+
+    Core's port is only used for its own API/frontend bind, so failing to
+    confirm the release must never stop Core from starting -- worst case
+    Core just logs and retries the bind itself, which beats leaving users
+    without a running Core at all.
+    """
+    coresys.homeassistant.http_server_host = None
+
+    orig_release = coresys.core._release_core_port
+    release_calls = 0
+
+    async def flaky_release() -> bool:
+        nonlocal release_calls
+        release_calls += 1
+        if release_calls == 1:
+            # Pre-cleanup release inside _reserve_core_port succeeds normally
+            return await orig_release()
+        # The real release before Core starts can't be confirmed
+        return False
+
+    with patch.object(coresys.core, "_release_core_port", side_effect=flaky_release):
+        await coresys.core.start()
+
+    coresys.homeassistant.core.start.assert_awaited_once()
+
+
+@pytest.mark.usefixtures("core_start_base_mocks")
 async def test_start_cleans_up_stale_active_unit_before_reserving(
     coresys: CoreSys,
     all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
@@ -679,14 +750,33 @@ async def test_release_core_port_resets_failed_unit(
     # Simulate a unit that is FAILED and stays that way: StopUnit's mock
     # unconditionally flips a *linked* unit to INACTIVE, so leave it unlinked
     # and set the state directly instead, matching a real FAILED unit that
-    # ignores a stop request.
+    # ignores a stop request. ResetFailedUnit is also a no-op when unlinked,
+    # so the unit never actually clears -- release can't be confirmed.
     systemd_service.response_get_unit = SystemdService.response_get_unit
     systemd_unit_service.active_state = "failed"
 
-    await coresys.core._release_core_port()
+    result = await coresys.core._release_core_port()
 
+    assert result is False
     assert (_PORT_RESERVE_UNIT, "replace") in systemd_service.StopUnit.calls
     assert (_PORT_RESERVE_UNIT,) in systemd_service.ResetFailedUnit.calls
+
+
+async def test_release_core_port_confirms_success_when_unit_goes_inactive(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+):
+    """Releasing returns True once both units are confirmed INACTIVE."""
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
+
+    systemd_service.response_get_unit = SystemdService.response_get_unit
+    systemd_service.mock_systemd_unit = systemd_unit_service
+    systemd_unit_service.active_state = "active"
+
+    result = await coresys.core._release_core_port()
+
+    assert result is True
 
 
 async def test_reserve_core_port_skips_when_dbus_not_connected(
@@ -698,7 +788,7 @@ async def test_reserve_core_port_skips_when_dbus_not_connected(
     systemd_service.StartTransientUnit.calls.clear()
 
     with patch.object(coresys.dbus.systemd, "dbus", None):
-        result = await coresys.core._reserve_core_port("0.0.0.0", 8123)
+        result = await coresys.core._reserve_core_port(["0.0.0.0"], 8123)
 
     assert result is False
     assert systemd_service.StartTransientUnit.calls == []
@@ -708,13 +798,14 @@ async def test_release_core_port_skips_when_dbus_not_connected(
     coresys: CoreSys,
     all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
 ):
-    """Releasing is a no-op if systemd D-Bus is not connected."""
+    """Releasing is a cheap no-op (confirmed released) if systemd D-Bus is not connected."""
     systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_service.StopUnit.calls.clear()
 
     with patch.object(coresys.dbus.systemd, "dbus", None):
-        await coresys.core._release_core_port()
+        result = await coresys.core._release_core_port()
 
+    assert result is True
     assert systemd_service.StopUnit.calls == []
 
 
@@ -731,13 +822,72 @@ async def test_reserve_core_port_returns_false_when_unit_ends_up_failed(
     systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_unit_service: SystemdUnitService = all_dbus_services["systemd_unit"]
 
-    # Leave mock_systemd_unit unlinked so StartTransientUnit's mock doesn't
-    # overwrite ActiveState back to "active" after we set it.
-    systemd_service.response_get_unit = SystemdService.response_get_unit
+    # First two GetUnit calls are the pre-cleanup check (one per unit) on a
+    # clean/fresh boot -- neither exists yet. The next GetUnit call is the
+    # post-creation poll for the newly created socket unit, which ends up
+    # FAILED rather than ACTIVE. Leave mock_systemd_unit unlinked so
+    # StartTransientUnit's mock doesn't overwrite ActiveState back to
+    # "active" after we set it.
+    systemd_service.response_get_unit = [
+        DBusError(DBUS_ERR_SYSTEMD_NO_SUCH_UNIT, "no such unit"),
+        DBusError(DBUS_ERR_SYSTEMD_NO_SUCH_UNIT, "no such unit"),
+    ] + [SystemdService.response_get_unit] * 5
     systemd_unit_service.active_state = "failed"
     systemd_service.StartTransientUnit.calls.clear()
 
-    result = await coresys.core._reserve_core_port("0.0.0.0", 8123)
+    result = await coresys.core._reserve_core_port(["0.0.0.0"], 8123)
 
     assert result is False
     assert len(systemd_service.StartTransientUnit.calls) == 1
+
+
+async def test_reserve_core_port_handles_dbus_disconnect_mid_call(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+):
+    """A mid-call D-Bus disconnect is treated as a non-fatal reservation failure.
+
+    DBusNotConnectedError is not a DBusError subclass -- it's raised directly
+    by the dbus_connected decorator when the bus drops after the initial
+    is_connected check passed -- so it must be caught via the broader
+    HassioError, or it would propagate and abort Supervisor startup.
+    """
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    # Pre-cleanup finds nothing on both units (clean/fresh boot); the
+    # disconnect happens on the create attempt itself.
+    systemd_service.response_get_unit = DBusError(
+        DBUS_ERR_SYSTEMD_NO_SUCH_UNIT, "no such unit"
+    )
+
+    with patch.object(
+        coresys.dbus.systemd,
+        "start_transient_unit",
+        side_effect=DBusNotConnectedError(),
+    ):
+        result = await coresys.core._reserve_core_port(["0.0.0.0"], 8123)
+
+    assert result is False
+
+
+async def test_release_core_port_handles_dbus_disconnect_mid_call(
+    coresys: CoreSys,
+    all_dbus_services: dict[str, DBusServiceMock | dict[str, DBusServiceMock]],
+):
+    """A mid-call D-Bus disconnect while stopping a unit does not propagate."""
+    systemd_service: SystemdService = all_dbus_services["systemd"]
+    systemd_service.response_get_unit = SystemdService.response_get_unit
+
+    # mock_systemd_unit is left unlinked, so the unit's ActiveState never
+    # actually moves off the "active" default -- shorten the wait so the
+    # test doesn't block for the real _PORT_RESERVE_TIMEOUT (10s).
+    with (
+        patch("supervisor.core._PORT_RESERVE_TIMEOUT", 0.01),
+        patch.object(
+            coresys.dbus.systemd,
+            "stop_unit",
+            side_effect=DBusNotConnectedError(),
+        ),
+    ):
+        result = await coresys.core._release_core_port()
+
+    assert result is False

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -513,9 +513,9 @@ def test_format_bind_address(host: str, expected: str) -> None:
 @pytest.mark.parametrize(
     ("http_server_host", "expected_listen"),
     [
-        (None, ["0.0.0.0:8123", "[::]:8123"]),
-        (["192.0.2.1", "0.0.0.0"], ["192.0.2.1:8123", "0.0.0.0:8123"]),
-        (["::"], ["[::]:8123"]),
+        (None, ["0.0.0.0:80", "[::]:80"]),
+        (["192.0.2.1", "0.0.0.0"], ["192.0.2.1:80", "0.0.0.0:80"]),
+        (["::"], ["[::]:80"]),
     ],
     ids=["no_server_host", "with_server_host", "ipv6_only"],
 )
@@ -532,7 +532,7 @@ async def test_start_reserves_core_port(
     host is reserved, not just the first one.
     """
     coresys.homeassistant.http_server_host = http_server_host
-    assert coresys.homeassistant.api_port == 8123
+    assert coresys.homeassistant.api_port == 80
 
     systemd_service: SystemdService = all_dbus_services["systemd"]
     systemd_service.StartTransientUnit.calls.clear()
@@ -549,6 +549,10 @@ async def test_start_reserves_core_port(
     assert listen_property == Variant(
         "a(ss)", [("Stream", entry) for entry in expected_listen]
     )
+    ipv6_only_property = next(
+        value for key, value in properties if key == "BindIPv6Only"
+    )
+    assert ipv6_only_property == Variant("s", "ipv6-only")
 
     # The socket must be paired atomically with a holder service, or the
     # first incoming connection during boot would tear the reservation down


### PR DESCRIPTION
## Proposed change

On a fresh system boot, Home Assistant Core and apps with `startup: system` or `startup: services` start in sequence before Core. Core runs with `--network host` and binds directly in the host network namespace. If an app claims Core's HTTP port (default 8123) before Core starts, Core fails to start entirely, leaving the user with no UI and no way to fix the situation without terminal access.

This change reserves Core's port in the host network namespace before any pre-Core apps are started, so that a conflicting app is the one that fails (surfacing the existing `APP_PORT_CONFLICT` issue/suggestion) rather than Core.

Because Supervisor runs on the `hassio` bridge network — not the host network namespace — a simple `socket.bind()` in Supervisor's own Python process is invisible to the host. The reservation is instead implemented by asking the host's systemd (over D-Bus, already a hard Supervisor dependency) to create a transient `.socket` unit (`hassio-port-reserve.socket`) listening on every configured bind address for Core's port (defaulting to both `0.0.0.0` and `::` if unset). Systemd binds the socket itself as part of activating the unit — no process or container is involved, and waiting for the unit to become active guarantees the bind has already happened before boot continues. The socket is paired atomically with a trivial oneshot `.service` unit (`hassio-port-reserve.service`, kept "active (exited)" via `RemainAfterExit`) so systemd always has a real activation target — without one, the first incoming connection attempt during boot would make systemd fail to activate a (nonexistent) service and tear the socket back down, silently releasing the reservation.

Both units are stopped right before Core is started so Core can claim the port itself. This release is attempted with retries and confirmed via the units' actual state rather than trusting a wait timeout, but it is still best-effort: Core is always started regardless of whether the release could be confirmed, since the reserved port only guards Core's own API/frontend bind — if Core can't claim it right away it just logs and keeps retrying the bind itself, which is far better than not starting Core at all (the single most critical piece of this orchestration).

On Supervisor restart (Core already running), no unit is created. If a previous Supervisor crash left a unit behind, it's detected and cleaned up (stopped, and reset if it ended up in a failed state) before a new one is created, since systemd refuses to redefine a transient unit that's still loaded under the same name.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #6790
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

### Design notes

- The reservation is best-effort: if systemd D-Bus isn't connected or the unit can't be created for any reason, reservation is skipped with a warning and boot continues unprotected, rather than blocking boot on a failed reservation.
- No container or subprocess is spun up, so there's no added boot latency and nothing visible in `docker ps` during boot.
- Waiting for the unit to reach the `active` state before continuing closes the race window a subprocess/container based approach would have — the bind is confirmed to have already happened by the time boot proceeds.
- Starting Home Assistant Core is never skipped because of this feature. The port reservation only protects Core's own bind; Core itself already handles and retries a failed bind, so the worst case of an unconfirmed release is a delayed UI, not a Supervisor that refuses to start Core.

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/supervisor/development)
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works
