### PR TITLE
Fix backup cleanup after begin failure

### DIFF
--- a/supervisor/homeassistant/module.py
+++ b/supervisor/homeassistant/module.py
@@ -500,8 +500,8 @@ class HomeAssistant(FileConfiguration, CoreSysAttributes):
                         _LOGGER.error,
                     ) from err
 
-        await self.begin_backup()
         try:
+            await self.begin_backup()
             _LOGGER.info("Backing up Home Assistant Core config folder")
             await self.sys_run_in_executor(_write_tarfile, self._data)
             _LOGGER.info("Backup Home Assistant Core config folder done")

--- a/tests/homeassistant/test_module.py
+++ b/tests/homeassistant/test_module.py
@@ -7,6 +7,7 @@ from pathlib import Path, PurePath
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from securetar import SecureTarFile
 
 from supervisor.backups.backup import Backup
 from supervisor.backups.const import BackupType
@@ -109,6 +110,22 @@ async def test_begin_backup_ws_error(coresys: CoreSys):
         ),
     ):
         await coresys.homeassistant.begin_backup()
+
+
+async def test_backup_begin_error_ends_backup(coresys: CoreSys, tmp_path: Path):
+    """Test backup cleanup runs when beginning the backup fails."""
+    error = HomeAssistantBackupError("Backup start rejected")
+    with (
+        patch.object(
+            HomeAssistant, "begin_backup", new_callable=AsyncMock, side_effect=error
+        ),
+        patch.object(HomeAssistant, "end_backup", new_callable=AsyncMock) as end_backup,
+        pytest.raises(HomeAssistantBackupError) as exc_info,
+    ):
+        await coresys.homeassistant.backup(SecureTarFile(tmp_path / "backup.tar"))
+
+    assert exc_info.value is error
+    end_backup.assert_awaited_once_with()
 
 
 async def test_end_backup_ws_error(coresys: CoreSys, caplog: pytest.LogCaptureFixture):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Move `begin_backup()` inside the existing `try`/`finally` in
`HomeAssistant.backup()`.

If a pre-backup hook fails after an earlier hook has already paused a
subsystem, the current code raises before entering the cleanup `finally`.
This change ensures `end_backup()` runs for that partial-start case while
preserving the original error. A regression test covers the behavior.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/
