### PR TITLE
Add Docker storage driver as a Sentry tag

### DIFF
--- a/supervisor/misc/filter.py
+++ b/supervisor/misc/filter.py
@@ -116,6 +116,11 @@ def filter_data(coresys: CoreSys, event: Event, hint: Hint) -> Event | None:
                     },
                 }
             )
+            event.setdefault("tags", {}).update(
+                {
+                    "storage_driver": coresys.docker.info.storage,
+                }
+            )
         return event
 
     # List installed apps
@@ -179,6 +184,7 @@ def filter_data(coresys: CoreSys, event: Event, hint: Hint) -> Event | None:
     event["tags"].update(
         {
             "installation_type": "os" if coresys.os.available else "supervised",
+            "storage_driver": coresys.docker.info.storage,
         }
     )
 

--- a/tests/misc/test_filter_data.py
+++ b/tests/misc/test_filter_data.py
@@ -153,6 +153,7 @@ async def test_not_started(coresys):
         filtered["contexts"]["docker"]["storage_driver"] == coresys.docker.info.storage
     )
     assert filtered["contexts"]["host"]["machine"] == coresys.machine
+    assert filtered["tags"]["storage_driver"] == coresys.docker.info.storage
 
 
 async def test_defaults(coresys):
@@ -164,6 +165,7 @@ async def test_defaults(coresys):
         filtered = filter_data(coresys, SAMPLE_EVENT, {})
 
     assert filtered["tags"]["installation_type"] == "supervised"
+    assert filtered["tags"]["storage_driver"] == coresys.docker.info.storage
     assert filtered["contexts"]["host"]["arch"] == "amd64"
     assert filtered["contexts"]["host"]["machine"] == "qemux86-64"
     assert filtered["contexts"]["versions"]["supervisor"] == AwesomeVersion(


### PR DESCRIPTION
## Proposed change

The Docker storage driver is currently reported to Sentry as event context only, which means Sentry cannot aggregate over it. This adds it as a tag as well, so issues can be filtered and broken down by storage driver, which makes it much easier to spot problems specific to a driver (e.g. containerd snapshotter vs. overlay2).

The tag is set during setup as well, mirroring the context information which is already reported in that state.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
