### PR TITLE
Preserve discovery message uuids across app backup/restore

### DIFF
--- a/supervisor/apps/app.py
+++ b/supervisor/apps/app.py
@@ -30,6 +30,8 @@ from ..const import (
     ATTR_AUDIO_OUTPUT,
     ATTR_AUTO_UPDATE,
     ATTR_BOOT,
+    ATTR_CONFIG,
+    ATTR_DISCOVERY,
     ATTR_IMAGE,
     ATTR_INGRESS_ENTRY,
     ATTR_INGRESS_PANEL,
@@ -41,6 +43,7 @@ from ..const import (
     ATTR_PORTS,
     ATTR_PROTECTED,
     ATTR_SCHEMA,
+    ATTR_SERVICE,
     ATTR_SLUG,
     ATTR_STATE,
     ATTR_SYSTEM,
@@ -59,6 +62,7 @@ from ..const import (
     BusEvent,
 )
 from ..coresys import CoreSys
+from ..discovery import Message
 from ..docker.app import DockerApp
 from ..docker.const import EXIT_CODE_SIGTERM_DEFAULT, ContainerState
 from ..docker.manager import ExecReturn
@@ -1019,9 +1023,7 @@ class App(AppModel):
             await self.sys_ingress.del_dynamic_port(self.slug)
 
         # Cleanup discovery data
-        for message in self.sys_discovery.list_messages:
-            if message.app != self.slug:
-                continue
+        for message in self.sys_discovery.messages_for_app(self.slug):
             await self.sys_discovery.remove(message)
 
         # Cleanup services data
@@ -1562,6 +1564,14 @@ class App(AppModel):
             ATTR_SYSTEM: self.data,
             ATTR_VERSION: self.version,
             ATTR_STATE: _MAP_APP_STATE.get(self.state, self.state),
+            ATTR_DISCOVERY: [
+                {
+                    ATTR_SERVICE: message.service,
+                    ATTR_UUID: message.uuid,
+                    ATTR_CONFIG: message.config,
+                }
+                for message in self.sys_discovery.messages_for_app(self.slug)
+            ],
         }
         apparmor_profile = (
             self.slug if self.sys_host.apparmor.exists(self.slug) else None
@@ -1666,6 +1676,21 @@ class App(AppModel):
             restore_image = self._image(data[ATTR_SYSTEM])
             await self.sys_apps.data.restore(
                 self.slug, data[ATTR_USER], data[ATTR_SYSTEM], restore_image
+            )
+
+            # Restore discovery messages before the app can send its own ones,
+            # so that a re-send updates the message which kept its uuid
+            await self.sys_discovery.restore_app_messages(
+                self,
+                [
+                    Message(
+                        app=self.slug,
+                        service=message[ATTR_SERVICE],
+                        config=message[ATTR_CONFIG],
+                        uuid=message[ATTR_UUID],
+                    )
+                    for message in data[ATTR_DISCOVERY]
+                ],
             )
 
             # Stop it first if its running

--- a/supervisor/apps/validate.py
+++ b/supervisor/apps/validate.py
@@ -27,6 +27,7 @@ from ..const import (
     ATTR_BACKUP_PRE,
     ATTR_BOOT,
     ATTR_BUILD_FROM,
+    ATTR_CONFIG,
     ATTR_CONFIGURATION,
     ATTR_DESCRIPTON,
     ATTR_DEVICES,
@@ -73,6 +74,7 @@ from ..const import (
     ATTR_REALTIME,
     ATTR_REPOSITORY,
     ATTR_SCHEMA,
+    ATTR_SERVICE,
     ATTR_SERVICES,
     ATTR_SLUG,
     ATTR_SQUASH,
@@ -656,12 +658,28 @@ SCHEMA_APPS_FILE = vol.Schema(
 )
 
 
+# Discovery messages of the app, stored to keep the uuid Home Assistant links
+# its config entries to. Added in 2026.09, absent in older backups.
+SCHEMA_APP_BACKUP_DISCOVERY = vol.Schema(
+    [
+        vol.Schema(
+            {
+                vol.Required(ATTR_SERVICE): str,
+                vol.Required(ATTR_UUID): uuid_match,
+                vol.Required(ATTR_CONFIG): vol.Maybe(dict),
+            },
+            extra=vol.REMOVE_EXTRA,
+        )
+    ]
+)
+
 SCHEMA_APP_BACKUP = vol.Schema(
     {
         vol.Required(ATTR_USER): SCHEMA_APP_USER,
         vol.Required(ATTR_SYSTEM): SCHEMA_APP_SYSTEM,
         vol.Required(ATTR_STATE): vol.Coerce(AppState),
         vol.Required(ATTR_VERSION): version_tag,
+        vol.Optional(ATTR_DISCOVERY, default=list): SCHEMA_APP_BACKUP_DISCOVERY,
     },
     extra=vol.REMOVE_EXTRA,
 )

--- a/supervisor/discovery/__init__.py
+++ b/supervisor/discovery/__init__.py
@@ -46,6 +46,10 @@ class Discovery(CoreSysAttributes, FileConfiguration):
         super().__init__(FILE_HASSIO_DISCOVERY, SCHEMA_DISCOVERY_CONFIG)
         self.coresys: CoreSys = coresys
         self.message_obj: dict[str, Message] = {}
+        # Messages restored from a backup which Home Assistant was not told
+        # about yet. Only the app knows when its service is actually up, so the
+        # push waits for the app to send the message itself (see send()).
+        self._unannounced: set[str] = set()
 
     async def load(self) -> None:
         """Load exists discovery message into storage."""
@@ -76,6 +80,10 @@ class Discovery(CoreSysAttributes, FileConfiguration):
         """Return list of available discovery messages."""
         return list(self.message_obj.values())
 
+    def messages_for_app(self, slug: str) -> list[Message]:
+        """Return list of discovery messages sent by an app."""
+        return [message for message in self.list_messages if message.app == slug]
+
     async def send(self, app: App, service: str, config: dict[str, Any]) -> Message:
         """Send a discovery message to Home Assistant."""
         # Create message
@@ -88,6 +96,10 @@ class Discovery(CoreSysAttributes, FileConfiguration):
             if exists_msg.config != config:
                 message = exists_msg
                 message.config = config
+            elif exists_msg.uuid in self._unannounced:
+                # Restored from a backup, this is the first time the app
+                # announces it, so Home Assistant still needs to hear about it
+                message = exists_msg
             else:
                 _LOGGER.debug("Duplicate discovery message from %s", app.slug)
                 return exists_msg
@@ -97,6 +109,7 @@ class Discovery(CoreSysAttributes, FileConfiguration):
             "Sending discovery to Home Assistant %s from %s", service, app.slug
         )
         self.message_obj[message.uuid] = message
+        self._unannounced.discard(message.uuid)
         await self.save()
 
         self.sys_create_task(self._push_discovery(message, CMD_NEW))
@@ -105,6 +118,7 @@ class Discovery(CoreSysAttributes, FileConfiguration):
     async def remove(self, message: Message) -> None:
         """Remove a discovery message from Home Assistant."""
         self.message_obj.pop(message.uuid, None)
+        self._unannounced.discard(message.uuid)
         await self.save()
 
         _LOGGER.info(
@@ -113,6 +127,47 @@ class Discovery(CoreSysAttributes, FileConfiguration):
             message.app,
         )
         self.sys_create_task(self._push_discovery(message, CMD_DEL))
+
+    async def restore_app_messages(self, app: App, messages: list[Message]) -> None:
+        """Restore discovery messages of an app from a backup.
+
+        Home Assistant ties a config entry to the uuid of the discovery message
+        it came from, so the uuid has to survive a backup/restore to keep that
+        link intact. Messages are only restored for services without a live
+        message: an existing one already carries the uuid Home Assistant knows,
+        restoring on top of it would break the link instead of preserving it.
+
+        A restored message is not pushed to Home Assistant here. The service
+        behind it is not up at this point, and it may never come up if the app
+        is not started again. Instead it is marked as unannounced so that the
+        push happens once the app sends the message itself.
+        """
+        live_services = {message.service for message in self.messages_for_app(app.slug)}
+        restored = False
+
+        for message in messages:
+            if message.service in live_services:
+                continue
+            if message.service not in app.discovery:
+                _LOGGER.info(
+                    "Skipping discovery message for service %s, app %s does not provide it anymore",
+                    message.service,
+                    app.slug,
+                )
+                continue
+
+            self.message_obj[message.uuid] = message
+            self._unannounced.add(message.uuid)
+            restored = True
+            _LOGGER.info(
+                "Restored discovery %s for service %s from %s",
+                message.uuid,
+                message.service,
+                app.slug,
+            )
+
+        if restored:
+            await self.save()
 
     async def _push_discovery(self, message: Message, command: str) -> None:
         """Send a discovery request."""

--- a/supervisor/discovery/__init__.py
+++ b/supervisor/discovery/__init__.py
@@ -142,11 +142,15 @@ class Discovery(CoreSysAttributes, FileConfiguration):
         is not started again. Instead it is marked as unannounced so that the
         push happens once the app sends the message itself.
         """
-        live_services = {message.service for message in self.messages_for_app(app.slug)}
+        # Services which already have a message, grown while restoring so that
+        # a backup listing a service twice does not end up with two messages
+        known_services = {
+            message.service for message in self.messages_for_app(app.slug)
+        }
         restored = False
 
         for message in messages:
-            if message.service in live_services:
+            if message.service in known_services:
                 continue
             if message.service not in app.discovery:
                 _LOGGER.info(
@@ -155,9 +159,20 @@ class Discovery(CoreSysAttributes, FileConfiguration):
                     app.slug,
                 )
                 continue
+            if message.uuid in self.message_obj:
+                # Messages are keyed by uuid across all apps, so restoring this
+                # one would drop the message it collides with
+                _LOGGER.warning(
+                    "Skipping discovery message for service %s of app %s, uuid %s is already in use",
+                    message.service,
+                    app.slug,
+                    message.uuid,
+                )
+                continue
 
             self.message_obj[message.uuid] = message
             self._unannounced.add(message.uuid)
+            known_services.add(message.service)
             restored = True
             _LOGGER.info(
                 "Restored discovery %s for service %s from %s",

--- a/supervisor/discovery/__init__.py
+++ b/supervisor/discovery/__init__.py
@@ -137,10 +137,15 @@ class Discovery(CoreSysAttributes, FileConfiguration):
 
         A message of the backup replaces the message of the same uuid, as the
         restore may bring back another version of the app which announces a
-        different config. A message for a service which already has a message
-        under a different uuid is dropped instead: that uuid is the one Home
-        Assistant knows the service by, taking it away would break the link
-        this is meant to keep.
+        different config.
+
+        A message for a service which already has a message under a different
+        uuid is dropped instead, the live message wins. Home Assistant knows
+        the service by the uuid of that message whenever its config entries
+        were not part of the restore, and when they were, its entry may be
+        left stale. Home Assistant cannot be kept in sync in every case
+        anyway, an app which is not part of the restore keeps its message
+        either way, so the app decides.
 
         A restored message is not pushed to Home Assistant here. The service
         behind it is not up at this point, and it may never come up if the app

--- a/supervisor/discovery/__init__.py
+++ b/supervisor/discovery/__init__.py
@@ -133,25 +133,28 @@ class Discovery(CoreSysAttributes, FileConfiguration):
 
         Home Assistant ties a config entry to the uuid of the discovery message
         it came from, so the uuid has to survive a backup/restore to keep that
-        link intact. Messages are only restored for services without a live
-        message: an existing one already carries the uuid Home Assistant knows,
-        restoring on top of it would break the link instead of preserving it.
+        link intact.
+
+        A message of the backup replaces the message of the same uuid, as the
+        restore may bring back another version of the app which announces a
+        different config. A message for a service which already has a message
+        under a different uuid is dropped instead: that uuid is the one Home
+        Assistant knows the service by, taking it away would break the link
+        this is meant to keep.
 
         A restored message is not pushed to Home Assistant here. The service
         behind it is not up at this point, and it may never come up if the app
         is not started again. Instead it is marked as unannounced so that the
         push happens once the app sends the message itself.
         """
-        # Services which already have a message, grown while restoring so that
-        # a backup listing a service twice does not end up with two messages
-        known_services = {
-            message.service for message in self.messages_for_app(app.slug)
+        # Message per service, grown while restoring so that a backup listing a
+        # service twice does not end up with two messages for it
+        known = {
+            message.service: message for message in self.messages_for_app(app.slug)
         }
         restored = False
 
         for message in messages:
-            if message.service in known_services:
-                continue
             if message.service not in app.discovery:
                 _LOGGER.info(
                     "Skipping discovery message for service %s, app %s does not provide it anymore",
@@ -159,6 +162,32 @@ class Discovery(CoreSysAttributes, FileConfiguration):
                     app.slug,
                 )
                 continue
+
+            if (exists_msg := known.get(message.service)) is not None:
+                if exists_msg.uuid != message.uuid:
+                    _LOGGER.info(
+                        "Keeping discovery %s for service %s of app %s, it replaces %s of the backup",
+                        exists_msg.uuid,
+                        message.service,
+                        app.slug,
+                        message.uuid,
+                    )
+                    continue
+                if exists_msg.config == message.config:
+                    continue
+
+                # Same message, but the backup was taken with another config
+                exists_msg.config = message.config
+                self._unannounced.add(exists_msg.uuid)
+                restored = True
+                _LOGGER.info(
+                    "Restored config of discovery %s for service %s from %s",
+                    exists_msg.uuid,
+                    message.service,
+                    app.slug,
+                )
+                continue
+
             if message.uuid in self.message_obj:
                 # Messages are keyed by uuid across all apps, so restoring this
                 # one would drop the message it collides with
@@ -172,7 +201,7 @@ class Discovery(CoreSysAttributes, FileConfiguration):
 
             self.message_obj[message.uuid] = message
             self._unannounced.add(message.uuid)
-            known_services.add(message.service)
+            known[message.service] = message
             restored = True
             _LOGGER.info(
                 "Restored discovery %s for service %s from %s",

--- a/supervisor/discovery/__init__.py
+++ b/supervisor/discovery/__init__.py
@@ -132,34 +132,30 @@ class Discovery(CoreSysAttributes, FileConfiguration):
         """Restore discovery messages of an app from a backup.
 
         Home Assistant ties a config entry to the uuid of the discovery message
-        it came from, so the uuid has to survive a backup/restore to keep that
-        link intact.
+        it came from. The uuid identifies an installation of the app, it stays
+        the same for as long as the data of the app does, and a restore brings
+        that data back, so the uuid of the backup comes with it.
 
-        A message of the backup replaces the message of the same uuid, as the
-        restore may bring back another version of the app which announces a
-        different config.
-
-        A message for a service which already has a message under a different
-        uuid is dropped instead, the live message wins. Home Assistant knows
-        the service by the uuid of that message whenever its config entries
-        were not part of the restore, and when they were, its entry may be
-        left stale. Home Assistant cannot be kept in sync in every case
-        anyway, an app which is not part of the restore keeps its message
-        either way, so the app decides.
+        A live message under the same uuid is the same installation, only its
+        config is taken from the backup, as the restore may bring back another
+        version of the app which announces a different config. A live message
+        under another uuid belongs to an installation which the restore just
+        replaced. It is retracted as an uninstall would, so that Home Assistant
+        drops its config entry, and the message of the backup takes its place.
 
         A restored message is not pushed to Home Assistant here. The service
         behind it is not up at this point, and it may never come up if the app
         is not started again. Instead it is marked as unannounced so that the
         push happens once the app sends the message itself.
         """
-        # Message per service, grown while restoring so that a backup listing a
-        # service twice does not end up with two messages for it
-        known = {
-            message.service: message for message in self.messages_for_app(app.slug)
-        }
+        live = {message.service: message for message in self.messages_for_app(app.slug)}
+        # Services restored so far, a backup listing a service twice keeps the first
+        seen: set[str] = set()
         restored = False
 
         for message in messages:
+            if message.service in seen:
+                continue
             if message.service not in app.discovery:
                 _LOGGER.info(
                     "Skipping discovery message for service %s, app %s does not provide it anymore",
@@ -168,30 +164,30 @@ class Discovery(CoreSysAttributes, FileConfiguration):
                 )
                 continue
 
-            if (exists_msg := known.get(message.service)) is not None:
-                if exists_msg.uuid != message.uuid:
+            if (live_msg := live.get(message.service)) is not None:
+                if live_msg.uuid == message.uuid:
+                    seen.add(message.service)
+                    if live_msg.config == message.config:
+                        continue
+                    live_msg.config = message.config
+                    self._unannounced.add(live_msg.uuid)
+                    restored = True
                     _LOGGER.info(
-                        "Keeping discovery %s for service %s of app %s, it replaces %s of the backup",
-                        exists_msg.uuid,
+                        "Restored config of discovery %s for service %s from %s",
+                        live_msg.uuid,
                         message.service,
                         app.slug,
-                        message.uuid,
                     )
                     continue
-                if exists_msg.config == message.config:
-                    continue
 
-                # Same message, but the backup was taken with another config
-                exists_msg.config = message.config
-                self._unannounced.add(exists_msg.uuid)
-                restored = True
                 _LOGGER.info(
-                    "Restored config of discovery %s for service %s from %s",
-                    exists_msg.uuid,
+                    "Retracting discovery %s for service %s from %s, the restore replaces it with %s",
+                    live_msg.uuid,
                     message.service,
                     app.slug,
+                    message.uuid,
                 )
-                continue
+                await self.remove(live_msg)
 
             if message.uuid in self.message_obj:
                 # Messages are keyed by uuid across all apps, so restoring this
@@ -206,7 +202,7 @@ class Discovery(CoreSysAttributes, FileConfiguration):
 
             self.message_obj[message.uuid] = message
             self._unannounced.add(message.uuid)
-            known[message.service] = message
+            seen.add(message.service)
             restored = True
             _LOGGER.info(
                 "Restored discovery %s for service %s from %s",

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -21,6 +21,7 @@ from supervisor.backups.const import LOCATION_TYPE, BackupJobStage, BackupType
 from supervisor.backups.manager import BackupManager
 from supervisor.const import FOLDER_HOMEASSISTANT, FOLDER_SHARE, AppState, CoreState
 from supervisor.coresys import CoreSys
+from supervisor.discovery import CMD_DEL, Discovery
 from supervisor.docker.app import DockerApp
 from supervisor.docker.const import ContainerState
 from supervisor.docker.homeassistant import DockerHomeAssistant
@@ -1724,6 +1725,62 @@ async def test_restore_twice_keeps_single_discovery_message(
         restored.uuid
         for restored in coresys.discovery.messages_for_app("local_example")
     ] == [message.uuid]
+
+
+@pytest.mark.usefixtures("supervisor_internet", "tmp_supervisor_data", "path_extern")
+async def test_full_restore_replaces_discovery_of_other_installation(
+    coresys: CoreSys, install_app_example: App
+):
+    """Test a full restore brings back the discovery uuid of the backup.
+
+    The app is in the backup and installed already, so the restore keeps it
+    installed and replaces its data. The uuid identifies that data, so the
+    message the app announced in the meantime is retracted and the one of the
+    backup takes its place.
+    """
+    await coresys.core.set_state(CoreState.RUNNING)
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    coresys.homeassistant.version = AwesomeVersion("2026.8.0")
+    coresys.homeassistant.core.start = AsyncMock(return_value=None)
+    coresys.homeassistant.core.stop = AsyncMock(return_value=None)
+    coresys.homeassistant.core.update = AsyncMock(return_value=None)
+    coresys.homeassistant.core.restart = AsyncMock(return_value=None)
+    coresys.homeassistant.core.is_running = AsyncMock(return_value=True)
+
+    install_app_example.data["discovery"] = ["mcp"]
+    install_app_example.path_data.mkdir(parents=True, exist_ok=True)
+    config = {"url": "http://local-example:8099/mcp"}
+
+    with patch.object(HomeAssistantAPI, "check_api_state", return_value=False):
+        backup_message = await coresys.discovery.send(
+            install_app_example, "mcp", dict(config)
+        )
+        backup: Backup = await coresys.backups.do_backup_full()
+
+        # The app got reinstalled since, so it announces itself under a new uuid
+        await coresys.discovery.remove(backup_message)
+        live_message = await coresys.discovery.send(
+            install_app_example, "mcp", dict(config)
+        )
+        assert live_message.uuid != backup_message.uuid
+
+        with (
+            patch.object(AppModel, "_validate_availability"),
+            patch.object(DockerApp, "attach"),
+            patch.object(
+                Discovery, "_push_discovery", new=AsyncMock()
+            ) as push_discovery,
+        ):
+            assert await coresys.backups.do_restore_full(backup)
+            await asyncio.sleep(0)
+
+    assert "local_example" in coresys.apps.local
+    assert [
+        message.uuid for message in coresys.discovery.messages_for_app("local_example")
+    ] == [backup_message.uuid]
+    # Home Assistant is told to drop the entry of the replaced installation, the
+    # restored message is announced by the app once it runs
+    push_discovery.assert_called_once_with(live_message, CMD_DEL)
 
 
 @pytest.mark.usefixtures("supervisor_internet", "tmp_supervisor_data", "path_extern")

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -1684,6 +1684,49 @@ async def test_restore_preserves_discovery_uuid(
 
 
 @pytest.mark.usefixtures("supervisor_internet", "tmp_supervisor_data", "path_extern")
+async def test_restore_twice_keeps_single_discovery_message(
+    coresys: CoreSys, install_app_example: App
+):
+    """Test restoring the same backup twice does not duplicate a discovery message.
+
+    The second restore finds the message of the first one and leaves it alone,
+    as that message is the one Home Assistant already knows.
+    """
+    await coresys.core.set_state(CoreState.RUNNING)
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+
+    install_app_example.data["discovery"] = ["mcp"]
+    with patch.object(HomeAssistantAPI, "check_api_state", return_value=False):
+        message = await coresys.discovery.send(
+            install_app_example, "mcp", {"url": "http://local-example:8099/mcp"}
+        )
+        backup: Backup = await coresys.backups.do_backup_partial(apps=["local_example"])
+        await coresys.apps.uninstall("local_example")
+
+        with (
+            patch.object(AppModel, "_validate_availability"),
+            patch.object(DockerApp, "attach"),
+        ):
+            assert await coresys.backups.do_restore_partial(
+                backup, apps=["local_example"]
+            )
+
+            # App announces itself again, as it does on every start
+            await coresys.discovery.send(
+                install_app_example, "mcp", {"url": "http://local-example:8099/mcp"}
+            )
+
+            assert await coresys.backups.do_restore_partial(
+                backup, apps=["local_example"]
+            )
+
+    assert [
+        restored.uuid
+        for restored in coresys.discovery.messages_for_app("local_example")
+    ] == [message.uuid]
+
+
+@pytest.mark.usefixtures("supervisor_internet", "tmp_supervisor_data", "path_extern")
 async def test_restore_app_image_missing(coresys: CoreSys, install_app_example: App):
     """Test restore when local image is missing installs from registry.
 

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -1644,6 +1644,46 @@ async def test_restore_new_app(coresys: CoreSys, install_app_example: App):
 
 
 @pytest.mark.usefixtures("supervisor_internet", "tmp_supervisor_data", "path_extern")
+async def test_restore_preserves_discovery_uuid(
+    coresys: CoreSys, install_app_example: App
+):
+    """Test a backup/restore round trip keeps the uuid of a discovery message.
+
+    Home Assistant uses the uuid of a discovery message as unique ID of the
+    config entry it creates from it, so a new uuid would leave the restored
+    config entry orphaned instead of updating it.
+    """
+    await coresys.core.set_state(CoreState.RUNNING)
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+
+    install_app_example.data["discovery"] = ["mcp"]
+    with patch.object(HomeAssistantAPI, "check_api_state", return_value=False):
+        message = await coresys.discovery.send(
+            install_app_example, "mcp", {"url": "http://local-example:8099/mcp"}
+        )
+
+        backup: Backup = await coresys.backups.do_backup_partial(apps=["local_example"])
+
+        # Uninstall drops the discovery message, as a fresh system would not
+        # have it either
+        await coresys.apps.uninstall("local_example")
+        assert coresys.discovery.messages_for_app("local_example") == []
+
+        with (
+            patch.object(AppModel, "_validate_availability"),
+            patch.object(DockerApp, "attach"),
+        ):
+            assert await coresys.backups.do_restore_partial(
+                backup, apps=["local_example"]
+            )
+
+    assert coresys.discovery.messages_for_app("local_example") == [message]
+    restored = coresys.discovery.get(message.uuid)
+    assert restored.service == "mcp"
+    assert restored.config == {"url": "http://local-example:8099/mcp"}
+
+
+@pytest.mark.usefixtures("supervisor_internet", "tmp_supervisor_data", "path_extern")
 async def test_restore_app_image_missing(coresys: CoreSys, install_app_example: App):
     """Test restore when local image is missing installs from registry.
 

--- a/tests/discovery/test_discovery.py
+++ b/tests/discovery/test_discovery.py
@@ -131,6 +131,67 @@ async def test_restore_app_messages_skips_dropped_service(
     assert "app local_ssh does not provide it anymore" in caplog.text
 
 
+async def test_restore_app_messages_skips_uuid_in_use(
+    coresys: CoreSys, app_with_discovery: App, caplog: pytest.LogCaptureFixture
+):
+    """Test a message does not overwrite the message another app owns.
+
+    Messages are keyed by uuid across all apps, so restoring a uuid which is
+    already taken would drop the message it collides with.
+    """
+    other = Message(app="core_mosquitto", service="mqtt", config={}, uuid=BACKUP_UUID)
+    coresys.discovery.message_obj[other.uuid] = other
+
+    await coresys.discovery.restore_app_messages(
+        app_with_discovery,
+        [
+            Message(
+                app=app_with_discovery.slug,
+                service="mcp",
+                config=MCP_CONFIG,
+                uuid=BACKUP_UUID,
+            )
+        ],
+    )
+
+    assert coresys.discovery.get(BACKUP_UUID) is other
+    assert coresys.discovery.messages_for_app(app_with_discovery.slug) == []
+    assert f"uuid {BACKUP_UUID} is already in use" in caplog.text
+
+
+async def test_restore_app_messages_service_only_once(
+    coresys: CoreSys, app_with_discovery: App
+):
+    """Test a service repeated in a backup only gets a single message.
+
+    Two messages for one service would both be handed to Home Assistant, and
+    only one of them can ever be updated or removed again, as send() and
+    remove() match on app and service.
+    """
+    await coresys.discovery.restore_app_messages(
+        app_with_discovery,
+        [
+            Message(
+                app=app_with_discovery.slug,
+                service="mcp",
+                config=MCP_CONFIG,
+                uuid=BACKUP_UUID,
+            ),
+            Message(
+                app=app_with_discovery.slug,
+                service="mcp",
+                config={"url": "http://local-ssh:9999/mcp"},
+                uuid="a1b2c3d4e5f60718293a4b5c6d7e8f90",
+            ),
+        ],
+    )
+
+    assert [
+        message.uuid
+        for message in coresys.discovery.messages_for_app(app_with_discovery.slug)
+    ] == [BACKUP_UUID]
+
+
 async def test_messages_for_app(coresys: CoreSys, app_with_discovery: App):
     """Test listing the messages of a single app."""
     message = await coresys.discovery.send(app_with_discovery, "mcp", dict(MCP_CONFIG))

--- a/tests/discovery/test_discovery.py
+++ b/tests/discovery/test_discovery.py
@@ -7,7 +7,7 @@ import pytest
 
 from supervisor.apps.app import App
 from supervisor.coresys import CoreSys
-from supervisor.discovery import CMD_NEW, Message
+from supervisor.discovery import CMD_DEL, CMD_NEW, Message
 
 BACKUP_UUID = "e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3"
 MCP_CONFIG = {"url": "http://local-ssh:8099/mcp"}
@@ -88,31 +88,50 @@ async def test_restore_app_messages_announced_by_app(
     ] == [BACKUP_UUID]
 
 
-async def test_restore_app_messages_keeps_live_message(
+async def test_restore_app_messages_replaces_other_installation(
     coresys: CoreSys, app_with_discovery: App
 ):
-    """Test a live message under another uuid wins over the one of the backup.
+    """Test the message of the backup replaces a live one under another uuid.
 
-    Home Assistant knows the service by the uuid of the live message, so that
-    message stays, config included.
+    The uuid identifies an installation of the app. The restore replaces the
+    data of the app, so a live message under another uuid belongs to an
+    installation which is gone. It is retracted like on an uninstall, so that
+    Home Assistant drops its config entry, and the app announces the restored
+    message under the uuid of the backup once it runs.
     """
     live = await coresys.discovery.send(app_with_discovery, "mcp", dict(MCP_CONFIG))
     assert live.uuid != BACKUP_UUID
-
-    await coresys.discovery.restore_app_messages(
-        app_with_discovery,
-        [
-            Message(
-                app=app_with_discovery.slug,
-                service="mcp",
-                config={"url": "http://local-ssh:9999/mcp"},
-                uuid=BACKUP_UUID,
-            )
-        ],
+    restored = Message(
+        app=app_with_discovery.slug,
+        service="mcp",
+        config={"url": "http://local-ssh:9999/mcp"},
+        uuid=BACKUP_UUID,
     )
 
-    assert coresys.discovery.get(BACKUP_UUID) is None
-    assert coresys.discovery.messages_for_app(app_with_discovery.slug) == [live]
+    with patch.object(
+        type(coresys.discovery), "_push_discovery", new=AsyncMock()
+    ) as push:
+        await coresys.discovery.restore_app_messages(app_with_discovery, [restored])
+        await asyncio.sleep(0)
+
+        # Only the retraction reaches Home Assistant at this point
+        push.assert_called_once_with(live, CMD_DEL)
+        assert coresys.discovery.get(live.uuid) is None
+        assert coresys.discovery.get(BACKUP_UUID) == restored
+
+        # The app announces itself, under the uuid of the backup
+        push.reset_mock()
+        resent = await coresys.discovery.send(
+            app_with_discovery, "mcp", {"url": "http://local-ssh:9999/mcp"}
+        )
+        await asyncio.sleep(0)
+
+    assert resent.uuid == BACKUP_UUID
+    push.assert_called_once_with(restored, CMD_NEW)
+    assert [
+        message.uuid
+        for message in coresys.discovery.messages_for_app(app_with_discovery.slug)
+    ] == [BACKUP_UUID]
 
 
 async def test_restore_app_messages_skips_dropped_service(
@@ -270,6 +289,7 @@ async def test_restore_app_messages_service_only_once(
         message.uuid
         for message in coresys.discovery.messages_for_app(app_with_discovery.slug)
     ] == [BACKUP_UUID]
+    assert coresys.discovery.get(BACKUP_UUID).config == MCP_CONFIG
 
 
 async def test_messages_for_app(coresys: CoreSys, app_with_discovery: App):

--- a/tests/discovery/test_discovery.py
+++ b/tests/discovery/test_discovery.py
@@ -91,7 +91,11 @@ async def test_restore_app_messages_announced_by_app(
 async def test_restore_app_messages_keeps_live_message(
     coresys: CoreSys, app_with_discovery: App
 ):
-    """Test a live message wins, it already carries the uuid in use."""
+    """Test a live message under another uuid wins over the one of the backup.
+
+    Home Assistant knows the service by the uuid of the live message, so that
+    message stays, config included.
+    """
     live = await coresys.discovery.send(app_with_discovery, "mcp", dict(MCP_CONFIG))
     assert live.uuid != BACKUP_UUID
 
@@ -129,6 +133,82 @@ async def test_restore_app_messages_skips_dropped_service(
 
     assert coresys.discovery.get(BACKUP_UUID) is None
     assert "app local_ssh does not provide it anymore" in caplog.text
+
+
+async def test_restore_app_messages_restores_config(
+    coresys: CoreSys, app_with_discovery: App
+):
+    """Test the config of the backup replaces the config of the same message.
+
+    A restore can bring back another version of an app, which announces a
+    different config than the version it replaces. Home Assistant may pull the
+    messages before the restored app announces itself, so the message has to
+    hold the config of the app which is now installed.
+    """
+    old_config = {"url": "http://local-ssh:8099/mcp-v1"}
+    live = await coresys.discovery.send(app_with_discovery, "mcp", dict(MCP_CONFIG))
+
+    with patch.object(
+        type(coresys.discovery), "_push_discovery", new=AsyncMock()
+    ) as push:
+        await coresys.discovery.restore_app_messages(
+            app_with_discovery,
+            [
+                Message(
+                    app=app_with_discovery.slug,
+                    service="mcp",
+                    config=old_config,
+                    uuid=live.uuid,
+                )
+            ],
+        )
+        await asyncio.sleep(0)
+
+        assert coresys.discovery.get(live.uuid).config == old_config
+        push.assert_not_called()
+
+        # The restored config reaches Home Assistant when the app announces it
+        push.reset_mock()
+        await coresys.discovery.send(app_with_discovery, "mcp", dict(old_config))
+        await asyncio.sleep(0)
+
+    push.assert_called_once_with(live, CMD_NEW)
+    assert [
+        message.uuid
+        for message in coresys.discovery.messages_for_app(app_with_discovery.slug)
+    ] == [live.uuid]
+
+
+async def test_restore_app_messages_unchanged_config_is_noop(
+    coresys: CoreSys, app_with_discovery: App
+):
+    """Test restoring the message which is already there changes nothing.
+
+    Home Assistant knows this message with this config already, so there is
+    nothing to announce.
+    """
+    live = await coresys.discovery.send(app_with_discovery, "mcp", dict(MCP_CONFIG))
+
+    with patch.object(
+        type(coresys.discovery), "_push_discovery", new=AsyncMock()
+    ) as push:
+        await coresys.discovery.restore_app_messages(
+            app_with_discovery,
+            [
+                Message(
+                    app=app_with_discovery.slug,
+                    service="mcp",
+                    config=dict(MCP_CONFIG),
+                    uuid=live.uuid,
+                )
+            ],
+        )
+        # App announces itself again after the restore
+        await coresys.discovery.send(app_with_discovery, "mcp", dict(MCP_CONFIG))
+        await asyncio.sleep(0)
+
+    push.assert_not_called()
+    assert coresys.discovery.get(live.uuid).config == MCP_CONFIG
 
 
 async def test_restore_app_messages_skips_uuid_in_use(

--- a/tests/discovery/test_discovery.py
+++ b/tests/discovery/test_discovery.py
@@ -1,0 +1,142 @@
+"""Test discovery message handling."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from supervisor.apps.app import App
+from supervisor.coresys import CoreSys
+from supervisor.discovery import CMD_NEW, Message
+
+BACKUP_UUID = "e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3"
+MCP_CONFIG = {"url": "http://local-ssh:8099/mcp"}
+
+
+@pytest.fixture(name="app_with_discovery")
+async def fixture_app_with_discovery(install_app_ssh: App) -> App:
+    """Return an app which provides a discoverable service."""
+    install_app_ssh.data["discovery"] = ["mcp"]
+    return install_app_ssh
+
+
+async def test_restore_app_messages_keeps_uuid(
+    coresys: CoreSys, app_with_discovery: App
+):
+    """Test a restored message keeps the uuid Home Assistant knows it by."""
+    message = Message(
+        app=app_with_discovery.slug,
+        service="mcp",
+        config=MCP_CONFIG,
+        uuid=BACKUP_UUID,
+    )
+
+    with patch.object(
+        type(coresys.discovery), "_push_discovery", new=AsyncMock()
+    ) as push:
+        await coresys.discovery.restore_app_messages(app_with_discovery, [message])
+        await asyncio.sleep(0)
+
+    assert coresys.discovery.get(BACKUP_UUID) == message
+    assert coresys.discovery.get(BACKUP_UUID).config == MCP_CONFIG
+    # The service behind the message is not up yet, only the app knows when it
+    # is, so Home Assistant is not told here
+    push.assert_not_called()
+
+
+async def test_restore_app_messages_announced_by_app(
+    coresys: CoreSys, app_with_discovery: App
+):
+    """Test the app announcing a restored message pushes it, uuid included.
+
+    An app sends its discovery message again on every start. send() drops such
+    a message as a duplicate when its config did not change, which for a
+    restored message would leave Home Assistant unaware of it until its next
+    start. That never comes when a single app is restored while Home Assistant
+    keeps running, so a restored message pushes on the first send instead.
+    """
+    message = Message(
+        app=app_with_discovery.slug,
+        service="mcp",
+        config=MCP_CONFIG,
+        uuid=BACKUP_UUID,
+    )
+    await coresys.discovery.restore_app_messages(app_with_discovery, [message])
+
+    with patch.object(
+        type(coresys.discovery), "_push_discovery", new=AsyncMock()
+    ) as push:
+        # App starts after the restore and sends the config it always sends.
+        # Message equality ignores the uuid, so compare it explicitly
+        resent = await coresys.discovery.send(
+            app_with_discovery, "mcp", dict(MCP_CONFIG)
+        )
+        await asyncio.sleep(0)
+
+        assert resent.uuid == BACKUP_UUID
+        push.assert_called_once_with(message, CMD_NEW)
+
+        # Every following start is a duplicate again
+        push.reset_mock()
+        await coresys.discovery.send(app_with_discovery, "mcp", dict(MCP_CONFIG))
+        await asyncio.sleep(0)
+
+    push.assert_not_called()
+    assert [
+        message.uuid
+        for message in coresys.discovery.messages_for_app(app_with_discovery.slug)
+    ] == [BACKUP_UUID]
+
+
+async def test_restore_app_messages_keeps_live_message(
+    coresys: CoreSys, app_with_discovery: App
+):
+    """Test a live message wins, it already carries the uuid in use."""
+    live = await coresys.discovery.send(app_with_discovery, "mcp", dict(MCP_CONFIG))
+    assert live.uuid != BACKUP_UUID
+
+    await coresys.discovery.restore_app_messages(
+        app_with_discovery,
+        [
+            Message(
+                app=app_with_discovery.slug,
+                service="mcp",
+                config={"url": "http://local-ssh:9999/mcp"},
+                uuid=BACKUP_UUID,
+            )
+        ],
+    )
+
+    assert coresys.discovery.get(BACKUP_UUID) is None
+    assert coresys.discovery.messages_for_app(app_with_discovery.slug) == [live]
+
+
+async def test_restore_app_messages_skips_dropped_service(
+    coresys: CoreSys, app_with_discovery: App, caplog: pytest.LogCaptureFixture
+):
+    """Test a message is not restored for a service the app no longer provides."""
+    await coresys.discovery.restore_app_messages(
+        app_with_discovery,
+        [
+            Message(
+                app=app_with_discovery.slug,
+                service="adguard",
+                config={"host": "127.0.0.1", "port": 3000},
+                uuid=BACKUP_UUID,
+            )
+        ],
+    )
+
+    assert coresys.discovery.get(BACKUP_UUID) is None
+    assert "app local_ssh does not provide it anymore" in caplog.text
+
+
+async def test_messages_for_app(coresys: CoreSys, app_with_discovery: App):
+    """Test listing the messages of a single app."""
+    message = await coresys.discovery.send(app_with_discovery, "mcp", dict(MCP_CONFIG))
+    other = Message(app="core_mosquitto", service="mqtt", config={})
+    coresys.discovery.message_obj[other.uuid] = other
+
+    assert coresys.discovery.messages_for_app(app_with_discovery.slug) == [message]
+    assert coresys.discovery.messages_for_app("core_mosquitto") == [other]
+    assert coresys.discovery.messages_for_app("local_example") == []


### PR DESCRIPTION
## Proposed change

Home Assistant links the config entry it creates from a discovery message to the uuid of that message. Several integrations make that uuid the unique ID of their config entry, most recently the Model Context Protocol integration in home-assistant/core#180378, so that uninstalling the app removes the entry and an app moving to another port updates the URL of the existing entry. Home Assistant also keys its rediscovery on it: removing such an entry re-triggers the discovery flow by looking the uuid up in Supervisor (home-assistant/core#127088).

The uuid identifies an installation of an app. It is minted when the app first announces a service and stays the same for as long as the data of the app does, since Supervisor matches a re-sent message on app and service and keeps the uuid. It only lives in `discovery.json` in Supervisor's own data directory though, which is not part of a backup. A restore brings the data of the app back, but not the uuid that identified it, so the app announces itself under a freshly generated one while the config entries restored with Home Assistant still reference the old one. The entry is then no longer removed together with the app, rediscovery finds nothing, and an app which comes back with a changed URL creates a second config entry next to the stale one.

This stores the discovery messages of an app in its backup metadata (`addon.json`) and restores them with their uuid, before the app can announce itself again. Backups written by older Supervisor versions carry no such metadata and restore exactly as before.

The uuid follows the data of the app. On restore this means:

- No live message for the service: the message of the backup is restored as is.
- Live message under the same uuid: same installation, only its config is taken from the backup, as the restore may bring back another version of the app which announces a different config.
- Live message under another uuid: it belongs to an installation which the restore just replaced. It is retracted as an uninstall would, so that Home Assistant drops its config entry, and the message of the backup takes its place. The app is then rediscovered under the uuid of the backup, which is what the config entries restored with Home Assistant reference.
- A message is skipped when the restored app no longer provides the service, or when its uuid is already taken by another message, which it would otherwise evict. A backup listing a service twice keeps the first message.

A restored message is not announced to Home Assistant during the restore. The service behind it is not up at that point, and it never comes up when the app is not started again. Only the app knows when its service is up and it sends its discovery message on every start, so that is where the push belongs. Such a send would normally be dropped as a duplicate, because the config the app sends is the config the backup restored, hence a restored message is marked as unannounced and pushed on the first send it gets.

### How the Core integrations deal with the discovery uuid

Every `async_step_hassio` in Core as of today. "New uuid" is a discovery for a service which already has a config entry, arriving under a uuid that entry does not know, which is what a restore without this PR produces. "Supervisor delete" is the delete Supervisor pushes on uninstall, and under this PR also for the message of a replaced installation; Home Assistant only removes entries whose unique ID equals the uuid.

| Integration | uuid stored as unique ID | Reaction to a new uuid | Entry removed on Supervisor delete | With the uuid preserved by this PR |
|---|---|---|---|---|
| otbr | yes | Not re-linked. The host fallback of home-assistant/core#179551 only matches entries without a unique ID, from the first version of the integration. When the existing entry is loaded, the router is found in use and the flow aborts, leaving the entry on the old uuid. When it is not loaded, which is the case while the app restarts, a second entry is created. | yes | Restored entries match the uuid the app announces. A replaced installation loses its entry through the delete and is rediscovered under the uuid of the backup. |
| wyoming | yes | Re-links the entry with the same host and port and adopts the new uuid. | yes | As otbr. |
| mcp | yes | Aborts on the matching URL, the entry keeps the old uuid. A changed URL creates a second entry. Shipped with home-assistant/core#180378. | yes | As otbr. Without this PR a restore onto a fresh system leaves the entry on a dead uuid, so it is no longer removed with the app and a changed URL duplicates it. |
| pyload, uptime_kuma | yes | Abort on the matching URL before looking at the uuid, the entry keeps the old uuid. A changed URL creates a second entry. | yes | As mcp. |
| adguard, matter, mealie, motioneye, mqtt, onewire | no, placeholder from `_async_handle_discovery_without_unique_id()` | Aborts whenever any entry of the integration exists. | never | Unaffected. |
| deconz, zwave_js, music_assistant | no, device identity (bridge ID, home ID, server ID) | Matches the device, updates host or URL. | never | Unaffected. |
| vlc_telnet | no, fixed `hassio` | Aborts, updates the config. | never | Unaffected. |
| esphome | no entry created | Records the dashboard location and aborts. | never | Unaffected. |

Independent of the unique ID, Home Assistant keeps the uuid of every discovery flow in the `discovery_keys` of the resulting entry and looks it up in Supervisor when the entry is removed, to offer the discovery again (home-assistant/core#127088). That lookup finds nothing for a uuid a restore did not preserve, for every integration in the table.

The retraction has a cost on a restore of a single app while Home Assistant keeps running and the app was reinstalled since the backup: the uuid keyed integrations lose their entry and offer the rediscovery again, so the user confirms the flow once more. That is the uninstall and reinstall Home Assistant would have seen if the app had been removed and set up again, which is what such a restore is.

Discovery data is still not cleaned up when an app update drops a service from its `discovery` config. That gap is independent of backups and left for a separate PR. Treating the uuid as a plain message handle in Home Assistant instead, keyed on app and service, is a larger change on the Core side and to be looked at separately as well.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/core#180378
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/


