### PR TITLE
Rename Core port reservation units to drop the hassio prefix

### DIFF
--- a/supervisor/core.py
+++ b/supervisor/core.py
@@ -41,8 +41,8 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 # socket is paired with a no-op oneshot service (RemainAfterExit) so systemd
 # always has a valid activation target -- otherwise it would tear the socket
 # down on the first connection attempt before Core is ready.
-_PORT_RESERVE_UNIT: Final = "hassio-port-reserve.socket"
-_PORT_RESERVE_SERVICE: Final = "hassio-port-reserve.service"
+_PORT_RESERVE_UNIT: Final = "homeassistant-core-port-reserve.socket"
+_PORT_RESERVE_SERVICE: Final = "homeassistant-core-port-reserve.service"
 _PORT_RESERVE_TIMEOUT: Final = 10
 _TERMINAL_STATES: Final = {UnitActiveState.INACTIVE, UnitActiveState.FAILED}
 
@@ -488,11 +488,11 @@ class Core(CoreSysAttributes):
     async def _reserve_core_port(self, hosts: list[str], port: int) -> bool:
         """Reserve Core's host TCP port(s) using a transient systemd socket.
 
-        Core runs with --network=host, so Supervisor (on the hassio bridge)
-        can't bind the port itself -- instead systemd is asked to bind a
-        transient ``.socket`` unit for each host, paired atomically (via
-        ``aux``) with a no-op oneshot service so it has a valid activation
-        target.
+        Core runs with --network=host, so Supervisor (on the ``hassio``
+        Docker bridge network) can't bind the port itself -- instead systemd
+        is asked to bind a transient ``.socket`` unit for each host, paired
+        atomically (via ``aux``) with a no-op oneshot service so it has a
+        valid activation target.
 
         Returns True if reserved (caller must later call
         ``_release_core_port``), or False if it couldn't be reserved

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,11 +12,7 @@ from dbus_fast import DBusError, ErrorType, Variant
 import pytest
 
 from supervisor.const import AppStartup, CoreState
-from supervisor.core import (
-    _PORT_RESERVE_SERVICE,
-    _PORT_RESERVE_UNIT,
-    _format_bind_address,
-)
+from supervisor.core import _format_bind_address
 from supervisor.coresys import CoreSys
 from supervisor.dbus.const import DBUS_ERR_SYSTEMD_NO_SUCH_UNIT
 from supervisor.exceptions import (
@@ -543,7 +539,7 @@ async def test_start_reserves_core_port(
     # A transient socket unit must be created listening on every address
     assert len(systemd_service.StartTransientUnit.calls) == 1
     unit_name, mode, properties, aux = systemd_service.StartTransientUnit.calls[0]
-    assert unit_name == _PORT_RESERVE_UNIT
+    assert unit_name == "homeassistant-core-port-reserve.socket"
     assert mode == "replace"
     listen_property = next(value for key, value in properties if key == "Listen")
     assert listen_property == Variant(
@@ -558,14 +554,20 @@ async def test_start_reserves_core_port(
     # first incoming connection during boot would tear the reservation down
     assert len(aux) == 1
     service_name, service_properties = aux[0]
-    assert service_name == _PORT_RESERVE_SERVICE
+    assert service_name == "homeassistant-core-port-reserve.service"
     service_properties_dict = dict(service_properties)
     assert service_properties_dict["Type"] == Variant("s", "oneshot")
     assert service_properties_dict["RemainAfterExit"] == Variant("b", True)
 
     # Reservation must be released before Core starts
-    assert (_PORT_RESERVE_UNIT, "replace") in systemd_service.StopUnit.calls
-    assert (_PORT_RESERVE_SERVICE, "replace") in systemd_service.StopUnit.calls
+    assert (
+        "homeassistant-core-port-reserve.socket",
+        "replace",
+    ) in systemd_service.StopUnit.calls
+    assert (
+        "homeassistant-core-port-reserve.service",
+        "replace",
+    ) in systemd_service.StopUnit.calls
 
     # Core must have started
     coresys.homeassistant.core.start.assert_awaited_once()
@@ -732,7 +734,10 @@ async def test_start_cleans_up_stale_active_unit_before_reserving(
     await coresys.core.start()
 
     # The stale unit must have been stopped before the new one was started
-    assert (_PORT_RESERVE_UNIT, "replace") in systemd_service.StopUnit.calls
+    assert (
+        "homeassistant-core-port-reserve.socket",
+        "replace",
+    ) in systemd_service.StopUnit.calls
     assert len(systemd_service.StartTransientUnit.calls) == 1
     # It cleanly reached INACTIVE, so there was nothing to reset
     assert systemd_service.ResetFailedUnit.calls == []
@@ -762,8 +767,13 @@ async def test_release_core_port_resets_failed_unit(
     result = await coresys.core._release_core_port()
 
     assert result is False
-    assert (_PORT_RESERVE_UNIT, "replace") in systemd_service.StopUnit.calls
-    assert (_PORT_RESERVE_UNIT,) in systemd_service.ResetFailedUnit.calls
+    assert (
+        "homeassistant-core-port-reserve.socket",
+        "replace",
+    ) in systemd_service.StopUnit.calls
+    assert (
+        "homeassistant-core-port-reserve.socket",
+    ) in systemd_service.ResetFailedUnit.calls
 
 
 async def test_release_core_port_confirms_success_when_unit_goes_inactive(


### PR DESCRIPTION
## Proposed change

Follow-up to #7131, which introduced two transient systemd units used to hold Home Assistant Core's HTTP port during boot while pre-Core apps start. They were named `hassio-port-reserve.socket` / `hassio-port-reserve.service`.

Unlike most internal names, these are host visible: they appear in `systemctl list-units`, in `journalctl`, and in any bug report from a boot where the reservation was involved. `hassio` is legacy branding we are moving away from, so it shouldn't get baked into a user-facing name. This renames both units to `homeassistant-core-port-reserve.{socket,service}`, which says whose port is being held.

The units are transient and only exist during the pre-Core boot window, so there is no upgrade or compatibility concern. A Supervisor update landing between reservation and release would at worst leave one inactive unit behind until the next host reboot; the cleanup path only ever looks for its own name.

Also reflows the `_reserve_core_port` docstring so its reference to the `hassio` Docker bridge network reads as the network name it actually is (that one is a real identifier and stays).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #7131
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
