### PR TITLE
Evaluate synchronous job conditions before awaiting ones

### DIFF
--- a/supervisor/jobs/decorator.py
+++ b/supervisor/jobs/decorator.py
@@ -382,6 +382,9 @@ class Job(CoreSysAttributes):
         coresys: CoreSysAttributes, conditions: set[JobCondition], method_name: str
     ):
         """Check conditions."""
+        # Evaluation order: synchronous state reads first, checks that await
+        # second, and PLUGINS_UPDATED last because it performs work. New
+        # conditions must be inserted in the matching section.
         used_conditions = set(conditions) - set(coresys.sys_jobs.ignore_conditions)
         ignored_conditions = set(conditions) & set(coresys.sys_jobs.ignore_conditions)
 
@@ -412,38 +415,6 @@ class Job(CoreSysAttributes):
             raise JobConditionException(
                 f"'{method_name}' blocked from execution, system is not frozen - {coresys.sys_core.state!s}"
             )
-
-        if (
-            JobCondition.FREE_SPACE in used_conditions
-            and (free_space := await coresys.sys_host.info.free_space())
-            < MINIMUM_FREE_SPACE_THRESHOLD
-        ):
-            coresys.sys_resolution.create_issue(
-                IssueType.FREE_SPACE, ContextType.SYSTEM
-            )
-            raise JobConditionException(
-                f"'{method_name}' blocked from execution, not enough free space ({free_space}GB) left on the device"
-            )
-
-        if JobCondition.INTERNET_SYSTEM in used_conditions:
-            # Precondition wants a recent result, not necessarily a fresh one;
-            # the min-interval short-circuit inside check_and_update_connectivity
-            # reuses the cached state when it's still within window.
-            await coresys.sys_supervisor.check_and_update_connectivity()
-            if not coresys.sys_supervisor.connectivity:
-                raise JobConditionException(
-                    f"'{method_name}' blocked from execution, no supervisor internet connection"
-                )
-
-        if JobCondition.INTERNET_HOST in used_conditions:
-            await coresys.sys_host.network.check_connectivity()
-            if (
-                coresys.sys_host.network.connectivity is not None
-                and not coresys.sys_host.network.connectivity
-            ):
-                raise JobConditionException(
-                    f"'{method_name}' blocked from execution, no host internet connection"
-                )
 
         if JobCondition.HAOS in used_conditions and not coresys.sys_os.available:
             raise JobConditionException(
@@ -507,6 +478,50 @@ class Job(CoreSysAttributes):
                 f"'{method_name}' blocked from execution, unsupported system architecture"
             )
 
+        if (
+            JobCondition.MOUNT_AVAILABLE in used_conditions
+            and HostFeature.MOUNT not in coresys.sys_host.features
+        ):
+            raise JobConditionException(
+                f"'{method_name}' blocked from execution, mounting not supported on system"
+            )
+
+        # Checks below await (executor call or connectivity probe). Keep them
+        # after the synchronous checks above so a refused job fails before
+        # the first suspension: that is faster, and callers that eagerly start
+        # a job task can rely on the refusal being visible immediately.
+        if (
+            JobCondition.FREE_SPACE in used_conditions
+            and (free_space := await coresys.sys_host.info.free_space())
+            < MINIMUM_FREE_SPACE_THRESHOLD
+        ):
+            coresys.sys_resolution.create_issue(
+                IssueType.FREE_SPACE, ContextType.SYSTEM
+            )
+            raise JobConditionException(
+                f"'{method_name}' blocked from execution, not enough free space ({free_space}GB) left on the device"
+            )
+
+        if JobCondition.INTERNET_SYSTEM in used_conditions:
+            # Precondition wants a recent result, not necessarily a fresh one;
+            # the min-interval short-circuit inside check_and_update_connectivity
+            # reuses the cached state when it's still within window.
+            await coresys.sys_supervisor.check_and_update_connectivity()
+            if not coresys.sys_supervisor.connectivity:
+                raise JobConditionException(
+                    f"'{method_name}' blocked from execution, no supervisor internet connection"
+                )
+
+        if JobCondition.INTERNET_HOST in used_conditions:
+            await coresys.sys_host.network.check_connectivity()
+            if (
+                coresys.sys_host.network.connectivity is not None
+                and not coresys.sys_host.network.connectivity
+            ):
+                raise JobConditionException(
+                    f"'{method_name}' blocked from execution, no host internet connection"
+                )
+
         if JobCondition.PLUGINS_UPDATED in used_conditions and (
             out_of_date := [
                 plugin
@@ -531,14 +546,6 @@ class Job(CoreSysAttributes):
                 raise JobConditionException(
                     f"'{method_name}' blocked from execution, was unable to update plugin(s) {', '.join(update_failures)} and all plugins must be up to date first"
                 )
-
-        if (
-            JobCondition.MOUNT_AVAILABLE in used_conditions
-            and HostFeature.MOUNT not in coresys.sys_host.features
-        ):
-            raise JobConditionException(
-                f"'{method_name}' blocked from execution, mounting not supported on system"
-            )
 
     def _clear_detached_task(self, task: asyncio.Task[Any]) -> None:
         """Drop the reference to a finished detached task.

--- a/tests/jobs/test_job_decorator.py
+++ b/tests/jobs/test_job_decorator.py
@@ -1528,6 +1528,58 @@ async def test_progress_syncing(coresys: CoreSys):
     assert job.done
 
 
+async def test_synchronous_conditions_refuse_before_awaiting_ones(coresys: CoreSys):
+    """Test a synchronous condition refuses the job before any awaiting check runs.
+
+    Callers that eagerly start a job as a task rely on a refusal being visible
+    before the first suspension, so the awaiting checks must come last.
+    """
+
+    class TestClass:
+        """Test class."""
+
+        def __init__(self, coresys: CoreSys):
+            """Initialize the test class."""
+            self.coresys = coresys
+            self.calls = 0
+
+        @Job(
+            name="test_synchronous_conditions_refuse_before_awaiting_ones_execute",
+            conditions=[
+                JobCondition.FREE_SPACE,
+                JobCondition.INTERNET_SYSTEM,
+                JobCondition.INTERNET_HOST,
+                JobCondition.ARCHITECTURE_SUPPORTED,
+            ],
+        )
+        async def execute(self) -> None:
+            """Execute the class method."""
+            self.calls += 1
+
+    test = TestClass(coresys)
+    coresys.resolution.add_unsupported_reason(UnsupportedReason.SYSTEM_ARCHITECTURE)
+
+    with (
+        patch.object(
+            type(coresys.host.info), "free_space", new=AsyncMock(return_value=5000)
+        ) as free_space,
+        patch.object(
+            type(coresys.supervisor), "check_and_update_connectivity", new=AsyncMock()
+        ) as system_connectivity,
+        patch.object(
+            type(coresys.host.network), "check_connectivity", new=AsyncMock()
+        ) as host_connectivity,
+    ):
+        task = coresys.create_task(test.execute(), eager_start=True)
+        assert task.done()
+        assert task.result() is None
+
+    assert test.calls == 0
+    free_space.assert_not_called()
+    system_connectivity.assert_not_called()
+    host_connectivity.assert_not_called()
+
+
 async def test_detach_runs_method_in_task(coresys: CoreSys):
     """Test a detached job returns a task and cleans up after it completes."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Reorder the checks in `Job.check_conditions` so that all synchronous state reads run first, the checks that await run second, and `PLUGINS_UPDATED` stays last because it performs plugin updates rather than only checking.

The current order grew by accretion. When the conditions were introduced in https://github.com/home-assistant/supervisor/pull/2250 every check was a cheap synchronous read, so the order did not matter and each later condition was simply inserted next to a related one. Since then `FREE_SPACE` became an executor call and `INTERNET_SYSTEM`/`INTERNET_HOST` started awaiting a connectivity probe in https://github.com/home-assistant/supervisor/pull/6765, without being moved. A job that is going to be refused for an unsupported OS or architecture, disabled auto update, or a missing host feature therefore first pays for a disk stat and a network probe.

With this change a refusal is visible before the first suspension. That also lets callers eagerly start a job as a task and rely on the task being done immediately when the job was refused, which the Supervisor auto update in https://github.com/home-assistant/supervisor/pull/7201 depends on. `MOUNT_AVAILABLE` moves out from behind `PLUGINS_UPDATED` into the synchronous section. Two comments document the rule so new conditions land in the right section.

The only observable difference is which condition is named in the log when several fail at once, and that the `FREE_SPACE` resolution issue is not created from this path when an earlier synchronous check already refuses the job.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/supervisor/pull/7201
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [ ] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
