### PR TITLE
Start the Supervisor auto update on every version reload

### DIFF
--- a/supervisor/api/supervisor.py
+++ b/supervisor/api/supervisor.py
@@ -40,7 +40,7 @@ from ..const import (
     UpdateChannel,
 )
 from ..coresys import CoreSysAttributes
-from ..exceptions import APIError, SupervisorJobError
+from ..exceptions import APIError
 from ..store.validate import repositories
 from ..utils.blockbuster import BlockBusterManager
 from ..utils.sentry import close_sentry, init_sentry
@@ -262,11 +262,11 @@ class APISupervisor(CoreSysAttributes):
         if not self.sys_dev:
             version = self.sys_updater.version_supervisor
 
-        try:
-            await asyncio.shield(self.sys_supervisor.update(version))
-        except SupervisorJobError:
-            # The auto update already runs, the caller sees it through the restart
-            _LOGGER.info("Supervisor update is already in progress")
+        # update() is detached: this may return a task already started by a
+        # concurrent call (manual or auto-update) instead of a new one. Await
+        # it so this request reflects the real (possibly shared) result.
+        if task := await asyncio.shield(self.sys_supervisor.update(version)):
+            await task
 
     @api_process
     async def reload(self, request: web.Request) -> None:

--- a/supervisor/api/supervisor.py
+++ b/supervisor/api/supervisor.py
@@ -40,7 +40,7 @@ from ..const import (
     UpdateChannel,
 )
 from ..coresys import CoreSysAttributes
-from ..exceptions import APIError
+from ..exceptions import APIError, SupervisorJobError
 from ..store.validate import repositories
 from ..utils.blockbuster import BlockBusterManager
 from ..utils.sentry import close_sentry, init_sentry
@@ -262,7 +262,11 @@ class APISupervisor(CoreSysAttributes):
         if not self.sys_dev:
             version = self.sys_updater.version_supervisor
 
-        await asyncio.shield(self.sys_supervisor.update(version))
+        try:
+            await asyncio.shield(self.sys_supervisor.update(version))
+        except SupervisorJobError:
+            # The auto update already runs, the caller sees it through the restart
+            _LOGGER.info("Supervisor update is already in progress")
 
     @api_process
     async def reload(self, request: web.Request) -> None:

--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -840,16 +840,20 @@ class BackupManager(FileConfiguration, JobGroup):
             return
 
         if self.sys_updater.auto_update:
-            if self.sys_supervisor.need_update:
-                # Already known that an update is available, make sure it's kicked off
-                self.sys_create_task(self.sys_supervisor.auto_update_supervisor())
-            else:
-                # Refresh version info in case a newer Supervisor was just
-                # released. This also kicks off an auto update if one is now
-                # available.
-                await self.sys_updater.reload()
+            if not self.sys_supervisor.need_update:
+                # Ensure the latest version info is known before concluding
+                # there's no update to wait for. Await the fetch task
+                # directly (rather than calling reload()) so a fetch that's
+                # already in-flight - or one that just failed - isn't masked
+                # by fetch_data's throttle window.
+                await self.sys_updater.start_fetch_data()
 
-            if self.sys_supervisor.need_update:
+            # Start (or reuse) the auto update. We can't await it here - the
+            # update stops this very Supervisor instance once it completes,
+            # which would drop the connection before a response could be
+            # served. Use the task's existence/done status instead.
+            update_task = self.sys_supervisor.auto_update_supervisor()
+            if update_task and not update_task.done():
                 raise BackupSupervisorUpdateInProgressError(
                     _LOGGER.error,
                     backup_version=backup.supervisor_version,

--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable
+from contextlib import suppress
 import errno
 import logging
 from pathlib import Path
@@ -28,6 +29,7 @@ from ..exceptions import (
     BackupMountDownError,
     BackupSupervisorUpdateInProgressError,
     BackupSupervisorVersionError,
+    UpdaterError,
 )
 from ..jobs.const import JOB_GROUP_BACKUP_MANAGER, JobConcurrency, JobCondition
 from ..jobs.decorator import Job
@@ -842,17 +844,20 @@ class BackupManager(FileConfiguration, JobGroup):
         if self.sys_updater.auto_update:
             if not self.sys_supervisor.need_update:
                 # Ensure the latest version info is known before concluding
-                # there's no update to wait for. Await the fetch task
-                # directly (rather than calling reload()) so a fetch that's
-                # already in-flight - or one that just failed - isn't masked
-                # by fetch_data's throttle window.
-                await self.sys_updater.start_fetch_data()
+                # there's no update to wait for. fetch_data is a detached,
+                # REJECT-concurrency job, so this reuses an already in-flight
+                # fetch instead of masking it behind the throttle window.
+                with suppress(UpdaterError):
+                    if task := await self.sys_updater.fetch_data():
+                        await task
 
-            # Start (or reuse) the auto update. We can't await it here - the
-            # update stops this very Supervisor instance once it completes,
-            # which would drop the connection before a response could be
-            # served. Use the task's existence/done status instead.
-            update_task = self.sys_supervisor.auto_update_supervisor()
+            # Start (or reuse) the auto update. We can't await its completion
+            # here - the update stops this very Supervisor instance once it
+            # completes, which would drop the connection before a response
+            # could be served. Use the returned task's done status instead;
+            # awaiting auto_update_supervisor() itself only waits for the
+            # update to be started (or reused), not for it to finish.
+            update_task = await self.sys_supervisor.auto_update_supervisor()
             if update_task and not update_task.done():
                 raise BackupSupervisorUpdateInProgressError(
                     _LOGGER.error,

--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -840,12 +840,21 @@ class BackupManager(FileConfiguration, JobGroup):
             return
 
         if self.sys_updater.auto_update:
-            self.sys_create_task(self.sys_tasks.auto_update_supervisor())
-            raise BackupSupervisorUpdateInProgressError(
-                _LOGGER.error,
-                backup_version=backup.supervisor_version,
-                supervisor_version=self.sys_supervisor.version,
-            )
+            if self.sys_supervisor.need_update:
+                # Already known that an update is available, make sure it's kicked off
+                self.sys_create_task(self.sys_supervisor.auto_update_supervisor())
+            else:
+                # Refresh version info in case a newer Supervisor was just
+                # released. This also kicks off an auto update if one is now
+                # available.
+                await self.sys_updater.reload()
+
+            if self.sys_supervisor.need_update:
+                raise BackupSupervisorUpdateInProgressError(
+                    _LOGGER.error,
+                    backup_version=backup.supervisor_version,
+                    supervisor_version=self.sys_supervisor.version,
+                )
 
         raise BackupSupervisorVersionError(
             _LOGGER.error,

--- a/supervisor/backups/manager.py
+++ b/supervisor/backups/manager.py
@@ -26,6 +26,8 @@ from ..exceptions import (
     BackupInvalidError,
     BackupJobError,
     BackupMountDownError,
+    BackupSupervisorUpdateInProgressError,
+    BackupSupervisorVersionError,
 )
 from ..jobs.const import JOB_GROUP_BACKUP_MANAGER, JobConcurrency, JobCondition
 from ..jobs.decorator import Job
@@ -832,6 +834,25 @@ class BackupManager(FileConfiguration, JobGroup):
 
         await backup.validate_backup(location_name)
 
+    async def _check_supervisor_version(self, backup: Backup) -> None:
+        """Check backup is not from a newer Supervisor version, raise if so."""
+        if backup.supervisor_version <= self.sys_supervisor.version:
+            return
+
+        if self.sys_updater.auto_update:
+            self.sys_create_task(self.sys_tasks.auto_update_supervisor())
+            raise BackupSupervisorUpdateInProgressError(
+                _LOGGER.error,
+                backup_version=backup.supervisor_version,
+                supervisor_version=self.sys_supervisor.version,
+            )
+
+        raise BackupSupervisorVersionError(
+            _LOGGER.error,
+            backup_version=backup.supervisor_version,
+            supervisor_version=self.sys_supervisor.version,
+        )
+
     @Job(
         name=JOB_FULL_RESTORE,
         conditions=[
@@ -863,13 +884,7 @@ class BackupManager(FileConfiguration, JobGroup):
             )
 
         await self._validate_backup_location(backup, password, location)
-
-        if backup.supervisor_version > self.sys_supervisor.version:
-            raise BackupInvalidError(
-                f"Backup was made on supervisor version {backup.supervisor_version}, "
-                f"can't restore on {self.sys_supervisor.version}. Must update supervisor first.",
-                _LOGGER.error,
-            )
+        await self._check_supervisor_version(backup)
 
         # If being run in the background, notify caller that validation has completed
         if validation_complete:
@@ -940,12 +955,7 @@ class BackupManager(FileConfiguration, JobGroup):
                 "No Home Assistant Core data inside the backup", _LOGGER.error
             )
 
-        if backup.supervisor_version > self.sys_supervisor.version:
-            raise BackupInvalidError(
-                f"Backup was made on supervisor version {backup.supervisor_version}, "
-                f"can't restore on {self.sys_supervisor.version}. Must update supervisor first.",
-                _LOGGER.error,
-            )
+        await self._check_supervisor_version(backup)
 
         # If being run in the background, notify caller that validation has completed
         if validation_complete:

--- a/supervisor/exceptions.py
+++ b/supervisor/exceptions.py
@@ -1599,6 +1599,55 @@ class BackupInvalidError(BackupError):
     """Raise if backup or password provided is invalid."""
 
 
+class BackupSupervisorVersionError(BackupError, APIError):
+    """Raise if backup requires a newer Supervisor version and auto update is disabled."""
+
+    error_key = "backup_supervisor_version_error"
+    message_template = (
+        "Backup was made on supervisor version {backup_version}, can't restore on "
+        "{supervisor_version}. Must update supervisor first."
+    )
+
+    def __init__(
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        backup_version: str,
+        supervisor_version: str,
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {
+            "backup_version": backup_version,
+            "supervisor_version": supervisor_version,
+        }
+        super().__init__(None, logger)
+
+
+class BackupSupervisorUpdateInProgressError(BackupError, APIError):
+    """Raise if backup requires a newer Supervisor version and an auto update was just started."""
+
+    status = 503
+    error_key = "backup_supervisor_update_in_progress_error"
+    message_template = (
+        "Backup was made on supervisor version {backup_version}, can't restore on "
+        "{supervisor_version}. Update is in-progress, try again after it completes."
+    )
+
+    def __init__(
+        self,
+        logger: Callable[..., None] | None = None,
+        *,
+        backup_version: str,
+        supervisor_version: str,
+    ) -> None:
+        """Initialize exception."""
+        self.extra_fields = {
+            "backup_version": backup_version,
+            "supervisor_version": supervisor_version,
+        }
+        super().__init__(None, logger)
+
+
 class BackupMountDownError(BackupError, APIError):
     """Raise if mount specified for backup is down."""
 

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -38,7 +38,6 @@ from ..exceptions import (
     HomeAssistantUpdateError,
     HomeAssistantUpdateImageError,
     JobException,
-    SupervisorJobError,
     SupervisorUpdateError,
 )
 from ..jobs import ChildJobSyncFilter
@@ -253,19 +252,13 @@ class HomeAssistantCore(JobGroup):
                             " before installing Home Assistant Core. Updating Supervisor first"
                         )
                         try:
-                            await self.sys_supervisor.update()
+                            if task := await self.sys_supervisor.update():
+                                await task
                         except SupervisorUpdateError as err:
                             _LOGGER.warning(
                                 "Supervisor update failed, retrying in %ssec: %s",
                                 INSTALL_RETRY_WAIT_SECS,
                                 err,
-                            )
-                            await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
-                            continue
-                        except SupervisorJobError:
-                            _LOGGER.debug(
-                                "Supervisor update is already in progress, waiting %ssec",
-                                INSTALL_RETRY_WAIT_SECS,
                             )
                             await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
                             continue

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -38,6 +38,7 @@ from ..exceptions import (
     HomeAssistantUpdateError,
     HomeAssistantUpdateImageError,
     JobException,
+    SupervisorJobError,
     SupervisorUpdateError,
 )
 from ..jobs import ChildJobSyncFilter
@@ -261,6 +262,14 @@ class HomeAssistantCore(JobGroup):
                             )
                             await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
                             continue
+                        except SupervisorJobError:
+                            _LOGGER.debug(
+                                "Supervisor update is already in progress, waiting %ssec",
+                                INSTALL_RETRY_WAIT_SECS,
+                            )
+                            await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
+                            continue
+
                     else:
                         _LOGGER.warning(
                             "Supervisor has a pending update but auto-update is"

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -245,30 +245,31 @@ class HomeAssistantCore(JobGroup):
 
                 # Supervisor must always be updated before Core to avoid
                 # incompatibilities between a newer Core and an older Supervisor.
-                if self.sys_supervisor.need_update:
-                    if self.sys_updater.auto_update:
-                        _LOGGER.info(
-                            "Supervisor has a pending update and must be updated"
-                            " before installing Home Assistant Core. Updating Supervisor first"
-                        )
-                        try:
-                            if task := await self.sys_supervisor.update():
-                                await task
-                        except SupervisorUpdateError as err:
-                            _LOGGER.warning(
-                                "Supervisor update failed, retrying in %ssec: %s",
-                                INSTALL_RETRY_WAIT_SECS,
-                                err,
-                            )
-                            await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
-                            continue
-
-                    else:
+                # Cache need_update: it's checked twice below and must reflect
+                # the same value both times.
+                supervisor_needs_update = self.sys_supervisor.need_update
+                if supervisor_needs_update and not self.sys_updater.auto_update:
+                    _LOGGER.warning(
+                        "Supervisor has a pending update but auto-update is"
+                        " disabled. Installing Home Assistant Core anyway —"
+                        " unknown issues may occur"
+                    )
+                elif supervisor_needs_update:
+                    _LOGGER.info(
+                        "Supervisor has a pending update and must be updated"
+                        " before installing Home Assistant Core. Updating Supervisor first"
+                    )
+                    try:
+                        if task := await self.sys_supervisor.update():
+                            await task
+                    except SupervisorUpdateError as err:
                         _LOGGER.warning(
-                            "Supervisor has a pending update but auto-update is"
-                            " disabled. Installing Home Assistant Core anyway —"
-                            " unknown issues may occur"
+                            "Supervisor update failed, retrying in %ssec: %s",
+                            INSTALL_RETRY_WAIT_SECS,
+                            err,
                         )
+                        await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
+                        continue
 
                 try:
                     install_image = self.sys_homeassistant.install_image

--- a/supervisor/misc/tasks.py
+++ b/supervisor/misc/tasks.py
@@ -399,7 +399,6 @@ class Tasks(CoreSysAttributes):
             "Found new Supervisor version %s, updating",
             self.sys_supervisor.latest_version,
         )
-        # A user may have started the same update already
         with suppress(SupervisorUpdateError, SupervisorJobError):
             await self.sys_supervisor.update()
 

--- a/supervisor/misc/tasks.py
+++ b/supervisor/misc/tasks.py
@@ -1,6 +1,5 @@
 """A collection of tasks."""
 
-from contextlib import suppress
 from datetime import datetime, timedelta
 import logging
 from typing import cast
@@ -15,11 +14,8 @@ from ..exceptions import (
     HomeAssistantError,
     HomeAssistantWSError,
     ObserverError,
-    SupervisorJobError,
-    SupervisorUpdateError,
 )
 from ..homeassistant.const import LANDINGPAGE, WSType
-from ..jobs.const import JobConcurrency
 from ..jobs.decorator import Job, JobCondition
 from ..plugins.const import PLUGIN_UPDATE_CONDITIONS
 from ..utils.dt import utcnow
@@ -375,32 +371,6 @@ class Tasks(CoreSysAttributes):
     async def _reload_store(self) -> None:
         """Reload store and check for app updates."""
         await self.sys_store.reload()
-
-    @Job(
-        name="tasks_update_supervisor",
-        conditions=[
-            JobCondition.AUTO_UPDATE,
-            JobCondition.FREE_SPACE,
-            JobCondition.HEALTHY,
-            JobCondition.INTERNET_HOST,
-            JobCondition.OS_SUPPORTED,
-            JobCondition.RUNNING,
-            JobCondition.ARCHITECTURE_SUPPORTED,
-        ],
-        concurrency=JobConcurrency.REJECT,
-        internal=True,
-    )
-    async def auto_update_supervisor(self) -> None:
-        """Auto update Supervisor if enabled."""
-        if not self.sys_supervisor.need_update:
-            return
-
-        _LOGGER.info(
-            "Found new Supervisor version %s, updating",
-            self.sys_supervisor.latest_version,
-        )
-        with suppress(SupervisorUpdateError, SupervisorJobError):
-            await self.sys_supervisor.update()
 
     @Job(
         name="tasks_core_backup_cleanup",

--- a/supervisor/misc/tasks.py
+++ b/supervisor/misc/tasks.py
@@ -15,6 +15,7 @@ from ..exceptions import (
     HomeAssistantError,
     HomeAssistantWSError,
     ObserverError,
+    SupervisorJobError,
     SupervisorUpdateError,
 )
 from ..homeassistant.const import LANDINGPAGE, WSType
@@ -80,7 +81,7 @@ class Tasks(CoreSysAttributes):
 
         # Reload
         self.sys_scheduler.register_task(self._reload_store, RUN_RELOAD_APPS)
-        self.sys_scheduler.register_task(self._reload_updater, RUN_RELOAD_UPDATER)
+        self.sys_scheduler.register_task(self.sys_updater.reload, RUN_RELOAD_UPDATER)
         self.sys_scheduler.register_task(self.sys_backups.reload, RUN_RELOAD_BACKUPS)
         self.sys_scheduler.register_task(self.sys_host.reload, RUN_RELOAD_HOST)
         self.sys_scheduler.register_task(self.sys_mounts.reload, RUN_RELOAD_MOUNTS)
@@ -375,15 +376,6 @@ class Tasks(CoreSysAttributes):
         """Reload store and check for app updates."""
         await self.sys_store.reload()
 
-    @Job(name="tasks_reload_updater", internal=True)
-    async def _reload_updater(self) -> None:
-        """Check for new versions of Home Assistant, Supervisor, OS, etc."""
-        await self.sys_updater.reload()
-
-        # If there's a new version of supervisor, update immediately
-        if self.sys_supervisor.need_update:
-            await self._auto_update_supervisor()
-
     @Job(
         name="tasks_update_supervisor",
         conditions=[
@@ -398,7 +390,7 @@ class Tasks(CoreSysAttributes):
         concurrency=JobConcurrency.REJECT,
         internal=True,
     )
-    async def _auto_update_supervisor(self):
+    async def auto_update_supervisor(self) -> None:
         """Auto update Supervisor if enabled."""
         if not self.sys_supervisor.need_update:
             return
@@ -407,7 +399,8 @@ class Tasks(CoreSysAttributes):
             "Found new Supervisor version %s, updating",
             self.sys_supervisor.latest_version,
         )
-        with suppress(SupervisorUpdateError):
+        # A user may have started the same update already
+        with suppress(SupervisorUpdateError, SupervisorJobError):
             await self.sys_supervisor.update()
 
     @Job(

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -32,7 +32,7 @@ from .exceptions import (
     SupervisorUpdateError,
 )
 from .jobs import ChildJobSyncFilter
-from .jobs.const import JobCondition
+from .jobs.const import JobConcurrency, JobCondition
 from .jobs.decorator import Job
 from .resolution.const import ContextType, IssueType
 from .utils.sentry import async_capture_exception
@@ -192,6 +192,9 @@ class Supervisor(CoreSysAttributes):
 
     @Job(
         name="supervisor_update",
+        # A reload can start the auto update while a user requests one too.
+        on_condition=SupervisorJobError,
+        concurrency=JobConcurrency.REJECT,
         # We assume for now the docker image pull is 100% of this task. But from
         # a user perspective that isn't true.  Other steps that take time which
         # is not accounted for in progress include: app armor update and restart

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -192,7 +192,6 @@ class Supervisor(CoreSysAttributes):
 
     @Job(
         name="supervisor_update",
-        # A reload can start the auto update while a user requests one too.
         on_condition=SupervisorJobError,
         concurrency=JobConcurrency.REJECT,
         # We assume for now the docker image pull is 100% of this task. But from

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -59,6 +59,7 @@ class Supervisor(CoreSysAttributes):
         # -inf means "never probed" so the first non-forced call always runs;
         # 0.0 would wrongly short-circuit while loop.time() < min_interval.
         self._connectivity_last_check: float = float("-inf")
+        self._update_task: asyncio.Task[None] | None = None
 
     async def load(self) -> None:
         """Prepare Supervisor object."""
@@ -192,6 +193,9 @@ class Supervisor(CoreSysAttributes):
 
     @Job(
         name="supervisor_update",
+        # Callers currently assume a SupervisorJobError raised means update in
+        # progress since that's the only way it can occur. If other conditions
+        # are added to this job that will require refactoring.
         on_condition=SupervisorJobError,
         concurrency=JobConcurrency.REJECT,
         # We assume for now the docker image pull is 100% of this task. But from
@@ -246,6 +250,26 @@ class Supervisor(CoreSysAttributes):
 
         self.sys_create_task(self.sys_core.stop())
 
+    def auto_update_supervisor(self) -> asyncio.Task[None] | None:
+        """Start the Supervisor auto update if enabled and needed.
+
+        Returns the task performing the update, which may already be in
+        progress from a previous call, or None if no update was started.
+        """
+        if self._update_task and not self._update_task.done():
+            return self._update_task
+
+        if not self.need_update:
+            return None
+
+        _LOGGER.info("Found new Supervisor version %s, updating", self.latest_version)
+        # Eager start so a synchronous, immediate failure (e.g. a job condition
+        # that doesn't need to await anything) is reflected in the task's done
+        # state right away, without requiring an extra loop iteration at the
+        # call site.
+        self._update_task = self.sys_create_task(self._auto_update(), eager_start=True)
+        return self._update_task
+
     @Job(
         name="supervisor_auto_update",
         conditions=[
@@ -257,15 +281,10 @@ class Supervisor(CoreSysAttributes):
             JobCondition.RUNNING,
             JobCondition.ARCHITECTURE_SUPPORTED,
         ],
-        concurrency=JobConcurrency.REJECT,
         internal=True,
     )
-    async def auto_update_supervisor(self) -> None:
-        """Auto update Supervisor if enabled."""
-        if not self.need_update:
-            return
-
-        _LOGGER.info("Found new Supervisor version %s, updating", self.latest_version)
+    async def _auto_update(self) -> None:
+        """Auto update Supervisor."""
         with suppress(SupervisorUpdateError, SupervisorJobError):
             await self.update()
 

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -59,7 +59,6 @@ class Supervisor(CoreSysAttributes):
         # -inf means "never probed" so the first non-forced call always runs;
         # 0.0 would wrongly short-circuit while loop.time() < min_interval.
         self._connectivity_last_check: float = float("-inf")
-        self._update_task: asyncio.Task[None] | None = None
 
     async def load(self) -> None:
         """Prepare Supervisor object."""
@@ -193,10 +192,6 @@ class Supervisor(CoreSysAttributes):
 
     @Job(
         name="supervisor_update",
-        # Callers currently assume a SupervisorJobError raised means update in
-        # progress since that's the only way it can occur. If other conditions
-        # are added to this job that will require refactoring.
-        on_condition=SupervisorJobError,
         concurrency=JobConcurrency.REJECT,
         # We assume for now the docker image pull is 100% of this task. But from
         # a user perspective that isn't true.  Other steps that take time which
@@ -204,9 +199,19 @@ class Supervisor(CoreSysAttributes):
         child_job_syncs=[
             ChildJobSyncFilter("docker_interface_install", progress_allocation=1.0)
         ],
+        detach=True,
     )
     async def update(self, version: AwesomeVersion | None = None) -> None:
-        """Update Supervisor version."""
+        """Update Supervisor version.
+
+        This job is detached: calling it returns the task performing the
+        update - which may already be in progress from a previous call,
+        whether that call was to this method directly or via
+        auto_update_supervisor() - or None if the job was refused (e.g.
+        throttled). Errors are raised on the returned task, not to the
+        caller of this method, so callers that need the result must await
+        the returned task themselves.
+        """
         version = version or self.latest_version or self.version
 
         if version == self.version:
@@ -250,26 +255,6 @@ class Supervisor(CoreSysAttributes):
 
         self.sys_create_task(self.sys_core.stop())
 
-    def auto_update_supervisor(self) -> asyncio.Task[None] | None:
-        """Start the Supervisor auto update if enabled and needed.
-
-        Returns the task performing the update, which may already be in
-        progress from a previous call, or None if no update was started.
-        """
-        if self._update_task and not self._update_task.done():
-            return self._update_task
-
-        if not self.need_update:
-            return None
-
-        _LOGGER.info("Found new Supervisor version %s, updating", self.latest_version)
-        # Eager start so a synchronous, immediate failure (e.g. a job condition
-        # that doesn't need to await anything) is reflected in the task's done
-        # state right away, without requiring an extra loop iteration at the
-        # call site.
-        self._update_task = self.sys_create_task(self._auto_update(), eager_start=True)
-        return self._update_task
-
     @Job(
         name="supervisor_auto_update",
         conditions=[
@@ -283,10 +268,25 @@ class Supervisor(CoreSysAttributes):
         ],
         internal=True,
     )
-    async def _auto_update(self) -> None:
-        """Auto update Supervisor."""
-        with suppress(SupervisorUpdateError, SupervisorJobError):
-            await self.update()
+    async def auto_update_supervisor(self) -> asyncio.Task[None] | None:
+        """Start the Supervisor auto update if enabled and needed.
+
+        Returns the task performing the update - which may already be in
+        progress, whether started by this call, a previous call, or a
+        direct call to update() elsewhere - or None if no update is
+        needed or the job was refused (e.g. a condition failed).
+
+        This never awaits the update to completion itself: update()
+        restarts Supervisor once done, and awaiting that here could drop
+        the caller's connection before a response is sent. Callers that
+        need to wait for the result should await the returned task
+        themselves.
+        """
+        if not self.need_update:
+            return None
+
+        _LOGGER.info("Found new Supervisor version %s, updating", self.latest_version)
+        return await self.update()
 
     @Job(
         name="supervisor_restart",

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -247,6 +247,29 @@ class Supervisor(CoreSysAttributes):
         self.sys_create_task(self.sys_core.stop())
 
     @Job(
+        name="supervisor_auto_update",
+        conditions=[
+            JobCondition.AUTO_UPDATE,
+            JobCondition.FREE_SPACE,
+            JobCondition.HEALTHY,
+            JobCondition.INTERNET_HOST,
+            JobCondition.OS_SUPPORTED,
+            JobCondition.RUNNING,
+            JobCondition.ARCHITECTURE_SUPPORTED,
+        ],
+        concurrency=JobConcurrency.REJECT,
+        internal=True,
+    )
+    async def auto_update_supervisor(self) -> None:
+        """Auto update Supervisor if enabled."""
+        if not self.need_update:
+            return
+
+        _LOGGER.info("Found new Supervisor version %s, updating", self.latest_version)
+        with suppress(SupervisorUpdateError, SupervisorJobError):
+            await self.update()
+
+    @Job(
         name="supervisor_restart",
         conditions=[JobCondition.RUNNING],
         on_condition=SupervisorJobError,

--- a/supervisor/updater.py
+++ b/supervisor/updater.py
@@ -74,7 +74,6 @@ class Updater(FileConfiguration, CoreSysAttributes):
         with suppress(UpdaterError):
             await self.fetch_data()
 
-        # A pending update blocks other updates, don't wait for the scheduled check
         if self.sys_core.state == CoreState.RUNNING and self.sys_supervisor.need_update:
             self.sys_create_task(self.sys_tasks.auto_update_supervisor())
 

--- a/supervisor/updater.py
+++ b/supervisor/updater.py
@@ -1,6 +1,5 @@
 """Fetch last versions from webserver."""
 
-import asyncio
 from contextlib import suppress
 from datetime import timedelta
 import json
@@ -48,7 +47,6 @@ class Updater(FileConfiguration, CoreSysAttributes):
         super().__init__(FILE_HASSIO_UPDATER, SCHEMA_UPDATER_CONFIG)
         self.coresys = coresys
         self._connectivity_listener: EventListener | None = None
-        self._fetch_task: asyncio.Task[None] | None = None
 
     async def load(self) -> None:
         """Update internal data."""
@@ -61,31 +59,6 @@ class Updater(FileConfiguration, CoreSysAttributes):
             )
             await self.reload()
 
-    def start_fetch_data(self) -> asyncio.Task[None]:
-        """Start (or reuse) a version data fetch, returning its task.
-
-        Returns the task performing the fetch, which may already be in
-        progress from a previous call.
-
-        Callers that need up to date version info should await the
-        returned task directly rather than calling fetch_data() themselves.
-        fetch_data() is throttled, so a second direct call while one is
-        already in-flight (or one that just failed) would silently be
-        skipped instead of reflecting the actual outcome of the fetch.
-        """
-        if self._fetch_task and not self._fetch_task.done():
-            return self._fetch_task
-
-        self._fetch_task = self.sys_create_task(
-            self._fetch_data_suppressed(), eager_start=True
-        )
-        return self._fetch_task
-
-    async def _fetch_data_suppressed(self) -> None:
-        """Fetch data, suppressing failures (already logged/issued in fetch_data)."""
-        with suppress(UpdaterError):
-            await self.fetch_data()
-
     async def reload(self) -> None:
         """Update internal data."""
         if not self.sys_supervisor.connectivity:
@@ -96,10 +69,16 @@ class Updater(FileConfiguration, CoreSysAttributes):
                     BusEvent.SUPERVISOR_CONNECTIVITY_CHANGE, self._check_connectivity
                 )
         else:
-            await self.start_fetch_data()
+            # fetch_data is a detached, REJECT-concurrency job. A call while
+            # one is already in-flight gets back that same task instead of
+            # starting a redundant fetch, and awaiting it here surfaces the
+            # real outcome instead of relying on the throttle window.
+            with suppress(UpdaterError):
+                if task := await self.fetch_data():
+                    await task
 
         if self.sys_core.state == CoreState.RUNNING and self.sys_supervisor.need_update:
-            self.sys_supervisor.auto_update_supervisor()
+            await self.sys_supervisor.auto_update_supervisor()
 
     @property
     def version_homeassistant(self) -> AwesomeVersion | None:
@@ -276,8 +255,9 @@ class Updater(FileConfiguration, CoreSysAttributes):
         ],
         on_condition=UpdaterJobError,
         throttle_period=timedelta(seconds=30),
-        concurrency=JobConcurrency.QUEUE,
+        concurrency=JobConcurrency.REJECT,
         throttle=JobThrottle.THROTTLE,
+        detach=True,
     )
     async def fetch_data(self):
         """Fetch current versions from Github.

--- a/supervisor/updater.py
+++ b/supervisor/updater.py
@@ -75,7 +75,7 @@ class Updater(FileConfiguration, CoreSysAttributes):
             await self.fetch_data()
 
         if self.sys_core.state == CoreState.RUNNING and self.sys_supervisor.need_update:
-            self.sys_create_task(self.sys_tasks.auto_update_supervisor())
+            self.sys_create_task(self.sys_supervisor.auto_update_supervisor())
 
     @property
     def version_homeassistant(self) -> AwesomeVersion | None:

--- a/supervisor/updater.py
+++ b/supervisor/updater.py
@@ -26,6 +26,7 @@ from .const import (
     FILE_HASSIO_UPDATER,
     URL_HASSIO_VERSION,
     BusEvent,
+    CoreState,
     UpdateChannel,
 )
 from .coresys import CoreSys, CoreSysAttributes
@@ -72,6 +73,12 @@ class Updater(FileConfiguration, CoreSysAttributes):
 
         with suppress(UpdaterError):
             await self.fetch_data()
+
+        # A pending Supervisor update blocks Core, OS and app updates until it
+        # is installed, so start it now instead of at the next scheduled check.
+        # Startup handles its own Supervisor update before anything else runs.
+        if self.sys_core.state == CoreState.RUNNING and self.sys_supervisor.need_update:
+            self.sys_create_task(self.sys_tasks.auto_update_supervisor())
 
     @property
     def version_homeassistant(self) -> AwesomeVersion | None:

--- a/supervisor/updater.py
+++ b/supervisor/updater.py
@@ -74,9 +74,7 @@ class Updater(FileConfiguration, CoreSysAttributes):
         with suppress(UpdaterError):
             await self.fetch_data()
 
-        # A pending Supervisor update blocks Core, OS and app updates until it
-        # is installed, so start it now instead of at the next scheduled check.
-        # Startup handles its own Supervisor update before anything else runs.
+        # A pending update blocks other updates, don't wait for the scheduled check
         if self.sys_core.state == CoreState.RUNNING and self.sys_supervisor.need_update:
             self.sys_create_task(self.sys_tasks.auto_update_supervisor())
 

--- a/supervisor/updater.py
+++ b/supervisor/updater.py
@@ -1,5 +1,6 @@
 """Fetch last versions from webserver."""
 
+import asyncio
 from contextlib import suppress
 from datetime import timedelta
 import json
@@ -47,6 +48,7 @@ class Updater(FileConfiguration, CoreSysAttributes):
         super().__init__(FILE_HASSIO_UPDATER, SCHEMA_UPDATER_CONFIG)
         self.coresys = coresys
         self._connectivity_listener: EventListener | None = None
+        self._fetch_task: asyncio.Task[None] | None = None
 
     async def load(self) -> None:
         """Update internal data."""
@@ -59,23 +61,45 @@ class Updater(FileConfiguration, CoreSysAttributes):
             )
             await self.reload()
 
-    async def reload(self) -> None:
-        """Update internal data."""
-        # If there's no connectivity, delay initial version fetch
-        if not self.sys_supervisor.connectivity:
-            _LOGGER.debug("No Supervisor connectivity, delaying version fetch")
-            if not self._connectivity_listener:
-                self._connectivity_listener = self.sys_bus.register_event(
-                    BusEvent.SUPERVISOR_CONNECTIVITY_CHANGE, self._check_connectivity
-                )
-            _LOGGER.info("No Supervisor connectivity, delaying version fetch")
-            return
+    def start_fetch_data(self) -> asyncio.Task[None]:
+        """Start (or reuse) a version data fetch, returning its task.
 
+        Returns the task performing the fetch, which may already be in
+        progress from a previous call.
+
+        Callers that need up to date version info should await the
+        returned task directly rather than calling fetch_data() themselves.
+        fetch_data() is throttled, so a second direct call while one is
+        already in-flight (or one that just failed) would silently be
+        skipped instead of reflecting the actual outcome of the fetch.
+        """
+        if self._fetch_task and not self._fetch_task.done():
+            return self._fetch_task
+
+        self._fetch_task = self.sys_create_task(
+            self._fetch_data_suppressed(), eager_start=True
+        )
+        return self._fetch_task
+
+    async def _fetch_data_suppressed(self) -> None:
+        """Fetch data, suppressing failures (already logged/issued in fetch_data)."""
         with suppress(UpdaterError):
             await self.fetch_data()
 
+    async def reload(self) -> None:
+        """Update internal data."""
+        if not self.sys_supervisor.connectivity:
+            # If there's no connectivity, delay version fetch until it's back
+            if not self._connectivity_listener:
+                _LOGGER.debug("No Supervisor connectivity, delaying version fetch")
+                self._connectivity_listener = self.sys_bus.register_event(
+                    BusEvent.SUPERVISOR_CONNECTIVITY_CHANGE, self._check_connectivity
+                )
+        else:
+            await self.start_fetch_data()
+
         if self.sys_core.state == CoreState.RUNNING and self.sys_supervisor.need_update:
-            self.sys_create_task(self.sys_supervisor.auto_update_supervisor())
+            self.sys_supervisor.auto_update_supervisor()
 
     @property
     def version_homeassistant(self) -> AwesomeVersion | None:

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -562,12 +562,21 @@ async def test_restore_immediate_errors(
             new=PropertyMock(return_value=AwesomeVersion("2023.12.0")),
         ),
     ):
+        coresys.updater.auto_update = False
         resp = await api_client.post(
             f"/backups/{mock_partial_backup.slug}/restore/partial",
             json={"background": True, "homeassistant": True},
         )
-    assert resp.status == 400
-    assert "Must update supervisor" in (await resp.json())["message"]
+        assert resp.status == 400
+        assert "Must update supervisor" in (await resp.json())["message"]
+
+        coresys.updater.auto_update = True
+        resp = await api_client.post(
+            f"/backups/{mock_partial_backup.slug}/restore/partial",
+            json={"background": True, "homeassistant": True},
+        )
+        assert resp.status == 503
+        assert "Update is in-progress" in (await resp.json())["message"]
 
     with (
         patch.object(

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -572,11 +572,16 @@ async def test_restore_immediate_errors(
         assert "Must update supervisor" in (await resp.json())["message"]
 
         coresys.updater.auto_update = True
+        update_task = MagicMock()
+        update_task.done.return_value = False
         with (
             patch.object(
                 Supervisor, "need_update", new=PropertyMock(return_value=True)
             ),
-            patch.object(Updater, "reload", new=AsyncMock()) as reload,
+            patch.object(Updater, "start_fetch_data") as start_fetch_data,
+            patch.object(
+                Supervisor, "auto_update_supervisor", return_value=update_task
+            ) as auto_update_supervisor,
         ):
             resp = await api_client.post(
                 f"/backups/{mock_partial_backup.slug}/restore/partial",
@@ -584,7 +589,8 @@ async def test_restore_immediate_errors(
             )
         assert resp.status == 503
         assert "Update is in-progress" in (await resp.json())["message"]
-        reload.assert_not_called()
+        start_fetch_data.assert_not_called()
+        auto_update_supervisor.assert_called_once()
 
     with (
         patch.object(

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -578,9 +578,11 @@ async def test_restore_immediate_errors(
             patch.object(
                 Supervisor, "need_update", new=PropertyMock(return_value=True)
             ),
-            patch.object(Updater, "start_fetch_data") as start_fetch_data,
+            patch.object(Updater, "fetch_data", new=AsyncMock()) as fetch_data,
             patch.object(
-                Supervisor, "auto_update_supervisor", return_value=update_task
+                Supervisor,
+                "auto_update_supervisor",
+                new=AsyncMock(return_value=update_task),
             ) as auto_update_supervisor,
         ):
             resp = await api_client.post(
@@ -589,7 +591,7 @@ async def test_restore_immediate_errors(
             )
         assert resp.status == 503
         assert "Update is in-progress" in (await resp.json())["message"]
-        start_fetch_data.assert_not_called()
+        fetch_data.assert_not_called()
         auto_update_supervisor.assert_called_once()
 
     with (

--- a/tests/api/test_backups.py
+++ b/tests/api/test_backups.py
@@ -31,6 +31,7 @@ from supervisor.homeassistant.websocket import HomeAssistantWebSocket
 from supervisor.jobs import SupervisorJob
 from supervisor.mounts.mount import Mount
 from supervisor.supervisor import Supervisor
+from supervisor.updater import Updater
 
 from tests.common import get_fixture_path
 from tests.const import TEST_ADDON_SLUG
@@ -571,12 +572,19 @@ async def test_restore_immediate_errors(
         assert "Must update supervisor" in (await resp.json())["message"]
 
         coresys.updater.auto_update = True
-        resp = await api_client.post(
-            f"/backups/{mock_partial_backup.slug}/restore/partial",
-            json={"background": True, "homeassistant": True},
-        )
+        with (
+            patch.object(
+                Supervisor, "need_update", new=PropertyMock(return_value=True)
+            ),
+            patch.object(Updater, "reload", new=AsyncMock()) as reload,
+        ):
+            resp = await api_client.post(
+                f"/backups/{mock_partial_backup.slug}/restore/partial",
+                json={"background": True, "homeassistant": True},
+            )
         assert resp.status == 503
         assert "Update is in-progress" in (await resp.json())["message"]
+        reload.assert_not_called()
 
     with (
         patch.object(

--- a/tests/api/test_root.py
+++ b/tests/api/test_root.py
@@ -88,7 +88,9 @@ async def test_api_reload_updates(
 ):
     """Test reload updates."""
     with (
-        patch("supervisor.updater.Updater.fetch_data") as fetch_data,
+        patch(
+            "supervisor.updater.Updater.fetch_data", AsyncMock(return_value=None)
+        ) as fetch_data,
     ):
         resp = await api_client.post("/reload_updates")
 

--- a/tests/api/test_supervisor.py
+++ b/tests/api/test_supervisor.py
@@ -1,6 +1,7 @@
 """Test Supervisor API."""
 
 # pylint: disable=protected-access
+import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
@@ -20,7 +21,6 @@ from supervisor.exceptions import (
     HostJournalGatewaydConnectionError,
     HostNotSupportedError,
     StoreGitError,
-    SupervisorJobError,
 )
 from supervisor.homeassistant.const import WSEvent
 from supervisor.store.repository import Repository
@@ -545,15 +545,22 @@ async def test_api_supervisor_update_no_update_available(
 async def test_api_supervisor_update_already_running(
     api_client_with_prefix: tuple[TestClient, str],
 ):
-    """Test an update request during a running update reports success."""
+    """Test an update request while one is already running awaits and reports its result."""
     api_client, prefix = api_client_with_prefix
+
+    async def _already_running_update() -> None:
+        """Simulate the shared, already-in-progress update completing successfully."""
 
     with (
         patch.object(Supervisor, "need_update", new=PropertyMock(return_value=True)),
         patch.object(
             Supervisor,
             "update",
-            side_effect=SupervisorJobError("Another job is running"),
+            AsyncMock(
+                return_value=asyncio.get_event_loop().create_task(
+                    _already_running_update()
+                )
+            ),
         ),
     ):
         resp = await api_client.post(f"{prefix}/supervisor/update")
@@ -570,7 +577,7 @@ async def test_api_supervisor_update_dev_explicit_version(
     with (
         patch.object(CoreSys, "dev", new=PropertyMock(return_value=True)),
         patch.object(Supervisor, "need_update", new=PropertyMock(return_value=False)),
-        patch.object(Supervisor, "update") as update,
+        patch.object(Supervisor, "update", AsyncMock(return_value=None)) as update,
     ):
         resp = await api_client.post(
             f"{prefix}/supervisor/update", json={"version": "2025.08.3"}

--- a/tests/api/test_supervisor.py
+++ b/tests/api/test_supervisor.py
@@ -20,6 +20,7 @@ from supervisor.exceptions import (
     HostJournalGatewaydConnectionError,
     HostNotSupportedError,
     StoreGitError,
+    SupervisorJobError,
 )
 from supervisor.homeassistant.const import WSEvent
 from supervisor.store.repository import Repository
@@ -539,6 +540,25 @@ async def test_api_supervisor_update_no_update_available(
     result = await resp.json()
     assert "No supervisor update available" in result["message"]
     update.assert_not_called()
+
+
+async def test_api_supervisor_update_already_running(
+    api_client_with_prefix: tuple[TestClient, str],
+):
+    """Test an update request during a running update reports success."""
+    api_client, prefix = api_client_with_prefix
+
+    with (
+        patch.object(Supervisor, "need_update", new=PropertyMock(return_value=True)),
+        patch.object(
+            Supervisor,
+            "update",
+            side_effect=SupervisorJobError("Another job is running"),
+        ),
+    ):
+        resp = await api_client.post(f"{prefix}/supervisor/update")
+
+    assert resp.status == 200
 
 
 async def test_api_supervisor_update_dev_explicit_version(

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -411,9 +411,7 @@ async def test_restore_fails_supervisor_version_auto_update_disabled(
             "version",
             new=PropertyMock(return_value="2022.08.3"),
         ),
-        patch.object(
-            type(coresys.tasks), "auto_update_supervisor", new=AsyncMock()
-        ) as auto_update_supervisor,
+        patch.object(type(coresys.updater), "reload", new=AsyncMock()) as reload,
         pytest.raises(BackupSupervisorVersionError) as exc_info,
     ):
         await getattr(manager, restore_method)(backup_instance)
@@ -423,17 +421,17 @@ async def test_restore_fails_supervisor_version_auto_update_disabled(
         "Backup was made on supervisor version 2022.08.4, can't restore on "
         "2022.08.3. Must update supervisor first." in str(exc_info.value)
     )
-    auto_update_supervisor.assert_not_called()
+    reload.assert_not_called()
 
 
 @pytest.mark.usefixtures("supervisor_internet")
 @pytest.mark.parametrize("restore_method", ["do_restore_full", "do_restore_partial"])
-async def test_restore_fails_supervisor_version_auto_update_enabled(
+async def test_restore_fails_supervisor_version_auto_update_already_in_progress(
     coresys: CoreSys,
     full_backup_mock: MagicMock,
     restore_method: str,
 ):
-    """Test restoring a backup from a newer Supervisor triggers an auto update."""
+    """Test restore raises update-in-progress without reloading if update is already known."""
     await coresys.core.set_state(CoreState.RUNNING)
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     coresys.updater.auto_update = True
@@ -449,7 +447,13 @@ async def test_restore_fails_supervisor_version_auto_update_enabled(
             new=PropertyMock(return_value="2022.08.3"),
         ),
         patch.object(
-            type(coresys.tasks), "auto_update_supervisor", new=AsyncMock()
+            type(coresys.supervisor),
+            "need_update",
+            new=PropertyMock(return_value=True),
+        ),
+        patch.object(type(coresys.updater), "reload", new=AsyncMock()) as reload,
+        patch.object(
+            type(coresys.supervisor), "auto_update_supervisor", new=AsyncMock()
         ) as auto_update_supervisor,
         pytest.raises(BackupSupervisorUpdateInProgressError) as exc_info,
     ):
@@ -461,8 +465,90 @@ async def test_restore_fails_supervisor_version_auto_update_enabled(
         "2022.08.3. Update is in-progress, try again after it completes."
         in str(exc_info.value)
     )
+    reload.assert_not_called()
     await asyncio.sleep(0)
     auto_update_supervisor.assert_called_once()
+
+
+@pytest.mark.usefixtures("supervisor_internet")
+@pytest.mark.parametrize("restore_method", ["do_restore_full", "do_restore_partial"])
+async def test_restore_fails_supervisor_version_auto_update_found_on_reload(
+    coresys: CoreSys,
+    full_backup_mock: MagicMock,
+    restore_method: str,
+):
+    """Test restore reloads updater and raises update-in-progress if reload finds an update."""
+    await coresys.core.set_state(CoreState.RUNNING)
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    coresys.updater.auto_update = True
+
+    manager = await BackupManager(coresys).load_config()
+    backup_instance = full_backup_mock.return_value
+    backup_instance.supervisor_version = "2022.08.4"
+
+    with (
+        patch.object(
+            type(coresys.supervisor),
+            "version",
+            new=PropertyMock(return_value="2022.08.3"),
+        ),
+        patch.object(
+            type(coresys.supervisor),
+            "need_update",
+            new=PropertyMock(side_effect=[False, True]),
+        ),
+        patch.object(type(coresys.updater), "reload", new=AsyncMock()) as reload,
+        pytest.raises(BackupSupervisorUpdateInProgressError) as exc_info,
+    ):
+        await getattr(manager, restore_method)(backup_instance)
+
+    assert exc_info.value.status == 503
+    assert (
+        "Backup was made on supervisor version 2022.08.4, can't restore on "
+        "2022.08.3. Update is in-progress, try again after it completes."
+        in str(exc_info.value)
+    )
+    reload.assert_called_once()
+
+
+@pytest.mark.usefixtures("supervisor_internet")
+@pytest.mark.parametrize("restore_method", ["do_restore_full", "do_restore_partial"])
+async def test_restore_fails_supervisor_version_no_update_available_on_reload(
+    coresys: CoreSys,
+    full_backup_mock: MagicMock,
+    restore_method: str,
+):
+    """Test restore falls back to version mismatch if reload finds no update available."""
+    await coresys.core.set_state(CoreState.RUNNING)
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    coresys.updater.auto_update = True
+
+    manager = await BackupManager(coresys).load_config()
+    backup_instance = full_backup_mock.return_value
+    backup_instance.supervisor_version = "2022.08.4"
+
+    with (
+        patch.object(
+            type(coresys.supervisor),
+            "version",
+            new=PropertyMock(return_value="2022.08.3"),
+        ),
+        patch.object(
+            type(coresys.supervisor),
+            "need_update",
+            new=PropertyMock(return_value=False),
+        ),
+        patch.object(type(coresys.updater), "reload", new=AsyncMock()) as reload,
+        pytest.raises(BackupSupervisorVersionError) as exc_info,
+    ):
+        await getattr(manager, restore_method)(backup_instance)
+
+    assert exc_info.value.status == 400
+    assert (
+        "Backup was made on supervisor version 2022.08.4, can't restore on "
+        "2022.08.3. Must update supervisor first." in str(exc_info.value)
+    )
+    reload.assert_called_once()
 
 
 @pytest.mark.usefixtures("install_app_ssh", "capture_exception")

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -458,7 +458,7 @@ async def test_restore_fails_supervisor_version_auto_update_already_in_progress(
         patch.object(
             type(coresys.supervisor),
             "auto_update_supervisor",
-            return_value=update_task,
+            new=AsyncMock(return_value=update_task),
         ) as auto_update_supervisor,
         pytest.raises(BackupSupervisorUpdateInProgressError) as exc_info,
     ):
@@ -508,12 +508,12 @@ async def test_restore_fails_supervisor_version_auto_update_found_on_reload(
             new=PropertyMock(return_value=False),
         ),
         patch.object(
-            type(coresys.updater), "start_fetch_data", return_value=fetch_task
-        ) as start_fetch_data,
+            type(coresys.updater), "fetch_data", new=AsyncMock(return_value=fetch_task)
+        ) as fetch_data,
         patch.object(
             type(coresys.supervisor),
             "auto_update_supervisor",
-            return_value=update_task,
+            new=AsyncMock(return_value=update_task),
         ) as auto_update_supervisor,
         pytest.raises(BackupSupervisorUpdateInProgressError) as exc_info,
     ):
@@ -525,7 +525,7 @@ async def test_restore_fails_supervisor_version_auto_update_found_on_reload(
         "2022.08.3. Update is in-progress, try again after it completes."
         in str(exc_info.value)
     )
-    start_fetch_data.assert_called_once()
+    fetch_data.assert_called_once()
     auto_update_supervisor.assert_called_once()
 
 
@@ -560,10 +560,12 @@ async def test_restore_fails_supervisor_version_no_update_available_on_reload(
             new=PropertyMock(return_value=False),
         ),
         patch.object(
-            type(coresys.updater), "start_fetch_data", return_value=fetch_task
-        ) as start_fetch_data,
+            type(coresys.updater), "fetch_data", new=AsyncMock(return_value=fetch_task)
+        ) as fetch_data,
         patch.object(
-            type(coresys.supervisor), "auto_update_supervisor", return_value=None
+            type(coresys.supervisor),
+            "auto_update_supervisor",
+            new=AsyncMock(return_value=None),
         ) as auto_update_supervisor,
         pytest.raises(BackupSupervisorVersionError) as exc_info,
     ):
@@ -574,7 +576,7 @@ async def test_restore_fails_supervisor_version_no_update_available_on_reload(
         "Backup was made on supervisor version 2022.08.4, can't restore on "
         "2022.08.3. Must update supervisor first." in str(exc_info.value)
     )
-    start_fetch_data.assert_called_once()
+    fetch_data.assert_called_once()
     auto_update_supervisor.assert_called_once()
 
 

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -31,6 +31,8 @@ from supervisor.exceptions import (
     BackupInvalidError,
     BackupJobError,
     BackupMountDownError,
+    BackupSupervisorUpdateInProgressError,
+    BackupSupervisorVersionError,
     DockerError,
     MountError,
 )
@@ -362,18 +364,6 @@ async def test_fail_invalid_full_backup(
     with pytest.raises(BackupInvalidError):
         await manager.do_restore_full(backup_instance)
 
-    backup_instance.all_locations[None].protected = False
-    backup_instance.supervisor_version = "2022.08.4"
-    with (
-        patch.object(
-            type(coresys.supervisor),
-            "version",
-            new=PropertyMock(return_value="2022.08.3"),
-        ),
-        pytest.raises(BackupInvalidError),
-    ):
-        await manager.do_restore_full(backup_instance)
-
 
 @pytest.mark.usefixtures("supervisor_internet")
 async def test_fail_invalid_partial_backup(
@@ -398,16 +388,81 @@ async def test_fail_invalid_partial_backup(
     with pytest.raises(BackupInvalidError):
         await manager.do_restore_partial(backup_instance, homeassistant=True)
 
+
+@pytest.mark.usefixtures("supervisor_internet")
+@pytest.mark.parametrize("restore_method", ["do_restore_full", "do_restore_partial"])
+async def test_restore_fails_supervisor_version_auto_update_disabled(
+    coresys: CoreSys,
+    full_backup_mock: MagicMock,
+    restore_method: str,
+):
+    """Test restoring a backup from a newer Supervisor raises when auto update is off."""
+    await coresys.core.set_state(CoreState.RUNNING)
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    coresys.updater.auto_update = False
+
+    manager = await BackupManager(coresys).load_config()
+    backup_instance = full_backup_mock.return_value
     backup_instance.supervisor_version = "2022.08.4"
+
     with (
         patch.object(
             type(coresys.supervisor),
             "version",
             new=PropertyMock(return_value="2022.08.3"),
         ),
-        pytest.raises(BackupInvalidError),
+        patch.object(
+            type(coresys.tasks), "auto_update_supervisor", new=AsyncMock()
+        ) as auto_update_supervisor,
+        pytest.raises(BackupSupervisorVersionError) as exc_info,
     ):
-        await manager.do_restore_partial(backup_instance)
+        await getattr(manager, restore_method)(backup_instance)
+
+    assert exc_info.value.status == 400
+    assert (
+        "Backup was made on supervisor version 2022.08.4, can't restore on "
+        "2022.08.3. Must update supervisor first." in str(exc_info.value)
+    )
+    auto_update_supervisor.assert_not_called()
+
+
+@pytest.mark.usefixtures("supervisor_internet")
+@pytest.mark.parametrize("restore_method", ["do_restore_full", "do_restore_partial"])
+async def test_restore_fails_supervisor_version_auto_update_enabled(
+    coresys: CoreSys,
+    full_backup_mock: MagicMock,
+    restore_method: str,
+):
+    """Test restoring a backup from a newer Supervisor triggers an auto update."""
+    await coresys.core.set_state(CoreState.RUNNING)
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    coresys.updater.auto_update = True
+
+    manager = await BackupManager(coresys).load_config()
+    backup_instance = full_backup_mock.return_value
+    backup_instance.supervisor_version = "2022.08.4"
+
+    with (
+        patch.object(
+            type(coresys.supervisor),
+            "version",
+            new=PropertyMock(return_value="2022.08.3"),
+        ),
+        patch.object(
+            type(coresys.tasks), "auto_update_supervisor", new=AsyncMock()
+        ) as auto_update_supervisor,
+        pytest.raises(BackupSupervisorUpdateInProgressError) as exc_info,
+    ):
+        await getattr(manager, restore_method)(backup_instance)
+
+    assert exc_info.value.status == 503
+    assert (
+        "Backup was made on supervisor version 2022.08.4, can't restore on "
+        "2022.08.3. Update is in-progress, try again after it completes."
+        in str(exc_info.value)
+    )
+    await asyncio.sleep(0)
+    auto_update_supervisor.assert_called_once()
 
 
 @pytest.mark.usefixtures("install_app_ssh", "capture_exception")

--- a/tests/backups/test_manager.py
+++ b/tests/backups/test_manager.py
@@ -440,6 +440,9 @@ async def test_restore_fails_supervisor_version_auto_update_already_in_progress(
     backup_instance = full_backup_mock.return_value
     backup_instance.supervisor_version = "2022.08.4"
 
+    update_task = MagicMock()
+    update_task.done.return_value = False
+
     with (
         patch.object(
             type(coresys.supervisor),
@@ -453,7 +456,9 @@ async def test_restore_fails_supervisor_version_auto_update_already_in_progress(
         ),
         patch.object(type(coresys.updater), "reload", new=AsyncMock()) as reload,
         patch.object(
-            type(coresys.supervisor), "auto_update_supervisor", new=AsyncMock()
+            type(coresys.supervisor),
+            "auto_update_supervisor",
+            return_value=update_task,
         ) as auto_update_supervisor,
         pytest.raises(BackupSupervisorUpdateInProgressError) as exc_info,
     ):
@@ -466,7 +471,6 @@ async def test_restore_fails_supervisor_version_auto_update_already_in_progress(
         in str(exc_info.value)
     )
     reload.assert_not_called()
-    await asyncio.sleep(0)
     auto_update_supervisor.assert_called_once()
 
 
@@ -477,7 +481,7 @@ async def test_restore_fails_supervisor_version_auto_update_found_on_reload(
     full_backup_mock: MagicMock,
     restore_method: str,
 ):
-    """Test restore reloads updater and raises update-in-progress if reload finds an update."""
+    """Test restore reloads updater and raises update-in-progress if an update is kicked off."""
     await coresys.core.set_state(CoreState.RUNNING)
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     coresys.updater.auto_update = True
@@ -485,6 +489,12 @@ async def test_restore_fails_supervisor_version_auto_update_found_on_reload(
     manager = await BackupManager(coresys).load_config()
     backup_instance = full_backup_mock.return_value
     backup_instance.supervisor_version = "2022.08.4"
+
+    update_task = MagicMock()
+    update_task.done.return_value = False
+
+    fetch_task = asyncio.get_running_loop().create_future()
+    fetch_task.set_result(None)
 
     with (
         patch.object(
@@ -495,9 +505,16 @@ async def test_restore_fails_supervisor_version_auto_update_found_on_reload(
         patch.object(
             type(coresys.supervisor),
             "need_update",
-            new=PropertyMock(side_effect=[False, True]),
+            new=PropertyMock(return_value=False),
         ),
-        patch.object(type(coresys.updater), "reload", new=AsyncMock()) as reload,
+        patch.object(
+            type(coresys.updater), "start_fetch_data", return_value=fetch_task
+        ) as start_fetch_data,
+        patch.object(
+            type(coresys.supervisor),
+            "auto_update_supervisor",
+            return_value=update_task,
+        ) as auto_update_supervisor,
         pytest.raises(BackupSupervisorUpdateInProgressError) as exc_info,
     ):
         await getattr(manager, restore_method)(backup_instance)
@@ -508,7 +525,8 @@ async def test_restore_fails_supervisor_version_auto_update_found_on_reload(
         "2022.08.3. Update is in-progress, try again after it completes."
         in str(exc_info.value)
     )
-    reload.assert_called_once()
+    start_fetch_data.assert_called_once()
+    auto_update_supervisor.assert_called_once()
 
 
 @pytest.mark.usefixtures("supervisor_internet")
@@ -527,6 +545,9 @@ async def test_restore_fails_supervisor_version_no_update_available_on_reload(
     backup_instance = full_backup_mock.return_value
     backup_instance.supervisor_version = "2022.08.4"
 
+    fetch_task = asyncio.get_running_loop().create_future()
+    fetch_task.set_result(None)
+
     with (
         patch.object(
             type(coresys.supervisor),
@@ -538,7 +559,12 @@ async def test_restore_fails_supervisor_version_no_update_available_on_reload(
             "need_update",
             new=PropertyMock(return_value=False),
         ),
-        patch.object(type(coresys.updater), "reload", new=AsyncMock()) as reload,
+        patch.object(
+            type(coresys.updater), "start_fetch_data", return_value=fetch_task
+        ) as start_fetch_data,
+        patch.object(
+            type(coresys.supervisor), "auto_update_supervisor", return_value=None
+        ) as auto_update_supervisor,
         pytest.raises(BackupSupervisorVersionError) as exc_info,
     ):
         await getattr(manager, restore_method)(backup_instance)
@@ -548,7 +574,8 @@ async def test_restore_fails_supervisor_version_no_update_available_on_reload(
         "Backup was made on supervisor version 2022.08.4, can't restore on "
         "2022.08.3. Must update supervisor first." in str(exc_info.value)
     )
-    reload.assert_called_once()
+    start_fetch_data.assert_called_once()
+    auto_update_supervisor.assert_called_once()
 
 
 @pytest.mark.usefixtures("install_app_ssh", "capture_exception")

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -29,6 +29,7 @@ from supervisor.exceptions import (
     HomeAssistantNotRunningError,
     HomeAssistantStatsTimeoutError,
     HomeAssistantUnknownError,
+    SupervisorJobError,
     SupervisorUpdateError,
 )
 from supervisor.homeassistant.api import APIState
@@ -324,6 +325,47 @@ async def test_install_supervisor_update_fails_retries(
         sleep.assert_any_await(30)
 
     assert "Supervisor update failed, retrying in 30sec" in caplog.text
+
+
+async def test_install_supervisor_update_already_in_progress_retries(
+    coresys: CoreSys, caplog: pytest.LogCaptureFixture
+):
+    """Test install retries after 30s when a supervisor update is already running."""
+    caplog.set_level("DEBUG", "supervisor.homeassistant.core")
+
+    # Supervisor reports needing update on first pass, not on second
+    need_update_values = [True, False]
+    need_update_mock = PropertyMock(side_effect=need_update_values)
+
+    with (
+        patch.object(HomeAssistantCore, "start"),
+        patch.object(DockerHomeAssistant, "cleanup"),
+        patch.object(
+            Updater,
+            "image_homeassistant",
+            new=PropertyMock(return_value="homeassistant"),
+        ),
+        patch.object(
+            Updater, "version_homeassistant", new=PropertyMock(return_value="2022.7.3")
+        ),
+        patch.object(
+            DockerInterface, "arch", new=PropertyMock(return_value=CpuArch.AMD64)
+        ),
+        patch.object(type(coresys.supervisor), "need_update", new=need_update_mock),
+        patch.object(
+            type(coresys.updater), "auto_update", new=PropertyMock(return_value=True)
+        ),
+        patch.object(
+            coresys.supervisor,
+            "update",
+            side_effect=SupervisorJobError("update already running"),
+        ),
+        patch("supervisor.homeassistant.core.asyncio.sleep") as sleep,
+    ):
+        await coresys.homeassistant.core.install()
+        sleep.assert_any_await(30)
+
+    assert "Supervisor update is already in progress, waiting 30sec" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -29,7 +29,6 @@ from supervisor.exceptions import (
     HomeAssistantNotRunningError,
     HomeAssistantStatsTimeoutError,
     HomeAssistantUnknownError,
-    SupervisorJobError,
     SupervisorUpdateError,
 )
 from supervisor.homeassistant.api import APIState
@@ -242,7 +241,9 @@ async def test_install_supervisor_needs_update_auto_update_enabled(
         patch.object(
             type(coresys.updater), "auto_update", new=PropertyMock(return_value=True)
         ),
-        patch.object(coresys.supervisor, "update") as supervisor_update,
+        patch.object(
+            coresys.supervisor, "update", AsyncMock(return_value=None)
+        ) as supervisor_update,
         patch("supervisor.homeassistant.core.asyncio.sleep"),
     ):
         await coresys.homeassistant.core.install()
@@ -327,15 +328,16 @@ async def test_install_supervisor_update_fails_retries(
     assert "Supervisor update failed, retrying in 30sec" in caplog.text
 
 
-async def test_install_supervisor_update_already_in_progress_retries(
+async def test_install_supervisor_update_shares_running_task(
     coresys: CoreSys, caplog: pytest.LogCaptureFixture
 ):
-    """Test install retries after 30s when a supervisor update is already running."""
-    caplog.set_level("DEBUG", "supervisor.homeassistant.core")
-
+    """Test install awaits the shared task when a supervisor update is already running."""
     # Supervisor reports needing update on first pass, not on second
     need_update_values = [True, False]
     need_update_mock = PropertyMock(side_effect=need_update_values)
+
+    async def _already_running_update() -> None:
+        """Simulate the shared, already-in-progress update completing successfully."""
 
     with (
         patch.object(HomeAssistantCore, "start"),
@@ -358,14 +360,21 @@ async def test_install_supervisor_update_already_in_progress_retries(
         patch.object(
             coresys.supervisor,
             "update",
-            side_effect=SupervisorJobError("update already running"),
-        ),
-        patch("supervisor.homeassistant.core.asyncio.sleep") as sleep,
+            AsyncMock(
+                return_value=asyncio.get_event_loop().create_task(
+                    _already_running_update()
+                )
+            ),
+        ) as supervisor_update,
+        patch("supervisor.homeassistant.core.asyncio.sleep"),
     ):
         await coresys.homeassistant.core.install()
-        sleep.assert_any_await(30)
+        supervisor_update.assert_awaited_once()
 
-    assert "Supervisor update is already in progress, waiting 30sec" in caplog.text
+    assert (
+        "Supervisor has a pending update and must be updated before installing Home Assistant Core"
+        in caplog.text
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/misc/test_tasks.py
+++ b/tests/misc/test_tasks.py
@@ -175,37 +175,6 @@ async def test_watchdog_homeassistant_api_reanimation_limit(
         rebuild.assert_not_called()
 
 
-@pytest.mark.usefixtures("no_job_throttle", "supervisor_internet")
-async def test_reload_updater_triggers_supervisor_update(
-    tasks: Tasks, coresys: CoreSys, mock_update_data: MockResponse
-):
-    """Test an updater reload triggers a supervisor update if there is one."""
-    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
-    await coresys.core.set_state(CoreState.RUNNING)
-
-    with (
-        patch.object(
-            Supervisor,
-            "version",
-            new=PropertyMock(return_value=AwesomeVersion("2024.10.0")),
-        ),
-        patch.object(Supervisor, "update") as update,
-    ):
-        # Set supervisor's version initially
-        await coresys.updater.reload()
-        assert coresys.supervisor.latest_version == AwesomeVersion("2024.10.0")
-
-        # No change in version means no update
-        await tasks._reload_updater()
-        update.assert_not_called()
-
-        # Version change causes an update
-        version_data = await mock_update_data.text()
-        mock_update_data.update_text(version_data.replace("2024.10.0", "2024.10.1"))
-        await tasks._reload_updater()
-        update.assert_called_once()
-
-
 @pytest.mark.usefixtures("path_extern", "tmp_supervisor_data")
 async def test_core_backup_cleanup(tasks: Tasks, coresys: CoreSys):
     """Test core backup task cleans up old backup files."""
@@ -249,12 +218,7 @@ async def test_update_dns_skipped_when_auto_update_disabled(
 async def test_scheduled_reload_updater_triggers_one_supervisor_update(
     tasks: Tasks, coresys: CoreSys, mock_update_data: MockResponse
 ):
-    """Test scheduled reload updater triggers exactly one supervisor update.
-
-    Regression test: previously _update_supervisor ran on a separate schedule
-    in addition to being called from _reload_updater, causing duplicate updates.
-    Now only _reload_updater triggers the supervisor auto-update.
-    """
+    """Test the scheduled updater reload triggers exactly one supervisor update."""
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     await coresys.core.set_state(CoreState.RUNNING)
 
@@ -290,6 +254,11 @@ async def test_scheduled_reload_updater_triggers_one_supervisor_update(
                 t.job for t in coresys.scheduler._tasks if t.job and not t.job.done()
             ]
             await asyncio.gather(*pending)
+
+            # The updater reload starts the supervisor update as a separate task
+            async with asyncio.timeout(5):
+                while not update.called:
+                    await asyncio.sleep(0)
 
             # Verify update was triggered exactly once
             update.assert_called_once()

--- a/tests/misc/test_tasks.py
+++ b/tests/misc/test_tasks.py
@@ -255,7 +255,6 @@ async def test_scheduled_reload_updater_triggers_one_supervisor_update(
             ]
             await asyncio.gather(*pending)
 
-            # The updater reload starts the supervisor update as a separate task
             async with asyncio.timeout(5):
                 while not update.called:
                     await asyncio.sleep(0)

--- a/tests/os/test_manager.py
+++ b/tests/os/test_manager.py
@@ -33,7 +33,9 @@ async def test_ota_url_generic_x86_64_rename(
     """Test download URL generated."""
     coresys.os._board = "intel-nuc"
     coresys.os._version = AwesomeVersion("5.13")
-    await coresys.updater.fetch_data()
+    task = await coresys.updater.fetch_data()
+    assert task
+    await task
 
     version6 = AwesomeVersion("6.0")
     url = coresys.updater.ota_url.format(

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -15,6 +15,7 @@ from supervisor.docker.supervisor import DockerSupervisor
 from supervisor.exceptions import (
     DockerError,
     SupervisorAppArmorError,
+    SupervisorJobError,
     SupervisorUpdateError,
 )
 from supervisor.host.apparmor import AppArmorControl
@@ -225,6 +226,35 @@ async def test_update_failed(coresys: CoreSys, capture_exception: Mock):
         Issue(IssueType.UPDATE_FAILED, ContextType.SUPERVISOR)
         in coresys.resolution.issues
     )
+
+
+async def test_update_rejects_concurrent_update(coresys: CoreSys):
+    """Test a second update request is rejected while an update is running."""
+    # pylint: disable-next=protected-access
+    coresys.updater._data.setdefault("image", {})["supervisor"] = (
+        "ghcr.io/home-assistant/aarch64-hassio-supervisor"
+    )
+    install_started = asyncio.Event()
+    install_finish = asyncio.Event()
+
+    async def install(*args, **kwargs):
+        install_started.set()
+        await install_finish.wait()
+
+    with (
+        patch.object(DockerSupervisor, "install", side_effect=install),
+        patch.object(DockerSupervisor, "update_start_tag"),
+        patch.object(type(coresys.supervisor), "update_apparmor"),
+        patch.object(type(coresys.core), "stop"),
+    ):
+        first = asyncio.create_task(coresys.supervisor.update(AwesomeVersion("1.0")))
+        await install_started.wait()
+
+        with pytest.raises(SupervisorJobError):
+            await coresys.supervisor.update(AwesomeVersion("1.0"))
+
+        install_finish.set()
+        await first
 
 
 @pytest.mark.parametrize(

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -15,7 +15,6 @@ from supervisor.docker.supervisor import DockerSupervisor
 from supervisor.exceptions import (
     DockerError,
     SupervisorAppArmorError,
-    SupervisorJobError,
     SupervisorUpdateError,
 )
 from supervisor.host.apparmor import AppArmorControl
@@ -217,9 +216,11 @@ async def test_update_failed(coresys: CoreSys, capture_exception: Mock):
     with (
         patch.object(DockerSupervisor, "install", side_effect=err),
         patch.object(type(coresys.supervisor), "update_apparmor"),
-        pytest.raises(SupervisorUpdateError),
     ):
-        await coresys.supervisor.update(AwesomeVersion("1.0"))
+        task = await coresys.supervisor.update(AwesomeVersion("1.0"))
+        assert task
+        with pytest.raises(SupervisorUpdateError):
+            await task
 
     capture_exception.assert_called_once_with(err)
     assert (
@@ -228,8 +229,8 @@ async def test_update_failed(coresys: CoreSys, capture_exception: Mock):
     )
 
 
-async def test_update_rejects_concurrent_update(coresys: CoreSys):
-    """Test a second update request is rejected while an update is running."""
+async def test_update_returns_running_task_for_concurrent_call(coresys: CoreSys):
+    """Test a second update call while one is running gets back the same task."""
     # pylint: disable-next=protected-access
     coresys.updater._data.setdefault("image", {})["supervisor"] = (
         "ghcr.io/home-assistant/aarch64-hassio-supervisor"
@@ -247,14 +248,16 @@ async def test_update_rejects_concurrent_update(coresys: CoreSys):
         patch.object(type(coresys.supervisor), "update_apparmor"),
         patch.object(type(coresys.core), "stop"),
     ):
-        first = asyncio.create_task(coresys.supervisor.update(AwesomeVersion("1.0")))
+        first_task = await coresys.supervisor.update(AwesomeVersion("1.0"))
         await install_started.wait()
+        assert first_task
+        assert not first_task.done()
 
-        with pytest.raises(SupervisorJobError):
-            await coresys.supervisor.update(AwesomeVersion("1.0"))
+        second_task = await coresys.supervisor.update(AwesomeVersion("1.0"))
+        assert second_task is first_task
 
         install_finish.set()
-        await first
+        await first_task
 
 
 @pytest.mark.parametrize(

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -227,7 +227,7 @@ async def test_reload_triggers_supervisor_update(
     update_done = asyncio.Event()
 
     async def find_update_job_end(job: SupervisorJob):
-        if job.name == "tasks_update_supervisor":
+        if job.name == "supervisor_auto_update":
             update_done.set()
 
     coresys.bus.register_event(BusEvent.SUPERVISOR_JOB_END, find_update_job_end)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -30,7 +30,9 @@ async def test_fetch_versions(
     """Test download and sync version."""
 
     coresys.security.force = True
-    await coresys.updater.fetch_data()
+    task = await coresys.updater.fetch_data()
+    assert task
+    await task
 
     data = json.loads(await mock_update_data.text())
     assert coresys.updater.version_supervisor == data["supervisor"]
@@ -87,7 +89,9 @@ async def test_os_update_path(
     """Test OS upgrade path across major versions."""
     coresys.os._board = "rpi4-64"  # pylint: disable=protected-access
     coresys.os._version = AwesomeVersion(version)  # pylint: disable=protected-access
-    await coresys.updater.fetch_data()
+    task = await coresys.updater.fetch_data()
+    assert task
+    await task
 
     assert coresys.updater.version_hassos == AwesomeVersion(expected)
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -224,7 +224,6 @@ async def test_reload_triggers_supervisor_update(
     coresys.hardware.disk.get_disk_free_space = lambda x: 5000
     await coresys.core.set_state(CoreState.RUNNING)
 
-    # The update runs as a separate task, wait for its job to finish
     update_done = asyncio.Event()
 
     async def find_update_job_end(job: SupervisorJob):
@@ -241,13 +240,11 @@ async def test_reload_triggers_supervisor_update(
         ),
         patch.object(Supervisor, "update") as update,
     ):
-        # No newer version means no update
         await coresys.updater.reload()
         assert coresys.supervisor.latest_version == AwesomeVersion("2024.10.0")
         await asyncio.sleep(0)
         update.assert_not_called()
 
-        # A newer version starts an update
         version_data = await mock_update_data.text()
         mock_update_data.update_text(version_data.replace("2024.10.0", "2024.10.1"))
         await coresys.updater.reload()

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -2,17 +2,18 @@
 
 import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from awesomeversion import AwesomeVersion
 import pytest
 
-from supervisor.const import ATTR_HASSOS_UNRESTRICTED, BusEvent
+from supervisor.const import ATTR_HASSOS_UNRESTRICTED, BusEvent, CoreState
 from supervisor.coresys import CoreSys
 from supervisor.dbus.const import ConnectivityState
 from supervisor.exceptions import UpdaterJobError
 from supervisor.jobs import SupervisorJob
 from supervisor.resolution.const import UnsupportedReason
+from supervisor.supervisor import Supervisor
 
 from tests.common import MockResponse, load_binary_fixture
 from tests.dbus_service_mocks.network_manager import (
@@ -213,3 +214,68 @@ async def test_fetch_data_no_update_when_os_unsupported(
     assert coresys.updater.version_supervisor == initial_supervisor_version
     assert coresys.updater.version_homeassistant == initial_homeassistant_version
     assert coresys.updater.version_hassos == initial_hassos_version
+
+
+@pytest.mark.usefixtures("no_job_throttle", "supervisor_internet")
+async def test_reload_triggers_supervisor_update(
+    coresys: CoreSys, mock_update_data: MockResponse
+) -> None:
+    """Test a reload starts the supervisor update when a newer version is found."""
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    await coresys.core.set_state(CoreState.RUNNING)
+
+    # The update runs as a separate task, wait for its job to finish
+    update_done = asyncio.Event()
+
+    async def find_update_job_end(job: SupervisorJob):
+        if job.name == "tasks_update_supervisor":
+            update_done.set()
+
+    coresys.bus.register_event(BusEvent.SUPERVISOR_JOB_END, find_update_job_end)
+
+    with (
+        patch.object(
+            Supervisor,
+            "version",
+            new=PropertyMock(return_value=AwesomeVersion("2024.10.0")),
+        ),
+        patch.object(Supervisor, "update") as update,
+    ):
+        # No newer version means no update
+        await coresys.updater.reload()
+        assert coresys.supervisor.latest_version == AwesomeVersion("2024.10.0")
+        await asyncio.sleep(0)
+        update.assert_not_called()
+
+        # A newer version starts an update
+        version_data = await mock_update_data.text()
+        mock_update_data.update_text(version_data.replace("2024.10.0", "2024.10.1"))
+        await coresys.updater.reload()
+        async with asyncio.timeout(5):
+            await update_done.wait()
+        update.assert_called_once()
+
+
+@pytest.mark.usefixtures("no_job_throttle", "supervisor_internet")
+async def test_reload_skips_supervisor_update_during_startup(
+    coresys: CoreSys, mock_update_data: MockResponse
+) -> None:
+    """Test a reload during startup leaves the supervisor update to the startup."""
+    coresys.hardware.disk.get_disk_free_space = lambda x: 5000
+    await coresys.core.set_state(CoreState.STARTUP)
+
+    version_data = await mock_update_data.text()
+    mock_update_data.update_text(version_data.replace("2024.10.0", "2024.10.1"))
+
+    with (
+        patch.object(
+            Supervisor,
+            "version",
+            new=PropertyMock(return_value=AwesomeVersion("2024.10.0")),
+        ),
+        patch.object(Supervisor, "update") as update,
+    ):
+        await coresys.updater.reload()
+        assert coresys.supervisor.need_update
+        await asyncio.sleep(0)
+        update.assert_not_called()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A pending Supervisor update blocks Core, OS and app updates through the `SUPERVISOR_UPDATED` job condition. Only startup and the daily scheduled reload started the auto update. Every other reload, such as the one Core requests when the user opens Settings, made the new version known without installing it. The user then saw `supervisor needs to be updated first` until the daily task ran.

The updater now starts the auto update after every reload while the system is running. `Supervisor.auto_update_supervisor()` was moved out of the scheduled task so it can be reused, and it now returns the task performing the update instead of firing-and-forgetting it, so callers can check whether an update is genuinely in progress instead of guessing from `need_update`.

This surfaced a few related problems that are fixed here as well:

- **API update requests during an in-progress auto update**: `Supervisor.update()` is now a detached job (using the `detach` option added to the Job decorator in #7211). A concurrent call - whether a manual update request or the auto update - returns the same in-progress task instead of raising `SupervisorJobError`, so `auto_update_supervisor()` and manual update requests always share one real task regardless of who started it. The update API and the Home Assistant Core install retry loop now await that returned task directly, so they reflect its real outcome (the caller sees the Supervisor restart it triggers) instead of surfacing an update-failed error.
- **Restoring a backup that requires a newer Supervisor version**: this previously always returned the same generic error, even if an update was about to happen automatically. It now raises a specific, translatable `BackupSupervisorVersionError` (400) when auto update is disabled or unavailable, or `BackupSupervisorUpdateInProgressError` (503) telling the caller to retry once an update is under way. Before deciding, the version data is refreshed (if there's connectivity) in case a newer Supervisor was just released, so the check isn't based on stale data.
- **Version fetch throttling could mask a needed refresh**: `Updater.fetch_data()` is throttled and records its throttle window even when a fetch fails, so a caller checking for fresh data right after a concurrent/failed fetch could be silently skipped. `fetch_data()` is now a detached job as well: a call while one is already in-flight returns that same task instead of starting a redundant fetch, so `reload()` and the backup restore version check above can await it directly to get the real outcome instead of relying on the throttle window.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAWqYzDiFEvYjZwfBWoxkC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAWqYzDiFEvYjZwfBWoxkC)_
