### PR TITLE
Strip whitespace from repository URLs in store validation

### DIFF
--- a/supervisor/store/validate.py
+++ b/supervisor/store/validate.py
@@ -19,6 +19,8 @@ SCHEMA_REPOSITORY_CONFIG = vol.Schema(
 
 def validate_repository(repository: str) -> str:
     """Validate a valid repository."""
+    repository = repository.strip()
+
     if repository in BuiltinRepository:
         return repository
 

--- a/supervisor/validate.py
+++ b/supervisor/validate.py
@@ -59,7 +59,7 @@ from .docker.utils import is_registry_domain, split_docker_domain
 from .utils.validate import validate_timezone
 
 # Move to store.validate when addons_repository config removed
-RE_REPOSITORY = re.compile(r"^(?P<url>[^#]+)(?:#(?P<branch>[\w\-./]+))?$")
+RE_REPOSITORY = re.compile(r"^(?P<url>[^#\s]+)(?:#(?P<branch>[\w\-./]+))?$")
 RE_REGISTRY = re.compile(r"^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$")
 
 # pylint: disable=no-value-for-parameter

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -129,6 +129,22 @@ async def test_api_store_add_repository_duplicate(
     assert result["message"] == f"Can't add {REPO_URL}, already in the store"
 
 
+async def test_api_store_add_repository_whitespace(
+    api_client: TestClient, coresys: CoreSys, supervisor_internet: AsyncMock
+) -> None:
+    """Test POST /store/repositories strips whitespace from the repository URL."""
+    with (
+        patch("supervisor.store.repository.RepositoryGit.load", return_value=None),
+        patch("supervisor.store.repository.RepositoryGit.validate", return_value=True),
+    ):
+        response = await api_client.post(
+            "/store/repositories", json={"repository": f"  {REPO_URL}  "}
+        )
+
+    assert response.status == 200
+    assert REPO_URL in coresys.store.repository_urls
+
+
 async def test_api_store_remove_repository(
     api_client: TestClient, coresys: CoreSys, test_repository: Repository
 ):

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -97,8 +97,12 @@ async def test_api_store_repositories_repository(
     assert result["data"]["slug"] == test_repository.slug
 
 
+@pytest.mark.parametrize("repo_url", [REPO_URL, f"  {REPO_URL}  "])
 async def test_api_store_add_repository(
-    api_client: TestClient, coresys: CoreSys, supervisor_internet: AsyncMock
+    api_client: TestClient,
+    coresys: CoreSys,
+    supervisor_internet: AsyncMock,
+    repo_url: str,
 ) -> None:
     """Test POST /store/repositories REST API."""
     with (
@@ -106,7 +110,7 @@ async def test_api_store_add_repository(
         patch("supervisor.store.repository.RepositoryGit.validate", return_value=True),
     ):
         response = await api_client.post(
-            "/store/repositories", json={"repository": REPO_URL}
+            "/store/repositories", json={"repository": repo_url}
         )
 
     assert response.status == 200
@@ -127,22 +131,6 @@ async def test_api_store_add_repository_duplicate(
     assert result["error_key"] == "store_repository_already_added_error"
     assert result["extra_fields"] == {"url": REPO_URL}
     assert result["message"] == f"Can't add {REPO_URL}, already in the store"
-
-
-async def test_api_store_add_repository_whitespace(
-    api_client: TestClient, coresys: CoreSys, supervisor_internet: AsyncMock
-) -> None:
-    """Test POST /store/repositories strips whitespace from the repository URL."""
-    with (
-        patch("supervisor.store.repository.RepositoryGit.load", return_value=None),
-        patch("supervisor.store.repository.RepositoryGit.validate", return_value=True),
-    ):
-        response = await api_client.post(
-            "/store/repositories", json={"repository": f"  {REPO_URL}  "}
-        )
-
-    assert response.status == 200
-    assert REPO_URL in coresys.store.repository_urls
 
 
 async def test_api_store_remove_repository(

--- a/tests/store/test_validate.py
+++ b/tests/store/test_validate.py
@@ -24,3 +24,27 @@ async def test_repository_validate(repo_list: list[str], valid: bool):
     else:
         with pytest.raises(Invalid):
             repositories(repo_list)
+
+
+@pytest.mark.parametrize(
+    ("repo_list", "expected"),
+    [
+        (
+            ["  https://github.com/hassio-addons/repository  "],
+            ["https://github.com/hassio-addons/repository"],
+        ),
+        (
+            ["\nhttps://github.com/hassio-addons/repository\n"],
+            ["https://github.com/hassio-addons/repository"],
+        ),
+        (
+            ["\thttps://github.com/hassio-addons/repository\t"],
+            ["https://github.com/hassio-addons/repository"],
+        ),
+    ],
+)
+async def test_repository_validate_strips_whitespace(
+    repo_list: list[str], expected: list[str]
+):
+    """Test repository validation strips leading/trailing whitespace."""
+    assert repositories(repo_list) == expected

--- a/tests/store/test_validate.py
+++ b/tests/store/test_validate.py
@@ -14,6 +14,10 @@ from supervisor.store.validate import repositories
         (["https://github.com/hassio-addons/repository#beta"], True),
         (["https://github.com/hassio-addons/repository#feature/hot-new-stuff"], True),
         (["not_a_url"], False),
+        (
+            ["https://github.com/hassio-addons/repository #beta"],
+            False,
+        ),
         (["https://fail.com/duplicate", "https://fail.com/duplicate"], False),
     ],
 )
@@ -30,15 +34,7 @@ async def test_repository_validate(repo_list: list[str], valid: bool):
     ("repo_list", "expected"),
     [
         (
-            ["  https://github.com/hassio-addons/repository  "],
-            ["https://github.com/hassio-addons/repository"],
-        ),
-        (
-            ["\nhttps://github.com/hassio-addons/repository\n"],
-            ["https://github.com/hassio-addons/repository"],
-        ),
-        (
-            ["\thttps://github.com/hassio-addons/repository\t"],
+            [" \t\nhttps://github.com/hassio-addons/repository \n\t"],
             ["https://github.com/hassio-addons/repository"],
         ),
     ],


### PR DESCRIPTION
## Proposed change

I noticed a bug where if you add a url in the 'add repository' screen on /config/apps/repositories and there were spaces before or after the url, it would error out without a clear error. Now they just get stripped

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

DISCLAIMER: GLM-5.2 was used to create the code for this PR. it's summary of what was changed:
> The fix is in validate_repository() in supervisor/store/validate.py — the repository URL is now stripped of leading/trailing whitespace before validation. This is the central validation function used by both the POST /store/repositories API endpoint and the store config file loader, so all entry points benefit from the fix.

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

