### PR TITLE
Harden mount storage usage edge cases

### DIFF
--- a/supervisor/api/host.py
+++ b/supervisor/api/host.py
@@ -475,6 +475,10 @@ class APIHost(CoreSysAttributes):
             raise MountUsageNotActiveError(name=name)
 
         max_depth = self._requested_max_depth(request, DISK_USAGE_MAX_DEPTH_MOUNT)
+        # All depths below 2 give totals only; normalize so concurrent callers
+        # share one probe regardless of the requested depth.
+        if max_depth < 2:
+            max_depth = DISK_USAGE_MAX_DEPTH_MOUNT
         return await self._mount_usage(mount, max_depth)
 
     async def _mount_usage(self, mount: Mount, max_depth: int) -> dict[str, Any]:
@@ -585,16 +589,28 @@ class APIHost(CoreSysAttributes):
             # Keep every node's children summing to its used_bytes, so a mount
             # breaks down like anything else in the tree. Files directly at the
             # mount root, reserved space, and anything the walk could not stat
-            # all land here. A walk racing deletion can overshoot the filesystem
-            # figure, so a non-positive remainder is dropped rather than
-            # reported as negative.
-            remainder = used - sum(child["used_bytes"] for child in children)
+            # all land here.
+            walked = sum(child["used_bytes"] for child in children)
+            remainder = used - walked
             if remainder > 0:
                 children = [
                     *children,
                     {"id": "other", "label": "Other", "used_bytes": remainder},
                 ]
+            elif remainder < 0:
+                # Walk raced a deletion; drop the breakdown rather than serve
+                # children summing past their parent.
+                _LOGGER.warning(
+                    "Directory sizes of mount %s (%d bytes) exceed its reported "
+                    "usage (%d bytes), likely because files changed during the "
+                    "scan. Omitting the breakdown for this request",
+                    mount.name,
+                    walked,
+                    used,
+                )
+                children = []
 
+        if children:
             data[ATTR_CHILDREN] = children
 
         return data
@@ -602,7 +618,15 @@ class APIHost(CoreSysAttributes):
     @api_process
     async def disk_usage_v1(self, request: web.Request) -> dict[str, Any]:
         """Return disk usage with legacy addon IDs for v1 compatibility."""
-        return self._legacy_disk_usage_ids_for_v1(await self._disk_usage_data(request))
+        data = await self._disk_usage_data(request)
+
+        # Legacy ids exist only in the system disk's labeled layer. Mount
+        # children are real directory names, and the shared probe result
+        # must not be mutated in place.
+        if request.match_info.get(DISK, DISK_TARGET_SYSTEM) == DISK_TARGET_SYSTEM:
+            data = self._legacy_disk_usage_ids_for_v1(data)
+
+        return data
 
     async def _get_container_last_epoch(self, identifier: str | list[str]) -> str:
         """Get Docker's internal log epoch of the latest log entry for given identifier(s)."""

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -1174,8 +1174,8 @@ async def test_disk_usage_api_mount_breakdown(
 
 
 @pytest.mark.parametrize(
-    "walked_bytes",
-    [1200000000, 1300000000],
+    ("walked_bytes", "expect_children"),
+    [(1200000000, True), (1300000000, False)],
     ids=["accounts-for-everything", "overshoots-the-filesystem"],
 )
 @pytest.mark.usefixtures("active_mount")
@@ -1183,13 +1183,10 @@ async def test_disk_usage_api_mount_breakdown_without_remainder(
     api_client_with_prefix: tuple[TestClient, str],
     coresys: CoreSys,
     walked_bytes: int,
+    expect_children: bool,
+    caplog: pytest.LogCaptureFixture,
 ):
-    """Test no "other" child when there is nothing left to attribute.
-
-    A walk that accounts for everything needs no remainder, and one that
-    overshoots (racing a deletion against the filesystem figure) must not
-    produce a negative one.
-    """
+    """Test an exact walk keeps its children and an overshooting walk drops them."""
     api_client, prefix = api_client_with_prefix
 
     with (
@@ -1211,10 +1208,21 @@ async def test_disk_usage_api_mount_breakdown_without_remainder(
 
     assert resp.status == 200
     result = await resp.json()
-    assert result["data"]["children"] == [
-        {"id": "movies", "label": "movies", "used_bytes": walked_bytes},
-    ]
-    assert all(child["id"] != "other" for child in result["data"]["children"])
+    if expect_children:
+        assert result["data"]["children"] == [
+            {"id": "movies", "label": "movies", "used_bytes": walked_bytes},
+        ]
+        assert "Omitting the breakdown" not in caplog.text
+    else:
+        assert "children" not in result["data"]
+        # Dropped data is not silent: leave a trace for user reports
+        assert "Directory sizes of mount media_test" in caplog.text
+        assert "Omitting the breakdown" in caplog.text
+    # Either way the children never sum past used_bytes
+    assert (
+        sum(child["used_bytes"] for child in result["data"].get("children", []))
+        <= result["data"]["used_bytes"]
+    )
 
 
 @pytest.mark.usefixtures("tmp_supervisor_data", "path_extern")
@@ -1446,6 +1454,59 @@ async def test_mount_usage_abandoned_probe_retrieves_its_exception(coresys: Core
     assert not reported
     # The entry is gone either way, so a later request starts a fresh probe
     assert not api_host._mount_usage_probes
+
+
+@pytest.mark.usefixtures("active_mount")
+async def test_disk_usage_api_mount_depths_below_two_share_one_probe(
+    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+):
+    """Test concurrent callers at depths 0 and 1 share a single probe."""
+    api_client, prefix = api_client_with_prefix
+
+    def _slow(_):
+        time.sleep(0.3)
+        return (2000000000, 999, 800000000)
+
+    with patch.object(
+        coresys.hardware.disk, "disk_usage_for_mount", side_effect=_slow
+    ) as mock_disk_usage:
+        first, second = await asyncio.gather(
+            api_client.get(f"{prefix}/host/disks/media_test/usage?max_depth=0"),
+            api_client.get(f"{prefix}/host/disks/media_test/usage?max_depth=1"),
+        )
+
+    assert first.status == 200
+    assert second.status == 200
+    assert (await first.json())["data"] == (await second.json())["data"]
+    mock_disk_usage.assert_called_once()
+
+
+@pytest.mark.usefixtures("active_mount")
+async def test_disk_usage_api_v1_mount_children_are_not_remapped(
+    api_client: TestClient, coresys: CoreSys
+):
+    """Test a mount directory named apps_data keeps its name in v1 responses."""
+    with (
+        patch.object(coresys.hardware.disk, "disk_usage_for_mount") as mock_disk_usage,
+        patch.object(
+            coresys.hardware.disk, "get_dir_structure_sizes"
+        ) as mock_structure,
+    ):
+        mock_disk_usage.return_value = (2000000000, 999, 800000000)
+        mock_structure.return_value = {
+            "used_bytes": 1200000000,
+            "children": [
+                {"id": "apps_data", "label": "apps_data", "used_bytes": 1200000000},
+            ],
+        }
+
+        resp = await api_client.get("/host/disks/media_test/usage?max_depth=2")
+
+    assert resp.status == 200
+    result = await resp.json()
+    assert result["data"]["children"] == [
+        {"id": "apps_data", "label": "apps_data", "used_bytes": 1200000000},
+    ]
 
 
 @pytest.mark.usefixtures("tmp_supervisor_data", "path_extern")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Follow-up to #7146, addressing three findings from the automated review that arrived after approval. Depths below 2 are normalized before keying the shared-probe registry, so concurrent callers varying only the depth share one probe; a breakdown whose walk raced a deletion (children summing past the parent) is dropped in favor of the consistent totals; and the v1 legacy addon-id remap is applied only to the system disk target, so a mount directory that happens to be named `apps_data` keeps its real name and the shared probe result is never mutated in place.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #7146
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

### Notes for reviewers

- One reviewed finding was deliberately not changed: a flat mount (files only at the root) at depth 2 still returns totals without an `other`-only breakdown — a single child covering the whole bar carries no information beyond the total.
- Each of the three fixes has a test that fails when the fix is reverted.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
