### PR TITLE
Fix OOM/memory growth in `tests/api` by clearing aiohttp's middleware cache

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from aiodocker.execs import Exec
 from aiodocker.networks import DockerNetwork, DockerNetworks
 from aiodocker.system import DockerSystem
 from aiodocker.volumes import DockerVolumes
-from aiohttp import ClientSession, web
+from aiohttp import ClientSession, web, web_app as aiohttp_web_app
 from aiohttp.test_utils import TestClient
 from awesomeversion import AwesomeVersion
 from blockbuster import BlockBuster, BlockBusterFunction
@@ -108,6 +108,28 @@ def blockbuster(request: pytest.FixtureRequest) -> BlockBuster | None:
     blockbuster.activate()
     yield blockbuster
     blockbuster.deactivate()
+
+
+@pytest.fixture(autouse=True)
+def _clear_aiohttp_middleware_cache() -> Generator[None]:
+    """Clear aiohttp's process-wide middleware-build cache after each test.
+
+    ``aiohttp.web_app._build_middlewares`` is memoized via a module-level
+    ``functools.lru_cache(maxsize=1024)`` (``_cached_build_middleware``)
+    keyed on the route handler and the chain of ``Application`` instances
+    involved. This test suite builds a fresh ``RestAPI``/``web.Application``
+    (with route handlers bound to a fresh ``CoreSys``) for nearly every
+    test, so each test populates new cache entries that are never reused by
+    later tests. Left uncleared, up to 1024 stale entries accumulate over a
+    full test run, each one pinning an entire ``CoreSys`` object graph
+    (docker mocks, D-Bus proxies, aiohttp routes, etc.) in memory - causing
+    steady memory growth that can OOM long/full suite runs. Use ``getattr``
+    defensively since this reaches into an aiohttp private implementation
+    detail that could change/disappear in a future aiohttp release.
+    """
+    yield
+    if cache := getattr(aiohttp_web_app, "_cached_build_middleware", None):
+        cache.cache_clear()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Proposed change

Running the full `tests/api` suite (or large subsets of it) reliably crashed with OOM. Root cause: aiohttp caches built middleware chains in a **module-level, process-wide** `functools.lru_cache(maxsize=1024)` keyed on `(handler, apps)` (`aiohttp.web_app._cached_build_middleware`). This exists to avoid rebuilding the middleware chain on every request in production, where an app is created once and lives for the process lifetime.

Our test suite instead builds a **fresh** `RestAPI`/`web.Application` (bound to a **fresh** `CoreSys`) for nearly every test. That means almost every test is a cache miss that inserts a brand-new, never-reused entry - and each entry pins an entire `CoreSys` object graph (Docker mocks, D-Bus proxies, aiohttp routes, etc.) in memory until 1024 stale entries force LRU eviction. Over a full `tests/api` run this causes steady, effectively unbounded memory growth that reliably OOMs.

This adds an autouse pytest fixture in `tests/conftest.py` that clears aiohttp's `_cached_build_middleware` cache after every test, using `getattr(..., None)` defensively since it's a private aiohttp implementation detail.

**Validation:**
- Full `tests/api` (1097 tests): now completes in ~2:15 with peak RSS ~490MB.
- Before the fix: peak RSS was already 856MB for just 3 files / 191 tests, growing without a plateau - the full suite would not complete without OOMing.
- Spot-checked other suites (`test_bootstrap.py`, `test_root.py`, `test_apps.py`, etc.) to confirm no regressions from the new autouse fixture.

This is purely a CI/test-infra fix - it does not touch any code that ships to users, and does not change any runtime behavior of the Supervisor itself.

<details>
<summary><b>Background: why this hits us and not (most) other aiohttp users</b> (click to expand)</summary>

**Is this unique to us?** No - the caching mechanism exists in every aiohttp app ≥ 3.11 (we picked it up on 2024-11-15 when bumping `aiohttp==3.10.11` → `3.11.2`). It was added in [aio-libs/aiohttp#9158](https://github.com/aio-libs/aiohttp/pull/9158) (Sept 2024) purely as a perf win (~18k → ~26k req/s in the author's benchmark). Notably, that PR was authored by `bdraco`, a well-known Home Assistant core contributor.

**Why doesn't it affect typical aiohttp usage (including our own production Supervisor process)?** The design explicitly assumes **one `Application` instance created once, living for the entire process lifetime** - a maintainer confirmed as much when reviewing the PR: *"They're frozen, they can't be modified once the app is started."* One long-lived app -> a handful of stable `(handler, apps)` cache keys -> the cache stays small and useful forever, exactly as intended.

**Why does our test suite hit it so hard?** `tests/api` builds a brand-new `Application`/`CoreSys` for ~every one of its ~1100 tests via the `api_client`/`api_client_v2` fixtures. Every test is therefore a guaranteed cache miss inserting a permanent entry - the opposite of the cache's intended usage pattern. It's also unusually expensive per-entry for us specifically: each entry's closure pins a full `CoreSys` graph (Docker mocks, D-Bus proxies, addon managers, etc.), far heavier than a typical toy aiohttp test app, which is why this manifests as an OOM for us rather than a barely-noticeable memory bump for most other projects hitting the same mechanism.

**Is this an aiohttp bug?** Not an acknowledged one, but not unprecedented either. The maintainers already fixed one instance of the same failure category: [aio-libs/aiohttp#9852](https://github.com/aio-libs/aiohttp/pull/9852) stopped `SystemRoute` (404/405) error handlers - which are constructed fresh per unmatched request - from polluting this same cache indefinitely. So "ephemeral objects flowing into this cache = unbounded growth" is a recognized risk category upstream; the "test suite recreates the whole `Application` repeatedly" variant just doesn't appear to have been reported. I couldn't find any open aiohttp issue describing this scenario.

**How do others handle it?** aiohttp's own test helpers (`AioHTTPTestCase`, `TestClient`/`TestServer`, `pytest-aiohttp`'s fixtures) don't clear this cache - it isn't handled upstream. Most other test suites likely avoid the problem by reusing a session/module-scoped `Application` across many tests rather than rebuilding one per test, or by not attaching anything nearly as heavy as a `CoreSys` to their test app. The fix in this PR (manually clearing the cache at a teardown boundary we control) is the standard workaround for "a library's module-level cache retains objects longer than you want," since aiohttp doesn't expose a supported API to scope/detach an `Application` from this cache.

</details>

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
