### PR TITLE
Block start/restart/rebuild/update APIs while Supervisor is not fully running

### DIFF
--- a/supervisor/api/apps.py
+++ b/supervisor/api/apps.py
@@ -108,7 +108,13 @@ from ..exceptions import (
 )
 from ..validate import docker_ports
 from .const import ATTR_BOOT_CONFIG, ATTR_REMOVE_CONFIG, ATTR_SIGNED
-from .utils import api_process, api_return_stats, api_validate, json_loads
+from .utils import (
+    api_process,
+    api_return_stats,
+    api_validate,
+    json_loads,
+    require_running_system,
+)
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -472,6 +478,7 @@ class APIApps(CoreSysAttributes):
         )
 
     @api_process
+    @require_running_system
     async def start(self, request: web.Request) -> None:
         """Start app."""
         app = self.get_app_for_request(request)
@@ -485,6 +492,7 @@ class APIApps(CoreSysAttributes):
         return asyncio.shield(app.stop())
 
     @api_process
+    @require_running_system
     async def restart(self, request: web.Request) -> None:
         """Restart app."""
         app: App = self.get_app_for_request(request)
@@ -492,6 +500,7 @@ class APIApps(CoreSysAttributes):
             await start_task
 
     @api_process
+    @require_running_system
     async def rebuild(self, request: web.Request) -> None:
         """Rebuild local build app."""
         app = self.get_app_for_request(request)

--- a/supervisor/api/audio.py
+++ b/supervisor/api/audio.py
@@ -29,7 +29,7 @@ from ..coresys import CoreSysAttributes
 from ..exceptions import APIError
 from ..host.sound import StreamType
 from ..validate import version_tag
-from .utils import api_process, api_return_stats, api_validate
+from .utils import api_process, api_return_stats, api_validate, require_running_system
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -93,6 +93,7 @@ class APIAudio(CoreSysAttributes):
         return api_return_stats(stats, legacy=True)
 
     @api_process
+    @require_running_system
     async def update(self, request: web.Request) -> None:
         """Update Audio plugin."""
         body = await api_validate(SCHEMA_VERSION, request)
@@ -103,6 +104,7 @@ class APIAudio(CoreSysAttributes):
         await asyncio.shield(self.sys_plugins.audio.update(version))
 
     @api_process
+    @require_running_system
     def restart(self, request: web.Request) -> Awaitable[None]:
         """Restart Audio plugin."""
         return asyncio.shield(self.sys_plugins.audio.restart())

--- a/supervisor/api/cli.py
+++ b/supervisor/api/cli.py
@@ -15,7 +15,7 @@ from ..const import (
 )
 from ..coresys import CoreSysAttributes
 from ..validate import version_tag
-from .utils import api_process, api_return_stats, api_validate
+from .utils import api_process, api_return_stats, api_validate, require_running_system
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -49,6 +49,7 @@ class APICli(CoreSysAttributes):
         return api_return_stats(stats, legacy=True)
 
     @api_process
+    @require_running_system
     async def update(self, request: web.Request) -> None:
         """Update HA CLI."""
         body = await api_validate(SCHEMA_VERSION, request)

--- a/supervisor/api/dns.py
+++ b/supervisor/api/dns.py
@@ -21,7 +21,7 @@ from ..coresys import CoreSysAttributes
 from ..exceptions import APIError
 from ..validate import dns_server_list, version_tag
 from .const import ATTR_FALLBACK, ATTR_LLMNR, ATTR_MDNS
-from .utils import api_process, api_return_stats, api_validate
+from .utils import api_process, api_return_stats, api_validate, require_running_system
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -88,6 +88,7 @@ class APICoreDNS(CoreSysAttributes):
         return api_return_stats(stats, legacy=True)
 
     @api_process
+    @require_running_system
     async def update(self, request: web.Request) -> None:
         """Update DNS plugin."""
         body = await api_validate(SCHEMA_VERSION, request)
@@ -98,6 +99,7 @@ class APICoreDNS(CoreSysAttributes):
         await asyncio.shield(self.sys_plugins.dns.update(version))
 
     @api_process
+    @require_running_system
     def restart(self, request: web.Request) -> Awaitable[None]:
         """Restart CoreDNS plugin."""
         return asyncio.shield(self.sys_plugins.dns.restart())

--- a/supervisor/api/homeassistant.py
+++ b/supervisor/api/homeassistant.py
@@ -33,7 +33,13 @@ from ..coresys import CoreSysAttributes
 from ..exceptions import APIDBMigrationInProgress, APIError
 from ..validate import docker_image, network_port, version_tag
 from .const import ATTR_BACKGROUND, ATTR_FORCE, ATTR_SAFE_MODE
-from .utils import api_process, api_return_stats, api_validate, background_task
+from .utils import (
+    api_process,
+    api_return_stats,
+    api_validate,
+    background_task,
+    require_running_system,
+)
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -167,6 +173,7 @@ class APIHomeAssistant(CoreSysAttributes):
         return api_return_stats(stats, legacy=True)
 
     @api_process
+    @require_running_system
     async def update(self, request: web.Request) -> dict[str, str] | None:
         """Update Home Assistant."""
         body = await api_validate(SCHEMA_UPDATE, request)
@@ -194,11 +201,13 @@ class APIHomeAssistant(CoreSysAttributes):
         return await asyncio.shield(self.sys_homeassistant.core.stop())
 
     @api_process
+    @require_running_system
     def start(self, request: web.Request) -> Awaitable[None]:
         """Start Home Assistant."""
         return asyncio.shield(self.sys_homeassistant.core.start())
 
     @api_process
+    @require_running_system
     async def restart(self, request: web.Request) -> None:
         """Restart Home Assistant."""
         body = await api_validate(SCHEMA_RESTART, request)
@@ -209,6 +218,7 @@ class APIHomeAssistant(CoreSysAttributes):
         )
 
     @api_process
+    @require_running_system
     async def rebuild(self, request: web.Request) -> None:
         """Rebuild Home Assistant."""
         body = await api_validate(SCHEMA_RESTART, request)

--- a/supervisor/api/multicast.py
+++ b/supervisor/api/multicast.py
@@ -17,7 +17,7 @@ from ..const import (
 from ..coresys import CoreSysAttributes
 from ..exceptions import APIError
 from ..validate import version_tag
-from .utils import api_process, api_return_stats, api_validate
+from .utils import api_process, api_return_stats, api_validate, require_running_system
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -51,6 +51,7 @@ class APIMulticast(CoreSysAttributes):
         return api_return_stats(stats, legacy=True)
 
     @api_process
+    @require_running_system
     async def update(self, request: web.Request) -> None:
         """Update Multicast plugin."""
         body = await api_validate(SCHEMA_VERSION, request)
@@ -61,6 +62,7 @@ class APIMulticast(CoreSysAttributes):
         await asyncio.shield(self.sys_plugins.multicast.update(version))
 
     @api_process
+    @require_running_system
     def restart(self, request: web.Request) -> Awaitable[None]:
         """Restart Multicast plugin."""
         return asyncio.shield(self.sys_plugins.multicast.restart())

--- a/supervisor/api/observer.py
+++ b/supervisor/api/observer.py
@@ -16,7 +16,7 @@ from ..const import (
 )
 from ..coresys import CoreSysAttributes
 from ..validate import version_tag
-from .utils import api_process, api_return_stats, api_validate
+from .utils import api_process, api_return_stats, api_validate, require_running_system
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -51,6 +51,7 @@ class APIObserver(CoreSysAttributes):
         return api_return_stats(stats, legacy=True)
 
     @api_process
+    @require_running_system
     async def update(self, request: web.Request) -> None:
         """Update HA observer."""
         body = await api_validate(SCHEMA_VERSION, request)

--- a/supervisor/api/store.py
+++ b/supervisor/api/store.py
@@ -60,7 +60,7 @@ from ..store.app import AppStore
 from ..store.repository import Repository
 from ..store.validate import validate_repository
 from .const import ATTR_BACKGROUND, CONTENT_TYPE_PNG, CONTENT_TYPE_TEXT
-from .utils import background_task
+from .utils import background_task, require_running_system
 
 SCHEMA_UPDATE = vol.Schema(
     {
@@ -253,6 +253,7 @@ class APIStore(CoreSysAttributes):
         return await install_task
 
     @api_process
+    @require_running_system
     async def apps_app_update(self, request: web.Request) -> dict[str, str] | None:
         """Update app."""
         app = self._extract_app(request, installed=True)

--- a/supervisor/api/utils.py
+++ b/supervisor/api/utils.py
@@ -39,8 +39,15 @@ from ..const import (
 )
 from ..coresys import CoreSys, CoreSysAttributes
 from ..docker.stats import DockerStats
-from ..exceptions import APIError, HassioError
+from ..exceptions import (
+    APIError,
+    APISystemNotReadyError,
+    HassioError,
+    JobConditionException,
+)
 from ..jobs import JobSchedulerOptions, SupervisorJob
+from ..jobs.const import JobCondition
+from ..jobs.decorator import Job
 from ..utils import get_message_from_exception_chain
 from ..utils.json import json_dumps, json_loads as json_loads_util
 from ..utils.sentry import async_capture_exception
@@ -181,6 +188,41 @@ def require_home_assistant(method):
         request: Request = args[0]
         if request[REQUEST_FROM] != coresys.homeassistant:
             raise HTTPUnauthorized
+        return await method(api, *args, **kwargs)
+
+    return wrap_api
+
+
+def require_running_system(method):
+    """Reject the API call unless Supervisor has fully started and is not frozen.
+
+    Supervisor boots apps and Home Assistant Core in a specific order, and
+    replays a similarly ordered sequence while restoring a backup (during
+    which it is in the freeze state). Starting, restarting, rebuilding or
+    updating something via the API while one of those sequences is still in
+    progress risks running it out of order, or blocking a scheduled start
+    from that sequence outright via job concurrency (see #7189). This does
+    not affect the internal calls Supervisor itself makes as part of those
+    sequences, only ones coming from the API.
+
+    This uses Job.check_conditions() directly instead of the @Job(...)
+    decorator on purpose: @Job() creates and tracks a full SupervisorJob
+    (job history, concurrency/throttle handling, ...) for the call it wraps,
+    and requires the wrapped object to be a JobGroup to use group-level
+    concurrency. The API view classes here are a separate layer from the
+    CoreSysAttributes business-logic classes (App, HomeAssistantCore, ...)
+    that already have their own @Job-decorated methods with that tracking;
+    wrapping the API handler in a second @Job would just create a duplicate,
+    misleading job entry for the same logical operation. check_conditions()
+    runs only the condition check, with none of that overhead.
+    """
+
+    async def wrap_api(api: CoreSysAttributes, *args, **kwargs) -> Any:
+        """Check system state then return API information."""
+        try:
+            await Job.check_conditions(api, {JobCondition.RUNNING}, method.__qualname__)
+        except JobConditionException as err:
+            raise APISystemNotReadyError from err
         return await method(api, *args, **kwargs)
 
     return wrap_api

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -132,7 +132,7 @@ class APIUnknownSupervisorError(APIError):
 
 
 class APISystemNotReadyError(APIError):
-    """Raise when an API call is rejected because Supervisor has not fully started.
+    """Raise when an API call is rejected because Supervisor isn't in a state that allows it.
 
     Used by require_running_system to reject start/restart/rebuild/update
     calls made while Supervisor's boot or backup-restore sequences are still
@@ -142,8 +142,8 @@ class APISystemNotReadyError(APIError):
 
     error_key = "system_not_ready_error"
     message_template = (
-        "Supervisor has not fully started yet, please try again once startup "
-        "has completed"
+        "Supervisor is currently starting up or restoring a backup, please "
+        "try again once that has completed"
     )
 
     def __init__(self, logger: Callable[..., None] | None = None) -> None:

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -142,8 +142,7 @@ class APISystemNotReadyError(APIError):
 
     error_key = "system_not_ready_error"
     message_template = (
-        "Supervisor is currently starting up or restoring a backup, please "
-        "try again once that has completed"
+        "Supervisor is not ready to perform this operation, please try again later"
     )
 
     def __init__(self, logger: Callable[..., None] | None = None) -> None:

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -131,6 +131,26 @@ class APIUnknownSupervisorError(APIError):
         super().__init__(None, logger, job_id=job_id)
 
 
+class APISystemNotReadyError(APIError):
+    """Raise when an API call is rejected because Supervisor has not fully started.
+
+    Used by require_running_system to reject start/restart/rebuild/update
+    calls made while Supervisor's boot or backup-restore sequences are still
+    in progress (see #7189), instead of letting the internal
+    JobConditionException (meant for job/log consumers) bubble up as-is.
+    """
+
+    error_key = "system_not_ready_error"
+    message_template = (
+        "Supervisor has not fully started yet, please try again once startup "
+        "has completed"
+    )
+
+    def __init__(self, logger: Callable[..., None] | None = None) -> None:
+        """Raise & log."""
+        super().__init__(None, logger)
+
+
 # JobManager
 
 

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -103,14 +103,18 @@ class APIInternalServerError(APIError):
     status = 500
 
 
+class APIServiceUnavailable(APIError):
+    """API service unavailable error."""
+
+    status = 503
+
+
 class APIAppNotInstalled(APIError):
     """Not installed app requested at apps API."""
 
 
-class APIDBMigrationInProgress(APIError):
+class APIDBMigrationInProgress(APIServiceUnavailable):
     """Service is unavailable due to an offline DB migration is in progress."""
-
-    status = 503
 
 
 class APIUnknownSupervisorError(APIError):
@@ -131,7 +135,7 @@ class APIUnknownSupervisorError(APIError):
         super().__init__(None, logger, job_id=job_id)
 
 
-class APISystemNotReadyError(APIError):
+class APISystemNotReadyError(APIServiceUnavailable):
     """Raise when an API call is rejected because Supervisor isn't in a state that allows it.
 
     Used by require_running_system to reject start/restart/rebuild/update

--- a/tests/api/test_apps.py
+++ b/tests/api/test_apps.py
@@ -14,7 +14,7 @@ import pytest
 from supervisor.apps.app import App
 from supervisor.apps.build import AppBuild
 from supervisor.arch import CpuArchManager
-from supervisor.const import AppState, CpuArch
+from supervisor.const import AppState, CoreState, CpuArch
 from supervisor.coresys import CoreSys
 from supervisor.docker.app import DockerApp
 from supervisor.docker.const import ContainerState
@@ -25,6 +25,17 @@ from supervisor.store.repository import Repository
 
 from ..common import force_app_state, load_json_fixture
 from ..const import TEST_ADDON_SLUG
+
+
+@pytest.fixture(autouse=True)
+async def running_state(coresys: CoreSys) -> None:
+    """Set the default state to a fully started system.
+
+    Starting/restarting/rebuilding an app via the API is only allowed once
+    Supervisor has fully started (see require_running_system). Tests
+    exercising other states set them explicitly.
+    """
+    await coresys.core.set_state(CoreState.RUNNING)
 
 
 def _create_test_event(name: str, state: ContainerState) -> DockerContainerStateEvent:

--- a/tests/api/test_homeassistant.py
+++ b/tests/api/test_homeassistant.py
@@ -28,6 +28,17 @@ from supervisor.updater import Updater
 from tests.common import AsyncIterator, load_json_fixture
 
 
+@pytest.fixture(autouse=True)
+async def running_state(coresys: CoreSys) -> None:
+    """Set the default state to a fully started system.
+
+    Starting/restarting/rebuilding Home Assistant Core via the API is only
+    allowed once Supervisor has fully started (see require_running_system).
+    Tests exercising other states set them explicitly.
+    """
+    await coresys.core.set_state(CoreState.RUNNING)
+
+
 @pytest.mark.parametrize("legacy_route", [True, False])
 async def test_api_core_logs(
     advanced_logs_tester: AsyncMock,

--- a/tests/api/test_require_running_system.py
+++ b/tests/api/test_require_running_system.py
@@ -1,0 +1,126 @@
+"""Test the require_running_system API guard.
+
+Covers the start/restart/rebuild/update routes gated by
+supervisor.api.utils.require_running_system: they must reject the call with
+a 400 and the system_not_ready_error error_key - and must not invoke the
+underlying business-logic method - whenever Supervisor isn't in
+CoreState.RUNNING (e.g. while still booting, or while frozen for a backup
+restore).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from aiohttp.test_utils import TestClient
+import pytest
+
+from supervisor.apps.app import App
+from supervisor.apps.manager import AppManager
+from supervisor.const import CoreState
+from supervisor.coresys import CoreSys
+from supervisor.homeassistant.core import HomeAssistantCore
+from supervisor.plugins.audio import PluginAudio
+from supervisor.plugins.cli import PluginCli
+from supervisor.plugins.dns import PluginDns
+from supervisor.plugins.multicast import PluginMulticast
+from supervisor.plugins.observer import PluginObserver
+
+from ..const import TEST_ADDON_SLUG
+
+# States that must be rejected. Not exhaustive (e.g. omits INITIALIZE,
+# SHUTDOWN, STOPPING, CLOSE) but covers the two scenarios called out in the
+# require_running_system docstring: still booting, and restoring a backup.
+BLOCKED_STATES = [CoreState.SETUP, CoreState.STARTUP, CoreState.FREEZE]
+
+
+async def _assert_blocked(resp, mocked: AsyncMock) -> None:
+    """Assert the call was rejected before reaching the business logic."""
+    assert resp.status == 400
+    body = await resp.json()
+    assert body["error_key"] == "system_not_ready_error"
+    mocked.assert_not_called()
+
+
+@pytest.mark.parametrize("blocked_state", BLOCKED_STATES)
+@pytest.mark.parametrize("method", ["start", "restart", "rebuild"])
+async def test_app_lifecycle_blocked_when_not_running(
+    app_api_client_with_root: tuple[TestClient, str],
+    install_app_ssh: App,
+    coresys: CoreSys,
+    method: str,
+    blocked_state: CoreState,
+):
+    """Test app start/restart/rebuild are rejected unless Supervisor is running."""
+    client, root = app_api_client_with_root
+    await coresys.core.set_state(blocked_state)
+
+    with patch.object(App, method, new=AsyncMock()) as mocked:
+        resp = await client.post(f"{root}/{TEST_ADDON_SLUG}/{method}")
+
+    await _assert_blocked(resp, mocked)
+
+
+@pytest.mark.parametrize("blocked_state", BLOCKED_STATES)
+async def test_app_update_blocked_when_not_running(
+    store_app_api_client_with_root: tuple[TestClient, str],
+    install_app_ssh: App,
+    coresys: CoreSys,
+    blocked_state: CoreState,
+):
+    """Test app update (via the store API) is rejected unless Supervisor is running."""
+    client, root = store_app_api_client_with_root
+    await coresys.core.set_state(blocked_state)
+
+    with patch.object(AppManager, "update", new=AsyncMock()) as mocked:
+        resp = await client.post(f"/{root}/{TEST_ADDON_SLUG}/update")
+
+    await _assert_blocked(resp, mocked)
+
+
+@pytest.mark.parametrize("blocked_state", BLOCKED_STATES)
+@pytest.mark.parametrize("method", ["start", "restart", "rebuild", "update"])
+async def test_core_lifecycle_blocked_when_not_running(
+    core_api_client_with_root: tuple[TestClient, str],
+    coresys: CoreSys,
+    method: str,
+    blocked_state: CoreState,
+):
+    """Test Core start/restart/rebuild/update are rejected unless Supervisor is running."""
+    client, root = core_api_client_with_root
+    await coresys.core.set_state(blocked_state)
+
+    with patch.object(HomeAssistantCore, method, new=AsyncMock()) as mocked:
+        resp = await client.post(f"{root}/{method}")
+
+    await _assert_blocked(resp, mocked)
+
+
+@pytest.mark.parametrize("blocked_state", BLOCKED_STATES)
+@pytest.mark.parametrize(
+    ("plugin_path", "plugin_class", "method"),
+    [
+        ("audio", PluginAudio, "update"),
+        ("audio", PluginAudio, "restart"),
+        ("dns", PluginDns, "update"),
+        ("dns", PluginDns, "restart"),
+        ("multicast", PluginMulticast, "update"),
+        ("multicast", PluginMulticast, "restart"),
+        ("cli", PluginCli, "update"),
+        ("observer", PluginObserver, "update"),
+    ],
+)
+async def test_plugin_lifecycle_blocked_when_not_running(
+    api_client_with_prefix: tuple[TestClient, str],
+    coresys: CoreSys,
+    plugin_path: str,
+    plugin_class: type,
+    method: str,
+    blocked_state: CoreState,
+):
+    """Test plugin update/restart routes are rejected unless Supervisor is running."""
+    client, prefix = api_client_with_prefix
+    await coresys.core.set_state(blocked_state)
+
+    with patch.object(plugin_class, method, new=AsyncMock()) as mocked:
+        resp = await client.post(f"{prefix}/{plugin_path}/{method}")
+
+    await _assert_blocked(resp, mocked)

--- a/tests/api/test_require_running_system.py
+++ b/tests/api/test_require_running_system.py
@@ -34,7 +34,7 @@ BLOCKED_STATES = [CoreState.SETUP, CoreState.STARTUP, CoreState.FREEZE]
 
 async def _assert_blocked(resp, mocked: AsyncMock) -> None:
     """Assert the call was rejected before reaching the business logic."""
-    assert resp.status == 400
+    assert resp.status == 503
     body = await resp.json()
     assert body["error_key"] == "system_not_ready_error"
     mocked.assert_not_called()

--- a/tests/api/test_store.py
+++ b/tests/api/test_store.py
@@ -33,6 +33,17 @@ from tests.const import TEST_ADDON_SLUG
 REPO_URL = "https://github.com/awesome-developer/awesome-repo"
 
 
+@pytest.fixture(autouse=True)
+async def running_state(coresys: CoreSys) -> None:
+    """Set the default state to a fully started system.
+
+    Updating an app via the API is only allowed once Supervisor has fully
+    started (see require_running_system). Tests exercising other states set
+    them explicitly.
+    """
+    await coresys.core.set_state(CoreState.RUNNING)
+
+
 async def test_api_store(
     api_client: TestClient,
     store_app: AppStore,


### PR DESCRIPTION
## Proposed change

Supervisor boots apps and Home Assistant Core in a specific, ordered sequence (`initialize` → `system` → `services`, then Core itself), and replays a similarly ordered sequence while restoring a backup (during which Supervisor is in the `FREEZE` state). Calling the API to start, restart, rebuild or update something while one of those sequences is still in progress can race with it: the boot sequence has *not yet* released state it holds for its own scheduled start (e.g. the port reservation behind #7189), it can find the container already started/updated and skip its own scheduled step, or the two calls can outright collide on job concurrency (`JobConcurrency.GROUP_REJECT` on the same `JobGroup` rejects the second caller immediately rather than queuing it).

This PR adds a `require_running_system` decorator that rejects the affected API calls with a clean 503 error unless `CoreState.RUNNING` (i.e. Supervisor has fully finished booting and is not currently restoring a backup), and applies it to:

- **Apps**: `start`, `restart`, `rebuild` (this is what #7189 asked for), and `update`
- **Home Assistant Core**: `start`, `restart`, `rebuild`, `update`
- **Plugins**: `restart`/`update` for Audio, DNS and Multicast, and `update` for the CLI and Observer plugins (they have no restart route)

This only affects calls coming in through the REST API - it does not change anything about the internal calls Supervisor itself makes while executing its own boot/restore sequences.

### Why more than just Core start/restart

The issue's reproduction was `POST /core/start`/`restart`, but the same race is not specific to Core:

- **Apps** boot in the same ordered phases as Core and can likewise be started/rebuilt out of order, or reject a scheduled boot outright via `JobConcurrency.GROUP_REJECT` if an API call to the same app is in flight when Supervisor's boot flow reaches it.
- **`update`** is included alongside `start`/`restart`/`rebuild` because app/Core update jobs share the same `JobGroup` and `GROUP_REJECT` concurrency as their other lifecycle jobs, so an in-progress update can cause a concurrent, Supervisor-scheduled boot-time start to fail immediately rather than queue.
- **Plugins** (Audio, DNS, Multicast, CLI, Observer) are, if anything, more exposed than Apps/Core: they are not `JobGroup`s and their `start()`/`restart()` methods have no `@Job` protection at all, so a racing API call has no concurrency guard to even reject it - it goes straight to Docker.

### Backup restore

Restoring a backup also drives Home Assistant Core, apps and plugins through an ordered restart/start sequence, while Supervisor is in the `FREEZE` core state rather than `RUNNING`. `require_running_system`'s single `JobCondition.RUNNING` check naturally also blocks calls during `FREEZE`, so this closes the same race during backup restore with no extra logic.

### Error handling

`require_running_system` runs `Job.check_conditions()` directly rather than wrapping the handler in `@Job(...)`, since the API view classes are a separate layer from the `CoreSysAttributes` business-logic classes (`App`, `HomeAssistantCore`, ...) that already have their own `@Job`-tracked methods; adding a second `@Job` here would just create a duplicate, misleading job entry for the same logical operation.

The resulting `JobConditionException` (meant for job/log consumers, and naming the internal method, e.g. `'App.start' blocked from execution, ...`) is caught and converted into a new, translatable `APISystemNotReadyError` (`error_key = "system_not_ready_error"`) so API callers get a clean, actionable message instead.

The error is a 503 (via a new `APIServiceUnavailable` base class, which `APIDBMigrationInProgress` now shares) rather than a 400: aiohasupervisor maps 400 to `SupervisorBadRequestError`, which Core treats as a definitive answer in places (e.g. "no update available" in https://github.com/home-assistant/core/pull/171129), whereas 503 surfaces as `SupervisorServiceUnavailableError` and signals a transient condition callers should retry.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: #7189

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html

