### PR TITLE
Surface fixup failures to the caller applying a suggestion

### DIFF
--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -1212,16 +1212,7 @@ class ResolutionNotFound(ResolutionError):
     """Raise if suggestion/issue was not found."""
 
 
-class ResolutionFixupError(APIError):
-    """Raise if a fixup fails."""
-
-    error_key = "resolution_fixup_error"
-    message_template = (
-        "Applying the suggestion failed. Check Supervisor logs for details"
-    )
-
-
-class ResolutionFixupJobError(ResolutionFixupError, JobException):
+class ResolutionFixupJobError(ResolutionError, JobException):
     """Raise on job error."""
 
 

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -1212,8 +1212,13 @@ class ResolutionNotFound(ResolutionError):
     """Raise if suggestion/issue was not found."""
 
 
-class ResolutionFixupError(HassioError):
+class ResolutionFixupError(APIError):
     """Raise if a fixup fails."""
+
+    error_key = "resolution_fixup_error"
+    message_template = (
+        "Applying the suggestion failed. Check Supervisor logs for details"
+    )
 
 
 class ResolutionFixupJobError(ResolutionFixupError, JobException):

--- a/supervisor/resolution/fixup.py
+++ b/supervisor/resolution/fixup.py
@@ -4,6 +4,7 @@ from importlib import import_module
 import logging
 
 from ..coresys import CoreSys, CoreSysAttributes
+from ..exceptions import HassioError
 from ..jobs.const import JobCondition
 from ..jobs.decorator import Job
 from ..utils.sentry import async_capture_exception
@@ -53,6 +54,10 @@ class ResolutionFixup(CoreSysAttributes):
                 continue
             try:
                 await fix()
+            except HassioError as err:
+                # Environmental/config failures — reported to Sentry at the
+                # raise site if warranted; here just log and continue
+                _LOGGER.warning("Error during processing %s: %s", fix.suggestion, err)
             except Exception as err:  # pylint: disable=broad-except
                 _LOGGER.warning("Error during processing %s: %s", fix.suggestion, err)
                 await async_capture_exception(err)

--- a/supervisor/resolution/fixup.py
+++ b/supervisor/resolution/fixup.py
@@ -15,6 +15,26 @@ from .validate import get_valid_modules
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
+async def apply_fixup_safely(
+    fix: FixupBase, suggestion: Suggestion | None = None
+) -> None:
+    """Apply a fixup without letting its failure propagate.
+
+    For the unattended paths (autofix, bus events): a HassioError is an
+    environmental/config failure — reported to Sentry at the raise site
+    if warranted, so just log it. Everything else is a Supervisor bug
+    and is captured. User-applied suggestions do not go through here;
+    their errors propagate to the API caller.
+    """
+    try:
+        await fix(suggestion)
+    except HassioError as err:
+        _LOGGER.warning("Error during processing %s: %s", fix.suggestion, err)
+    except Exception as err:  # pylint: disable=broad-except
+        _LOGGER.warning("Error during processing %s: %s", fix.suggestion, err)
+        await async_capture_exception(err)
+
+
 class ResolutionFixup(CoreSysAttributes):
     """Suggestion class for resolution."""
 
@@ -52,15 +72,7 @@ class ResolutionFixup(CoreSysAttributes):
         for fix in self.all_fixes:
             if not fix.auto:
                 continue
-            try:
-                await fix()
-            except HassioError as err:
-                # Environmental/config failures — reported to Sentry at the
-                # raise site if warranted; here just log and continue
-                _LOGGER.warning("Error during processing %s: %s", fix.suggestion, err)
-            except Exception as err:  # pylint: disable=broad-except
-                _LOGGER.warning("Error during processing %s: %s", fix.suggestion, err)
-                await async_capture_exception(err)
+            await apply_fixup_safely(fix)
 
         _LOGGER.info("System autofix complete")
 

--- a/supervisor/resolution/fixups/app_execute_remove.py
+++ b/supervisor/resolution/fixups/app_execute_remove.py
@@ -3,7 +3,6 @@
 import logging
 
 from ...coresys import CoreSys
-from ...exceptions import AppsError, ResolutionFixupError
 from ..const import ContextType, IssueType, SuggestionType
 from ..data import Suggestion
 from .base import FixupBase
@@ -30,11 +29,7 @@ class FixupAppExecuteRemove(FixupBase):
 
         # Remove app
         _LOGGER.info("Remove app: %s", suggestion.reference)
-        try:
-            await app.uninstall(remove_config=False)
-        except AppsError as err:
-            _LOGGER.error("Could not remove %s due to %s", suggestion.reference, err)
-            raise ResolutionFixupError from None
+        await app.uninstall(remove_config=False)
 
     @property
     def suggestion(self) -> SuggestionType:

--- a/supervisor/resolution/fixups/app_execute_repair.py
+++ b/supervisor/resolution/fixups/app_execute_repair.py
@@ -3,13 +3,6 @@
 import logging
 
 from ...coresys import CoreSys
-from ...exceptions import (
-    DockerBuildError,
-    DockerNoSpaceOnDevice,
-    DockerRegistryAuthError,
-    DockerRegistryRateLimitExceeded,
-    ResolutionFixupError,
-)
 from ..const import ContextType, IssueType, SuggestionType
 from ..data import Suggestion
 from .base import FixupBase
@@ -61,23 +54,13 @@ class FixupAppExecuteRepair(FixupBase):
             )
             return
 
+        # A failing install (broken Dockerfile or unavailable base/builder
+        # image; disk full; bad credentials; registry rate limit) propagates
+        # to the caller. The repair stays available for manual retry once
+        # the underlying cause is fixed.
         _LOGGER.info("Installing image for app %s", suggestion.reference)
         self.attempts += 1
-        try:
-            await app.instance.install(app.version)
-        except (
-            DockerBuildError,
-            DockerNoSpaceOnDevice,
-            DockerRegistryAuthError,
-            DockerRegistryRateLimitExceeded,
-        ) as err:
-            # These failures won't be resolved by an immediate retry (broken
-            # Dockerfile or unavailable base/builder image; disk full; bad
-            # credentials; registry rate limit). Surface as a fixup error so
-            # FixupBase swallows it without a Sentry event. The repair stays
-            # available for manual retry once the underlying cause is fixed.
-            _LOGGER.warning("Cannot repair app %s: %s", suggestion.reference, err)
-            raise ResolutionFixupError from err
+        await app.instance.install(app.version)
 
     @property
     def suggestion(self) -> SuggestionType:

--- a/supervisor/resolution/fixups/app_execute_restart.py
+++ b/supervisor/resolution/fixups/app_execute_restart.py
@@ -3,7 +3,7 @@
 import logging
 
 from ...coresys import CoreSys
-from ...exceptions import AppsError, ResolutionFixupError
+from ...exceptions import AppsError
 from ..const import ContextType, IssueType, SuggestionType
 from ..data import Suggestion
 from .base import FixupBase
@@ -31,11 +31,7 @@ class FixupAppExecuteRestart(FixupBase):
             return
 
         # Stop app
-        try:
-            await app.stop()
-        except AppsError as err:
-            _LOGGER.error("Could not stop %s due to %s", suggestion.reference, err)
-            raise ResolutionFixupError from None
+        await app.stop()
 
         # Start app
         # Removing the container has already fixed the issue and dismissed it

--- a/supervisor/resolution/fixups/app_execute_start.py
+++ b/supervisor/resolution/fixups/app_execute_start.py
@@ -4,7 +4,7 @@ import logging
 
 from ...const import AppState
 from ...coresys import CoreSys
-from ...exceptions import AppsError, ResolutionFixupError
+from ...exceptions import AppsError
 from ..const import ContextType, IssueType, SuggestionType
 from ..data import Suggestion
 from .base import FixupBase
@@ -32,17 +32,15 @@ class FixupAppExecuteStart(FixupBase):
             return
 
         # Start app
-        try:
-            start_task = await app.start()
-        except AppsError as err:
-            _LOGGER.error("Could not start %s due to %s", suggestion.reference, err)
-            raise ResolutionFixupError from None
+        start_task = await app.start()
 
         # Wait for app start. If it ends up in error or unknown state it's not fixed
         await start_task
         if app.state in {AppState.ERROR, AppState.UNKNOWN}:
-            _LOGGER.error("App %s could not start successfully", suggestion.reference)
-            raise ResolutionFixupError
+            raise AppsError(
+                f"App {suggestion.reference} could not start successfully",
+                _LOGGER.error,
+            )
 
     @property
     def suggestion(self) -> SuggestionType:

--- a/supervisor/resolution/fixups/base.py
+++ b/supervisor/resolution/fixups/base.py
@@ -28,10 +28,11 @@ class FixupBase(ABC, CoreSysAttributes):
         if fixing_suggestion is None:
             return
 
-        # Process fixup. A failure propagates to the caller: the autofix
-        # loop logs and continues with the next fixup, while a user-applied
-        # suggestion surfaces the failure as an API error so the repair is
-        # not reported as successful (the issue and suggestion stay around).
+        # Process fixup. A failure propagates to the caller with its
+        # original, well-defined error: the autofix loop logs and continues
+        # with the next fixup, while a user-applied suggestion surfaces the
+        # failure as an API error so the repair is not reported as
+        # successful (the issue and suggestion stay around).
         _LOGGER.debug("Run fixup for %s/%s", self.suggestion, self.context)
         await self.process_fixup(fixing_suggestion)
 

--- a/supervisor/resolution/fixups/base.py
+++ b/supervisor/resolution/fixups/base.py
@@ -5,7 +5,6 @@ import logging
 
 from ...const import BusEvent
 from ...coresys import CoreSys, CoreSysAttributes
-from ...exceptions import ResolutionFixupError
 from ..const import ContextType, IssueType, SuggestionType
 from ..data import Issue, Suggestion
 
@@ -29,12 +28,12 @@ class FixupBase(ABC, CoreSysAttributes):
         if fixing_suggestion is None:
             return
 
-        # Process fixup
+        # Process fixup. A failure propagates to the caller: the autofix
+        # loop logs and continues with the next fixup, while a user-applied
+        # suggestion surfaces the failure as an API error so the repair is
+        # not reported as successful (the issue and suggestion stay around).
         _LOGGER.debug("Run fixup for %s/%s", self.suggestion, self.context)
-        try:
-            await self.process_fixup(fixing_suggestion)
-        except ResolutionFixupError:
-            return
+        await self.process_fixup(fixing_suggestion)
 
         # Cleanup issue
         for issue in self.sys_resolution.issues_for_suggestion(fixing_suggestion):

--- a/supervisor/resolution/fixups/mount_execute_reload.py
+++ b/supervisor/resolution/fixups/mount_execute_reload.py
@@ -3,7 +3,7 @@
 import logging
 
 from ...coresys import CoreSys
-from ...exceptions import MountError, MountNotFound, ResolutionFixupError
+from ...exceptions import MountNotFound
 from ..const import ContextType, IssueType, SuggestionType
 from ..data import Suggestion
 from .base import FixupBase
@@ -21,17 +21,13 @@ class FixupMountExecuteReload(FixupBase):
 
     async def process_fixup(self, suggestion: Suggestion) -> None:
         """Attempt to remount using the same config to fix failure."""
+        # A reload failure (e.g. unreachable server) propagates to the
+        # caller and leaves the issue/suggestion in place so the user can
+        # try again once the underlying problem is fixed.
         try:
             await self.sys_mounts.reload_mount(suggestion.reference)
         except MountNotFound:
             _LOGGER.warning("Can't find mount %s for fixup", suggestion.reference)
-        except MountError as err:
-            # Leave the issue/suggestion in place so the user can try again
-            # once the underlying problem (e.g. unreachable server) is fixed.
-            _LOGGER.warning(
-                "Reload fixup for mount %s failed: %s", suggestion.reference, err
-            )
-            raise ResolutionFixupError from err
 
     @property
     def suggestion(self) -> SuggestionType:

--- a/supervisor/resolution/fixups/store_execute_reload.py
+++ b/supervisor/resolution/fixups/store_execute_reload.py
@@ -4,12 +4,7 @@ import logging
 
 from ...const import BusEvent
 from ...coresys import CoreSys
-from ...exceptions import (
-    ResolutionFixupError,
-    ResolutionFixupJobError,
-    StoreError,
-    StoreNotFound,
-)
+from ...exceptions import ResolutionFixupJobError, StoreNotFound
 from ...jobs.const import JobCondition
 from ...jobs.decorator import Job
 from ..const import ContextType, IssueType, SuggestionType
@@ -45,11 +40,8 @@ class FixupStoreExecuteReload(FixupBase):
             return
 
         # Load data again
-        try:
-            await repository.load()
-            await self.sys_store.reload(repository)
-        except StoreError:
-            raise ResolutionFixupError from None
+        await repository.load()
+        await self.sys_store.reload(repository)
 
     @property
     def suggestion(self) -> SuggestionType:

--- a/supervisor/resolution/fixups/store_execute_remove.py
+++ b/supervisor/resolution/fixups/store_execute_remove.py
@@ -3,7 +3,7 @@
 import logging
 
 from ...coresys import CoreSys
-from ...exceptions import ResolutionFixupError, StoreError, StoreNotFound
+from ...exceptions import StoreNotFound
 from ..const import ContextType, IssueType, SuggestionType
 from ..data import Suggestion
 from .base import FixupBase
@@ -32,10 +32,7 @@ class FixupStoreExecuteRemove(FixupBase):
             return
 
         # Remove repository
-        try:
-            await self.sys_store.remove_repository(repository)
-        except StoreError:
-            raise ResolutionFixupError from None
+        await self.sys_store.remove_repository(repository)
 
     @property
     def suggestion(self) -> SuggestionType:

--- a/supervisor/resolution/fixups/store_execute_reset.py
+++ b/supervisor/resolution/fixups/store_execute_reset.py
@@ -3,13 +3,7 @@
 import logging
 
 from ...coresys import CoreSys
-from ...exceptions import (
-    ResolutionFixupError,
-    ResolutionFixupJobError,
-    StoreError,
-    StoreInvalidAppRepo,
-    StoreNotFound,
-)
+from ...exceptions import ResolutionFixupJobError, StoreInvalidAppRepo, StoreNotFound
 from ...jobs.const import JobCondition
 from ...jobs.decorator import Job
 from ..const import ContextType, IssueType, SuggestionType
@@ -52,9 +46,7 @@ class FixupStoreExecuteReset(FixupBase):
             # suggestion to stop the hourly auto-retry, while leaving the
             # issue (and its remove suggestion) so the user stays informed.
             self.sys_resolution.dismiss_suggestion(suggestion)
-            raise ResolutionFixupError from None
-        except StoreError:
-            raise ResolutionFixupError from None
+            raise
 
     @property
     def suggestion(self) -> SuggestionType:

--- a/supervisor/resolution/fixups/system_adopt_data_disk.py
+++ b/supervisor/resolution/fixups/system_adopt_data_disk.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from ...coresys import CoreSys
 from ...dbus.udisks2.data import DeviceSpecification
-from ...exceptions import DBusError, HostError, ResolutionFixupError
+from ...exceptions import DBusError, HassOSDataDiskError, HostError
 from ...os.const import FILESYSTEM_LABEL_DATA_DISK, FILESYSTEM_LABEL_OLD_DATA_DISK
 from ..const import ContextType, IssueType, SuggestionType
 from ..data import Suggestion
@@ -48,7 +48,7 @@ class FixupSystemAdoptDataDisk(FixupBase):
             )
             or not current_resolved[0].filesystem
         ):
-            raise ResolutionFixupError(
+            raise HassOSDataDiskError(
                 "Cannot resolve current data disk for rename", _LOGGER.error
             )
 
@@ -61,7 +61,7 @@ class FixupSystemAdoptDataDisk(FixupBase):
             try:
                 await new_resolved[0].filesystem.set_label(FILESYSTEM_LABEL_DATA_DISK)
             except DBusError as err:
-                raise ResolutionFixupError(
+                raise HassOSDataDiskError(
                     f"Could not rename filesystem at {suggestion.reference}: {err!s}",
                     _LOGGER.error,
                 ) from err
@@ -77,7 +77,7 @@ class FixupSystemAdoptDataDisk(FixupBase):
                 FILESYSTEM_LABEL_OLD_DATA_DISK
             )
         except DBusError as err:
-            raise ResolutionFixupError(
+            raise HassOSDataDiskError(
                 f"Could not rename filesystem at {current.as_posix()}: {err!s}",
                 _LOGGER.error,
             ) from err

--- a/supervisor/resolution/fixups/system_rename_data_disk.py
+++ b/supervisor/resolution/fixups/system_rename_data_disk.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from ...coresys import CoreSys
 from ...dbus.udisks2.data import DeviceSpecification
-from ...exceptions import DBusError, ResolutionFixupError
+from ...exceptions import DBusError, HassOSDataDiskError
 from ...os.const import FILESYSTEM_LABEL_OLD_DATA_DISK
 from ..const import ContextType, IssueType, SuggestionType
 from ..data import Suggestion
@@ -53,7 +53,7 @@ class FixupSystemRenameDataDisk(FixupBase):
         try:
             await resolved[0].filesystem.set_label(FILESYSTEM_LABEL_OLD_DATA_DISK)
         except DBusError as err:
-            raise ResolutionFixupError(
+            raise HassOSDataDiskError(
                 f"Could not rename filesystem at {suggestion.reference}: {err!s}",
                 _LOGGER.error,
             ) from err

--- a/supervisor/resolution/fixups/systemd_unit_execute_reset.py
+++ b/supervisor/resolution/fixups/systemd_unit_execute_reset.py
@@ -3,7 +3,7 @@
 import logging
 
 from ...coresys import CoreSys
-from ...exceptions import DBusError, DBusSystemdNoSuchUnit, ResolutionFixupError
+from ...exceptions import DBusError, DBusSystemdNoSuchUnit
 from ...resolution.const import ContextType, IssueType, SuggestionType
 from ...resolution.data import Suggestion
 from .base import FixupBase
@@ -33,7 +33,7 @@ class FixupSystemdUnitExecuteReset(FixupBase):
             _LOGGER.warning("Systemd unit not found: %s", unit_name)
         except DBusError as err:
             _LOGGER.error("Failed to reset systemd unit %s: %s", unit_name, err)
-            raise ResolutionFixupError from err
+            raise
 
     @property
     def suggestion(self) -> SuggestionType:

--- a/supervisor/resolution/fixups/systemd_unit_execute_restart.py
+++ b/supervisor/resolution/fixups/systemd_unit_execute_restart.py
@@ -4,7 +4,7 @@ import logging
 
 from ...coresys import CoreSys
 from ...dbus.const import StartUnitMode
-from ...exceptions import DBusError, DBusSystemdNoSuchUnit, ResolutionFixupError
+from ...exceptions import DBusError, DBusSystemdNoSuchUnit
 from ...resolution.const import ContextType, IssueType, SuggestionType
 from ...resolution.data import Suggestion
 from .base import FixupBase
@@ -34,7 +34,7 @@ class FixupSystemdUnitExecuteRestart(FixupBase):
             _LOGGER.warning("Systemd unit not found: %s", unit_name)
         except DBusError as err:
             _LOGGER.error("Failed to restart systemd unit %s: %s", unit_name, err)
-            raise ResolutionFixupError from err
+            raise
 
     @property
     def suggestion(self) -> SuggestionType:

--- a/supervisor/resolution/module.py
+++ b/supervisor/resolution/module.py
@@ -9,8 +9,8 @@ from ..bus import EventListener
 from ..const import FeatureFlag
 from ..coresys import CoreSys, CoreSysAttributes
 from ..exceptions import (
+    HassioError,
     ResolutionError,
-    ResolutionFixupError,
     ResolutionIssueNotFound,
     ResolutionSuggestionNotFound,
 )
@@ -136,7 +136,7 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
                 async def event_callback(reference, fixup=fixup):
                     try:
                         await fixup(suggestion)
-                    except ResolutionFixupError as err:
+                    except HassioError as err:
                         # Same as during autofix: log and wait for the
                         # next occasion instead of leaving an unhandled
                         # error in the bus event task

--- a/supervisor/resolution/module.py
+++ b/supervisor/resolution/module.py
@@ -10,7 +10,6 @@ from ..bus import EventListener
 from ..const import FeatureFlag
 from ..coresys import CoreSys, CoreSysAttributes
 from ..exceptions import (
-    HassioError,
     ResolutionError,
     ResolutionIssueNotFound,
     ResolutionSuggestionNotFound,
@@ -33,7 +32,7 @@ from .const import (
 )
 from .data import HealthChanged, Issue, Suggestion, SupportedChanged
 from .evaluate import ResolutionEvaluation
-from .fixup import ResolutionFixup
+from .fixup import ResolutionFixup, apply_fixup_safely
 from .validate import SCHEMA_RESOLUTION_CONFIG
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -136,18 +135,8 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
         for fixup in self.fixup.fixes_for_suggestion(suggestion):
             if fixup.auto and fixup.bus_event:
 
-                async def event_callback(reference, fixup=fixup):
-                    try:
-                        await fixup(suggestion)
-                    except HassioError as err:
-                        # Same as during autofix: log and wait for the
-                        # next occasion instead of leaving an unhandled
-                        # error in the bus event task
-                        _LOGGER.warning(
-                            "Fixup for %s failed on bus event: %s",
-                            fixup.suggestion,
-                            err,
-                        )
+                def event_callback(reference, fixup=fixup):
+                    return apply_fixup_safely(fixup, suggestion)
 
                 listener = self.sys_bus.register_event(fixup.bus_event, event_callback)
                 listeners.append(listener)

--- a/supervisor/resolution/module.py
+++ b/supervisor/resolution/module.py
@@ -10,6 +10,7 @@ from ..const import FeatureFlag
 from ..coresys import CoreSys, CoreSysAttributes
 from ..exceptions import (
     ResolutionError,
+    ResolutionFixupError,
     ResolutionIssueNotFound,
     ResolutionSuggestionNotFound,
 )
@@ -132,8 +133,18 @@ class ResolutionManager(FileConfiguration, CoreSysAttributes):
         for fixup in self.fixup.fixes_for_suggestion(suggestion):
             if fixup.auto and fixup.bus_event:
 
-                def event_callback(reference, fixup=fixup):
-                    return fixup(suggestion)
+                async def event_callback(reference, fixup=fixup):
+                    try:
+                        await fixup(suggestion)
+                    except ResolutionFixupError as err:
+                        # Same as during autofix: log and wait for the
+                        # next occasion instead of leaving an unhandled
+                        # error in the bus event task
+                        _LOGGER.warning(
+                            "Fixup for %s failed on bus event: %s",
+                            fixup.suggestion,
+                            err,
+                        )
 
                 listener = self.sys_bus.register_event(fixup.bus_event, event_callback)
                 listeners.append(listener)

--- a/tests/api/test_resolution.py
+++ b/tests/api/test_resolution.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from http import HTTPStatus
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from aiohttp.test_utils import TestClient
 import pytest
@@ -16,7 +16,7 @@ from supervisor.const import (
     FeatureFlag,
 )
 from supervisor.coresys import CoreSys
-from supervisor.exceptions import ResolutionError
+from supervisor.exceptions import ResolutionError, ResolutionFixupError
 from supervisor.homeassistant.const import WSType
 from supervisor.resolution.const import (
     ContextType,
@@ -92,6 +92,33 @@ async def test_api_resolution_apply_suggestion(
 
     with pytest.raises(ResolutionError):
         await coresys.resolution.apply_suggestion(clear_backup)
+
+
+async def test_api_resolution_apply_suggestion_fixup_error(
+    coresys: CoreSys, api_client_with_prefix: tuple[TestClient, str]
+):
+    """Test a failing fixup surfaces as API error and keeps issue and suggestion."""
+    api_client, prefix = api_client_with_prefix
+    coresys.resolution.add_issue(
+        issue := Issue(IssueType.MOUNT_FAILED, ContextType.MOUNT, reference="test"),
+        suggestions=[SuggestionType.EXECUTE_RELOAD],
+    )
+    suggestion = coresys.resolution.suggestions[-1]
+
+    with patch(
+        "supervisor.resolution.fixups.mount_execute_reload.FixupMountExecuteReload.process_fixup",
+        side_effect=ResolutionFixupError("Test fixup failure"),
+    ):
+        resp = await api_client.post(
+            f"{prefix}/resolution/suggestion/{suggestion.uuid}"
+        )
+
+    assert resp.status == 400
+    body = await resp.json()
+    assert body["message"] == "Test fixup failure"
+
+    assert issue in coresys.resolution.issues
+    assert suggestion in coresys.resolution.suggestions
 
 
 async def test_api_resolution_dismiss_issue(

--- a/tests/api/test_resolution.py
+++ b/tests/api/test_resolution.py
@@ -16,7 +16,7 @@ from supervisor.const import (
     FeatureFlag,
 )
 from supervisor.coresys import CoreSys
-from supervisor.exceptions import ResolutionError, ResolutionFixupError
+from supervisor.exceptions import MountActivationError, ResolutionError
 from supervisor.homeassistant.const import WSType
 from supervisor.resolution.const import (
     ContextType,
@@ -107,7 +107,7 @@ async def test_api_resolution_apply_suggestion_fixup_error(
 
     with patch(
         "supervisor.resolution.fixups.mount_execute_reload.FixupMountExecuteReload.process_fixup",
-        side_effect=ResolutionFixupError("Test fixup failure"),
+        side_effect=MountActivationError("Test fixup failure"),
     ):
         resp = await api_client.post(
             f"{prefix}/resolution/suggestion/{suggestion.uuid}"

--- a/tests/resolution/fixup/test_app_execute_restart.py
+++ b/tests/resolution/fixup/test_app_execute_restart.py
@@ -9,7 +9,7 @@ from supervisor.const import AppState
 from supervisor.coresys import CoreSys
 from supervisor.docker.app import DockerApp
 from supervisor.docker.interface import DockerInterface
-from supervisor.exceptions import DockerError
+from supervisor.exceptions import DockerError, ResolutionFixupError
 from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.data import Issue, Suggestion
 from supervisor.resolution.fixups.app_execute_restart import FixupAppExecuteRestart
@@ -71,7 +71,8 @@ async def test_fixup_stop_error(
         patch.object(DockerInterface, "stop", side_effect=DockerError),
         patch.object(DockerApp, "run") as run,
     ):
-        await app_execute_start()
+        with pytest.raises(ResolutionFixupError):
+            await app_execute_start()
         run.assert_not_called()
 
     assert DEVICE_ACCESS_MISSING_ISSUE in coresys.resolution.issues

--- a/tests/resolution/fixup/test_app_execute_restart.py
+++ b/tests/resolution/fixup/test_app_execute_restart.py
@@ -9,7 +9,7 @@ from supervisor.const import AppState
 from supervisor.coresys import CoreSys
 from supervisor.docker.app import DockerApp
 from supervisor.docker.interface import DockerInterface
-from supervisor.exceptions import DockerError, ResolutionFixupError
+from supervisor.exceptions import AppUnknownError, DockerError
 from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.data import Issue, Suggestion
 from supervisor.resolution.fixups.app_execute_restart import FixupAppExecuteRestart
@@ -71,13 +71,13 @@ async def test_fixup_stop_error(
         patch.object(DockerInterface, "stop", side_effect=DockerError),
         patch.object(DockerApp, "run") as run,
     ):
-        with pytest.raises(ResolutionFixupError):
+        with pytest.raises(AppUnknownError):
             await app_execute_start()
         run.assert_not_called()
 
     assert DEVICE_ACCESS_MISSING_ISSUE in coresys.resolution.issues
     assert EXECUTE_RESTART_SUGGESTION in coresys.resolution.suggestions
-    assert "Could not stop local_ssh" in caplog.text
+    assert "Could not stop container for app local_ssh" in caplog.text
 
 
 @pytest.mark.usefixtures("path_extern")

--- a/tests/resolution/fixup/test_app_execute_start.py
+++ b/tests/resolution/fixup/test_app_execute_start.py
@@ -8,7 +8,7 @@ from supervisor.apps.app import App
 from supervisor.const import AppState
 from supervisor.coresys import CoreSys
 from supervisor.docker.app import DockerApp
-from supervisor.exceptions import DockerError, ResolutionFixupError
+from supervisor.exceptions import AppsError, AppUnknownError, DockerError
 from supervisor.resolution.const import ContextType, SuggestionType
 from supervisor.resolution.data import Suggestion
 from supervisor.resolution.fixups.app_execute_start import FixupAppExecuteStart
@@ -64,7 +64,7 @@ async def test_fixup_start_error(coresys: CoreSys, install_app_ssh: App):
         patch.object(DockerApp, "run", side_effect=DockerError) as run,
         patch.object(App, "write_options"),
     ):
-        with pytest.raises(ResolutionFixupError):
+        with pytest.raises(AppUnknownError):
             await app_execute_start()
         run.assert_called_once()
 
@@ -93,7 +93,7 @@ async def test_fixup_wait_start_failure(
         patch.object(App, "_wait_for_startup", new=mock_start),
         patch.object(App, "write_options"),
     ):
-        with pytest.raises(ResolutionFixupError):
+        with pytest.raises(AppsError):
             await app_execute_start()
         run.assert_called_once()
 

--- a/tests/resolution/fixup/test_app_execute_start.py
+++ b/tests/resolution/fixup/test_app_execute_start.py
@@ -8,7 +8,7 @@ from supervisor.apps.app import App
 from supervisor.const import AppState
 from supervisor.coresys import CoreSys
 from supervisor.docker.app import DockerApp
-from supervisor.exceptions import DockerError
+from supervisor.exceptions import DockerError, ResolutionFixupError
 from supervisor.resolution.const import ContextType, SuggestionType
 from supervisor.resolution.data import Suggestion
 from supervisor.resolution.fixups.app_execute_start import FixupAppExecuteStart
@@ -64,7 +64,8 @@ async def test_fixup_start_error(coresys: CoreSys, install_app_ssh: App):
         patch.object(DockerApp, "run", side_effect=DockerError) as run,
         patch.object(App, "write_options"),
     ):
-        await app_execute_start()
+        with pytest.raises(ResolutionFixupError):
+            await app_execute_start()
         run.assert_called_once()
 
     assert BOOT_FAIL_ISSUE in coresys.resolution.issues
@@ -92,7 +93,8 @@ async def test_fixup_wait_start_failure(
         patch.object(App, "_wait_for_startup", new=mock_start),
         patch.object(App, "write_options"),
     ):
-        await app_execute_start()
+        with pytest.raises(ResolutionFixupError):
+            await app_execute_start()
         run.assert_called_once()
 
     assert BOOT_FAIL_ISSUE in coresys.resolution.issues

--- a/tests/resolution/fixup/test_fixup.py
+++ b/tests/resolution/fixup/test_fixup.py
@@ -1,12 +1,14 @@
 """Test check."""
 
 # pylint: disable=import-error, protected-access
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 from supervisor.const import CoreState
 from supervisor.coresys import CoreSys
+from supervisor.exceptions import HassioError
 from supervisor.resolution.const import ContextType, SuggestionType
 from supervisor.resolution.data import Suggestion
+from supervisor.resolution.fixup import ResolutionFixup
 from supervisor.resolution.validate import get_valid_modules
 
 
@@ -41,6 +43,41 @@ async def test_check_autofix(coresys: CoreSys):
         "system_create_full_backup"
     ].process_fixup.assert_called_once()
     assert len(coresys.resolution.suggestions) == 0
+
+
+async def test_autofix_error_handling(coresys: CoreSys):
+    """Test autofix continues on errors and only captures unexpected ones."""
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    fix_hassio_error = AsyncMock(side_effect=HassioError("fail"))
+    fix_hassio_error.auto = True
+    fix_hassio_error.suggestion = SuggestionType.EXECUTE_RELOAD
+
+    unexpected = RuntimeError("boom")
+    fix_unexpected_error = AsyncMock(side_effect=unexpected)
+    fix_unexpected_error.auto = True
+    fix_unexpected_error.suggestion = SuggestionType.EXECUTE_RESET
+
+    with (
+        patch.object(
+            ResolutionFixup,
+            "all_fixes",
+            new_callable=PropertyMock,
+            return_value=[fix_hassio_error, fix_unexpected_error],
+        ),
+        patch(
+            "supervisor.resolution.fixup.async_capture_exception",
+            new_callable=AsyncMock,
+        ) as capture,
+    ):
+        await coresys.resolution.fixup.run_autofix()
+
+    # The HassioError did not abort the loop, the next fixup still ran
+    fix_hassio_error.assert_awaited_once()
+    fix_unexpected_error.assert_awaited_once()
+
+    # Only the unexpected error is reported to Sentry
+    capture.assert_awaited_once_with(unexpected)
 
 
 async def test_dynamic_fixup_loader(coresys: CoreSys):

--- a/tests/resolution/fixup/test_mount_execute_reload.py
+++ b/tests/resolution/fixup/test_mount_execute_reload.py
@@ -3,7 +3,10 @@
 import errno
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from supervisor.coresys import CoreSys
+from supervisor.exceptions import ResolutionFixupError
 from supervisor.mounts.mount import Mount
 from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.data import Issue
@@ -89,11 +92,14 @@ async def test_fixup_error_after_reload(
     )
     # Probe (statvfs) fails — the mount stays unreachable through the
     # reload -> restart cycle. Fixup catches MountError and re-raises
-    # ResolutionFixupError, which FixupBase.__call__ swallows to skip
-    # issue cleanup. Caller sees no error.
-    with patch(
-        "supervisor.mounts.mount._probe_network_mount",
-        side_effect=OSError(errno.EHOSTDOWN, "Host is down"),
+    # ResolutionFixupError, which propagates to the caller so the
+    # issue cleanup is skipped.
+    with (
+        patch(
+            "supervisor.mounts.mount._probe_network_mount",
+            side_effect=OSError(errno.EHOSTDOWN, "Host is down"),
+        ),
+        pytest.raises(ResolutionFixupError),
     ):
         await mount_execute_reload()
 

--- a/tests/resolution/fixup/test_mount_execute_reload.py
+++ b/tests/resolution/fixup/test_mount_execute_reload.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from supervisor.coresys import CoreSys
-from supervisor.exceptions import ResolutionFixupError
+from supervisor.exceptions import MountActivationError
 from supervisor.mounts.mount import Mount
 from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.data import Issue
@@ -91,15 +91,14 @@ async def test_fixup_error_after_reload(
         suggestions=[SuggestionType.EXECUTE_RELOAD, SuggestionType.EXECUTE_REMOVE],
     )
     # Probe (statvfs) fails — the mount stays unreachable through the
-    # reload -> restart cycle. Fixup catches MountError and re-raises
-    # ResolutionFixupError, which propagates to the caller so the
-    # issue cleanup is skipped.
+    # reload -> restart cycle. The MountActivationError propagates to
+    # the caller so the issue cleanup is skipped.
     with (
         patch(
             "supervisor.mounts.mount._probe_network_mount",
             side_effect=OSError(errno.EHOSTDOWN, "Host is down"),
         ),
-        pytest.raises(ResolutionFixupError),
+        pytest.raises(MountActivationError),
     ):
         await mount_execute_reload()
 

--- a/tests/resolution/fixup/test_store_execute_reload.py
+++ b/tests/resolution/fixup/test_store_execute_reload.py
@@ -8,7 +8,7 @@ import pytest
 
 from supervisor.const import BusEvent
 from supervisor.coresys import CoreSys
-from supervisor.exceptions import ResolutionFixupError
+from supervisor.exceptions import StoreError
 from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.data import Issue, Suggestion
 from supervisor.resolution.fixups.store_execute_reload import FixupStoreExecuteReload
@@ -116,7 +116,7 @@ async def test_store_execute_reload_dismiss_suggestion_removes_listener(
     )
 
     with patch.object(
-        FixupStoreExecuteReload, "process_fixup", side_effect=ResolutionFixupError
+        FixupStoreExecuteReload, "process_fixup", side_effect=StoreError
     ) as mock_fixup:
         # Fire event with issue there to trigger fixup
         await fire_bus_event(coresys, BusEvent.SUPERVISOR_CONNECTIVITY_CHANGE, True)

--- a/tests/resolution/fixup/test_store_execute_reset.py
+++ b/tests/resolution/fixup/test_store_execute_reset.py
@@ -9,7 +9,7 @@ import pytest
 
 from supervisor.config import CoreConfig
 from supervisor.coresys import CoreSys
-from supervisor.exceptions import StoreGitCloneError
+from supervisor.exceptions import ResolutionFixupError, StoreGitCloneError
 from supervisor.resolution.const import (
     ContextType,
     IssueType,
@@ -114,6 +114,7 @@ async def test_fixup_still_invalid_after_reset(coresys: CoreSys):
         # Repository re-clones fine but its content is still not valid
         patch.object(RepositoryGit, "validate", return_value=False),
         patch("shutil.disk_usage", return_value=(42, 42, 2 * (1024.0**3))),
+        pytest.raises(ResolutionFixupError),
     ):
         await store_execute_reset()
 
@@ -147,6 +148,7 @@ async def test_fixup_clone_fail(coresys: CoreSys):
         patch.object(GitRepo, "load"),
         patch.object(GitRepo, "_clone", side_effect=StoreGitCloneError),
         patch("shutil.disk_usage", return_value=(42, 42, 2 * (1024.0**3))),
+        pytest.raises(ResolutionFixupError),
     ):
         await store_execute_reset()
 
@@ -182,7 +184,8 @@ async def test_fixup_move_fail(coresys: CoreSys, error_num: int, unhealthy: bool
         patch("shutil.disk_usage", return_value=(42, 42, 2 * (1024.0**3))),
     ):
         err.errno = error_num
-        await store_execute_reset()
+        with pytest.raises(ResolutionFixupError):
+            await store_execute_reset()
 
     assert len(coresys.resolution.suggestions) == 1
     assert len(coresys.resolution.issues) == 1

--- a/tests/resolution/fixup/test_store_execute_reset.py
+++ b/tests/resolution/fixup/test_store_execute_reset.py
@@ -9,7 +9,11 @@ import pytest
 
 from supervisor.config import CoreConfig
 from supervisor.coresys import CoreSys
-from supervisor.exceptions import ResolutionFixupError, StoreGitCloneError
+from supervisor.exceptions import (
+    StoreGitCloneError,
+    StoreInvalidAppRepo,
+    StoreRepositoryUnknownError,
+)
 from supervisor.resolution.const import (
     ContextType,
     IssueType,
@@ -114,7 +118,7 @@ async def test_fixup_still_invalid_after_reset(coresys: CoreSys):
         # Repository re-clones fine but its content is still not valid
         patch.object(RepositoryGit, "validate", return_value=False),
         patch("shutil.disk_usage", return_value=(42, 42, 2 * (1024.0**3))),
-        pytest.raises(ResolutionFixupError),
+        pytest.raises(StoreInvalidAppRepo),
     ):
         await store_execute_reset()
 
@@ -148,7 +152,7 @@ async def test_fixup_clone_fail(coresys: CoreSys):
         patch.object(GitRepo, "load"),
         patch.object(GitRepo, "_clone", side_effect=StoreGitCloneError),
         patch("shutil.disk_usage", return_value=(42, 42, 2 * (1024.0**3))),
-        pytest.raises(ResolutionFixupError),
+        pytest.raises(StoreRepositoryUnknownError),
     ):
         await store_execute_reset()
 
@@ -184,7 +188,7 @@ async def test_fixup_move_fail(coresys: CoreSys, error_num: int, unhealthy: bool
         patch("shutil.disk_usage", return_value=(42, 42, 2 * (1024.0**3))),
     ):
         err.errno = error_num
-        with pytest.raises(ResolutionFixupError):
+        with pytest.raises(StoreRepositoryUnknownError):
             await store_execute_reset()
 
     assert len(coresys.resolution.suggestions) == 1

--- a/tests/resolution/fixup/test_systemd_unit_execute_reset.py
+++ b/tests/resolution/fixup/test_systemd_unit_execute_reset.py
@@ -2,8 +2,10 @@
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from supervisor.coresys import CoreSys
-from supervisor.exceptions import DBusError, DBusSystemdNoSuchUnit
+from supervisor.exceptions import DBusError, DBusSystemdNoSuchUnit, ResolutionFixupError
 from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.data import Issue, Suggestion
 from supervisor.resolution.fixups.systemd_unit_execute_reset import (
@@ -66,12 +68,15 @@ async def test_fixup_reset_dbus_error_keeps_issue(coresys: CoreSys):
     coresys.resolution.add_suggestion(SUGGESTION)
     coresys.resolution.add_issue(ISSUE)
 
-    with patch.object(
-        coresys.dbus.systemd,
-        "reset_failed_unit",
-        new_callable=AsyncMock,
-        side_effect=DBusError("boom"),
-    ) as reset_failed_unit:
+    with (
+        patch.object(
+            coresys.dbus.systemd,
+            "reset_failed_unit",
+            new_callable=AsyncMock,
+            side_effect=DBusError("boom"),
+        ) as reset_failed_unit,
+        pytest.raises(ResolutionFixupError),
+    ):
         await systemd_unit_execute_reset()
 
     reset_failed_unit.assert_awaited_once_with("a.service")

--- a/tests/resolution/fixup/test_systemd_unit_execute_reset.py
+++ b/tests/resolution/fixup/test_systemd_unit_execute_reset.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from supervisor.coresys import CoreSys
-from supervisor.exceptions import DBusError, DBusSystemdNoSuchUnit, ResolutionFixupError
+from supervisor.exceptions import DBusError, DBusSystemdNoSuchUnit
 from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.data import Issue, Suggestion
 from supervisor.resolution.fixups.systemd_unit_execute_reset import (
@@ -75,7 +75,7 @@ async def test_fixup_reset_dbus_error_keeps_issue(coresys: CoreSys):
             new_callable=AsyncMock,
             side_effect=DBusError("boom"),
         ) as reset_failed_unit,
-        pytest.raises(ResolutionFixupError),
+        pytest.raises(DBusError),
     ):
         await systemd_unit_execute_reset()
 

--- a/tests/resolution/fixup/test_systemd_unit_execute_restart.py
+++ b/tests/resolution/fixup/test_systemd_unit_execute_restart.py
@@ -6,7 +6,7 @@ import pytest
 
 from supervisor.coresys import CoreSys
 from supervisor.dbus.const import StartUnitMode
-from supervisor.exceptions import DBusError, DBusSystemdNoSuchUnit, ResolutionFixupError
+from supervisor.exceptions import DBusError, DBusSystemdNoSuchUnit
 from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.data import Issue, Suggestion
 from supervisor.resolution.fixups.systemd_unit_execute_restart import (
@@ -76,7 +76,7 @@ async def test_fixup_restart_dbus_error_keeps_issue(coresys: CoreSys):
             new_callable=AsyncMock,
             side_effect=DBusError("boom"),
         ) as restart_unit,
-        pytest.raises(ResolutionFixupError),
+        pytest.raises(DBusError),
     ):
         await systemd_unit_execute_restart()
 

--- a/tests/resolution/fixup/test_systemd_unit_execute_restart.py
+++ b/tests/resolution/fixup/test_systemd_unit_execute_restart.py
@@ -2,9 +2,11 @@
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from supervisor.coresys import CoreSys
 from supervisor.dbus.const import StartUnitMode
-from supervisor.exceptions import DBusError, DBusSystemdNoSuchUnit
+from supervisor.exceptions import DBusError, DBusSystemdNoSuchUnit, ResolutionFixupError
 from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.data import Issue, Suggestion
 from supervisor.resolution.fixups.systemd_unit_execute_restart import (
@@ -67,12 +69,15 @@ async def test_fixup_restart_dbus_error_keeps_issue(coresys: CoreSys):
     coresys.resolution.add_suggestion(SUGGESTION)
     coresys.resolution.add_issue(ISSUE)
 
-    with patch.object(
-        coresys.dbus.systemd,
-        "restart_unit",
-        new_callable=AsyncMock,
-        side_effect=DBusError("boom"),
-    ) as restart_unit:
+    with (
+        patch.object(
+            coresys.dbus.systemd,
+            "restart_unit",
+            new_callable=AsyncMock,
+            side_effect=DBusError("boom"),
+        ) as restart_unit,
+        pytest.raises(ResolutionFixupError),
+    ):
         await systemd_unit_execute_restart()
 
     restart_unit.assert_awaited_once_with("a.service", StartUnitMode.REPLACE)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Applying a resolution suggestion whose fixup failed reported success to the caller: `FixupBase.__call__` swallowed `ResolutionFixupError`, so the API returned OK and the repair flow in Home Assistant completed — which removes the repair from the UI — while the issue persisted in Supervisor. Observed with the mount repairs (#7089 testing): the fixup logged a warning, the repair dialog claimed success, and the repair disappeared from Home Assistant while `ha resolution info` still showed the issue and suggestion.

Let the error propagate from the fixup instead, handling each caller appropriately:

- **User-applied suggestions** (`apply_suggestion` API): the failure now surfaces as an API error. Home Assistant's repair flow aborts with its existing "Could not apply the fix" message instead of completing, and the repair stays visible.
- **Autofix loop**: already catches and logs per-fixup errors — unchanged behavior.
- **Bus-event triggered fixups** (e.g. store reload on connectivity change): the event callback now catches and logs the failure the same way autofix does, instead of leaving an unhandled error in the bus event task.

`ResolutionFixupError` becomes an `APIError` with a translatable `resolution_fixup_error` error key and a default message, so it is reported as a client-visible error (HTTP 400 with message) rather than an unexpected server error with traceback and Sentry report. Fixup tests that exercise failing fixups now assert the raise; their existing assertions that the issue and suggestion remain are kept.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #7089, home-assistant/core#179369
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

Note: when this merges, the fixup-failure test added in #7089 (`test_fixup_failure_keeps_suggestion`) needs a `pytest.raises` added — whichever PR lands second takes the small adjustment.

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
