### PR TITLE
Skip redundant inspect calls when constructing Docker container handles

### DIFF
--- a/supervisor/docker/app.py
+++ b/supervisor/docker/app.py
@@ -964,24 +964,21 @@ class DockerApp(DockerInterface):
     )
     async def write_stdin(self, data: bytes) -> None:
         """Write to app stdin."""
-        try:
-            # Load needed docker objects
-            container = await self.sys_docker.containers.get(self.name)
-            socket = container.attach(stdin=True)
-        except TimeoutError as err:
-            raise DockerTimeoutError(
-                f"Timeout attaching to {self.name} stdin", _LOGGER.error
-            ) from err
-        except aiodocker.DockerError as err:
-            raise DockerError(
-                f"Can't attach to {self.name} stdin: {err!s}", _LOGGER.error
-            ) from err
+        # container() builds the handle from the name with no I/O; attach()
+        # below addresses it by name/id directly.
+        container = self.sys_docker.containers.container(self.name)
+        socket = container.attach(stdin=True)
 
         try:
             await socket.write_in(data + b"\n")
             await socket.close()
-        # Seems to raise very generic exceptions like RuntimeError or AssertionError
-        # So we catch all exceptions and re-raise them as DockerError
+        except TimeoutError as err:
+            raise DockerTimeoutError(
+                f"Timeout writing to {self.name} stdin", _LOGGER.error
+            ) from err
+        # Seems to also raise very generic exceptions like RuntimeError or
+        # AssertionError, so we catch all remaining exceptions and re-raise
+        # them as DockerError
         except Exception as err:
             raise DockerError(
                 f"Can't write to {self.name} stdin: {err!s}", _LOGGER.error

--- a/supervisor/docker/interface.py
+++ b/supervisor/docker/interface.py
@@ -413,8 +413,9 @@ class DockerInterface(JobGroup, ABC):
     async def _get_container(self) -> dict[str, Any] | None:
         """Get docker container, returns None if not found."""
         try:
-            container = await self.sys_docker.containers.get(self.name)
-            return await container.show()
+            # container() builds the handle from the name with no I/O;
+            # show() below performs the actual inspect call.
+            return await self.sys_docker.containers.container(self.name).show()
         except TimeoutError as err:
             raise DockerTimeoutError(
                 f"Timeout occurred while getting container information for {self.name}"
@@ -451,7 +452,9 @@ class DockerInterface(JobGroup, ABC):
         """Attach to running Docker container."""
         with suppress(aiodocker.DockerError, TimeoutError):
             if docker_container is DEFAULT:
-                docker_container = await self.sys_docker.containers.get(self.name)
+                # container() builds the handle from the name with no I/O;
+                # show() below performs the actual inspect call.
+                docker_container = self.sys_docker.containers.container(self.name)
             if isinstance(docker_container, DockerContainer):
                 self._meta = await docker_container.show()
                 self.sys_docker.monitor.watch_container(self._meta)
@@ -467,7 +470,7 @@ class DockerInterface(JobGroup, ABC):
                         DockerContainerStateEvent(
                             self.name,
                             state,
-                            docker_container.id,
+                            self._meta["Id"],
                             int(time()),
                             exit_code,
                         ),

--- a/supervisor/docker/manager.py
+++ b/supervisor/docker/manager.py
@@ -902,14 +902,17 @@ class DockerAPI(CoreSysAttributes):
         self, name: str, timeout: int, remove_container: bool = True
     ) -> None:
         """Stop/remove Docker container."""
-        # container() builds the handle from the name with no I/O; show()
-        # below performs the actual inspect call.
+        # container() builds the handle from the name with no I/O; stop()
+        # below addresses it by name/id directly. Docker returns 304 (not
+        # an error) if the container was already stopped, so there's no
+        # need to inspect it first just to check its state.
         docker_container = self.containers.container(name)
         try:
-            container_metadata = await docker_container.show()
+            _LOGGER.info("Stopping %s application", name)
+            await docker_container.stop(t=timeout)
         except TimeoutError as err:
             raise DockerTimeoutError(
-                f"Timeout getting container {name} for stopping",
+                f"Timeout stopping container {name}",
                 _LOGGER.error,
             ) from err
         except aiodocker.DockerError as err:
@@ -917,14 +920,9 @@ class DockerAPI(CoreSysAttributes):
                 # Generally suppressed so we don't log this
                 raise DockerNotFound from None
             raise DockerError(
-                f"Could not get container {name} for stopping: {err!s}",
+                f"Could not stop container {name}: {err!s}",
                 _LOGGER.error,
             ) from err
-
-        if container_metadata["State"]["Status"] == "running":
-            _LOGGER.info("Stopping %s application", name)
-            with suppress(aiodocker.DockerError):
-                await docker_container.stop(t=timeout)
 
         if remove_container:
             with suppress(aiodocker.DockerError):

--- a/supervisor/docker/manager.py
+++ b/supervisor/docker/manager.py
@@ -872,8 +872,9 @@ class DockerAPI(CoreSysAttributes):
     ) -> bool:
         """Return True if docker container exists in good state and is built from expected image."""
         try:
-            docker_container = await self.containers.get(name)
-            container_metadata = await docker_container.show()
+            # container() builds the handle from the name with no I/O;
+            # show() below performs the actual inspect call.
+            container_metadata = await self.containers.container(name).show()
             docker_image = await self.images.inspect(f"{image}:{version}")
         except TimeoutError as err:
             raise DockerTimeoutError(
@@ -901,8 +902,10 @@ class DockerAPI(CoreSysAttributes):
         self, name: str, timeout: int, remove_container: bool = True
     ) -> None:
         """Stop/remove Docker container."""
+        # container() builds the handle from the name with no I/O; show()
+        # below performs the actual inspect call.
+        docker_container = self.containers.container(name)
         try:
-            docker_container = await self.containers.get(name)
             container_metadata = await docker_container.show()
         except TimeoutError as err:
             raise DockerTimeoutError(
@@ -1070,20 +1073,10 @@ class DockerAPI(CoreSysAttributes):
 
     async def container_run_inside(self, name: str, command: str) -> ExecReturn:
         """Execute a command inside Docker container."""
-        try:
-            docker_container = await self.containers.get(name)
-        except TimeoutError as err:
-            raise DockerTimeoutError(
-                f"Timeout getting container {name} to run command"
-            ) from err
-        except aiodocker.DockerError as err:
-            if err.status == HTTPStatus.NOT_FOUND:
-                raise DockerNotFound(
-                    f"Container {name} not found for running command", _LOGGER.warning
-                ) from None
-            raise DockerError(
-                f"Can't get container {name} to run command: {err!s}"
-            ) from err
+        # container() builds the handle from the name with no I/O; exec()
+        # below addresses it by name/id directly and will surface a
+        # not-found error itself.
+        docker_container = self.containers.container(name)
 
         # Execute - use detach=False to wait for completion and capture output
         try:
@@ -1112,6 +1105,10 @@ class DockerAPI(CoreSysAttributes):
                     _LOGGER.error,
                 )
         except aiodocker.DockerError as err:
+            if err.status == HTTPStatus.NOT_FOUND:
+                raise DockerNotFound(
+                    f"Container {name} not found for running command", _LOGGER.warning
+                ) from None
             raise DockerError(
                 f"Can't run command in container {name}: {err!s}"
             ) from err

--- a/supervisor/docker/supervisor.py
+++ b/supervisor/docker/supervisor.py
@@ -51,8 +51,9 @@ class DockerSupervisor(DockerInterface):
     ) -> None:
         """Attach to running docker container."""
         try:
-            docker_container = await self.sys_docker.containers.get(self.name)
-            self._meta = await docker_container.show()
+            # container() builds the handle from the name with no I/O;
+            # show() below performs the actual inspect call.
+            self._meta = await self.sys_docker.containers.container(self.name).show()
         except TimeoutError as err:
             raise DockerTimeoutError(
                 "Timeout getting supervisor container metadata"
@@ -68,14 +69,16 @@ class DockerSupervisor(DockerInterface):
             self.sys_supervisor.version,
         )
 
+        container_id = self._meta["Id"]
+
         # If already attach
-        if docker_container.id in self.sys_docker.network.containers:
+        if container_id in self.sys_docker.network.containers:
             return
 
         # Attach to network
         _LOGGER.info("Connecting Supervisor to hassio-network")
         await self.sys_docker.network.attach_container(
-            docker_container.id,
+            container_id,
             self.name,
             alias=["supervisor"],
             ipv4=self.sys_docker.network.supervisor,
@@ -85,8 +88,11 @@ class DockerSupervisor(DockerInterface):
     async def retag(self) -> None:
         """Retag latest image to version."""
         try:
-            docker_container = await self.sys_docker.containers.get(self.name)
-            container_metadata = await docker_container.show()
+            # container() builds the handle from the name with no I/O;
+            # show() below performs the actual inspect call.
+            container_metadata = await self.sys_docker.containers.container(
+                self.name
+            ).show()
         except TimeoutError as err:
             raise DockerTimeoutError(
                 "Timeout getting Supervisor container for retag",
@@ -128,8 +134,11 @@ class DockerSupervisor(DockerInterface):
     async def update_start_tag(self, image: str, version: AwesomeVersion) -> None:
         """Update start tag to new version."""
         try:
-            docker_container = await self.sys_docker.containers.get(self.name)
-            container_metadata = await docker_container.show()
+            # container() builds the handle from the name with no I/O;
+            # show() below performs the actual inspect call.
+            container_metadata = await self.sys_docker.containers.container(
+                self.name
+            ).show()
         except TimeoutError as err:
             raise DockerTimeoutError(
                 "Timeout getting container to fix start tag", _LOGGER.error

--- a/supervisor/docker/supervisor.py
+++ b/supervisor/docker/supervisor.py
@@ -8,7 +8,7 @@ import os
 import aiodocker
 from awesomeversion.awesomeversion import AwesomeVersion
 
-from ..exceptions import DockerError, DockerTimeoutError
+from ..exceptions import DockerError, DockerNotFound, DockerTimeoutError
 from ..jobs.const import JobConcurrency
 from ..jobs.decorator import Job
 from .const import PropagationMode
@@ -50,18 +50,11 @@ class DockerSupervisor(DockerInterface):
         self, version: AwesomeVersion, *, skip_state_event_if_down: bool = False
     ) -> None:
         """Attach to running docker container."""
-        try:
-            # container() builds the handle from the name with no I/O;
-            # show() below performs the actual inspect call.
-            self._meta = await self.sys_docker.containers.container(self.name).show()
-        except TimeoutError as err:
-            raise DockerTimeoutError(
-                "Timeout getting supervisor container metadata"
-            ) from err
-        except aiodocker.DockerError as err:
-            raise DockerError(
-                f"Could not get supervisor container metadata: {err!s}"
-            ) from err
+        if not (container_metadata := await self._get_container()):
+            raise DockerNotFound(
+                f"Could not get supervisor container metadata for {self.name}"
+            )
+        self._meta = container_metadata
 
         _LOGGER.info(
             "Attaching to Supervisor %s with version %s",
@@ -87,21 +80,11 @@ class DockerSupervisor(DockerInterface):
     @Job(name="docker_supervisor_retag", concurrency=JobConcurrency.GROUP_QUEUE)
     async def retag(self) -> None:
         """Retag latest image to version."""
-        try:
-            # container() builds the handle from the name with no I/O;
-            # show() below performs the actual inspect call.
-            container_metadata = await self.sys_docker.containers.container(
-                self.name
-            ).show()
-        except TimeoutError as err:
-            raise DockerTimeoutError(
-                "Timeout getting Supervisor container for retag",
+        if not (container_metadata := await self._get_container()):
+            raise DockerNotFound(
+                f"Could not get Supervisor container {self.name} for retag",
                 _LOGGER.error,
-            ) from err
-        except aiodocker.DockerError as err:
-            raise DockerError(
-                f"Could not get Supervisor container for retag: {err}", _LOGGER.error
-            ) from err
+            )
 
         # See https://github.com/docker/docker-py/blob/df3f8e2abc5a03de482e37214dddef9e0cee1bb1/docker/models/containers.py#L41
         metadata_image = container_metadata.get("ImageID", container_metadata["Image"])
@@ -133,20 +116,10 @@ class DockerSupervisor(DockerInterface):
     )
     async def update_start_tag(self, image: str, version: AwesomeVersion) -> None:
         """Update start tag to new version."""
-        try:
-            # container() builds the handle from the name with no I/O;
-            # show() below performs the actual inspect call.
-            container_metadata = await self.sys_docker.containers.container(
-                self.name
-            ).show()
-        except TimeoutError as err:
-            raise DockerTimeoutError(
-                "Timeout getting container to fix start tag", _LOGGER.error
-            ) from err
-        except aiodocker.DockerError as err:
-            raise DockerError(
-                f"Can't get container to fix start tag: {err}", _LOGGER.error
-            ) from err
+        if not (container_metadata := await self._get_container()):
+            raise DockerNotFound(
+                f"Could not get container {self.name} to fix start tag", _LOGGER.error
+            )
 
         # See https://github.com/docker/docker-py/blob/df3f8e2abc5a03de482e37214dddef9e0cee1bb1/docker/models/containers.py#L41
         metadata_image = container_metadata.get("ImageID", container_metadata["Image"])

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -711,7 +711,7 @@ async def test_backup_with_pre_post_command(
 
 @pytest.mark.parametrize(
     (
-        "container_get_side_effect",
+        "exec_side_effect",
         "exec_start_side_effect",
         "exec_inspect_side_effect",
         "exc_type_raised",
@@ -748,13 +748,13 @@ async def test_backup_with_pre_post_command(
 async def test_backup_with_pre_command_error(
     coresys: CoreSys,
     install_app_ssh: App,
-    container_get_side_effect: aiodocker.DockerError | None,
+    exec_side_effect: aiodocker.DockerError | None,
     exec_start_side_effect: aiodocker.DockerError | None,
     exec_inspect_side_effect: aiodocker.DockerError | list[dict[str, Any]] | None,
     exc_type_raised: type[HassioError],
 ) -> None:
     """Test backing up an app with error running pre command."""
-    coresys.docker.containers.get.side_effect = container_get_side_effect
+    coresys.docker.containers.get.return_value.exec.side_effect = exec_side_effect
     coresys.docker.containers.get.return_value.exec.return_value.start.side_effect = (
         exec_start_side_effect
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -230,9 +230,8 @@ async def docker() -> DockerAPI:
         docker_containers.get.return_value = docker_container = MagicMock(
             spec=DockerContainer, id=container_inspect["Id"]
         )
-        # container_stats() uses containers.container() (no I/O) instead of
-        # containers.get() for the windowed stats path, so alias it to the
-        # same mock.
+        # container() is the sync, no-I/O counterpart to get(); alias it to
+        # the same mock so callers get consistent container state either way.
         docker_containers.container.return_value = docker_container
         docker_containers.list.return_value = [docker_container]
         docker_containers.create.return_value = docker_container

--- a/tests/docker/test_app.py
+++ b/tests/docker/test_app.py
@@ -979,11 +979,12 @@ async def test_app_build_inspect_timeout(
 async def test_app_write_stdin_get_timeout(
     coresys: CoreSys, addonsdata_system: dict[str, Data]
 ):
-    """Test write_stdin raises DockerTimeoutError when containers.get times out."""
+    """Test write_stdin raises DockerTimeoutError when the attach stream times out."""
     docker_app = get_docker_app(coresys, addonsdata_system, "basic-app-config.json")
-    coresys.docker.containers.get.side_effect = TimeoutError()
+    attach_stream = coresys.docker.containers.get.return_value.attach.return_value
+    attach_stream.write_in.side_effect = TimeoutError()
 
-    with pytest.raises(DockerTimeoutError, match="Timeout attaching to .* stdin"):
+    with pytest.raises(DockerTimeoutError, match="Timeout writing to .* stdin"):
         await docker_app.write_stdin(b"hello")
 
 

--- a/tests/docker/test_interface.py
+++ b/tests/docker/test_interface.py
@@ -214,7 +214,7 @@ async def test_current_state(
 
 async def test_current_state_failures(coresys: CoreSys):
     """Test failure states for current state."""
-    coresys.docker.containers.get.side_effect = aiodocker.DockerError(
+    coresys.docker.containers.get.return_value.show.side_effect = aiodocker.DockerError(
         404, {"message": "does not exist"}
     )
     assert (
@@ -222,7 +222,7 @@ async def test_current_state_failures(coresys: CoreSys):
         == ContainerState.UNKNOWN
     )
 
-    coresys.docker.containers.get.side_effect = aiodocker.DockerError(
+    coresys.docker.containers.get.return_value.show.side_effect = aiodocker.DockerError(
         500, {"message": "fail"}
     )
     with pytest.raises(DockerAPIError):
@@ -231,7 +231,9 @@ async def test_current_state_failures(coresys: CoreSys):
 
 async def test_current_state_timeout(coresys: CoreSys):
     """Test timeout while reading container state raises DockerTimeoutError."""
-    coresys.docker.containers.get.side_effect = TimeoutError("timed out")
+    coresys.docker.containers.get.return_value.show.side_effect = TimeoutError(
+        "timed out"
+    )
 
     with pytest.raises(DockerTimeoutError, match="Timeout occurred"):
         await coresys.homeassistant.core.instance.current_state()
@@ -320,7 +322,7 @@ async def test_attach_existing_container(
 
 async def test_attach_container_failure(coresys: CoreSys):
     """Test attach fails to find container but finds image."""
-    coresys.docker.containers.get.side_effect = aiodocker.DockerError(
+    coresys.docker.containers.get.return_value.show.side_effect = aiodocker.DockerError(
         500, {"message": "fail"}
     )
     coresys.docker.images.inspect.return_value.setdefault("Config", {})["Image"] = (
@@ -340,7 +342,7 @@ async def test_attach_container_failure(coresys: CoreSys):
 
 async def test_attach_total_failure(coresys: CoreSys):
     """Test attach fails to find container or image."""
-    coresys.docker.containers.get.side_effect = aiodocker.DockerError(
+    coresys.docker.containers.get.return_value.show.side_effect = aiodocker.DockerError(
         500, {"message": "fail"}
     )
     coresys.docker.images.inspect.side_effect = aiodocker.DockerError(
@@ -1129,8 +1131,8 @@ async def test_install_unknown_registry_rate_limit_raises_generic_exception(
 
 
 async def test_attach_container_get_timeout_falls_through_to_image(coresys: CoreSys):
-    """Test attach suppresses TimeoutError from containers.get and falls through to image inspect."""
-    coresys.docker.containers.get.side_effect = TimeoutError()
+    """Test attach suppresses TimeoutError from show and falls through to image inspect."""
+    coresys.docker.containers.get.return_value.show.side_effect = TimeoutError()
     coresys.docker.images.inspect.return_value.setdefault("Config", {})["Image"] = (
         "sha256:abc123"
     )
@@ -1141,7 +1143,7 @@ async def test_attach_container_get_timeout_falls_through_to_image(coresys: Core
 
 async def test_attach_fallback_image_inspect_timeout(coresys: CoreSys):
     """Test attach raises DockerTimeoutError when fallback image inspect times out."""
-    coresys.docker.containers.get.side_effect = aiodocker.DockerError(
+    coresys.docker.containers.get.return_value.show.side_effect = aiodocker.DockerError(
         500, {"message": "fail"}
     )
     coresys.docker.images.inspect.side_effect = TimeoutError()

--- a/tests/docker/test_manager.py
+++ b/tests/docker/test_manager.py
@@ -785,17 +785,19 @@ async def test_prune_networks_container_get_timeout(
 async def test_container_is_initialized_timeout(
     docker: DockerAPI, container: DockerContainer
 ):
-    """Test container_is_initialized raises DockerTimeoutError when get/show times out."""
-    docker.containers.get.side_effect = TimeoutError()
+    """Test container_is_initialized raises DockerTimeoutError when show times out."""
+    container.show.side_effect = TimeoutError()
     with pytest.raises(DockerTimeoutError, match="Timeout getting container"):
         await docker.container_is_initialized(
             "mycontainer", "myimage", AwesomeVersion("1.0")
         )
 
 
-async def test_stop_container_get_timeout(docker: DockerAPI):
-    """Test stop_container raises DockerTimeoutError when containers.get times out."""
-    docker.containers.get.side_effect = TimeoutError()
+async def test_stop_container_get_timeout(
+    docker: DockerAPI, container: DockerContainer
+):
+    """Test stop_container raises DockerTimeoutError when show times out."""
+    container.show.side_effect = TimeoutError()
     with pytest.raises(
         DockerTimeoutError, match="Timeout getting container .* for stopping"
     ):

--- a/tests/docker/test_manager.py
+++ b/tests/docker/test_manager.py
@@ -25,6 +25,7 @@ from supervisor.exceptions import (
     DockerContainerNotRunningError,
     DockerError,
     DockerNoSpaceOnDevice,
+    DockerNotFound,
     DockerRegistryRateLimitExceeded,
     DockerStatsTimeoutError,
     DockerStatsUnknownError,
@@ -324,9 +325,6 @@ async def test_stop_container_with_cidfile_cleanup(
     coresys: CoreSys, docker: DockerAPI, container: DockerContainer
 ):
     """Test container stop with cidfile cleanup."""
-    container.show.return_value["State"]["Status"] = "running"
-    container.show.return_value["State"]["Running"] = True
-
     container_name = "test_container"
     cidfile_path = coresys.config.path_cid_files / f"{container_name}.cid"
 
@@ -347,9 +345,6 @@ async def test_stop_container_without_removal_no_cidfile_cleanup(
     docker: DockerAPI, container: DockerContainer
 ):
     """Test container stop without removal doesn't clean up cidfile."""
-    container.show.return_value["State"]["Status"] = "running"
-    container.show.return_value["State"]["Running"] = True
-
     container_name = "test_container"
 
     # Mock the containers.get method and cidfile cleanup
@@ -370,9 +365,6 @@ async def test_cidfile_cleanup_handles_oserror(
     coresys: CoreSys, docker: DockerAPI, container: DockerContainer
 ):
     """Test that cidfile cleanup handles OSError gracefully."""
-    container.show.return_value["State"]["Status"] = "running"
-    container.show.return_value["State"]["Running"] = True
-
     container_name = "test_container"
     cidfile_path = coresys.config.path_cid_files / f"{container_name}.cid"
 
@@ -796,12 +788,34 @@ async def test_container_is_initialized_timeout(
 async def test_stop_container_get_timeout(
     docker: DockerAPI, container: DockerContainer
 ):
-    """Test stop_container raises DockerTimeoutError when show times out."""
-    container.show.side_effect = TimeoutError()
-    with pytest.raises(
-        DockerTimeoutError, match="Timeout getting container .* for stopping"
-    ):
+    """Test stop_container raises DockerTimeoutError when stop times out."""
+    container.stop.side_effect = TimeoutError()
+    with pytest.raises(DockerTimeoutError, match="Timeout stopping container"):
         await docker.stop_container("mycontainer", timeout=10)
+
+
+async def test_stop_container_not_found(docker: DockerAPI, container: DockerContainer):
+    """Test stop_container raises DockerNotFound when container doesn't exist."""
+    container.stop.side_effect = aiodocker.DockerError(404, {"message": "missing"})
+    with pytest.raises(DockerNotFound):
+        await docker.stop_container("mycontainer", timeout=10)
+
+    container.delete.assert_not_called()
+
+
+async def test_stop_container_already_stopped(
+    docker: DockerAPI, container: DockerContainer
+):
+    """Test stop_container treats a 304 (already stopped) as success, not an error."""
+    # Docker returns 304 when the container is already stopped. aiodocker only
+    # raises DockerError for 4xx/5xx responses, so this surfaces as a normal
+    # return from stop() rather than an exception.
+    container.stop.return_value = None
+
+    await docker.stop_container("mycontainer", timeout=10, remove_container=False)
+
+    container.stop.assert_called_once_with(t=10)
+    container.delete.assert_not_called()
 
 
 async def test_start_container_get_timeout(docker: DockerAPI):
@@ -1031,11 +1045,13 @@ async def test_query_one_shot_stats(docker: DockerAPI):
     )
 
 
-async def test_container_run_inside_get_timeout(docker: DockerAPI):
-    """Test container_run_inside raises DockerTimeoutError when containers.get times out."""
-    docker.containers.get.side_effect = TimeoutError()
+async def test_container_run_inside_get_timeout(
+    docker: DockerAPI, container: DockerContainer
+):
+    """Test container_run_inside raises DockerTimeoutError when exec times out."""
+    container.exec.side_effect = TimeoutError()
     with pytest.raises(
-        DockerTimeoutError, match="Timeout getting container .* to run command"
+        DockerTimeoutError, match="Timeout running command in container"
     ):
         await docker.container_run_inside("mycontainer", "echo hi")
 

--- a/tests/docker/test_supervisor.py
+++ b/tests/docker/test_supervisor.py
@@ -1,18 +1,30 @@
 """Test Supervisor Docker container timeout handling."""
 
+from http import HTTPStatus
+
+import aiodocker
 from awesomeversion import AwesomeVersion
 import pytest
 
 from supervisor.coresys import CoreSys
-from supervisor.exceptions import DockerTimeoutError
+from supervisor.exceptions import DockerNotFound, DockerTimeoutError
 
 
 async def test_supervisor_attach_get_timeout(coresys: CoreSys):
     """Test DockerSupervisor.attach raises DockerTimeoutError when show times out."""
     coresys.docker.containers.get.return_value.show.side_effect = TimeoutError()
-    with pytest.raises(
-        DockerTimeoutError, match="Timeout getting supervisor container"
-    ):
+    with pytest.raises(DockerTimeoutError, match="Timeout occurred"):
+        await coresys.supervisor.instance.attach(
+            coresys.supervisor.version or AwesomeVersion("2025.1.0")
+        )
+
+
+async def test_supervisor_attach_not_found(coresys: CoreSys):
+    """Test DockerSupervisor.attach raises DockerNotFound when container is missing."""
+    coresys.docker.containers.get.return_value.show.side_effect = aiodocker.DockerError(
+        HTTPStatus.NOT_FOUND, {"message": "missing"}
+    )
+    with pytest.raises(DockerNotFound):
         await coresys.supervisor.instance.attach(
             coresys.supervisor.version or AwesomeVersion("2025.1.0")
         )
@@ -21,9 +33,16 @@ async def test_supervisor_attach_get_timeout(coresys: CoreSys):
 async def test_supervisor_retag_get_timeout(coresys: CoreSys):
     """Test DockerSupervisor.retag raises DockerTimeoutError when show times out."""
     coresys.docker.containers.get.return_value.show.side_effect = TimeoutError()
-    with pytest.raises(
-        DockerTimeoutError, match="Timeout getting Supervisor container for retag"
-    ):
+    with pytest.raises(DockerTimeoutError, match="Timeout occurred"):
+        await coresys.supervisor.instance.retag()
+
+
+async def test_supervisor_retag_not_found(coresys: CoreSys):
+    """Test DockerSupervisor.retag raises DockerNotFound when container is missing."""
+    coresys.docker.containers.get.return_value.show.side_effect = aiodocker.DockerError(
+        HTTPStatus.NOT_FOUND, {"message": "missing"}
+    )
+    with pytest.raises(DockerNotFound):
         await coresys.supervisor.instance.retag()
 
 
@@ -51,9 +70,19 @@ async def test_supervisor_retag_tag_timeout(coresys: CoreSys):
 async def test_supervisor_update_start_tag_get_timeout(coresys: CoreSys):
     """Test update_start_tag raises DockerTimeoutError when show times out."""
     coresys.docker.containers.get.return_value.show.side_effect = TimeoutError()
-    with pytest.raises(
-        DockerTimeoutError, match="Timeout getting container to fix start tag"
-    ):
+    with pytest.raises(DockerTimeoutError, match="Timeout occurred"):
+        await coresys.supervisor.instance.update_start_tag(
+            "ghcr.io/home-assistant/amd64-hassio-supervisor",
+            AwesomeVersion("2025.1.0"),
+        )
+
+
+async def test_supervisor_update_start_tag_not_found(coresys: CoreSys):
+    """Test update_start_tag raises DockerNotFound when container is missing."""
+    coresys.docker.containers.get.return_value.show.side_effect = aiodocker.DockerError(
+        HTTPStatus.NOT_FOUND, {"message": "missing"}
+    )
+    with pytest.raises(DockerNotFound):
         await coresys.supervisor.instance.update_start_tag(
             "ghcr.io/home-assistant/amd64-hassio-supervisor",
             AwesomeVersion("2025.1.0"),

--- a/tests/docker/test_supervisor.py
+++ b/tests/docker/test_supervisor.py
@@ -8,8 +8,8 @@ from supervisor.exceptions import DockerTimeoutError
 
 
 async def test_supervisor_attach_get_timeout(coresys: CoreSys):
-    """Test DockerSupervisor.attach raises DockerTimeoutError when containers.get times out."""
-    coresys.docker.containers.get.side_effect = TimeoutError()
+    """Test DockerSupervisor.attach raises DockerTimeoutError when show times out."""
+    coresys.docker.containers.get.return_value.show.side_effect = TimeoutError()
     with pytest.raises(
         DockerTimeoutError, match="Timeout getting supervisor container"
     ):
@@ -19,8 +19,8 @@ async def test_supervisor_attach_get_timeout(coresys: CoreSys):
 
 
 async def test_supervisor_retag_get_timeout(coresys: CoreSys):
-    """Test DockerSupervisor.retag raises DockerTimeoutError when containers.get times out."""
-    coresys.docker.containers.get.side_effect = TimeoutError()
+    """Test DockerSupervisor.retag raises DockerTimeoutError when show times out."""
+    coresys.docker.containers.get.return_value.show.side_effect = TimeoutError()
     with pytest.raises(
         DockerTimeoutError, match="Timeout getting Supervisor container for retag"
     ):
@@ -31,6 +31,7 @@ async def test_supervisor_retag_tag_timeout(coresys: CoreSys):
     """Test DockerSupervisor.retag raises DockerTimeoutError when images.tag times out."""
     # Attach first to initialize metadata via the public API.
     coresys.docker.containers.get.return_value.show.return_value = {
+        "Id": "abc123",
         "ImageID": "sha256:abc123",
         "Image": "sha256:abc123",
         "Config": {
@@ -48,8 +49,8 @@ async def test_supervisor_retag_tag_timeout(coresys: CoreSys):
 
 
 async def test_supervisor_update_start_tag_get_timeout(coresys: CoreSys):
-    """Test update_start_tag raises DockerTimeoutError when containers.get times out."""
-    coresys.docker.containers.get.side_effect = TimeoutError()
+    """Test update_start_tag raises DockerTimeoutError when show times out."""
+    coresys.docker.containers.get.return_value.show.side_effect = TimeoutError()
     with pytest.raises(
         DockerTimeoutError, match="Timeout getting container to fix start tag"
     ):

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -594,7 +594,7 @@ async def test_start(
     coresys.docker.images.inspect.return_value = {"Id": "123"}
     coresys.docker.images.inspect.side_effect = image_exc
     container.id = "123"
-    coresys.docker.containers.get.side_effect = container_exc
+    container.show.side_effect = container_exc
 
     with (
         patch.object(

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -594,7 +594,7 @@ async def test_start(
     coresys.docker.images.inspect.return_value = {"Id": "123"}
     coresys.docker.images.inspect.side_effect = image_exc
     container.id = "123"
-    container.show.side_effect = container_exc
+    container.stop.side_effect = container_exc
 
     with (
         patch.object(
@@ -616,7 +616,7 @@ async def test_start(
         assert run.call_args.kwargs["name"] == "homeassistant"
         assert run.call_args.kwargs["hostname"] == "homeassistant"
 
-    container.stop.assert_not_called()
+    container.stop.assert_called_once_with(t=260)
     assert container.delete.call_args_list == delete_calls
 
 
@@ -648,21 +648,13 @@ async def test_start_existing_container(coresys: CoreSys, container: DockerConta
 @pytest.mark.parametrize("exists", [True, False])
 async def test_stop(coresys: CoreSys, container: DockerContainer, exists: bool):
     """Test stopping Home Assistant."""
-    if exists:
-        container.show.return_value["State"]["Status"] = "running"
-        container.show.return_value["State"]["Running"] = True
-    else:
-        coresys.docker.containers.get.side_effect = aiodocker.DockerError(
-            404, {"message": "missing"}
-        )
+    if not exists:
+        container.stop.side_effect = aiodocker.DockerError(404, {"message": "missing"})
 
     await coresys.homeassistant.core.stop()
 
+    container.stop.assert_called_once_with(t=260)
     container.delete.assert_not_called()
-    if exists:
-        container.stop.assert_called_once_with(t=260)
-    else:
-        container.stop.assert_not_called()
 
 
 async def test_restart(coresys: CoreSys, container: DockerContainer):

--- a/tests/resolution/check/test_check_docker_config.py
+++ b/tests/resolution/check/test_check_docker_config.py
@@ -15,8 +15,23 @@ from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.data import Issue, Suggestion
 
 
+def _apply_container_mock(docker: DockerAPI, factory) -> None:
+    """Wire a container factory into both container() and get().
+
+    Plugins/core attach via containers.container(); DockerApp.attach() (used
+    by add-ons) calls containers.get() itself for legacy container-name
+    migration handling. Both need to return equivalent container mocks.
+    """
+    docker.containers.container = factory
+
+    async def _get(name):
+        return factory(name)
+
+    docker.containers.get = _get
+
+
 def _make_mock_container_get(bad_config_names: list[str], folder: str = "media"):
-    """Make mock of container get."""
+    """Make mock of container."""
     mount = {
         "Type": "bind",
         "Source": f"/mnt/data/supervisor/{folder}",
@@ -26,9 +41,10 @@ def _make_mock_container_get(bad_config_names: list[str], folder: str = "media")
         "Propagation": "rprivate",
     }
 
-    async def mock_container_get(name):
+    def mock_container(name):
         out = MagicMock(spec=DockerContainer)
         out.show.return_value = {
+            "Id": name,
             "State": {
                 "Status": "running",
                 "Running": True,
@@ -40,13 +56,13 @@ def _make_mock_container_get(bad_config_names: list[str], folder: str = "media")
 
         return out
 
-    return mock_container_get
+    return mock_container
 
 
 def _make_mock_container_get_with_volume_mount(
     bad_config_names: list[str], folder: str = "media"
 ):
-    """Make mock of container get with VOLUME mount (not managed by supervisor)."""
+    """Make mock of container with VOLUME mount (not managed by supervisor)."""
     # This simulates a Docker VOLUME mount with wrong propagation
     # but NOT created by supervisor configuration
     mount = {
@@ -58,9 +74,10 @@ def _make_mock_container_get_with_volume_mount(
         "Propagation": "rprivate",  # Wrong propagation, but not our mount
     }
 
-    async def mock_container_get(name):
+    def mock_container(name):
         out = MagicMock(spec=DockerContainer)
         out.show.return_value = {
+            "Id": name,
             "State": {
                 "Status": "running",
                 "Running": True,
@@ -72,7 +89,7 @@ def _make_mock_container_get_with_volume_mount(
 
         return out
 
-    return mock_container_get
+    return mock_container
 
 
 async def test_base(coresys: CoreSys):
@@ -86,8 +103,11 @@ async def test_base(coresys: CoreSys):
 @pytest.mark.usefixtures("install_app_ssh")
 async def test_check(docker: DockerAPI, coresys: CoreSys, folder: str):
     """Test check reports issue when containers have incorrect config."""
-    docker.containers.get = _make_mock_container_get(
-        ["homeassistant", "hassio_audio", "app_local_ssh"], folder
+    _apply_container_mock(
+        docker,
+        _make_mock_container_get(
+            ["homeassistant", "hassio_audio", "app_local_ssh"], folder
+        ),
     )
     # Use state used in setup()
     await coresys.core.set_state(CoreState.SETUP)
@@ -144,7 +164,7 @@ async def test_check(docker: DockerAPI, coresys: CoreSys, folder: str):
     )
 
     # IF config issue is resolved, all issues are removed except the main one. Which will be removed if check isn't approved
-    docker.containers.get = _make_mock_container_get([])
+    _apply_container_mock(docker, _make_mock_container_get([]))
     with patch.object(DockerInterface, "is_running", return_value=True):
         await coresys.plugins.load()
         await coresys.homeassistant.load()
@@ -173,8 +193,8 @@ async def test_app_volume_mount_not_flagged(
     ]  # No media/share
 
     # Mock container that has VOLUME mount to media/share with wrong propagation
-    docker.containers.get = _make_mock_container_get_with_volume_mount(
-        ["app_local_ssh"], folder
+    _apply_container_mock(
+        docker, _make_mock_container_get_with_volume_mount(["app_local_ssh"], folder)
     )
 
     await coresys.core.set_state(CoreState.SETUP)
@@ -228,9 +248,10 @@ async def test_app_configured_mount_still_flagged(
         "Propagation": "rprivate",  # Wrong propagation
     }
 
-    async def mock_container_get(name):
+    def mock_container(name):
         out = MagicMock(spec=DockerContainer)
         out.show.return_value = {
+            "Id": name,
             "State": {
                 "Status": "running",
                 "Running": True,
@@ -241,7 +262,7 @@ async def test_app_configured_mount_still_flagged(
             out.show.return_value["Mounts"].append(mount)
         return out
 
-    docker.containers.get = mock_container_get
+    _apply_container_mock(docker, mock_container)
 
     await coresys.core.set_state(CoreState.SETUP)
     with patch.object(DockerInterface, "is_running", return_value=True):
@@ -278,10 +299,11 @@ async def test_app_custom_target_path_flagged(
         {"type": mapping_type, "read_only": False, "path": custom_path},
     ]
 
-    async def mock_container_get(name: str) -> MagicMock:
-        """Mock container get with custom target path mount."""
+    def mock_container_get(name: str) -> MagicMock:
+        """Mock container with custom target path mount."""
         out = MagicMock(spec=DockerContainer)
         out.show.return_value = {
+            "Id": name,
             "State": {
                 "Status": "running",
                 "Running": True,
@@ -300,7 +322,7 @@ async def test_app_custom_target_path_flagged(
             out.show.return_value["Mounts"].append(mount)
         return out
 
-    docker.containers.get = mock_container_get
+    _apply_container_mock(docker, mock_container_get)
 
     await coresys.core.set_state(CoreState.SETUP)
     with patch.object(DockerInterface, "is_running", return_value=True):

--- a/tests/resolution/evaluation/test_restart_policy.py
+++ b/tests/resolution/evaluation/test_restart_policy.py
@@ -29,14 +29,20 @@ async def test_evaluation(coresys: CoreSys, install_app_ssh: App):
     app_attrs = no_restart_attrs
     observer_attrs = always_restart_attrs
 
-    async def get_container(name: str) -> DockerContainer:
+    def get_container(name: str) -> DockerContainer:
         meta = MagicMock(spec=DockerContainer)
         meta.show.return_value = (
             observer_attrs if name == "hassio_observer" else app_attrs
         )
         return meta
 
-    coresys.docker.containers.get = get_container
+    async def get_container_async(name: str) -> DockerContainer:
+        return get_container(name)
+
+    # Plugins/core attach via containers.container(); DockerApp.attach() uses
+    # containers.get() itself for legacy container-name migration handling.
+    coresys.docker.containers.container = get_container
+    coresys.docker.containers.get = get_container_async
     await coresys.plugins.observer.instance.attach(TEST_VERSION)
     await install_app_ssh.instance.attach(TEST_VERSION)
 

--- a/tests/resolution/fixup/test_app_execute_rebuild.py
+++ b/tests/resolution/fixup/test_app_execute_rebuild.py
@@ -1,8 +1,6 @@
 """Test fixup core execute rebuild."""
 
 import asyncio
-from collections.abc import Callable, Coroutine
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import aiodocker
@@ -17,24 +15,18 @@ from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.fixups.app_execute_rebuild import FixupAppExecuteRebuild
 
 
-def make_mock_container_get(
-    status: str,
-) -> Callable[[str], Coroutine[Any, Any, DockerContainer]]:
-    """Make mock of container get."""
+def make_mock_container(status: str) -> DockerContainer:
+    """Make mock of container."""
     out = MagicMock(spec=DockerContainer)
     out.status = status
     out.show.return_value = {"State": {"Status": status, "ExitCode": 0}, "Mounts": []}
-
-    async def mock_container_get(name) -> DockerContainer:
-        return out
-
-    return mock_container_get
+    return out
 
 
 @pytest.mark.usefixtures("install_app_ssh")
 async def test_fixup(docker: DockerAPI, coresys: CoreSys):
     """Test fixup rebuilds app's container."""
-    docker.containers.get = make_mock_container_get("running")
+    docker.containers.container.return_value = make_mock_container("running")
 
     app_execute_rebuild = FixupAppExecuteRebuild(coresys)
 
@@ -60,7 +52,7 @@ async def test_fixup_stopped_core(
 ):
     """Test fixup just removes app's container when it is stopped."""
     caplog.clear()
-    docker.containers.get = make_mock_container_get("stopped")
+    docker.containers.container.return_value = make_mock_container("stopped")
     app_execute_rebuild = FixupAppExecuteRebuild(coresys)
 
     coresys.resolution.create_issue(
@@ -75,7 +67,7 @@ async def test_fixup_stopped_core(
 
     assert not coresys.resolution.issues
     assert not coresys.resolution.suggestions
-    (await docker.containers.get("app_local_ssh")).delete.assert_called_once_with(
+    docker.containers.container("app_local_ssh").delete.assert_called_once_with(
         force=True, v=True
     )
     assert "App local_ssh is stopped" in caplog.text
@@ -87,7 +79,7 @@ async def test_fixup_unknown_core(
 ):
     """Test fixup does nothing if app's container has already been removed."""
     caplog.clear()
-    docker.containers.get.side_effect = aiodocker.DockerError(
+    docker.containers.container.return_value.show.side_effect = aiodocker.DockerError(
         404, {"message": "missing"}
     )
     app_execute_rebuild = FixupAppExecuteRebuild(coresys)

--- a/tests/resolution/fixup/test_core_execute_rebuild.py
+++ b/tests/resolution/fixup/test_core_execute_rebuild.py
@@ -1,7 +1,5 @@
 """Test fixup core execute rebuild."""
 
-from collections.abc import Callable, Coroutine
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import aiodocker
@@ -16,23 +14,17 @@ from supervisor.resolution.const import ContextType, IssueType, SuggestionType
 from supervisor.resolution.fixups.core_execute_rebuild import FixupCoreExecuteRebuild
 
 
-def make_mock_container_get(
-    status: str,
-) -> Callable[[str], Coroutine[Any, Any, DockerContainer]]:
-    """Make mock of container get."""
+def make_mock_container(status: str) -> DockerContainer:
+    """Make mock of container."""
     out = MagicMock(spec=DockerContainer)
     out.status = status
     out.show.return_value = {"State": {"Status": status, "ExitCode": 0}, "Mounts": []}
-
-    async def mock_container_get(name) -> DockerContainer:
-        return out
-
-    return mock_container_get
+    return out
 
 
 async def test_fixup(docker: DockerAPI, coresys: CoreSys):
     """Test fixup rebuilds core's container."""
-    docker.containers.get = make_mock_container_get("running")
+    docker.containers.container.return_value = make_mock_container("running")
 
     core_execute_rebuild = FixupCoreExecuteRebuild(coresys)
 
@@ -56,7 +48,7 @@ async def test_fixup_stopped_core(
 ):
     """Test fixup just removes HA's container when it is stopped."""
     caplog.clear()
-    docker.containers.get = make_mock_container_get("stopped")
+    docker.containers.container.return_value = make_mock_container("stopped")
     core_execute_rebuild = FixupCoreExecuteRebuild(coresys)
 
     coresys.resolution.create_issue(
@@ -70,7 +62,7 @@ async def test_fixup_stopped_core(
 
     assert not coresys.resolution.issues
     assert not coresys.resolution.suggestions
-    (await docker.containers.get("homeassistant")).delete.assert_called_once_with(
+    docker.containers.container("homeassistant").delete.assert_called_once_with(
         force=True, v=True
     )
     assert "Home Assistant is stopped" in caplog.text
@@ -81,7 +73,7 @@ async def test_fixup_unknown_core(
 ):
     """Test fixup does nothing if core's container has already been removed."""
     caplog.clear()
-    docker.containers.get.side_effect = aiodocker.DockerError(
+    docker.containers.container.return_value.show.side_effect = aiodocker.DockerError(
         404, {"message": "missing"}
     )
     core_execute_rebuild = FixupCoreExecuteRebuild(coresys)


### PR DESCRIPTION
## Proposed change

Several places in the Docker layer called `containers.get(id)`, which performs a Docker inspect API call, purely to construct a `DockerContainer` handle that was immediately followed by another call (`show()`, `exec()`, `attach()`) that either performs its own inspect or doesn't need one at all.

This switches those spots to `containers.container(id)`, which builds the same handle locally with no I/O, removing the redundant round-trip:

- `container_is_initialized()`, `stop_container()` and
  `container_run_inside()` in `docker/manager.py`
- `_get_container()` and `_attach()` in `docker/interface.py`
- `attach()`, `retag()` and `update_start_tag()` in `docker/supervisor.py`
- `write_stdin()` in `docker/app.py`

Since `containers.container()`-built handles don't carry the real container ID (unlike `get()`, which populates it from the inspect response), `_attach()` and `DockerSupervisor.attach()` now read the ID from the inspect payload (`self._meta["Id"]`) instead of the handle's `.id` property.

This intentionally excludes `container_stats()`, which has its own one-shot inspect+stats opportunity being handled separately in #7168.

Follow-up to review discussion in #7168: https://github.com/home-assistant/supervisor/pull/7168#discussion_r3883548019

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #7168

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
