### PR TITLE
Use store version's architecture when updating an app

### DIFF
--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -1057,7 +1057,11 @@ class App(AppModel):
         store = self.app_store.clone()
 
         try:
-            await self.instance.update(store.version, store.image, arch=self.arch)
+            # Use the store's architecture list to pick the image architecture. The
+            # installed version may not support any of the system's architectures
+            # anymore (e.g. after 32-bit support was dropped), while the new version
+            # does — availability of the store version was validated by the caller.
+            await self.instance.update(store.version, store.image, arch=store.arch)
         except DockerBuildError as err:
             _LOGGER.error("Could not build image for app %s: %s", self.slug, err)
             raise AppBuildFailedUnknownError(app=self.slug) from err

--- a/tests/apps/test_manager.py
+++ b/tests/apps/test_manager.py
@@ -13,7 +13,14 @@ import pytest
 from supervisor.apps.app import App
 from supervisor.arch import CpuArchManager
 from supervisor.config import CoreConfig
-from supervisor.const import ATTR_INGRESS, AppBoot, AppStartup, AppState, BusEvent
+from supervisor.const import (
+    ATTR_INGRESS,
+    AppBoot,
+    AppStartup,
+    AppState,
+    BusEvent,
+    CpuArch,
+)
 from supervisor.coresys import CoreSys
 from supervisor.docker.app import DockerApp
 from supervisor.docker.const import ContainerState
@@ -25,6 +32,7 @@ from supervisor.exceptions import (
     AppsError,
     DockerAPIError,
     DockerNotFound,
+    HassioArchNotFound,
 )
 from supervisor.plugins.dns import PluginDns
 from supervisor.resolution.const import (
@@ -342,6 +350,42 @@ async def test_update(
         start_task = await coresys.apps.update(TEST_ADDON_SLUG)
 
     assert bool(start_task) is (status == "running")
+
+
+@pytest.mark.usefixtures("tmp_supervisor_data", "path_extern")
+async def test_update_uses_store_architecture(
+    coresys: CoreSys,
+    install_app_ssh: App,
+    container: DockerContainer,
+):
+    """Test update uses the store version's architecture list to pick the image arch."""
+    container.show.return_value["State"]["Status"] = "stopped"
+    container.show.return_value["State"]["Running"] = False
+    install_app_ssh.path_data.mkdir()
+    await install_app_ssh.load()
+    with patch(
+        "supervisor.store.data.read_json_or_yaml_file",
+        return_value=load_json_fixture("app-config-add-image.json"),
+    ):
+        await coresys.store.data.update()
+
+    # Simulate an app installed when the system still supported 32-bit
+    # architectures: the installed version's arch list no longer matches
+    # any supported architecture, but the store version's does.
+    coresys.apps.data.system[TEST_ADDON_SLUG]["arch"] = ["armv7"]
+    with pytest.raises(HassioArchNotFound):
+        _ = install_app_ssh.arch
+
+    with (
+        patch.object(DockerInterface, "install") as install,
+        patch.object(DockerApp, "is_running", return_value=False),
+    ):
+        await coresys.apps.update(TEST_ADDON_SLUG)
+
+    install.assert_called_once_with(
+        AwesomeVersion("10.0.0"), "test/amd64-my-ssh-addon", False, CpuArch.AMD64
+    )
+    assert install_app_ssh.arch == CpuArch.AMD64
 
 
 @pytest.mark.parametrize("status", ["running", "stopped"])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`App.update()` passed `self.arch` to `DockerApp.update()`, which matches the system's supported architectures against the architecture list of the *installed* version. When the installed version no longer supports any of the system's architectures while the new store version does, this raised an unhandled `HassioArchNotFound`, surfacing as "Unexpected error during API call" (500) instead of performing the update.

This situation occurs in practice since 32-bit architectures were dropped (#6607): an app installed as 32-bit only on a 64-bit machine gets flagged by the `deprecated_arch_addon` repair, but once the store publishes a version that adds a supported architecture (e.g. RustDesk Server v0.2.2 adding amd64), updating to it crashed. The availability of the store version is already validated by the update job before this point, so the update itself is legitimate.

Use the cached store data's architecture list instead, which is also the semantically correct source since it describes the image being pulled. The other `arch=self.arch` call sites are unaffected: `install()` persists the store data before using `self.arch`, and the restore path uses the backup's data which matches the image being restored.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
