### PR TITLE
Report storage usage per mount

### DIFF
--- a/supervisor/api/__init__.py
+++ b/supervisor/api/__init__.py
@@ -263,7 +263,7 @@ class RestAPI(CoreSysAttributes):
                 web.post("/host/options", api_host.options),
                 web.get("/host/services", api_host.services),
                 web.get(
-                    "/host/disks/default/usage",
+                    "/host/disks/{disk}/usage",
                     api_host.disk_usage_v1
                     if app is self.versions[AppVersion.V1]
                     else api_host.disk_usage,

--- a/supervisor/api/host.py
+++ b/supervisor/api/host.py
@@ -37,11 +37,17 @@ from ..const import (
     ATTR_TIMEZONE,
 )
 from ..coresys import CoreSysAttributes
+from ..dbus.const import UnitActiveState
 from ..exceptions import (
     APIDBMigrationInProgress,
     APIError,
     HostContainerLogEpochError,
     HostLogError,
+    MountNotFound,
+    MountUsageNotActiveError,
+    MountUsageNotMountedError,
+    MountUsageReadError,
+    MountUsageTimeoutError,
 )
 from ..host.const import (
     PARAM_BOOT_ID,
@@ -51,6 +57,7 @@ from ..host.const import (
     LogFormatter,
 )
 from ..host.logs import SYSTEMD_JOURNAL_GATEWAYD_LINES_MAX
+from ..mounts.mount import Mount
 from ..utils.systemd_journal import journal_logs_reader
 from .const import (
     ATTR_AGENT_VERSION,
@@ -59,6 +66,7 @@ from .const import (
     ATTR_BOOTS,
     ATTR_BROADCAST_LLMNR,
     ATTR_BROADCAST_MDNS,
+    ATTR_CHILDREN,
     ATTR_DT_SYNCHRONIZED,
     ATTR_DT_UTC,
     ATTR_FORCE,
@@ -79,6 +87,26 @@ IDENTIFIER = "identifier"
 BOOTID = "bootid"
 DEFAULT_LINES = 100
 
+DISK = "disk"
+
+# Reserved disk target naming the system disk. Takes precedence over a mount of
+# the same name, which the mount name pattern permits.
+DISK_TARGET_SYSTEM = "default"
+
+# The system disk lists labeled known paths at depth 1. A mount has no such
+# labels, so depth 1 would walk its whole tree to report a single total; mounts
+# therefore default to totals only and opt in to a breakdown explicitly.
+DISK_USAGE_MAX_DEPTH_SYSTEM = 1
+DISK_USAGE_MAX_DEPTH_MOUNT = 0
+
+# How long a caller waits on a mount usage probe before getting a timeout
+# error. Bounds only the wait, never the probe: the probe keeps running so
+# later requests join it instead of stacking executor threads against the
+# same slow mount. Deliberately longer than any protocol timeout, since a
+# probe of an unreachable network mount is expected to run to the kernel's
+# own bound.
+MOUNT_USAGE_TIMEOUT = 60
+
 SCHEMA_OPTIONS = vol.Schema({vol.Optional(ATTR_HOSTNAME): str})
 
 # pylint: disable=no-value-for-parameter
@@ -92,6 +120,17 @@ SCHEMA_SHUTDOWN = vol.Schema(
 
 class APIHost(CoreSysAttributes):
     """Handle RESTful API for host functions."""
+
+    def __init__(self) -> None:
+        """Initialize host API handler."""
+        # In-flight mount usage probes, keyed by (mount name, max depth). A probe
+        # of an unreachable mount blocks until the kernel gives up, so callers
+        # asking for the same thing await the pending probe rather than parking
+        # another executor thread on identical work. Mounts only: the system disk
+        # keeps its existing per-request behavior.
+        self._mount_usage_probes: dict[
+            tuple[str, int], asyncio.Task[dict[str, Any]]
+        ] = {}
 
     @staticmethod
     def _legacy_disk_usage_ids_for_v1(data: dict[str, Any]) -> dict[str, Any]:
@@ -360,17 +399,29 @@ class APIHost(CoreSysAttributes):
 
     @api_process
     async def disk_usage(self, request: web.Request) -> dict[str, Any]:
-        """Return a breakdown of storage usage for the system."""
+        """Return a breakdown of storage usage for the system disk or a mount."""
         return await self._disk_usage_data(request)
 
     async def _disk_usage_data(self, request: web.Request) -> dict[str, Any]:
-        """Build disk usage response data."""
+        """Build disk usage response data for the requested disk."""
+        target = request.match_info.get(DISK, DISK_TARGET_SYSTEM)
+        if target == DISK_TARGET_SYSTEM:
+            return await self._system_disk_usage_data(request)
 
-        max_depth = request.query.get(ATTR_MAX_DEPTH, 1)
+        return await self._mount_disk_usage_data(request, target)
+
+    @staticmethod
+    def _requested_max_depth(request: web.Request, default: int) -> int:
+        """Return the requested max depth, falling back to default if unusable."""
+        max_depth = request.query.get(ATTR_MAX_DEPTH, default)
         try:
-            max_depth = int(max_depth)
+            return int(max_depth)
         except ValueError:
-            max_depth = 1
+            return default
+
+    async def _system_disk_usage_data(self, request: web.Request) -> dict[str, Any]:
+        """Build disk usage response data for the system disk."""
+        max_depth = self._requested_max_depth(request, DISK_USAGE_MAX_DEPTH_SYSTEM)
 
         disk = self.sys_hardware.disk
 
@@ -401,7 +452,7 @@ class APIHost(CoreSysAttributes):
             "label": "Root",
             "total_bytes": total,
             "used_bytes": used,
-            "children": [
+            ATTR_CHILDREN: [
                 {
                     "id": "system",
                     "label": "System",
@@ -411,6 +462,142 @@ class APIHost(CoreSysAttributes):
                 *known_paths,
             ],
         }
+
+    async def _mount_disk_usage_data(
+        self, request: web.Request, name: str
+    ) -> dict[str, Any]:
+        """Build disk usage response data for a supervisor mount."""
+        if name not in self.sys_mounts:
+            raise MountNotFound(name=name)
+
+        mount = self.sys_mounts.get(name)
+        if mount.state != UnitActiveState.ACTIVE:
+            raise MountUsageNotActiveError(name=name)
+
+        max_depth = self._requested_max_depth(request, DISK_USAGE_MAX_DEPTH_MOUNT)
+        return await self._mount_usage(mount, max_depth)
+
+    async def _mount_usage(self, mount: Mount, max_depth: int) -> dict[str, Any]:
+        """Return usage for a mount, joining an identical probe already running."""
+        key = (mount.name, max_depth)
+        if (probe := self._mount_usage_probes.get(key)) is None:
+
+            def _probe_done(task: asyncio.Task[dict[str, Any]]) -> None:
+                # Drop the entry so a failed probe cannot poison later requests
+                # and a stale result is never served. Guarded by identity so a
+                # replacement probe registered under the same key can never be
+                # evicted by a stale callback.
+                if self._mount_usage_probes.get(key) is task:
+                    del self._mount_usage_probes[key]
+
+                # Retrieve the failure even when nobody is left to receive it. A
+                # probe outlives the caller that started it, so a client giving up
+                # on an unreachable mount leaves a probe that still fails later;
+                # an unretrieved task exception would then be reported as though
+                # supervisor had faulted rather than a mount having not answered.
+                if not task.cancelled() and (err := task.exception()) is not None:
+                    _LOGGER.debug(
+                        "Storage usage probe for mount %s failed: %s", mount.name, err
+                    )
+
+            probe = self.sys_create_task(self._mount_usage_data(mount, max_depth))
+            self._mount_usage_probes[key] = probe
+            probe.add_done_callback(_probe_done)
+
+        # Waiting on the probe rather than awaiting it directly keeps a client
+        # that disconnects from cancelling work other callers share.
+        #
+        # Deliberately not asyncio.shield: it achieves the same isolation, but
+        # once its own await is cancelled it attaches a handler that pushes any
+        # failure through the loop exception handler as "<error> exception in
+        # shielded future". An unreachable mount is the case this endpoint exists
+        # to report on, so that would log a traceback for an expected outcome
+        # every time a user navigated away from a spinner.
+        #
+        # The timeout belongs to this wait, not to the probe. A probe killed by
+        # its own timeout would be popped from the registry while its executor
+        # thread stays parked in the kernel, so the next request would stack a
+        # fresh thread against the same unresponsive mount - the exact pile-up
+        # the registry exists to prevent. Timing out only the wait keeps the
+        # probe and its entry alive: slow callers get their error, later
+        # callers join the same probe, and the one thread is released by the
+        # kernel exactly once. Reachable legitimately via a long depth walk of
+        # a big share, not only via a dead server.
+        done, _ = await asyncio.wait({probe}, timeout=MOUNT_USAGE_TIMEOUT)
+        if not done:
+            raise MountUsageTimeoutError(name=mount.name)
+        return probe.result()
+
+    async def _mount_usage_data(self, mount: Mount, max_depth: int) -> dict[str, Any]:
+        """Probe a mount for its storage usage.
+
+        Runs to the kernel's own bound rather than a timeout of its own: the
+        frontend shows a loader per mount and a real answer is worth waiting
+        for. Callers bound their wait without cancelling this probe.
+        """
+        disk = self.sys_hardware.disk
+
+        try:
+            usage = await self.sys_run_in_executor(
+                disk.disk_usage_for_mount, mount.local_where
+            )
+
+            children: list[dict[str, Any]] = []
+            # The walker recurses regardless of max_depth and only emits
+            # children when max_depth exceeds 1, so it is skipped whenever it
+            # could not produce output - otherwise a request would walk the
+            # whole mount for nothing. Depth 1 emits nothing here because for
+            # the system disk that level is the labeled known paths, which
+            # come from get_dir_sizes rather than this walker, and a mount
+            # has no equivalent layer. Read errors from the walk stay this
+            # mount's problem: reporting them to the resolution center would
+            # mark the whole system unhealthy over an unreachable server.
+            if usage is not None and max_depth > 1:
+                structure = await self.sys_run_in_executor(
+                    disk.get_dir_structure_sizes,
+                    mount.local_where,
+                    max_depth,
+                    check_oserror=False,
+                )
+                children = structure.get(ATTR_CHILDREN, [])
+        except OSError as err:
+            raise MountUsageReadError(name=mount.name, reason=str(err)) from err
+
+        if usage is None:
+            # Ghost mount: systemd still reports the unit active, but the path
+            # no longer crosses a filesystem boundary, so statvfs was reading
+            # the host's data disk and would report its numbers under the
+            # mount's name.
+            raise MountUsageNotMountedError(name=mount.name)
+
+        total, _, free = usage
+        # Same reserved-space convention as the system disk
+        used = total - free
+
+        data: dict[str, Any] = {
+            "id": mount.name,
+            "label": mount.name,
+            "total_bytes": total,
+            "used_bytes": used,
+        }
+        # Omitted rather than empty, matching every other node in the tree
+        if children:
+            # Keep every node's children summing to its used_bytes, so a mount
+            # breaks down like anything else in the tree. Files directly at the
+            # mount root, reserved space, and anything the walk could not stat
+            # all land here. A walk racing deletion can overshoot the filesystem
+            # figure, so a non-positive remainder is dropped rather than
+            # reported as negative.
+            remainder = used - sum(child["used_bytes"] for child in children)
+            if remainder > 0:
+                children = [
+                    *children,
+                    {"id": "other", "label": "Other", "used_bytes": remainder},
+                ]
+
+            data[ATTR_CHILDREN] = children
+
+        return data
 
     @api_process
     async def disk_usage_v1(self, request: web.Request) -> dict[str, Any]:

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -1504,6 +1504,86 @@ class MountTargetNotEmptyError(MountInvalidError):
 class MountNotFound(MountError, APINotFound):
     """Raise on mount not found."""
 
+    error_key = "mount_not_found_error"
+    message_template = "No mount exists with name {name}"
+
+    def __init__(
+        self,
+        message: str | None = None,
+        logger: Callable[..., None] | None = None,
+        *,
+        name: str | None = None,
+    ) -> None:
+        """Initialize exception.
+
+        Callers either pass a ready-made message, as the mount manager does, or
+        just the mount name to get the template message and translation fields.
+        """
+        if name is not None:
+            self.extra_fields = {"name": name}
+        super().__init__(message, logger)
+
+
+class MountUsageNotActiveError(MountError):
+    """Raise when storage usage is requested for a mount that is not active."""
+
+    error_key = "mount_usage_not_active_error"
+    message_template = "Mount {name} is not active, cannot report storage usage"
+
+    def __init__(self, logger: Callable[..., None] | None = None, *, name: str) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"name": name}
+        super().__init__(None, logger)
+
+
+class MountUsageNotMountedError(MountError):
+    """Raise when a mount's path turns out to no longer be mounted.
+
+    The ghost mount case: systemd still reports the unit active, but the path
+    no longer crosses a filesystem boundary, so any numbers read from it would
+    be the host disk's, not the mount's.
+    """
+
+    error_key = "mount_usage_not_mounted_error"
+    message_template = (
+        "Could not read storage usage for mount {name}: no longer mounted"
+    )
+
+    def __init__(self, logger: Callable[..., None] | None = None, *, name: str) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"name": name}
+        super().__init__(None, logger)
+
+
+class MountUsageReadError(MountError):
+    """Raise when reading a mount's storage usage fails."""
+
+    error_key = "mount_usage_read_error"
+    message_template = "Could not read storage usage for mount {name}: {reason}"
+
+    def __init__(
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        name: str,
+        reason: str,
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"name": name, "reason": reason}
+        super().__init__(None, logger)
+
+
+class MountUsageTimeoutError(MountError):
+    """Raise when a caller gives up waiting on a mount's storage usage probe."""
+
+    error_key = "mount_usage_timeout_error"
+    message_template = "Timed out reading storage usage for mount {name}"
+
+    def __init__(self, logger: Callable[..., None] | None = None, *, name: str) -> None:
+        """Initialize exception."""
+        self.extra_fields = {"name": name}
+        super().__init__(None, logger)
+
 
 class MountJobError(MountError, JobException):
     """Raise on Mount job error."""

--- a/supervisor/hardware/disk.py
+++ b/supervisor/hardware/disk.py
@@ -87,11 +87,32 @@ class HwDisk(CoreSysAttributes):
         """
         return shutil.disk_usage(path)
 
-    def get_dir_structure_sizes(self, path: Path, max_depth: int = 1) -> dict[str, Any]:
+    def disk_usage_for_mount(self, path: Path) -> tuple[int, int, int] | None:
+        """Return (total, used, free) in bytes for a mount path, or None if not mounted.
+
+        Must be run in executor. statvfs succeeds on a ghost mount — a systemd
+        unit still reported active whose path is no longer actually mounted — by
+        returning the underlying filesystem's numbers, so only the device
+        boundary check tells the mount's own figures apart from the host disk's.
+        Mirrors `_probe_network_mount` in mounts/mount.py; keep the two agreeing.
+        """
+        usage = shutil.disk_usage(path)
+        if path.stat().st_dev == path.parent.stat().st_dev:
+            return None
+        return usage
+
+    def get_dir_structure_sizes(
+        self, path: Path, max_depth: int = 1, *, check_oserror: bool = True
+    ) -> dict[str, Any]:
         """Return a recursive dict of subdirectories and their sizes, only if size > 0.
 
         Excludes external mounts and symlinks to avoid counting files on other filesystems
         or following symlinks that could lead to infinite loops or incorrect sizes.
+
+        `check_oserror` reports read errors to the resolution center, which
+        documents its checks as local-path-only. Disable it when walking a
+        network mount: an I/O error from an unreachable server is that mount's
+        problem and must not mark the whole system unhealthy.
         """
 
         size = 0
@@ -113,7 +134,8 @@ class HwDisk(CoreSysAttributes):
                 _LOGGER.warning("File not found: %s", child.as_posix())
                 continue
             except OSError as err:
-                self.sys_resolution.check_oserror(err)
+                if check_oserror:
+                    self.sys_resolution.check_oserror(err)
                 if err.errno == errno.EBADMSG:
                     break
                 continue
@@ -125,7 +147,9 @@ class HwDisk(CoreSysAttributes):
                 size += stat.st_size
                 continue
 
-            child_result = self.get_dir_structure_sizes(child, max_depth - 1)
+            child_result = self.get_dir_structure_sizes(
+                child, max_depth - 1, check_oserror=check_oserror
+            )
             if child_result["used_bytes"] > 0:
                 size += child_result["used_bytes"]
                 if max_depth > 1:

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -1,7 +1,13 @@
 """Test Host API."""
 
+import asyncio
 from collections.abc import AsyncGenerator
+from contextlib import suppress
 from datetime import UTC, datetime
+import errno
+import gc
+import time
+from typing import Any
 from unittest.mock import ANY, MagicMock, patch
 
 from aiohttp import ClientPayloadError
@@ -10,12 +16,18 @@ from dbus_fast import DBusError, ErrorType
 import pytest
 import time_machine
 
+from supervisor.api.host import APIHost
 from supervisor.coresys import CoreSys
+from supervisor.dbus.const import UnitActiveState
 from supervisor.dbus.resolved import Resolved
-from supervisor.exceptions import HostJournalGatewaydConnectionError
+from supervisor.exceptions import (
+    HostJournalGatewaydConnectionError,
+    MountUsageTimeoutError,
+)
 from supervisor.homeassistant.api import APIState
 from supervisor.host.const import LogFormat, LogFormatter
 from supervisor.host.control import SystemControl
+from supervisor.mounts.mount import Mount
 
 from tests.dbus_service_mocks.base import DBusServiceMock
 from tests.dbus_service_mocks.hostname import Hostname as HostnameService
@@ -1037,3 +1049,428 @@ async def test_set_hostname_invalid_returns_400(
     assert body["message"] == "Invalid hostname 'bad name'"
     assert body["error_key"] == "host_invalid_hostname"
     assert body["extra_fields"] == {"hostname": "bad name"}
+
+
+def _register_mount(coresys: CoreSys, name: str, state: UnitActiveState) -> Mount:
+    """Register a CIFS mount with the manager in the given systemd state."""
+    mount = Mount.from_dict(
+        coresys,
+        {
+            "name": name,
+            "type": "cifs",
+            "usage": "media",
+            "server": "media.local",
+            "share": "media",
+        },
+    )
+    mount._state = state
+    coresys.mounts._mounts = {mount.name: mount}
+    return mount
+
+
+@pytest.fixture(name="active_mount")
+async def fixture_active_mount(
+    coresys: CoreSys, tmp_supervisor_data, path_extern
+) -> Mount:
+    """Return an active CIFS mount registered with the mount manager."""
+    return _register_mount(coresys, "media_test", UnitActiveState.ACTIVE)
+
+
+@pytest.mark.parametrize(
+    "query",
+    ["", "?max_depth=0", "?max_depth=1"],
+    ids=["depth-default", "depth-explicit-0", "depth-1-emits-nothing"],
+)
+async def test_disk_usage_api_mount_totals_only(
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    active_mount: Mount,
+    query: str,
+):
+    """Test a mount reports totals only without ever walking the tree.
+
+    The directory walker recurses regardless of max_depth and only emits
+    children beyond depth 1, so whenever it could not produce output — depth 0
+    and depth 1 alike — it has to be skipped outright. Calling it would walk
+    the whole mount on every request just to discard the result.
+    """
+    api_client, prefix = api_client_with_prefix
+
+    with (
+        patch.object(coresys.hardware.disk, "disk_usage_for_mount") as mock_disk_usage,
+        patch.object(
+            coresys.hardware.disk, "get_dir_structure_sizes"
+        ) as mock_structure,
+    ):
+        # Middle value is deliberately wrong: used must come from total - free so
+        # that reserved space counts as used, as it does for the system disk.
+        mock_disk_usage.return_value = (2000000000, 999, 800000000)
+
+        resp = await api_client.get(f"{prefix}/host/disks/media_test/usage{query}")
+
+    assert resp.status == 200
+    result = await resp.json()
+    assert result["data"] == {
+        "id": "media_test",
+        "label": "media_test",
+        "total_bytes": 2000000000,
+        "used_bytes": 1200000000,
+    }
+    # Omitted entirely rather than empty, like every other node in the tree
+    assert "children" not in result["data"]
+    mock_structure.assert_not_called()
+    mock_disk_usage.assert_called_once_with(active_mount.local_where)
+
+
+async def test_disk_usage_api_mount_breakdown(
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    active_mount: Mount,
+):
+    """Test a mount breakdown at depth 2.
+
+    Depth means the same thing as it does for the system disk: level 1 is the
+    labeled known paths, which a mount does not have, so a mount's own
+    subdirectories start at level 2.
+    """
+    api_client, prefix = api_client_with_prefix
+
+    with (
+        patch.object(coresys.hardware.disk, "disk_usage_for_mount") as mock_disk_usage,
+        patch.object(
+            coresys.hardware.disk, "get_dir_structure_sizes"
+        ) as mock_structure,
+    ):
+        mock_disk_usage.return_value = (2000000000, 999, 800000000)
+        mock_structure.return_value = {
+            "used_bytes": 1100000000,
+            "children": [
+                {"id": "movies", "label": "movies", "used_bytes": 900000000},
+                {"id": "music", "label": "music", "used_bytes": 200000000},
+            ],
+        }
+
+        resp = await api_client.get(f"{prefix}/host/disks/media_test/usage?max_depth=2")
+
+    assert resp.status == 200
+    result = await resp.json()
+    children = result["data"]["children"]
+
+    # What the walk could not attribute is reported as "other", so a mount's
+    # children add up to its used_bytes like every other node in the tree.
+    assert children == [
+        {"id": "movies", "label": "movies", "used_bytes": 900000000},
+        {"id": "music", "label": "music", "used_bytes": 200000000},
+        {"id": "other", "label": "Other", "used_bytes": 100000000},
+    ]
+    assert (
+        sum(child["used_bytes"] for child in children) == (result["data"]["used_bytes"])
+    )
+    # check_oserror off: read errors from a mount walk must stay the mount's
+    # problem instead of marking the whole system unhealthy
+    mock_structure.assert_called_once_with(
+        active_mount.local_where, 2, check_oserror=False
+    )
+
+
+@pytest.mark.parametrize(
+    "walked_bytes",
+    [1200000000, 1300000000],
+    ids=["accounts-for-everything", "overshoots-the-filesystem"],
+)
+@pytest.mark.usefixtures("active_mount")
+async def test_disk_usage_api_mount_breakdown_without_remainder(
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    walked_bytes: int,
+):
+    """Test no "other" child when there is nothing left to attribute.
+
+    A walk that accounts for everything needs no remainder, and one that
+    overshoots (racing a deletion against the filesystem figure) must not
+    produce a negative one.
+    """
+    api_client, prefix = api_client_with_prefix
+
+    with (
+        patch.object(coresys.hardware.disk, "disk_usage_for_mount") as mock_disk_usage,
+        patch.object(
+            coresys.hardware.disk, "get_dir_structure_sizes"
+        ) as mock_structure,
+    ):
+        # used = total - free = 1200000000
+        mock_disk_usage.return_value = (2000000000, 999, 800000000)
+        mock_structure.return_value = {
+            "used_bytes": walked_bytes,
+            "children": [
+                {"id": "movies", "label": "movies", "used_bytes": walked_bytes},
+            ],
+        }
+
+        resp = await api_client.get(f"{prefix}/host/disks/media_test/usage?max_depth=2")
+
+    assert resp.status == 200
+    result = await resp.json()
+    assert result["data"]["children"] == [
+        {"id": "movies", "label": "movies", "used_bytes": walked_bytes},
+    ]
+    assert all(child["id"] != "other" for child in result["data"]["children"])
+
+
+@pytest.mark.usefixtures("tmp_supervisor_data", "path_extern")
+async def test_disk_usage_api_unknown_mount(
+    api_client_with_prefix: tuple[TestClient, str],
+):
+    """Test requesting usage for a mount that does not exist."""
+    api_client, prefix = api_client_with_prefix
+
+    resp = await api_client.get(f"{prefix}/host/disks/nope/usage")
+
+    assert resp.status == 404
+    result = await resp.json()
+    assert result["message"] == "No mount exists with name nope"
+    assert result["error_key"] == "mount_not_found_error"
+    assert result["extra_fields"] == {"name": "nope"}
+
+
+@pytest.mark.usefixtures("tmp_supervisor_data", "path_extern")
+async def test_disk_usage_api_inactive_mount(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
+    """Test a mount that is not active cannot report usage."""
+    api_client, prefix = api_client_with_prefix
+    _register_mount(coresys, "media_test", UnitActiveState.FAILED)
+
+    with patch.object(coresys.hardware.disk, "disk_usage_for_mount") as mock_disk_usage:
+        resp = await api_client.get(f"{prefix}/host/disks/media_test/usage")
+
+    assert resp.status == 400
+    result = await resp.json()
+    assert result["error_key"] == "mount_usage_not_active_error"
+    assert result["extra_fields"] == {"name": "media_test"}
+    # Rejected before any probe is attempted
+    mock_disk_usage.assert_not_called()
+
+
+@pytest.mark.usefixtures("active_mount")
+async def test_disk_usage_api_mount_timeout(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
+    """Test a probe that never returns fails cleanly for that mount."""
+    api_client, prefix = api_client_with_prefix
+
+    def _never_returns(_):
+        time.sleep(0.5)
+        return (1, 1, 1)
+
+    with (
+        patch("supervisor.api.host.MOUNT_USAGE_TIMEOUT", 0.05),
+        patch.object(
+            coresys.hardware.disk, "disk_usage_for_mount", side_effect=_never_returns
+        ),
+    ):
+        resp = await api_client.get(f"{prefix}/host/disks/media_test/usage")
+
+    assert resp.status == 400
+    result = await resp.json()
+    assert result["error_key"] == "mount_usage_timeout_error"
+    assert result["extra_fields"] == {"name": "media_test"}
+
+
+@pytest.mark.usefixtures("active_mount")
+async def test_disk_usage_api_mount_unreachable(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
+    """Test an unreachable mount reports an error rather than failing the API."""
+    api_client, prefix = api_client_with_prefix
+
+    with patch.object(
+        coresys.hardware.disk,
+        "disk_usage_for_mount",
+        side_effect=OSError(errno.EHOSTDOWN, "Host is down"),
+    ):
+        resp = await api_client.get(f"{prefix}/host/disks/media_test/usage")
+
+    assert resp.status == 400
+    result = await resp.json()
+    assert result["error_key"] == "mount_usage_read_error"
+    assert result["extra_fields"]["name"] == "media_test"
+    assert "Host is down" in result["extra_fields"]["reason"]
+
+
+@pytest.mark.usefixtures("active_mount")
+async def test_disk_usage_api_ghost_mount(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
+    """Test a ghost mount is reported unreadable, not misreported.
+
+    systemd can still report a unit active after the path stopped being a
+    mount point; statvfs then silently returns the host data disk's numbers.
+    Serving those under the mount's name would be a plausible-looking lie.
+    """
+    api_client, prefix = api_client_with_prefix
+
+    with (
+        patch.object(coresys.hardware.disk, "disk_usage_for_mount", return_value=None),
+        patch.object(
+            coresys.hardware.disk, "get_dir_structure_sizes"
+        ) as mock_structure,
+    ):
+        resp = await api_client.get(f"{prefix}/host/disks/media_test/usage?max_depth=2")
+
+    assert resp.status == 400
+    result = await resp.json()
+    assert result["error_key"] == "mount_usage_not_mounted_error"
+    assert result["extra_fields"] == {"name": "media_test"}
+    # A ghost is never walked either
+    mock_structure.assert_not_called()
+
+
+@pytest.mark.usefixtures("tmp_supervisor_data", "path_extern")
+async def test_mount_usage_caller_timeout_joins_same_probe(coresys: CoreSys):
+    """Test a caller's timeout neither cancels nor orphans the shared probe.
+
+    A probe killed by its own timeout would be dropped from the registry while
+    its executor thread stays parked in the kernel, so the next request would
+    stack a fresh thread against the same mount. The timeout therefore bounds
+    only the caller's wait: the probe and its registry entry outlive slow
+    callers, and later callers join the same probe.
+    """
+    api_host = APIHost()
+    api_host.coresys = coresys
+    mount = _register_mount(coresys, "media_test", UnitActiveState.ACTIVE)
+
+    def _slow(_):
+        time.sleep(0.4)
+        return (2000000000, 999, 800000000)
+
+    with patch.object(
+        coresys.hardware.disk, "disk_usage_for_mount", side_effect=_slow
+    ) as mock_usage:
+        with (
+            patch("supervisor.api.host.MOUNT_USAGE_TIMEOUT", 0.05),
+            pytest.raises(
+                MountUsageTimeoutError, match="Timed out reading storage usage"
+            ),
+        ):
+            await api_host._mount_usage(mount, 0)
+
+        # The probe survived its caller: still registered, still running
+        assert ("media_test", 0) in api_host._mount_usage_probes
+
+        # A later caller (with the real, generous timeout) joins that same
+        # probe rather than starting another executor thread
+        result = await api_host._mount_usage(mount, 0)
+
+    assert result["used_bytes"] == 1200000000
+    mock_usage.assert_called_once()
+    # Completion popped the entry, so the next request starts fresh
+    assert not api_host._mount_usage_probes
+
+
+@pytest.mark.usefixtures("active_mount")
+async def test_disk_usage_api_mount_shares_in_flight_probe(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
+    """Test concurrent requests for the same mount share one probe.
+
+    A probe of an unreachable mount blocks until the kernel gives up, so
+    stacking one executor thread per caller is what this guards against.
+    """
+    api_client, prefix = api_client_with_prefix
+
+    def _slow(_):
+        time.sleep(0.3)
+        return (2000000000, 999, 800000000)
+
+    with patch.object(
+        coresys.hardware.disk, "disk_usage_for_mount", side_effect=_slow
+    ) as mock_disk_usage:
+        first, second = await asyncio.gather(
+            api_client.get(f"{prefix}/host/disks/media_test/usage"),
+            api_client.get(f"{prefix}/host/disks/media_test/usage"),
+        )
+
+    assert first.status == 200
+    assert second.status == 200
+    assert (await first.json())["data"] == (await second.json())["data"]
+    mock_disk_usage.assert_called_once()
+
+
+@pytest.mark.usefixtures("tmp_supervisor_data", "path_extern")
+async def test_mount_usage_abandoned_probe_retrieves_its_exception(coresys: CoreSys):
+    """Test an abandoned failing probe is not reported as an unretrieved exception.
+
+    The shield deliberately keeps a probe alive past the caller that started it,
+    so a browser giving up on an unreachable mount leaves a probe that still
+    fails later with nobody waiting on it. Left unretrieved, asyncio reports it
+    with a traceback that reads like a supervisor fault rather than a mount that
+    was never going to answer.
+    """
+    api_host = APIHost()
+    api_host.coresys = coresys
+    mount = _register_mount(coresys, "media_test", UnitActiveState.ACTIVE)
+
+    reported: list[dict[str, Any]] = []
+    loop = asyncio.get_running_loop()
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: reported.append(context))
+
+    def _fails_slowly(_):
+        time.sleep(0.2)
+        raise OSError(errno.EHOSTDOWN, "Host is down")
+
+    try:
+        with patch.object(
+            coresys.hardware.disk, "disk_usage_for_mount", side_effect=_fails_slowly
+        ):
+            waiter = asyncio.create_task(api_host._mount_usage(mount, 0))
+
+            # Let the probe get going, then abandon it the way a disconnecting
+            # client does
+            await asyncio.sleep(0.05)
+            waiter.cancel()
+            with suppress(asyncio.CancelledError):
+                await waiter
+
+            # Give the orphaned probe time to fail, then force collection so an
+            # unretrieved exception would be surfaced
+            await asyncio.sleep(0.5)
+            gc.collect()
+            await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    # Nothing at all should reach the loop exception handler: an unreachable
+    # mount is an expected outcome, not a supervisor fault
+    assert not reported
+    # The entry is gone either way, so a later request starts a fresh probe
+    assert not api_host._mount_usage_probes
+
+
+@pytest.mark.usefixtures("tmp_supervisor_data", "path_extern")
+async def test_disk_usage_api_default_wins_over_mount_of_that_name(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
+    """Test "default" always means the system disk.
+
+    The mount name pattern permits a mount called "default", so the resolution
+    order has to be documented and pinned: the reserved target wins.
+    """
+    api_client, prefix = api_client_with_prefix
+    _register_mount(coresys, "default", UnitActiveState.ACTIVE)
+
+    with (
+        patch.object(coresys.hardware.disk, "disk_usage") as mock_disk_usage,
+        patch.object(coresys.hardware.disk, "get_dir_sizes") as mock_dir_sizes,
+    ):
+        mock_disk_usage.return_value = (1000000000, 500000000, 500000000)
+        mock_dir_sizes.return_value = []
+
+        resp = await api_client.get(f"{prefix}/host/disks/default/usage")
+
+    assert resp.status == 200
+    result = await resp.json()
+    # The system disk, not the mount
+    assert result["data"]["id"] == "root"
+    assert result["data"]["label"] == "Root"

--- a/tests/hardware/test_disk.py
+++ b/tests/hardware/test_disk.py
@@ -3,7 +3,7 @@
 # pylint: disable=protected-access
 import errno
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from dbus_fast.aio import MessageBus
 import pytest
@@ -387,3 +387,42 @@ async def test_try_get_nvme_life_time_dbus_not_connected(coresys: CoreSys):
         coresys.config.path_supervisor
     )
     assert lifetime is None
+
+
+async def test_dir_walker_oserror_reporting_can_be_gated(coresys: CoreSys):
+    """Test the walker only reports read errors to resolution when asked to.
+
+    The resolution center's OSError checks are documented local-path-only, so a
+    read error from a network mount walk must not mark the whole system
+    unhealthy. The EBADMSG break-out stays either way: whatever the source, a
+    corrupted-message error means the rest of the walk is untrustworthy.
+    """
+
+    def make_path() -> tuple[MagicMock, MagicMock]:
+        path = MagicMock(spec=Path)
+        path.exists.return_value = True
+        path.stat.return_value.st_dev = 1
+        failing = MagicMock(spec=Path)
+        failing.is_symlink.return_value = False
+        failing.stat.side_effect = OSError(errno.EBADMSG, "Bad message")
+        never_reached = MagicMock(spec=Path)
+        never_reached.is_symlink.return_value = False
+        path.iterdir.return_value = [failing, never_reached]
+        return path, never_reached
+
+    # Gated off (a mount walk): resolution never hears about it
+    path, never_reached = make_path()
+    with patch.object(coresys.resolution, "check_oserror") as check:
+        result = coresys.hardware.disk.get_dir_structure_sizes(
+            path, 2, check_oserror=False
+        )
+    check.assert_not_called()
+    assert result == {"used_bytes": 0}
+    # EBADMSG still aborts the walk regardless of the gating
+    never_reached.stat.assert_not_called()
+
+    # Default (the system disk): reported as before
+    path, _ = make_path()
+    with patch.object(coresys.resolution, "check_oserror") as check:
+        coresys.hardware.disk.get_dir_structure_sizes(path, 2)
+    check.assert_called_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Parameterize the disk usage endpoint as `GET /host/disks/{disk}/usage` so it can also report storage usage for an active supervisor mount by name. `default` — the literal URL today's clients call — keeps its existing response byte for byte. Per-mount probes are shared between concurrent callers, run to the kernel's own bound rather than an artificial timeout, and are confined to an executor thread so a hung probe never blocks the rest of the API.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/orgs/home-assistant/discussions/1747
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3302
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/53683
- Link to cli pull request:
- Link to client library pull request:

### Notes for reviewers

- Depth semantics are uniform across targets: level 1 is the system disk's labeled known-paths layer, which a mount does not have, so a mount breakdown starts at `max_depth=2`.
- Mounts default to totals only (`max_depth=0`). The directory walker recurses regardless of `max_depth` — the parameter only gates whether children appear in its output — so whenever it could not produce output (depth 0 and 1 for a mount) it is skipped outright rather than called; otherwise a request would walk the whole network mount to report a single number.
- When a breakdown is produced, whatever the walk cannot attribute is reported as an `other` child, keeping every node's children summing to its `used_bytes` — same invariant as the system disk's `system` entry.
- `default` wins over a mount literally named `default`, which the mount name pattern permits.
- The probe deliberately does not use `asyncio.shield` even though this file uses it elsewhere; the code comment at the call site explains why.

### Testing

End-to-end against a real CIFS mount (Samba in a container, guest share with known contents: 30 MiB `movies/`, 10 MiB `music/`, 5 MiB at the share root):

- Totals: `total_bytes` byte-identical to `df` on the server side; totals-only response carries no `children` key.
- Depth-2 breakdown: `movies` 31457280 and `music` 10485760 — exactly the sizes written into the share — plus `other` absorbing the rest; children sum exactly to `used_bytes`.
- Dead server: stopping Samba mid-flight returned a clean error in 10 s via the kernel's own `soft,echo_interval=10` bound (`Host is down`), while concurrent `/supervisor/ping` answered in 25–46 ms and the system disk usage in 52 ms during the hang.
- Inactive mount → 400 with no probe attempted; unknown mount → 404.
- `default` unchanged, including the v1 legacy addon-ID remap confirmed live through the parameterized route.
- Recovery: after the server returned, a mount reload restored usage reporting.

Unit tests: 69 pass in `tests/api/test_host.py` (46 pre-existing untouched, 23 new, v1+v2 parametrized); full suite green; 10 targeted mutations of the new behavior each produce a failing test.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/

