### PR TITLE
Reinstall the stored Core version when its image is lost

### DIFF
--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -26,6 +26,7 @@ from ..exceptions import (
     DockerContainerNotFoundError,
     DockerContainerNotRunningError,
     DockerError,
+    DockerRegistryRateLimitExceeded,
     DockerStatsTimeoutError,
     HomeAssistantCrashError,
     HomeAssistantError,
@@ -103,10 +104,11 @@ class HomeAssistantCore(JobGroup):
             BusEvent.SUPERVISOR_STATE_CHANGE, self._supervisor_state_changed
         )
 
+        stored_version = self.sys_homeassistant.version
         try:
             # Evaluate Version if we lost this information
-            if self.sys_homeassistant.version:
-                version = self.sys_homeassistant.version
+            if stored_version:
+                version = stored_version
             else:
                 self.sys_homeassistant.version = (
                     version
@@ -124,6 +126,15 @@ class HomeAssistantCore(JobGroup):
             _LOGGER.info(
                 "No Home Assistant Docker image %s found.", self.sys_homeassistant.image
             )
+            # The image of an installed Core got lost (e.g. Docker storage was
+            # wiped). Reinstall that version instead of installing the latest
+            # release through the landingpage.
+            if (
+                stored_version
+                and stored_version != LANDINGPAGE
+                and await self._reinstall(stored_version)
+            ):
+                return
             await self.install_landingpage()
         else:
             self.sys_homeassistant.version = self.instance.version or version
@@ -189,6 +200,63 @@ class HomeAssistantCore(JobGroup):
         self.sys_homeassistant.set_image(install_image)
         await self.sys_homeassistant.save_data()
 
+    async def _periodic_progress_log(self, stop: asyncio.Event) -> None:
+        """Log installation progress periodically for user visibility."""
+        while not stop.is_set():
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=15)
+            except TimeoutError:
+                if (job := self.instance.active_job) and job.progress:
+                    _LOGGER.info(
+                        "Downloading Home Assistant Core image, %d%%",
+                        int(job.progress),
+                    )
+                else:
+                    _LOGGER.info("Home Assistant Core installation in progress")
+
+    async def _reinstall(self, version: AwesomeVersion) -> bool:
+        """Reinstall the lost image of an installed Home Assistant version.
+
+        Return False if the image could not be pulled.
+        """
+        image = (
+            self.sys_homeassistant.image
+            if self.sys_homeassistant.override_image
+            else self.sys_homeassistant.default_image
+        )
+        _LOGGER.info("Reinstalling Home Assistant %s", version)
+        stop_progress_log = asyncio.Event()
+        progress_task = self.sys_create_task(
+            self._periodic_progress_log(stop_progress_log)
+        )
+        try:
+            while True:
+                try:
+                    await self.instance.install(version, image=image)
+                    break
+                except DockerRegistryRateLimitExceeded:
+                    _LOGGER.warning(
+                        "Rate limit reached while reinstalling Home Assistant,"
+                        " retrying in %ssec",
+                        INSTALL_RETRY_WAIT_SECS,
+                    )
+                    await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
+                except DockerError, JobException:
+                    _LOGGER.warning(
+                        "Could not reinstall Home Assistant %s,"
+                        " installing latest version instead",
+                        version,
+                    )
+                    return False
+        finally:
+            stop_progress_log.set()
+            await progress_task
+
+        self.sys_homeassistant.version = self.instance.version or version
+        self.sys_homeassistant.set_image(image)
+        await self.sys_homeassistant.save_data()
+        return True
+
     @Job(
         name="home_assistant_core_install",
         on_condition=HomeAssistantJobError,
@@ -211,22 +279,9 @@ class HomeAssistantCore(JobGroup):
         """Install Home Assistant Core."""
         _LOGGER.info("Home Assistant setup")
         stop_progress_log = asyncio.Event()
-
-        async def _periodic_progress_log() -> None:
-            """Log installation progress periodically for user visibility."""
-            while not stop_progress_log.is_set():
-                try:
-                    await asyncio.wait_for(stop_progress_log.wait(), timeout=15)
-                except TimeoutError:
-                    if (job := self.instance.active_job) and job.progress:
-                        _LOGGER.info(
-                            "Downloading Home Assistant Core image, %d%%",
-                            int(job.progress),
-                        )
-                    else:
-                        _LOGGER.info("Home Assistant Core installation in progress")
-
-        progress_task = self.sys_create_task(_periodic_progress_log())
+        progress_task = self.sys_create_task(
+            self._periodic_progress_log(stop_progress_log)
+        )
         install_image: str | None = None
         try:
             while True:

--- a/supervisor/homeassistant/core.py
+++ b/supervisor/homeassistant/core.py
@@ -172,16 +172,8 @@ class HomeAssistantCore(JobGroup):
             return
 
         _LOGGER.info("Setting up Home Assistant landingpage")
+        install_image = self.sys_homeassistant.install_image
         while True:
-            if not (install_image := self.sys_homeassistant.install_image):
-                _LOGGER.warning(
-                    "Updater has no Home Assistant image information yet. Retrying in %ssec",
-                    INSTALL_RETRY_WAIT_SECS,
-                )
-                await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
-                await self.sys_updater.reload()
-                continue
-
             try:
                 await self.instance.install(LANDINGPAGE, image=install_image)
                 break
@@ -200,57 +192,31 @@ class HomeAssistantCore(JobGroup):
         self.sys_homeassistant.set_image(install_image)
         await self.sys_homeassistant.save_data()
 
-    async def _periodic_progress_log(self, stop: asyncio.Event) -> None:
-        """Log installation progress periodically for user visibility."""
-        while not stop.is_set():
-            try:
-                await asyncio.wait_for(stop.wait(), timeout=15)
-            except TimeoutError:
-                if (job := self.instance.active_job) and job.progress:
-                    _LOGGER.info(
-                        "Downloading Home Assistant Core image, %d%%",
-                        int(job.progress),
-                    )
-                else:
-                    _LOGGER.info("Home Assistant Core installation in progress")
-
     async def _reinstall(self, version: AwesomeVersion) -> bool:
         """Reinstall the lost image of an installed Home Assistant version.
 
         Return False if the image could not be pulled.
         """
-        image = (
-            self.sys_homeassistant.image
-            if self.sys_homeassistant.override_image
-            else self.sys_homeassistant.default_image
-        )
+        image = self.sys_homeassistant.install_image
         _LOGGER.info("Reinstalling Home Assistant %s", version)
-        stop_progress_log = asyncio.Event()
-        progress_task = self.sys_create_task(
-            self._periodic_progress_log(stop_progress_log)
-        )
-        try:
-            while True:
-                try:
-                    await self.instance.install(version, image=image)
-                    break
-                except DockerRegistryRateLimitExceeded:
-                    _LOGGER.warning(
-                        "Rate limit reached while reinstalling Home Assistant,"
-                        " retrying in %ssec",
-                        INSTALL_RETRY_WAIT_SECS,
-                    )
-                    await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
-                except DockerError, JobException:
-                    _LOGGER.warning(
-                        "Could not reinstall Home Assistant %s,"
-                        " installing latest version instead",
-                        version,
-                    )
-                    return False
-        finally:
-            stop_progress_log.set()
-            await progress_task
+        while True:
+            try:
+                await self.instance.install(version, image=image)
+                break
+            except DockerRegistryRateLimitExceeded:
+                _LOGGER.warning(
+                    "Rate limit reached while reinstalling Home Assistant,"
+                    " retrying in %ssec",
+                    INSTALL_RETRY_WAIT_SECS,
+                )
+                await asyncio.sleep(INSTALL_RETRY_WAIT_SECS)
+            except DockerError, JobException:
+                _LOGGER.warning(
+                    "Could not reinstall Home Assistant %s,"
+                    " installing latest version instead",
+                    version,
+                )
+                return False
 
         self.sys_homeassistant.version = self.instance.version or version
         self.sys_homeassistant.set_image(image)
@@ -279,10 +245,23 @@ class HomeAssistantCore(JobGroup):
         """Install Home Assistant Core."""
         _LOGGER.info("Home Assistant setup")
         stop_progress_log = asyncio.Event()
-        progress_task = self.sys_create_task(
-            self._periodic_progress_log(stop_progress_log)
-        )
-        install_image: str | None = None
+
+        async def _periodic_progress_log() -> None:
+            """Log installation progress periodically for user visibility."""
+            while not stop_progress_log.is_set():
+                try:
+                    await asyncio.wait_for(stop_progress_log.wait(), timeout=15)
+                except TimeoutError:
+                    if (job := self.instance.active_job) and job.progress:
+                        _LOGGER.info(
+                            "Downloading Home Assistant Core image, %d%%",
+                            int(job.progress),
+                        )
+                    else:
+                        _LOGGER.info("Home Assistant Core installation in progress")
+
+        progress_task = self.sys_create_task(_periodic_progress_log())
+        install_image = self.sys_homeassistant.install_image
         try:
             while True:
                 # read homeassistant tag and install it

--- a/supervisor/homeassistant/module.py
+++ b/supervisor/homeassistant/module.py
@@ -229,15 +229,15 @@ class HomeAssistant(FileConfiguration, CoreSysAttributes):
         self._data[ATTR_OVERRIDE_IMAGE] = value
 
     @property
-    def install_image(self) -> str | None:
+    def install_image(self) -> str:
         """Return image to pull when installing or updating Home Assistant Core.
 
         Uses the user-overridden image if set, otherwise the image from the
-        update information.
+        update information, falling back to the default image for this system.
         """
         if self.override_image:
             return self.image
-        return self.sys_updater.image_homeassistant
+        return self.sys_updater.image_homeassistant or self.default_image
 
     @property
     def version(self) -> AwesomeVersion | None:

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -22,6 +22,7 @@ from supervisor.exceptions import (
     DockerContainerNotFoundError,
     DockerContainerNotRunningError,
     DockerError,
+    DockerHubRateLimitExceeded,
     DockerStatsTimeoutError,
     HomeAssistantCrashError,
     HomeAssistantError,
@@ -1009,3 +1010,126 @@ async def test_core_loads_wrong_image_for_architecture(
     assert (
         coresys.homeassistant.image == "ghcr.io/home-assistant/qemux86-64-homeassistant"
     )
+
+
+async def test_load_missing_image_reinstalls_stored_version(
+    coresys: CoreSys, caplog: pytest.LogCaptureFixture
+):
+    """Test a lost image of an installed Core is reinstalled at the same version.
+
+    When the Docker storage is wiped (e.g. storage driver migration) the image
+    of the installed Core is gone. Supervisor must reinstall the version that
+    was installed before instead of jumping to the latest release, and it
+    must not install the landingpage in between.
+    """
+    coresys.homeassistant.version = AwesomeVersion("2026.2.3")
+
+    with (
+        patch.object(DockerHomeAssistant, "attach", side_effect=DockerError()),
+        patch.object(DockerHomeAssistant, "install") as install,
+        patch.object(HomeAssistantCore, "install_landingpage") as install_landingpage,
+        patch.object(HomeAssistantCore, "start") as start,
+    ):
+        await coresys.homeassistant.core.load()
+
+    install.assert_called_once_with(
+        AwesomeVersion("2026.2.3"),
+        image="ghcr.io/home-assistant/qemux86-64-homeassistant",
+    )
+    install_landingpage.assert_not_called()
+    start.assert_not_called()
+    assert coresys.homeassistant.version == AwesomeVersion("2026.2.3")
+    assert "Reinstalling Home Assistant 2026.2.3" in caplog.text
+
+
+async def test_load_missing_image_reinstall_uses_overridden_image(coresys: CoreSys):
+    """Test reinstalling a lost Core image pulls the user-overridden image."""
+    coresys.homeassistant.version = AwesomeVersion("2026.2.3")
+    coresys.homeassistant.set_image("myorg/qemux86-64-homeassistant")
+    coresys.homeassistant.override_image = True
+
+    with (
+        patch.object(DockerHomeAssistant, "attach", side_effect=DockerError()),
+        patch.object(DockerHomeAssistant, "install") as install,
+        patch.object(HomeAssistantCore, "install_landingpage"),
+    ):
+        await coresys.homeassistant.core.load()
+
+    install.assert_called_once_with(
+        AwesomeVersion("2026.2.3"), image="myorg/qemux86-64-homeassistant"
+    )
+    assert coresys.homeassistant.image == "myorg/qemux86-64-homeassistant"
+
+
+@pytest.mark.parametrize("stored_version", [None, LANDINGPAGE])
+async def test_load_missing_image_fresh_install_uses_landingpage(
+    coresys: CoreSys, stored_version: AwesomeVersion | None
+):
+    """Test a new installation still goes through the landingpage."""
+    coresys.homeassistant.version = stored_version
+
+    with (
+        patch.object(DockerHomeAssistant, "attach", side_effect=DockerError()),
+        patch.object(
+            DockerHomeAssistant, "get_latest_version", side_effect=DockerError()
+        ),
+        patch.object(
+            DockerHomeAssistant, "version", new=PropertyMock(return_value=LANDINGPAGE)
+        ),
+        patch.object(DockerHomeAssistant, "install") as install,
+        patch.object(HomeAssistantCore, "install_landingpage") as install_landingpage,
+        patch.object(HomeAssistantCore, "start"),
+    ):
+        await coresys.homeassistant.core.load()
+
+    install.assert_not_called()
+    install_landingpage.assert_called_once()
+
+
+async def test_load_missing_image_falls_back_to_landingpage(
+    coresys: CoreSys, caplog: pytest.LogCaptureFixture
+):
+    """Test load falls back to the landingpage if the stored version can't be pulled."""
+    coresys.homeassistant.version = AwesomeVersion("2026.2.3")
+
+    with (
+        patch.object(DockerHomeAssistant, "attach", side_effect=DockerError()),
+        patch.object(DockerHomeAssistant, "install", side_effect=DockerError()),
+        patch.object(
+            DockerHomeAssistant, "version", new=PropertyMock(return_value=LANDINGPAGE)
+        ),
+        patch.object(HomeAssistantCore, "install_landingpage") as install_landingpage,
+        patch.object(HomeAssistantCore, "start"),
+    ):
+        await coresys.homeassistant.core.load()
+
+    install_landingpage.assert_called_once()
+    assert (
+        "Could not reinstall Home Assistant 2026.2.3, installing latest version instead"
+        in caplog.text
+    )
+
+
+async def test_load_missing_image_reinstall_retries_on_ratelimit(
+    coresys: CoreSys, caplog: pytest.LogCaptureFixture
+):
+    """Test a registry rate limit retries the reinstall instead of falling back."""
+    coresys.homeassistant.version = AwesomeVersion("2026.2.3")
+
+    with (
+        patch.object(DockerHomeAssistant, "attach", side_effect=DockerError()),
+        patch.object(
+            DockerHomeAssistant,
+            "install",
+            side_effect=[DockerHubRateLimitExceeded(), None],
+        ) as install,
+        patch.object(HomeAssistantCore, "install_landingpage") as install_landingpage,
+        patch("supervisor.homeassistant.core.asyncio.sleep") as sleep,
+    ):
+        await coresys.homeassistant.core.load()
+        sleep.assert_awaited_once_with(30)
+
+    assert install.call_count == 2
+    install_landingpage.assert_not_called()
+    assert coresys.homeassistant.version == AwesomeVersion("2026.2.3")
+    assert "Could not reinstall" not in caplog.text

--- a/tests/homeassistant/test_core.py
+++ b/tests/homeassistant/test_core.py
@@ -22,7 +22,6 @@ from supervisor.exceptions import (
     DockerContainerNotFoundError,
     DockerContainerNotRunningError,
     DockerError,
-    DockerHubRateLimitExceeded,
     DockerStatsTimeoutError,
     HomeAssistantCrashError,
     HomeAssistantError,
@@ -1012,6 +1011,14 @@ async def test_core_loads_wrong_image_for_architecture(
     )
 
 
+def _lose_core_image(coresys: CoreSys) -> None:
+    """Make Docker report neither a Core container nor a Core image."""
+    not_found = aiodocker.DockerError(HTTPStatus.NOT_FOUND, {"message": "missing"})
+    coresys.docker.containers.container.return_value.show.side_effect = not_found
+    coresys.docker.images.inspect.side_effect = not_found
+    coresys.docker.images.list.return_value = []
+
+
 async def test_load_missing_image_reinstalls_stored_version(
     coresys: CoreSys, caplog: pytest.LogCaptureFixture
 ):
@@ -1023,22 +1030,30 @@ async def test_load_missing_image_reinstalls_stored_version(
     must not install the landingpage in between.
     """
     coresys.homeassistant.version = AwesomeVersion("2026.2.3")
+    _lose_core_image(coresys)
 
-    with (
-        patch.object(DockerHomeAssistant, "attach", side_effect=DockerError()),
-        patch.object(DockerHomeAssistant, "install") as install,
-        patch.object(HomeAssistantCore, "install_landingpage") as install_landingpage,
-        patch.object(HomeAssistantCore, "start") as start,
-    ):
+    with patch.object(
+        DockerAPI,
+        "pull_image",
+        return_value={
+            "Id": "abc123",
+            "Config": {"Labels": {"io.hass.version": "2026.2.3"}},
+        },
+    ) as pull_image:
         await coresys.homeassistant.core.load()
 
-    install.assert_called_once_with(
-        AwesomeVersion("2026.2.3"),
-        image="ghcr.io/home-assistant/qemux86-64-homeassistant",
+    pull_image.assert_called_once_with(
+        ANY,
+        "ghcr.io/home-assistant/qemux86-64-homeassistant",
+        "2026.2.3",
+        platform="linux/amd64",
+        auth=None,
     )
-    install_landingpage.assert_not_called()
-    start.assert_not_called()
+    coresys.docker.containers.create.assert_not_called()
     assert coresys.homeassistant.version == AwesomeVersion("2026.2.3")
+    assert (
+        coresys.homeassistant.image == "ghcr.io/home-assistant/qemux86-64-homeassistant"
+    )
     assert "Reinstalling Home Assistant 2026.2.3" in caplog.text
 
 
@@ -1047,63 +1062,102 @@ async def test_load_missing_image_reinstall_uses_overridden_image(coresys: CoreS
     coresys.homeassistant.version = AwesomeVersion("2026.2.3")
     coresys.homeassistant.set_image("myorg/qemux86-64-homeassistant")
     coresys.homeassistant.override_image = True
+    _lose_core_image(coresys)
 
-    with (
-        patch.object(DockerHomeAssistant, "attach", side_effect=DockerError()),
-        patch.object(DockerHomeAssistant, "install") as install,
-        patch.object(HomeAssistantCore, "install_landingpage"),
-    ):
+    with patch.object(
+        DockerAPI,
+        "pull_image",
+        return_value={
+            "Id": "abc123",
+            "Config": {"Labels": {"io.hass.version": "2026.2.3"}},
+        },
+    ) as pull_image:
         await coresys.homeassistant.core.load()
 
-    install.assert_called_once_with(
-        AwesomeVersion("2026.2.3"), image="myorg/qemux86-64-homeassistant"
+    pull_image.assert_called_once_with(
+        ANY,
+        "myorg/qemux86-64-homeassistant",
+        "2026.2.3",
+        platform="linux/amd64",
+        auth=None,
     )
     assert coresys.homeassistant.image == "myorg/qemux86-64-homeassistant"
 
 
 @pytest.mark.parametrize("stored_version", [None, LANDINGPAGE])
+@pytest.mark.usefixtures("path_extern")
 async def test_load_missing_image_fresh_install_uses_landingpage(
     coresys: CoreSys, stored_version: AwesomeVersion | None
 ):
     """Test a new installation still goes through the landingpage."""
     coresys.homeassistant.version = stored_version
+    _lose_core_image(coresys)
 
     with (
-        patch.object(DockerHomeAssistant, "attach", side_effect=DockerError()),
         patch.object(
-            DockerHomeAssistant, "get_latest_version", side_effect=DockerError()
-        ),
+            DockerAPI,
+            "pull_image",
+            return_value={
+                "Id": "abc123",
+                "Config": {"Labels": {"io.hass.version": LANDINGPAGE}},
+            },
+        ) as pull_image,
         patch.object(
-            DockerHomeAssistant, "version", new=PropertyMock(return_value=LANDINGPAGE)
+            DockerAPI,
+            "run",
+            return_value={
+                "Id": "abc123",
+                "Config": {"Labels": {"io.hass.type": "landingpage"}},
+                "State": {"Status": "running", "Running": True, "ExitCode": 0},
+            },
         ),
-        patch.object(DockerHomeAssistant, "install") as install,
-        patch.object(HomeAssistantCore, "install_landingpage") as install_landingpage,
-        patch.object(HomeAssistantCore, "start"),
     ):
         await coresys.homeassistant.core.load()
 
-    install.assert_not_called()
-    install_landingpage.assert_called_once()
+    pull_image.assert_called_once_with(
+        ANY,
+        "ghcr.io/home-assistant/qemux86-64-homeassistant",
+        LANDINGPAGE,
+        platform="linux/amd64",
+        auth=None,
+    )
+    assert coresys.homeassistant.version == LANDINGPAGE
 
 
+@pytest.mark.usefixtures("path_extern")
 async def test_load_missing_image_falls_back_to_landingpage(
     coresys: CoreSys, caplog: pytest.LogCaptureFixture
 ):
     """Test load falls back to the landingpage if the stored version can't be pulled."""
     coresys.homeassistant.version = AwesomeVersion("2026.2.3")
+    _lose_core_image(coresys)
 
     with (
-        patch.object(DockerHomeAssistant, "attach", side_effect=DockerError()),
-        patch.object(DockerHomeAssistant, "install", side_effect=DockerError()),
         patch.object(
-            DockerHomeAssistant, "version", new=PropertyMock(return_value=LANDINGPAGE)
+            DockerAPI,
+            "pull_image",
+            side_effect=[
+                aiodocker.DockerError(HTTPStatus.NOT_FOUND, {"message": "missing"}),
+                {
+                    "Id": "abc123",
+                    "Config": {"Labels": {"io.hass.version": LANDINGPAGE}},
+                },
+            ],
+        ) as pull_image,
+        patch.object(
+            DockerAPI,
+            "run",
+            return_value={
+                "Id": "abc123",
+                "Config": {"Labels": {"io.hass.type": "landingpage"}},
+                "State": {"Status": "running", "Running": True, "ExitCode": 0},
+            },
         ),
-        patch.object(HomeAssistantCore, "install_landingpage") as install_landingpage,
-        patch.object(HomeAssistantCore, "start"),
     ):
         await coresys.homeassistant.core.load()
 
-    install_landingpage.assert_called_once()
+    assert [c.args[2] for c in pull_image.call_args_list] == ["2026.2.3", LANDINGPAGE]
+    assert coresys.homeassistant.version == LANDINGPAGE
     assert (
         "Could not reinstall Home Assistant 2026.2.3, installing latest version instead"
         in caplog.text
@@ -1115,21 +1169,27 @@ async def test_load_missing_image_reinstall_retries_on_ratelimit(
 ):
     """Test a registry rate limit retries the reinstall instead of falling back."""
     coresys.homeassistant.version = AwesomeVersion("2026.2.3")
+    _lose_core_image(coresys)
 
     with (
-        patch.object(DockerHomeAssistant, "attach", side_effect=DockerError()),
         patch.object(
-            DockerHomeAssistant,
-            "install",
-            side_effect=[DockerHubRateLimitExceeded(), None],
-        ) as install,
-        patch.object(HomeAssistantCore, "install_landingpage") as install_landingpage,
+            DockerAPI,
+            "pull_image",
+            side_effect=[
+                aiodocker.DockerError(
+                    HTTPStatus.TOO_MANY_REQUESTS, {"message": "ratelimit"}
+                ),
+                {
+                    "Id": "abc123",
+                    "Config": {"Labels": {"io.hass.version": "2026.2.3"}},
+                },
+            ],
+        ) as pull_image,
         patch("supervisor.homeassistant.core.asyncio.sleep") as sleep,
     ):
         await coresys.homeassistant.core.load()
         sleep.assert_awaited_once_with(30)
 
-    assert install.call_count == 2
-    install_landingpage.assert_not_called()
+    assert [c.args[2] for c in pull_image.call_args_list] == ["2026.2.3", "2026.2.3"]
     assert coresys.homeassistant.version == AwesomeVersion("2026.2.3")
     assert "Could not reinstall" not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When the Docker storage is wiped, for example by the containerd snapshotter migration on Home Assistant OS 17 (`ha docker migrate-storage-driver`) or a Docker storage reset, the image of the installed Home Assistant Core is gone. On the next start Supervisor treated this like a fresh installation: it installed the landingpage and then pulled the latest Core release. Users on an older Core unexpectedly ended up on the newest release, see the reports linked below.

This PR remembers the stored Core version in `HomeAssistantCore.load()`. If the image is missing and a real version is stored, Supervisor now pulls exactly that version directly, without going through the landingpage. Core is then started by the regular startup sequence once the image is present. Apps already behave this way through the repair path.

A registry rate limit retries the pull, like the landingpage install does. Any other pull failure, for example a version that is no longer published, logs a warning and falls back to the existing landingpage flow, which installs the latest release. New installations, where no version is stored, are unaffected.

The `install_image` property now falls back to the default image for this system when the updater has no image information yet, so all Core install paths select the image the same way. This makes the wait-for-updater loop in the landingpage install obsolete.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/operating-system/discussions/4867#discussioncomment-17953296 and https://github.com/home-assistant/operating-system/discussions/4487#discussioncomment-15566751
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
