### PR TITLE
Report mount storage usage from the probe, not cached state

### DIFF
--- a/supervisor/api/host.py
+++ b/supervisor/api/host.py
@@ -37,14 +37,12 @@ from ..const import (
     ATTR_TIMEZONE,
 )
 from ..coresys import CoreSysAttributes
-from ..dbus.const import UnitActiveState
 from ..exceptions import (
     APIDBMigrationInProgress,
     APIError,
     HostContainerLogEpochError,
     HostLogError,
     MountNotFound,
-    MountUsageNotActiveError,
     MountUsageNotMountedError,
     MountUsageReadError,
     MountUsageTimeoutError,
@@ -471,8 +469,10 @@ class APIHost(CoreSysAttributes):
             raise MountNotFound(name=name)
 
         mount = self.sys_mounts.get(name)
-        if mount.state != UnitActiveState.ACTIVE:
-            raise MountUsageNotActiveError(name=name)
+        # Deliberately not gated on the mount's cached state: that is only as
+        # fresh as the last reconcile probe, 15 minutes apart, so gating it
+        # withheld usage from healthy mounts. The probe below activates a
+        # dormant automount, which makes it the authority.
 
         max_depth = self._requested_max_depth(request, DISK_USAGE_MAX_DEPTH_MOUNT)
         # All depths below 2 give totals only; normalize so concurrent callers
@@ -568,10 +568,11 @@ class APIHost(CoreSysAttributes):
             raise MountUsageReadError(name=mount.name, reason=str(err)) from err
 
         if usage is None:
-            # Ghost mount: systemd still reports the unit active, but the path
-            # no longer crosses a filesystem boundary, so statvfs was reading
-            # the host's data disk and would report its numbers under the
-            # mount's name.
+            # The statvfs above would have triggered a dormant automount, so a
+            # path that still does not cross a filesystem boundary is one whose
+            # trigger is gone and which reverted to a plain directory. Reading
+            # it would report the host data disk's numbers under this mount's
+            # name.
             raise MountUsageNotMountedError(name=mount.name)
 
         total, _, free = usage

--- a/supervisor/api/host.py
+++ b/supervisor/api/host.py
@@ -469,10 +469,8 @@ class APIHost(CoreSysAttributes):
             raise MountNotFound(name=name)
 
         mount = self.sys_mounts.get(name)
-        # Deliberately not gated on the mount's cached state: that is only as
-        # fresh as the last reconcile probe, 15 minutes apart, so gating it
-        # withheld usage from healthy mounts. The probe below activates a
-        # dormant automount, which makes it the authority.
+        # Don't use cached mount state — it can be 15 minutes stale.
+        # The probe below activates a dormant automount if needed.
 
         max_depth = self._requested_max_depth(request, DISK_USAGE_MAX_DEPTH_MOUNT)
         # All depths below 2 give totals only; normalize so concurrent callers
@@ -568,11 +566,9 @@ class APIHost(CoreSysAttributes):
             raise MountUsageReadError(name=mount.name, reason=str(err)) from err
 
         if usage is None:
-            # The statvfs above would have triggered a dormant automount, so a
-            # path that still does not cross a filesystem boundary is one whose
-            # trigger is gone and which reverted to a plain directory. Reading
-            # it would report the host data disk's numbers under this mount's
-            # name.
+            # Not a mount point. The probe would already have activated a
+            # dormant automount, so this is a plain directory — don't report
+            # the host data disk's numbers as this mount.
             raise MountUsageNotMountedError(name=mount.name)
 
         total, _, free = usage

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -1825,18 +1825,6 @@ class MountNotFound(MountError, APINotFound):
         super().__init__(message, logger)
 
 
-class MountUsageNotActiveError(MountError):
-    """Raise when storage usage is requested for a mount that is not active."""
-
-    error_key = "mount_usage_not_active_error"
-    message_template = "Mount {name} is not active, cannot report storage usage"
-
-    def __init__(self, logger: Callable[..., None] | None = None, *, name: str) -> None:
-        """Initialize exception."""
-        self.extra_fields = {"name": name}
-        super().__init__(None, logger)
-
-
 class MountUsageNotMountedError(MountError):
     """Raise when a mount's path turns out to no longer be mounted.
 

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -1826,11 +1826,10 @@ class MountNotFound(MountError, APINotFound):
 
 
 class MountUsageNotMountedError(MountError):
-    """Raise when a mount's path turns out to no longer be mounted.
+    """Raise when a mount's path is no longer a mount point.
 
-    The ghost mount case: systemd still reports the unit active, but the path
-    no longer crosses a filesystem boundary, so any numbers read from it would
-    be the host disk's, not the mount's.
+    The probe would already have activated a dormant automount, so this is a
+    plain directory. Numbers from it would be the host disk's, not the mount's.
     """
 
     error_key = "mount_usage_not_mounted_error"

--- a/supervisor/hardware/disk.py
+++ b/supervisor/hardware/disk.py
@@ -90,11 +90,13 @@ class HwDisk(CoreSysAttributes):
     def disk_usage_for_mount(self, path: Path) -> tuple[int, int, int] | None:
         """Return (total, used, free) in bytes for a mount path, or None if not mounted.
 
-        Must be run in executor. statvfs succeeds on a ghost mount — a systemd
-        unit still reported active whose path is no longer actually mounted — by
-        returning the underlying filesystem's numbers, so only the device
-        boundary check tells the mount's own figures apart from the host disk's.
-        Mirrors `_probe_network_mount` in mounts/mount.py; keep the two agreeing.
+        Must be run in executor. The statvfs doubles as the trigger: it walks
+        with LOOKUP_AUTOMOUNT, so it activates a dormant automount and raises if
+        the mount cannot be activated. It still succeeds on a path whose trigger
+        is gone and which reverted to a plain directory, returning the
+        underlying filesystem's numbers, so only the device boundary check tells
+        this mount's figures apart from the host disk's. Same pairing as
+        `_probe_network_mount` in mounts/mount.py; keep the two agreeing.
         """
         usage = shutil.disk_usage(path)
         if path.stat().st_dev == path.parent.stat().st_dev:

--- a/supervisor/hardware/disk.py
+++ b/supervisor/hardware/disk.py
@@ -90,12 +90,11 @@ class HwDisk(CoreSysAttributes):
     def disk_usage_for_mount(self, path: Path) -> tuple[int, int, int] | None:
         """Return (total, used, free) in bytes for a mount path, or None if not mounted.
 
-        Must be run in executor. The statvfs doubles as the trigger: it walks
-        with LOOKUP_AUTOMOUNT, so it activates a dormant automount and raises if
-        the mount cannot be activated. It still succeeds on a path whose trigger
-        is gone and which reverted to a plain directory, returning the
-        underlying filesystem's numbers, so only the device boundary check tells
-        this mount's figures apart from the host disk's. Same pairing as
+        Must be run in executor. statvfs walks with LOOKUP_AUTOMOUNT, so it
+        activates a dormant automount and raises if that fails. A path whose
+        trigger is gone is a plain directory; statvfs then returns the
+        underlying filesystem's numbers. Only the device-boundary check
+        distinguishes this mount from the host disk. Mirrors
         `_probe_network_mount` in mounts/mount.py; keep the two agreeing.
         """
         usage = shutil.disk_usage(path)

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -1051,7 +1051,9 @@ async def test_set_hostname_invalid_returns_400(
     assert body["extra_fields"] == {"hostname": "bad name"}
 
 
-def _register_mount(coresys: CoreSys, name: str, state: UnitActiveState) -> Mount:
+def _register_mount(
+    coresys: CoreSys, name: str, state: UnitActiveState | None
+) -> Mount:
     """Register a CIFS mount with the manager in the given systemd state."""
     mount = Mount.from_dict(
         coresys,
@@ -1242,22 +1244,34 @@ async def test_disk_usage_api_unknown_mount(
 
 
 @pytest.mark.usefixtures("tmp_supervisor_data", "path_extern")
-async def test_disk_usage_api_inactive_mount(
-    api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
+@pytest.mark.parametrize(
+    "stale_state",
+    [UnitActiveState.INACTIVE, UnitActiveState.FAILED, None],
+    ids=["dormant-trigger", "last-probe-failed", "state-unknown"],
+)
+async def test_disk_usage_api_probes_regardless_of_cached_state(
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    stale_state: UnitActiveState | None,
 ):
-    """Test a mount that is not active cannot report usage."""
+    """Test usage is reported whenever the probe succeeds, whatever state says.
+
+    The cached state is only as fresh as the last reconcile probe, 15 minutes
+    apart, so gating on it withheld usage from healthy mounts for up to that
+    long after a server came back. The probe activates a dormant automount and
+    is the authority.
+    """
     api_client, prefix = api_client_with_prefix
-    _register_mount(coresys, "media_test", UnitActiveState.FAILED)
+    _register_mount(coresys, "media_test", stale_state)
 
     with patch.object(coresys.hardware.disk, "disk_usage_for_mount") as mock_disk_usage:
+        mock_disk_usage.return_value = (2000000000, 999, 800000000)
         resp = await api_client.get(f"{prefix}/host/disks/media_test/usage")
 
-    assert resp.status == 400
+    assert resp.status == 200
     result = await resp.json()
-    assert result["error_key"] == "mount_usage_not_active_error"
-    assert result["extra_fields"] == {"name": "media_test"}
-    # Rejected before any probe is attempted
-    mock_disk_usage.assert_not_called()
+    assert result["data"]["used_bytes"] == 1200000000
+    mock_disk_usage.assert_called_once()
 
 
 @pytest.mark.usefixtures("active_mount")
@@ -1310,11 +1324,12 @@ async def test_disk_usage_api_mount_unreachable(
 async def test_disk_usage_api_ghost_mount(
     api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
 ):
-    """Test a ghost mount is reported unreadable, not misreported.
+    """Test a path whose trigger is gone is reported unreadable, not misreported.
 
-    systemd can still report a unit active after the path stopped being a
-    mount point; statvfs then silently returns the host data disk's numbers.
-    Serving those under the mount's name would be a plausible-looking lie.
+    The probe's statvfs activates a dormant automount, so a path that still
+    does not cross a filesystem boundary has lost its trigger and reverted to
+    a plain directory. statvfs then returns the host data disk's numbers, and
+    serving those under the mount's name would be a plausible-looking lie.
     """
     api_client, prefix = api_client_with_prefix
 

--- a/tests/api/test_host.py
+++ b/tests/api/test_host.py
@@ -1254,13 +1254,7 @@ async def test_disk_usage_api_probes_regardless_of_cached_state(
     coresys: CoreSys,
     stale_state: UnitActiveState | None,
 ):
-    """Test usage is reported whenever the probe succeeds, whatever state says.
-
-    The cached state is only as fresh as the last reconcile probe, 15 minutes
-    apart, so gating on it withheld usage from healthy mounts for up to that
-    long after a server came back. The probe activates a dormant automount and
-    is the authority.
-    """
+    """Test usage comes from the probe, not cached mount state."""
     api_client, prefix = api_client_with_prefix
     _register_mount(coresys, "media_test", stale_state)
 
@@ -1324,13 +1318,7 @@ async def test_disk_usage_api_mount_unreachable(
 async def test_disk_usage_api_ghost_mount(
     api_client_with_prefix: tuple[TestClient, str], coresys: CoreSys
 ):
-    """Test a path whose trigger is gone is reported unreadable, not misreported.
-
-    The probe's statvfs activates a dormant automount, so a path that still
-    does not cross a filesystem boundary has lost its trigger and reverted to
-    a plain directory. statvfs then returns the host data disk's numbers, and
-    serving those under the mount's name would be a plausible-looking lie.
-    """
+    """Test a vanished mount is an error, not host-disk numbers."""
     api_client, prefix = api_client_with_prefix
 
     with (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The per-mount storage usage endpoint gated on the mount's cached state, refusing anything not currently `active`. Since #7167 made mounts autofs-triggered, that state is only as fresh as the last reconcile probe — 15 minutes apart — so a share that came back stayed unreportable for up to that long even though a probe would have found it healthy. This drops the gate and lets the probe decide: its `statvfs` walks with `LOOKUP_AUTOMOUNT`, so it activates a dormant trigger and reports what it finds.

**To reproduce:** ask for usage on a healthy mount whose last probe failed, and you get `400` until the next reconcile. The parametrized test added here is the repro — it covers a cached state of `INACTIVE`, `FAILED` and unknown, all of which return `400` before this change and real usage after it.

**One caveat:** a usage request is no longer strictly read-only with respect to system state. The probe can now cause the mount it measures. Callers still share one probe rather than stacking executor threads.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #7146, #7167
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3325
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/