### PR TITLE
Use port 80 as default for Core/landingpage, omit scheme's default port in API URL

### DIFF
--- a/supervisor/homeassistant/module.py
+++ b/supervisor/homeassistant/module.py
@@ -167,16 +167,25 @@ class HomeAssistant(FileConfiguration, CoreSysAttributes):
         self._http_server_host = value
 
     @property
+    def api_authority(self) -> str:
+        """Return host with port for Home Assistant URLs.
+
+        The port is left out when it is the default one for the scheme, so
+        URLs stay in the form users see them in.
+        """
+        if self.api_port == (443 if self.api_ssl else 80):
+            return str(self.ip_address)
+        return f"{self.ip_address}:{self.api_port}"
+
+    @property
     def api_url(self) -> str:
         """Return API url to Home Assistant."""
-        return (
-            f"{'https' if self.api_ssl else 'http'}://{self.ip_address}:{self.api_port}"
-        )
+        return f"{'https' if self.api_ssl else 'http'}://{self.api_authority}"
 
     @property
     def ws_url(self) -> str:
         """Return API url to Home Assistant."""
-        return f"{'wss' if self.api_ssl else 'ws'}://{self.ip_address}:{self.api_port}/api/websocket"
+        return f"{'wss' if self.api_ssl else 'ws'}://{self.api_authority}/api/websocket"
 
     @property
     def watchdog(self) -> bool:

--- a/supervisor/homeassistant/validate.py
+++ b/supervisor/homeassistant/validate.py
@@ -30,7 +30,7 @@ SCHEMA_HASS_CONFIG = vol.Schema(
         vol.Optional(ATTR_IMAGE): docker_image,
         vol.Optional(ATTR_ACCESS_TOKEN): token,
         vol.Optional(ATTR_BOOT, default=True): vol.Boolean(),
-        vol.Optional(ATTR_PORT, default=8123): network_port,
+        vol.Optional(ATTR_PORT, default=80): network_port,
         vol.Optional(ATTR_REFRESH_TOKEN): vol.Maybe(str),
         vol.Optional(ATTR_SSL, default=False): vol.Boolean(),
         vol.Optional(ATTR_WATCHDOG, default=True): vol.Boolean(),

--- a/tests/api/test_discovery.py
+++ b/tests/api/test_discovery.py
@@ -105,7 +105,7 @@ async def test_api_send_del_discovery(
     assert coresys.websession.request.call_args.args[0] == "post"
     assert (
         coresys.websession.request.call_args.args[1]
-        == f"http://172.30.32.1:8123/api/hassio_push/discovery/{uuid}"
+        == f"http://172.30.32.1/api/hassio_push/discovery/{uuid}"
     )
     assert coresys.websession.request.call_args.kwargs["json"] == {
         "addon": install_app_ssh.slug,
@@ -125,7 +125,7 @@ async def test_api_send_del_discovery(
     assert coresys.websession.request.call_args.args[0] == "delete"
     assert (
         coresys.websession.request.call_args.args[1]
-        == f"http://172.30.32.1:8123/api/hassio_push/discovery/{uuid}"
+        == f"http://172.30.32.1/api/hassio_push/discovery/{uuid}"
     )
     assert coresys.websession.request.call_args.kwargs["json"] == {
         "addon": install_app_ssh.slug,

--- a/tests/apps/test_manager.py
+++ b/tests/apps/test_manager.py
@@ -254,7 +254,7 @@ async def test_app_uninstall_removes_discovery(coresys: CoreSys, install_app_ssh
     assert len(delete_calls) == 1
     assert (
         delete_calls[0].args[1]
-        == f"http://172.30.32.1:8123/api/hassio_push/discovery/{message.uuid}"
+        == f"http://172.30.32.1/api/hassio_push/discovery/{message.uuid}"
     )
     assert delete_calls[0].kwargs["json"] == {
         "addon": TEST_ADDON_SLUG,

--- a/tests/homeassistant/test_api.py
+++ b/tests/homeassistant/test_api.py
@@ -140,7 +140,7 @@ async def test_use_unix_socket(
     ("use_unix", "expected_api_url", "expected_ws_url"),
     [
         (True, "http://localhost", "ws://localhost/api/websocket"),
-        (False, "http://172.30.32.1:8123", "ws://172.30.32.1:8123/api/websocket"),
+        (False, "http://172.30.32.1", "ws://172.30.32.1/api/websocket"),
     ],
 )
 async def test_api_and_ws_urls(
@@ -150,6 +150,41 @@ async def test_api_and_ws_urls(
     with patch.object(type(coresys.homeassistant.api), "use_unix_socket", use_unix):
         assert coresys.homeassistant.api.api_url == expected_api_url
         assert coresys.homeassistant.api.ws_url == expected_ws_url
+
+
+@pytest.mark.parametrize(
+    ("port", "ssl", "expected_api_url", "expected_ws_url"),
+    [
+        (80, False, "http://172.30.32.1", "ws://172.30.32.1/api/websocket"),
+        (443, True, "https://172.30.32.1", "wss://172.30.32.1/api/websocket"),
+        (
+            8123,
+            False,
+            "http://172.30.32.1:8123",
+            "ws://172.30.32.1:8123/api/websocket",
+        ),
+        (
+            8123,
+            True,
+            "https://172.30.32.1:8123",
+            "wss://172.30.32.1:8123/api/websocket",
+        ),
+        (80, True, "https://172.30.32.1:80", "wss://172.30.32.1:80/api/websocket"),
+    ],
+)
+async def test_url_omits_default_scheme_port(
+    coresys: CoreSys,
+    port: int,
+    ssl: bool,
+    expected_api_url: str,
+    expected_ws_url: str,
+):
+    """Test the port is only part of the url when the scheme doesn't imply it."""
+    coresys.homeassistant.api_port = port
+    coresys.homeassistant.api_ssl = ssl
+
+    assert coresys.homeassistant.api_url == expected_api_url
+    assert coresys.homeassistant.ws_url == expected_ws_url
 
 
 # --- connection lifecycle ---
@@ -357,8 +392,8 @@ async def test_http_config_pulled_on_connect(
         return_value={"state": "RUNNING", "recorder_state": {}}
     )
     coresys.homeassistant.save_data = AsyncMock()
+    coresys.homeassistant.api_port = 8123
 
-    assert coresys.homeassistant.api_port == 8123
     assert coresys.homeassistant.http_server_host is None
 
     with (
@@ -404,7 +439,7 @@ async def test_http_config_unchanged_not_saved(
     )
     coresys.homeassistant.save_data = AsyncMock()
 
-    config = {**TEST_HTTP_CONFIG, "port": 8123, "server_host": ["172.30.32.1"]}
+    config = {**TEST_HTTP_CONFIG, "server_host": ["172.30.32.1"]}
     with (
         patch.object(type(api), "use_unix_socket", True),
         patch.object(api, "_get_json", return_value=config),

--- a/tests/homeassistant/test_module.py
+++ b/tests/homeassistant/test_module.py
@@ -10,7 +10,7 @@ import pytest
 
 from supervisor.backups.backup import Backup
 from supervisor.backups.const import BackupType
-from supervisor.const import CoreState
+from supervisor.const import ATTR_PORT, CoreState
 from supervisor.coresys import CoreSys
 from supervisor.docker.interface import DockerInterface
 from supervisor.exceptions import (
@@ -19,6 +19,7 @@ from supervisor.exceptions import (
 )
 from supervisor.homeassistant.module import HomeAssistant
 from supervisor.homeassistant.secrets import HomeAssistantSecrets
+from supervisor.homeassistant.validate import SCHEMA_HASS_CONFIG
 from supervisor.homeassistant.websocket import HomeAssistantWebSocket
 from supervisor.utils.dt import utcnow
 
@@ -56,6 +57,16 @@ async def test_load(
     await coresys.core.set_state(CoreState.RUNNING)
     await asyncio.sleep(0)
     assert ha_ws_client.async_send_command.call_args_list[0][0][0] == {"lorem": "ipsum"}
+
+
+async def test_api_port_default(coresys: CoreSys):
+    """Test a fresh config defaults to the port Core and the landingpage serve on."""
+    assert coresys.homeassistant.api_port == 80
+
+
+def test_api_port_kept_from_config():
+    """Test an existing installation keeps the port it was set up with."""
+    assert SCHEMA_HASS_CONFIG({"port": 8123})[ATTR_PORT] == 8123
 
 
 async def test_list_users_none(coresys: CoreSys, ha_ws_client: AsyncMock):


### PR DESCRIPTION
## Proposed change

Set default port of HA to 80, as this default is authoritative for what's shown on the HA CLI banner when landing page is running - there's no homeassistant.json at this time, so this value applies. We shouldn't need to care about installs running an old landing page (without port 80 support at all), as Supervisor update results in the old default being persisted homeassistant.json which is written on Supervisor restart, so the banner still shows port 8123 if the old Supervisor (and hence old landing page) were baked in an OS image.

Also append the port to the API URL only when it's not the scheme's default to avoid :80/:443 suffixes when they're not necessary.



## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #7151 
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
