### PR TITLE
Parse image references using Docker's domain splitting logic

### DIFF
--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -56,7 +56,7 @@ from .manager import CommandReturn, ExecReturn, PullLogEntry
 from .monitor import DockerContainerStateEvent
 from .pull_progress import ImagePullProgress
 from .stats import DockerStats
-from .utils import get_registry_from_image
+from .utils import get_registry_from_image, split_docker_domain, split_image_tag
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -167,7 +167,7 @@ class DockerInterface(JobGroup, ABC):
     def image(self) -> str | None:
         """Return name of Docker image."""
         try:
-            return self.meta_config["Image"].partition(":")[0]
+            return split_image_tag(self.meta_config["Image"])[0]
         except KeyError:
             return None
 
@@ -227,9 +227,11 @@ class DockerInterface(JobGroup, ABC):
             # prefix (e.g. "homeassistant/foo" instead of "docker.io/homeassistant/foo").
             # aiodocker derives ServerAddress from image.partition("/"), so without
             # the prefix it would use the namespace ("homeassistant") as ServerAddress,
-            # which Docker's containerd resolver rejects as a host mismatch.
+            # which Docker's containerd resolver rejects as a host mismatch. Qualify
+            # the remainder so an image which already carries a Docker Hub domain
+            # does not end up with a doubled prefix.
             if registry in (DOCKER_HUB, DOCKER_HUB_LEGACY):
-                qualified_image = f"{DOCKER_HUB}/{image}"
+                qualified_image = f"{DOCKER_HUB}/{split_docker_domain(image)[1]}"
 
             _LOGGER.info(
                 "Using stored registry credentials for %s (user: %s) to pull %s",
@@ -711,7 +713,9 @@ class DockerInterface(JobGroup, ABC):
                 filters={"reference": [self.image]}
             ):
                 for tag in image["RepoTags"]:
-                    version = AwesomeVersion(tag.partition(":")[2])
+                    if (image_tag := split_image_tag(tag)[1]) is None:
+                        continue
+                    version = AwesomeVersion(image_tag)
                     if version.strategy == AwesomeVersionStrategy.UNKNOWN:
                         continue
                     available_version.append(version)

--- a/supervisor/docker/manager.py
+++ b/supervisor/docker/manager.py
@@ -249,16 +249,14 @@ class DockerConfig(FileConfiguration):
 
         # Check if image uses a custom registry (e.g., ghcr.io/org/image)
         registry = get_registry_from_image(image)
-        if registry:
-            if registry in self.registries:
-                return registry
-        else:
-            # No registry prefix means Docker Hub
-            # Support both docker.io (official) and hub.docker.com (legacy)
-            if DOCKER_HUB in self.registries:
-                return DOCKER_HUB
-            if DOCKER_HUB_LEGACY in self.registries:
-                return DOCKER_HUB_LEGACY
+        if registry and registry != DOCKER_HUB:
+            return registry if registry in self.registries else None
+
+        # No registry prefix or an explicit Docker Hub domain
+        # Support both docker.io (official) and hub.docker.com (legacy)
+        for hub_registry in (DOCKER_HUB, DOCKER_HUB_LEGACY):
+            if hub_registry in self.registries:
+                return hub_registry
 
         return None
 

--- a/supervisor/docker/manifest.py
+++ b/supervisor/docker/manifest.py
@@ -59,7 +59,7 @@ def parse_image_reference(image: str, tag: str) -> tuple[str, str, str]:
     # Split off the registry host if the image reference has one
     domain, repository = split_docker_domain(image)
     registry = domain or DOCKER_HUB
-    if not domain and "/" not in repository:
+    if registry == DOCKER_HUB and "/" not in repository:
         # Docker Hub requires "library/" prefix for official images
         repository = f"library/{repository}"
 

--- a/supervisor/docker/manifest.py
+++ b/supervisor/docker/manifest.py
@@ -13,9 +13,8 @@ from typing import TYPE_CHECKING
 
 import aiohttp
 
-from supervisor.docker.utils import get_registry_from_image
-
 from .const import DOCKER_HUB, DOCKER_HUB_API, DOCKER_HUB_LEGACY
+from .utils import split_docker_domain
 
 if TYPE_CHECKING:
     from ..coresys import CoreSys
@@ -57,16 +56,12 @@ def parse_image_reference(image: str, tag: str) -> tuple[str, str, str]:
             -> (registry-1.docker.io, library/alpine, 3.18)
 
     """
-    # Check if image has explicit registry host
-    registry = get_registry_from_image(image)
-    if registry:
-        repository = image[len(registry) + 1 :]  # Remove "registry/" prefix
-    else:
-        registry = DOCKER_HUB
-        repository = image
+    # Split off the registry host if the image reference has one
+    domain, repository = split_docker_domain(image)
+    registry = domain or DOCKER_HUB
+    if not domain and "/" not in repository:
         # Docker Hub requires "library/" prefix for official images
-        if "/" not in repository:
-            repository = f"library/{repository}"
+        repository = f"library/{repository}"
 
     return registry, repository, tag
 

--- a/supervisor/docker/supervisor.py
+++ b/supervisor/docker/supervisor.py
@@ -13,6 +13,7 @@ from ..jobs.const import JobConcurrency
 from ..jobs.decorator import Job
 from .const import PropagationMode
 from .interface import DockerInterface
+from .utils import split_image_tag
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -168,8 +169,8 @@ class DockerSupervisor(DockerInterface):
                 if tag == "<none>:<none>":
                     continue
 
-                start_image = tag.partition(":")[0]
-                start_tag = tag.partition(":")[2] or "latest"
+                start_image, image_tag = split_image_tag(tag)
+                start_tag = image_tag or "latest"
 
                 # If version tag
                 if start_tag != "latest":

--- a/supervisor/docker/utils.py
+++ b/supervisor/docker/utils.py
@@ -4,54 +4,102 @@ from __future__ import annotations
 
 import re
 
-# Docker image reference domain regex
-# Based on Docker's reference implementation:
-# vendor/github.com/distribution/reference/normalize.go
+from .const import DOCKER_HUB
+
+# Docker's legacy default registry domain, canonicalized to DOCKER_HUB
+LEGACY_DEFAULT_DOMAIN = "index.docker.io"
+# Reserved namespace which is always treated as a registry domain
+LOCALHOST_DOMAIN = "localhost"
+
+# Registry domain of an image reference, covering domain names, IPv6 addresses
+# and an optional port.
 #
-# A domain is detected if the part before the first / contains:
-# - "localhost" (with optional port)
-# - Contains "." (like registry.example.com or 127.0.0.1)
-# - Contains ":" (like myregistry:5000)
-# - IPv6 addresses in brackets (like [::1]:5000)
-#
-# Note: Docker also treats uppercase letters as registry indicators since
-# namespaces must be lowercase, but this regex handles lowercase matching
-# and the get_registry_from_image() function validates the registry rules.
-IMAGE_REGISTRY_REGEX = re.compile(
-    r"^(?P<registry>"
-    r"localhost(?::[0-9]+)?|"  # localhost with optional port
-    r"(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])"  # domain component
-    r"(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))*"  # more components
-    r"(?::[0-9]+)?|"  # optional port
-    r"\[[a-fA-F0-9:]+\](?::[0-9]+)?"  # IPv6 with optional port
-    r")/"  # must be followed by /
+# Port of DomainRegexp from Docker's reference implementation:
+# https://github.com/distribution/reference/blob/main/regexp.go
+_DOMAIN_NAME_COMPONENT = r"(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])"
+_IPV6_ADDRESS = r"\[(?:[a-fA-F0-9:]+)\]"
+IMAGE_DOMAIN_REGEX = re.compile(
+    rf"(?:{_DOMAIN_NAME_COMPONENT}(?:\.{_DOMAIN_NAME_COMPONENT})*|{_IPV6_ADDRESS})"
+    r"(?::[0-9]+)?"
 )
 
 
-def get_registry_from_image(image_ref: str) -> str | None:
-    """Extract registry from Docker image reference.
+def split_docker_domain(image_ref: str) -> tuple[str | None, str]:
+    """Split a Docker image reference into registry domain and remainder.
 
-    Returns the registry if the image reference contains one,
-    or None if the image uses Docker Hub (docker.io).
+    Returns None as the domain for images without an explicit registry, which
+    are hosted on Docker Hub. The domain is not validated, use
+    is_registry_domain() for that.
 
-    Based on Docker's reference implementation:
-    vendor/github.com/distribution/reference/normalize.go
+    Port of splitDockerDomain() from Docker's reference implementation:
+    https://github.com/distribution/reference/blob/main/normalize.go
 
     Examples:
-        get_registry_from_image("nginx")                        -> None (docker.io)
-        get_registry_from_image("library/nginx")                -> None (docker.io)
-        get_registry_from_image("myregistry.com/nginx")         -> "myregistry.com"
-        get_registry_from_image("localhost/myimage")            -> "localhost"
-        get_registry_from_image("localhost:5000/myimage")       -> "localhost:5000"
-        get_registry_from_image("registry.io:5000/org/app:v1")  -> "registry.io:5000"
-        get_registry_from_image("[::1]:5000/myimage")           -> "[::1]:5000"
+        split_docker_domain("nginx")               -> (None, "nginx")
+        split_docker_domain("library/nginx")       -> (None, "library/nginx")
+        split_docker_domain("ghcr.io/org/app:v1")  -> ("ghcr.io", "org/app:v1")
+        split_docker_domain("localhost/myimage")   -> ("localhost", "myimage")
+        split_docker_domain("myregistry:5000/app") -> ("myregistry:5000", "app")
+        split_docker_domain("[::1]:5000/myimage")  -> ("[::1]:5000", "myimage")
+        split_docker_domain("index.docker.io/a/b") -> ("docker.io", "a/b")
 
     """
-    match = IMAGE_REGISTRY_REGEX.match(image_ref)
-    if match:
-        registry = match.group("registry")
-        # Must contain '.' or ':' or be 'localhost' to be a real registry
-        # This prevents treating "myuser/myimage" as having registry "myuser"
-        if "." in registry or ":" in registry or registry == "localhost":
-            return registry
-    return None  # No registry = Docker Hub (docker.io)
+    maybe_domain, separator, maybe_remainder = image_ref.partition("/")
+    if not separator:
+        # Single element like "nginx" is never a domain
+        return None, image_ref
+
+    if maybe_domain == LEGACY_DEFAULT_DOMAIN:
+        # Canonicalize the legacy Docker Hub domain
+        return DOCKER_HUB, maybe_remainder
+
+    if (
+        # localhost is a reserved namespace and always considered a domain
+        maybe_domain == LOCALHOST_DOMAIN
+        # A dot or colon means a domain, covering ports, IPv4 and IPv6 as well
+        or "." in maybe_domain
+        or ":" in maybe_domain
+        # Uppercase is not allowed in a path component, so it must be a domain
+        or maybe_domain.lower() != maybe_domain
+    ):
+        return maybe_domain, maybe_remainder
+
+    return None, image_ref
+
+
+def is_registry_domain(domain: str) -> bool:
+    """Return True if the domain is a well-formed registry domain."""
+    return IMAGE_DOMAIN_REGEX.fullmatch(domain) is not None
+
+
+def get_registry_from_image(image_ref: str) -> str | None:
+    """Return the registry of a Docker image reference.
+
+    Returns None if the image reference has no registry, meaning it is hosted
+    on Docker Hub.
+    """
+    return split_docker_domain(image_ref)[0]
+
+
+def split_image_tag(image_ref: str) -> tuple[str, str | None]:
+    """Split a Docker image reference into image name and tag.
+
+    A colon only separates the tag if no slash follows it, which keeps the port
+    of a registry (e.g. "myregistry:5000/nginx") part of the image name. This
+    mirrors Docker's TagRegexp, which does not allow a slash in a tag. Any
+    digest is stripped along with the tag.
+
+    Examples:
+        split_image_tag("nginx")                   -> ("nginx", None)
+        split_image_tag("nginx:latest")            -> ("nginx", "latest")
+        split_image_tag("myregistry:5000/nginx")   -> ("myregistry:5000/nginx", None)
+        split_image_tag("registry.io:5000/app:v1") -> ("registry.io:5000/app", "v1")
+        split_image_tag("[::1]:5000/myimage")      -> ("[::1]:5000/myimage", None)
+        split_image_tag("nginx@sha256:1234")       -> ("nginx", None)
+
+    """
+    image_ref = image_ref.partition("@")[0]
+    name, separator, tag = image_ref.rpartition(":")
+    if not separator or "/" in tag:
+        return image_ref, None
+    return name, tag

--- a/supervisor/resolution/evaluations/container.py
+++ b/supervisor/resolution/evaluations/container.py
@@ -8,6 +8,7 @@ import aiodocker
 from ...const import CoreState
 from ...coresys import CoreSys
 from ...docker.const import ADDON_BUILDER_IMAGE
+from ...docker.utils import split_image_tag
 from ..const import (
     ContextType,
     IssueType,
@@ -96,7 +97,7 @@ class EvaluateContainer(EvaluateBase):
         for image in images:
             self.sys_resolution.evaluate.cached_images.add(image)
 
-            image_name = image.partition(":")[0]
+            image_name = split_image_tag(image)[0]
             if image_name not in IGNORE_IMAGES and image_name not in self.known_images:
                 self._images.add(image_name)
                 if any(

--- a/supervisor/validate.py
+++ b/supervisor/validate.py
@@ -55,7 +55,7 @@ from .const import (
     LogLevel,
     UpdateChannel,
 )
-from .docker.utils import get_registry_from_image
+from .docker.utils import is_registry_domain, split_docker_domain
 from .utils.validate import validate_timezone
 
 # Move to store.validate when addons_repository config removed
@@ -74,20 +74,19 @@ def docker_image(image: str) -> str:
     """Validate a Docker image name without tag.
 
     Tags are not allowed as the version/tag is managed separately.
-    Uses IMAGE_REGISTRY_REGEX from docker.utils for robust registry detection.
     """
     if not image or not isinstance(image, str):
         raise vol.Invalid(f"Expected a non-empty string for docker image, got: {image}")
 
-    # Extract registry if present (handles domains, IPv4/IPv6, ports, localhost)
-    registry = get_registry_from_image(image)
+    # Split off the registry if present (handles domains, IPv4/IPv6, ports,
+    # localhost) to validate the remaining image path components
+    registry, path = split_docker_domain(image)
     if registry:
         # Registry must be lowercase
         if registry != registry.lower():
             raise vol.Invalid(f"Docker image registry must be lowercase: {image}")
-        path = image[len(registry) + 1 :]  # Remove "registry/" prefix
-    else:
-        path = image
+        if not is_registry_domain(registry):
+            raise vol.Invalid(f"Invalid Docker image registry '{registry}' in: {image}")
 
     if not path:
         raise vol.Invalid(f"Docker image has no name: {image}")

--- a/tests/docker/test_credentials.py
+++ b/tests/docker/test_credentials.py
@@ -1,5 +1,7 @@
 """Test docker login."""
 
+import pytest
+
 # pylint: disable=protected-access
 from supervisor.coresys import CoreSys
 from supervisor.docker.const import DOCKER_HUB, DOCKER_HUB_LEGACY
@@ -78,21 +80,35 @@ def test_legacy_docker_hub_credentials(
     assert image == f"{DOCKER_HUB}/homeassistant/amd64-supervisor"
 
 
-def test_explicit_docker_hub_domain_not_doubled(
-    coresys: CoreSys, test_docker_interface: DockerInterface
-):
-    """Test an image already carrying a Docker Hub domain is not prefixed twice."""
-    coresys.docker.config._data["registries"] = {
-        DOCKER_HUB: {"username": "Spongebob Squarepants", "password": "Password1!"},
-    }
-
-    for image in (
+@pytest.mark.parametrize("registry_key", [DOCKER_HUB, DOCKER_HUB_LEGACY])
+@pytest.mark.parametrize(
+    "image",
+    [
+        "homeassistant/amd64-supervisor",
         f"{DOCKER_HUB}/homeassistant/amd64-supervisor",
         "index.docker.io/homeassistant/amd64-supervisor",
-    ):
-        credentials, qualified_image = test_docker_interface._get_credentials(image)
-        assert credentials["registry"] == DOCKER_HUB
-        assert qualified_image == f"{DOCKER_HUB}/homeassistant/amd64-supervisor"
+    ],
+)
+def test_docker_hub_image_qualified_once(
+    coresys: CoreSys,
+    test_docker_interface: DockerInterface,
+    registry_key: str,
+    image: str,
+):
+    """Test a Docker Hub image gets exactly one docker.io prefix to pull with.
+
+    Applies to references without a domain and to both Docker Hub domains, with
+    credentials stored under either the official or the legacy registry key.
+    """
+    coresys.docker.config._data["registries"] = {
+        registry_key: {"username": "Spongebob Squarepants", "password": "Password1!"},
+    }
+
+    credentials, qualified_image = test_docker_interface._get_credentials(image)
+
+    assert credentials["username"] == "Spongebob Squarepants"
+    assert credentials["registry"] == registry_key
+    assert qualified_image == f"{DOCKER_HUB}/homeassistant/amd64-supervisor"
 
 
 def test_docker_hub_preferred_over_legacy(

--- a/tests/docker/test_credentials.py
+++ b/tests/docker/test_credentials.py
@@ -1,49 +1,9 @@
 """Test docker login."""
 
-import pytest
-
 # pylint: disable=protected-access
 from supervisor.coresys import CoreSys
 from supervisor.docker.const import DOCKER_HUB, DOCKER_HUB_LEGACY
 from supervisor.docker.interface import DockerInterface
-from supervisor.docker.utils import get_registry_from_image
-
-
-@pytest.mark.parametrize(
-    ("image_ref", "expected_registry"),
-    [
-        # No registry - Docker Hub images
-        ("nginx", None),
-        ("nginx:latest", None),
-        ("library/nginx", None),
-        ("library/nginx:latest", None),
-        ("homeassistant/amd64-supervisor", None),
-        ("homeassistant/amd64-supervisor:1.2.3", None),
-        # Registry with dot
-        ("ghcr.io/homeassistant/amd64-supervisor", "ghcr.io"),
-        ("ghcr.io/homeassistant/amd64-supervisor:latest", "ghcr.io"),
-        ("myregistry.com/nginx", "myregistry.com"),
-        ("registry.example.com/org/image:v1", "registry.example.com"),
-        ("127.0.0.1/myimage", "127.0.0.1"),
-        # Registry with port
-        ("myregistry:5000/myimage", "myregistry:5000"),
-        ("localhost:5000/myimage", "localhost:5000"),
-        ("registry.io:5000/org/app:v1", "registry.io:5000"),
-        # localhost special case
-        ("localhost/myimage", "localhost"),
-        ("localhost/myimage:tag", "localhost"),
-        # IPv6
-        ("[::1]:5000/myimage", "[::1]:5000"),
-        ("[2001:db8::1]:5000/myimage:tag", "[2001:db8::1]:5000"),
-    ],
-)
-def test_get_registry_from_image(image_ref: str, expected_registry: str | None):
-    """Test get_registry_from_image extracts registry from image reference.
-
-    Based on Docker's reference implementation:
-    vendor/github.com/distribution/reference/normalize.go
-    """
-    assert get_registry_from_image(image_ref) == expected_registry
 
 
 def test_no_credentials(coresys: CoreSys, test_docker_interface: DockerInterface):

--- a/tests/docker/test_credentials.py
+++ b/tests/docker/test_credentials.py
@@ -78,6 +78,23 @@ def test_legacy_docker_hub_credentials(
     assert image == f"{DOCKER_HUB}/homeassistant/amd64-supervisor"
 
 
+def test_explicit_docker_hub_domain_not_doubled(
+    coresys: CoreSys, test_docker_interface: DockerInterface
+):
+    """Test an image already carrying a Docker Hub domain is not prefixed twice."""
+    coresys.docker.config._data["registries"] = {
+        DOCKER_HUB: {"username": "Spongebob Squarepants", "password": "Password1!"},
+    }
+
+    for image in (
+        f"{DOCKER_HUB}/homeassistant/amd64-supervisor",
+        "index.docker.io/homeassistant/amd64-supervisor",
+    ):
+        credentials, qualified_image = test_docker_interface._get_credentials(image)
+        assert credentials["registry"] == DOCKER_HUB
+        assert qualified_image == f"{DOCKER_HUB}/homeassistant/amd64-supervisor"
+
+
 def test_docker_hub_preferred_over_legacy(
     coresys: CoreSys, test_docker_interface: DockerInterface
 ):

--- a/tests/docker/test_utils.py
+++ b/tests/docker/test_utils.py
@@ -1,0 +1,121 @@
+"""Test Docker utilities."""
+
+import pytest
+
+from supervisor.docker.const import DOCKER_HUB
+from supervisor.docker.utils import (
+    get_registry_from_image,
+    is_registry_domain,
+    split_docker_domain,
+    split_image_tag,
+)
+
+
+@pytest.mark.parametrize(
+    ("image_ref", "expected"),
+    [
+        # No registry, hosted on Docker Hub
+        ("nginx", (None, "nginx")),
+        ("nginx:latest", (None, "nginx:latest")),
+        ("library/nginx", (None, "library/nginx")),
+        ("homeassistant/amd64-supervisor", (None, "homeassistant/amd64-supervisor")),
+        # Registry with a dot
+        (
+            "ghcr.io/home-assistant/amd64-supervisor",
+            ("ghcr.io", "home-assistant/amd64-supervisor"),
+        ),
+        ("registry.example.com/org/image:v1", ("registry.example.com", "org/image:v1")),
+        ("127.0.0.1/myimage", ("127.0.0.1", "myimage")),
+        # Registry with a port
+        ("myregistry:5000/myimage", ("myregistry:5000", "myimage")),
+        ("registry.io:5000/org/app:v1", ("registry.io:5000", "org/app:v1")),
+        # localhost is a reserved namespace and always a registry
+        ("localhost/myimage", ("localhost", "myimage")),
+        ("localhost:5000/myimage:tag", ("localhost:5000", "myimage:tag")),
+        # IPv6 registry
+        ("[::1]:5000/myimage", ("[::1]:5000", "myimage")),
+        ("[2001:db8::1]:5000/myimage:tag", ("[2001:db8::1]:5000", "myimage:tag")),
+        # Legacy Docker Hub domain gets canonicalized
+        ("index.docker.io/library/nginx", (DOCKER_HUB, "library/nginx")),
+        # Uppercase is not allowed in a path component, so it is a registry
+        ("Foo/bar", ("Foo", "bar")),
+    ],
+)
+def test_split_docker_domain(image_ref: str, expected: tuple[str | None, str]):
+    """Test splitting an image reference into registry domain and remainder."""
+    assert split_docker_domain(image_ref) == expected
+
+
+def test_get_registry_from_image():
+    """Test get_registry_from_image returns only the registry domain."""
+    assert get_registry_from_image("ghcr.io/home-assistant/supervisor") == "ghcr.io"
+    assert get_registry_from_image("homeassistant/supervisor") is None
+    assert get_registry_from_image("index.docker.io/library/nginx") == DOCKER_HUB
+
+
+@pytest.mark.parametrize(
+    ("domain", "valid"),
+    [
+        ("ghcr.io", True),
+        ("registry.example.com", True),
+        ("myregistry:5000", True),
+        ("localhost", True),
+        ("localhost:5000", True),
+        ("127.0.0.1", True),
+        ("[::1]:5000", True),
+        ("[2001:db8::1]", True),
+        # Malformed domains
+        (".ghcr.io", False),
+        ("ghcr.io.", False),
+        ("-bad-.com", False),
+        ("bad-.com", False),
+        ("....", False),
+        ("ghcr.io:", False),
+        ("ghcr.io:port", False),
+        ("ghcr.io/org", False),
+    ],
+)
+def test_is_registry_domain(domain: str, valid: bool):
+    """Test validation of registry domains."""
+    assert is_registry_domain(domain) is valid
+
+
+@pytest.mark.parametrize(
+    ("image_ref", "expected"),
+    [
+        # No tag
+        ("nginx", ("nginx", None)),
+        ("library/nginx", ("library/nginx", None)),
+        (
+            "ghcr.io/home-assistant/amd64-supervisor",
+            ("ghcr.io/home-assistant/amd64-supervisor", None),
+        ),
+        # With tag
+        ("nginx:latest", ("nginx", "latest")),
+        (
+            "homeassistant/amd64-supervisor:1.2.3",
+            ("homeassistant/amd64-supervisor", "1.2.3"),
+        ),
+        # Registry with a port, the port must stay part of the image name
+        ("myregistry:5000/myimage", ("myregistry:5000/myimage", None)),
+        ("registry.io:5000/org/app:v1", ("registry.io:5000/org/app", "v1")),
+        (
+            "gitlab.example.com:5005/org/app/aarch64:0.3.3-dev1",
+            ("gitlab.example.com:5005/org/app/aarch64", "0.3.3-dev1"),
+        ),
+        # localhost with a port
+        ("localhost:5000/myimage", ("localhost:5000/myimage", None)),
+        ("localhost:5000/myimage:tag", ("localhost:5000/myimage", "tag")),
+        # IPv6 registry
+        ("[::1]:5000/myimage", ("[::1]:5000/myimage", None)),
+        ("[2001:db8::1]:5000/myimage:tag", ("[2001:db8::1]:5000/myimage", "tag")),
+        # Digests are stripped along with the tag
+        ("nginx@sha256:1234abcd", ("nginx", None)),
+        ("ghcr.io/org/app@sha256:1234abcd", ("ghcr.io/org/app", None)),
+        # A bare digest keeps its algorithm prefix as the name
+        ("sha256:1234abcd", ("sha256", "1234abcd")),
+    ],
+)
+def test_split_image_tag(image_ref: str, expected: tuple[str, str | None]):
+    """Test splitting an image reference into image name and tag."""
+    assert split_image_tag(image_ref) == expected

--- a/tests/resolution/evaluation/test_evaluate_container.py
+++ b/tests/resolution/evaluation/test_evaluate_container.py
@@ -1,7 +1,7 @@
 """Test evaluation base."""
 
 # pylint: disable=import-error,protected-access
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import aiodocker
 from aiodocker.containers import DockerContainer
@@ -53,6 +53,24 @@ async def test_evaluation(coresys: CoreSys):
     assert container.reason not in coresys.resolution.unsupported
 
     assert coresys.resolution.evaluate.cached_images == set()
+
+
+async def test_evaluation_registry_with_port(coresys: CoreSys):
+    """Test an app image from a registry with a port is not flagged unsupported."""
+    container = EvaluateContainer(coresys)
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    image = "gitlab.example.com:5005/home-assistant/addon-connector/aarch64"
+    with patch.object(
+        EvaluateContainer, "known_images", new=PropertyMock(return_value={image})
+    ):
+        coresys.docker.containers.list.return_value = [
+            _make_image_attr(f"{image}:0.3.3-dev1")
+        ]
+        await container()
+
+    assert container.reason not in coresys.resolution.unsupported
+    assert UnhealthyReason.DOCKER not in coresys.resolution.unhealthy
 
 
 async def test_corrupt_docker(coresys: CoreSys):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -33,6 +33,8 @@ IMAGE_NAME_GOOD = [
     "[::1]:5000/myimage",
     "dockeruser/nice-app-1.2",
     "ghcr.io/blakeblackshear/frigate",
+    "index.docker.io/homeassistant/amd64-homeassistant",
+    "[2001:db8::1]/myimage",
 ]
 IMAGE_NAME_BAD = [
     "ghcr.io/home-assistant/homeassistant:123",
@@ -43,6 +45,9 @@ IMAGE_NAME_BAD = [
     "homeassistant/_homeassistant",
     "homeassistant/-homeassistant",
     "GHCR.IO/home-assistant/homeassistant",
+    "myreg.local:8080/homeassistant:1.2.3",
+    "myreg.local:port/homeassistant",
+    "-badreg-.local/homeassistant",
 ]
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The unsupported container evaluation split an image reference on its first colon to strip the tag. For a registry with a port that colon belongs to the port, so `gitlab.example.com:5005/org/app/aarch64:0.3.3-dev1` was reduced to `gitlab.example.com` and reported as an unsupported image running on the host.

Splitting an image reference correctly requires knowing where the registry domain ends, and the pieces for that already existed but were wired up in a way that could not be reused. `IMAGE_REGISTRY_REGEX` is a port of Docker's `DomainRegexp`, which Docker uses to *validate* a domain rather than to *find* one. Putting it in front of the search meant `get_registry_from_image()` still had to re-derive the answer with the dot/colon/localhost checks that follow the match, and callers needing the rest of the reference recovered it by slicing off `len(registry) + 1` characters.

This splits the two jobs apart, following Docker's own reference implementation:

- `split_docker_domain()` finds the domain the way [`splitDockerDomain()`](https://github.com/distribution/reference/blob/main/normalize.go) does, by cutting at the first slash and testing the candidate. It returns the remainder too, so callers no longer slice by length. It also canonicalizes `index.docker.io` to `docker.io`, which lets stored Docker Hub credentials apply to references using the legacy domain.
- `is_registry_domain()` validates a domain against [`DomainRegexp`](https://github.com/distribution/reference/blob/main/regexp.go), which is what the regex is for. Image validation keeps rejecting malformed domains such as `.ghcr.io` through this check.
- `get_registry_from_image()` remains as a wrapper for the callers that only need the domain.

With the domain handled, splitting off the tag reduces to taking the last colon that has no slash after it, which is exactly what Docker's `TagRegexp` permits. `split_image_tag()` does that and drops any digest, so a digest-pinned image no longer reads as unsupported either.

Three further sites split an image reference on its first colon and are converted as well, since a registry with a port breaks them the same way:

- The `image` property of `DockerInterface` reported `myreg:5000/supervisor:1.0` as `myreg`, and a digest reference as `name@sha256`.
- `get_latest_version()` read the tag of a `RepoTags` entry, which for `myreg:5000/homeassistant:2026.8.0` yielded `5000/homeassistant:2026.8.0`. That is not a known version strategy, so every tag was skipped and the lookup failed with "No version found". This is reachable with a user-overridden Core image or a plugin image on a registry with a port.
- The Supervisor start tag repair took the image name from a `RepoTags` entry the same way, leaving `myreg` as the name to tag.

Two Docker Hub details now match `normalize.go` as well: the `library/` prefix for official images applies whenever the resolved registry is Docker Hub rather than only when the reference carried no domain, and credential lookup falls back to the legacy `hub.docker.com` key for an explicit Docker Hub domain as it already did for references without one. Qualifying a Docker Hub image for the auth header is done from the remainder, so a reference already carrying `docker.io/` or `index.docker.io/` no longer gains a second prefix.

The image reference tests move to `tests/docker/test_utils.py`, next to the code under test.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #7125
- This PR is related to issue: #7128 fixes the same report by splitting on the last colon unconditionally. That handles the reported case but turns an untagged `myregistry:5000/nginx` into name `myregistry` with tag `5000/nginx`; requiring that no slash follows the colon covers both. #6360 introduced the registry detection this builds on.
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
