### PR TITLE
Add detach option to the Job decorator

### DIFF
--- a/supervisor/jobs/decorator.py
+++ b/supervisor/jobs/decorator.py
@@ -345,8 +345,13 @@ class Job(CoreSysAttributes):
                         # Record before the task is scheduled so a concurrent
                         # call is throttled instead of starting a second task
                         record_call()
+                        # Start eagerly so the runner is inside its try block
+                        # before the task is exposed. A task cancelled before
+                        # its first step never runs its finally, which would
+                        # leave the lock held and the job registered.
                         self._detached_task = self.sys_create_task(
-                            self._run_detached(job_group, job, cleanup, execute())
+                            self._run_detached(job_group, job, cleanup, execute()),
+                            eager_start=True,
                         )
                         detached = True
                         return self._detached_task

--- a/supervisor/jobs/decorator.py
+++ b/supervisor/jobs/decorator.py
@@ -23,6 +23,7 @@ from ..resolution.const import (
     IssueType,
     UnsupportedReason,
 )
+from ..utils.sentinel import DEFAULT
 from ..utils.sentry import async_capture_exception
 from . import ChildJobSyncFilter, SupervisorJob
 from .const import JobConcurrency, JobCondition, JobThrottle
@@ -275,11 +276,14 @@ class Job(CoreSysAttributes):
                 if job_group:
                     job.reference = job_group.job_reference
             else:
+                # A detached job runs in its own task, which has no current job,
+                # and may outlive the caller. It is therefore a root job.
                 job = self.sys_jobs.new_job(
                     self.name,
                     job_group.job_reference if job_group else None,
                     internal=self._internal,
                     child_job_syncs=self._child_job_syncs,
+                    parent_id=None if self._detach else DEFAULT,
                 )
 
             cleanup = (
@@ -288,16 +292,16 @@ class Job(CoreSysAttributes):
                 else _job_override__cleanup
             )
 
+            def record_call() -> None:
+                """Record an accepted call for throttling."""
+                self.set_last_call(datetime.now(), group_name)
+                if self._rate_limited_calls is not None:
+                    self.add_rate_limited_call(self.last_call(group_name), group_name)
+
             async def execute() -> Any:
                 """Run the method within the started job."""
                 with job.start():
                     try:
-                        self.set_last_call(datetime.now(), group_name)
-                        if self._rate_limited_calls is not None:
-                            self.add_rate_limited_call(
-                                self.last_call(group_name), group_name
-                            )
-
                         return await method(obj, *args, **kwargs)
 
                     # If a method has a conditional JobCondition, they must check it in the method
@@ -338,6 +342,9 @@ class Job(CoreSysAttributes):
                         if not await self._handle_throttling(group_name):
                             return None  # Job was throttled, exit early
 
+                        # Record before the task is scheduled so a concurrent
+                        # call is throttled instead of starting a second task
+                        record_call()
                         self._detached_task = self.sys_create_task(
                             self._run_detached(job_group, job, cleanup, execute())
                         )
@@ -352,6 +359,7 @@ class Job(CoreSysAttributes):
                     if not await self._handle_throttling(group_name):
                         return None  # Job was throttled, exit early
 
+                    record_call()
                     return await execute()
 
             # Jobs that weren't started are always cleaned up. Also clean up done jobs if required.

--- a/supervisor/jobs/decorator.py
+++ b/supervisor/jobs/decorator.py
@@ -349,12 +349,14 @@ class Job(CoreSysAttributes):
                         # before the task is exposed. A task cancelled before
                         # its first step never runs its finally, which would
                         # leave the lock held and the job registered.
-                        self._detached_task = self.sys_create_task(
+                        task = self.sys_create_task(
                             self._run_detached(job_group, job, cleanup, execute()),
                             eager_start=True,
                         )
                         detached = True
-                        return self._detached_task
+                        self._detached_task = task
+                        task.add_done_callback(self._clear_detached_task)
+                        return task
                     finally:
                         if not detached:
                             self._release_concurrency_control(job_group, job)
@@ -537,6 +539,14 @@ class Job(CoreSysAttributes):
             raise JobConditionException(
                 f"'{method_name}' blocked from execution, mounting not supported on system"
             )
+
+    def _clear_detached_task(self, task: asyncio.Task[Any]) -> None:
+        """Drop the reference to a finished detached task.
+
+        Guarded by identity so an older task cannot clear a newer one.
+        """
+        if self._detached_task is task:
+            self._detached_task = None
 
     async def _run_detached(
         self,

--- a/supervisor/jobs/decorator.py
+++ b/supervisor/jobs/decorator.py
@@ -1,7 +1,7 @@
 """Job decorator."""
 
 import asyncio
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine
 from contextlib import asynccontextmanager, suppress
 from datetime import datetime, timedelta
 from functools import wraps
@@ -49,6 +49,8 @@ class Job(CoreSysAttributes):
         throttle_max_calls: int | None = None,
         internal: bool = False,
         child_job_syncs: list[ChildJobSyncFilter] | None = None,
+        *,
+        detach: bool = False,
     ):  # pylint: disable=too-many-positional-arguments
         """Initialize the Job decorator.
 
@@ -62,7 +64,8 @@ class Job(CoreSysAttributes):
             throttle_period (timedelta | Callable | None): Throttle period as a timedelta or a callable returning a timedelta (for throttled jobs).
             throttle_max_calls (int | None): Maximum number of calls allowed within the throttle period (for rate-limited jobs).
             internal (bool): Whether the job is internal (not exposed through the Supervisor API). Defaults to False.
-            child_job_syncs (list[ChildJobSyncFilter] | None): Use if jobs progress should be kept in sync with progress of one or more of its child jobs.ye
+            child_job_syncs (list[ChildJobSyncFilter] | None): Use if jobs progress should be kept in sync with progress of one or more of its child jobs.
+            detach (bool): Run the method in a separate task once conditions, concurrency and throttling allow it. The call then returns the task, or None if the job was refused. With REJECT concurrency a call while the job runs returns the running task. Not supported with group concurrency.
 
         Raises:
             RuntimeError: If job name is not unique, or required throttle parameters are missing for the selected throttle policy.
@@ -83,6 +86,8 @@ class Job(CoreSysAttributes):
         self._rate_limited_calls: dict[str | None, list[datetime]] | None = None
         self._internal = internal
         self._child_job_syncs = child_job_syncs
+        self._detach = detach
+        self._detached_task: asyncio.Task[Any] | None = None
 
         self.concurrency = concurrency
         self.throttle = throttle
@@ -113,6 +118,11 @@ class Job(CoreSysAttributes):
 
     def _validate_parameters(self) -> None:
         """Validate job parameters."""
+        if self._detach and self._is_group_concurrency():
+            raise RuntimeError(
+                f"Job {self.name} cannot combine detach with group concurrency ({self.concurrency})!"
+            )
+
         # Validate throttle parameters
         if self.throttle is not None and self._throttle_period is None:
             raise RuntimeError(
@@ -272,6 +282,38 @@ class Job(CoreSysAttributes):
                     child_job_syncs=self._child_job_syncs,
                 )
 
+            cleanup = (
+                self.cleanup
+                if _job_override__cleanup is None
+                else _job_override__cleanup
+            )
+
+            async def execute() -> Any:
+                """Run the method within the started job."""
+                with job.start():
+                    try:
+                        self.set_last_call(datetime.now(), group_name)
+                        if self._rate_limited_calls is not None:
+                            self.add_rate_limited_call(
+                                self.last_call(group_name), group_name
+                            )
+
+                        return await method(obj, *args, **kwargs)
+
+                    # If a method has a conditional JobCondition, they must check it in the method
+                    # These should be handled like normal JobConditions as much as possible
+                    except JobConditionException as err:
+                        return self._handle_job_condition_exception(err)
+                    except HassioError as err:
+                        job.capture_error(err)
+                        raise err
+                    except Exception as err:
+                        _LOGGER.exception("Unhandled exception: %s", err)
+                        job.capture_error()
+                        await async_capture_exception(err)
+                        raise JobException from err
+
+            detached = False
             try:
                 # Handle condition
                 if self.conditions:
@@ -282,43 +324,40 @@ class Job(CoreSysAttributes):
                     except JobConditionException as err:
                         return self._handle_job_condition_exception(err)
 
+                if self._detach:
+                    # A running detached job is returned instead of rejected
+                    if (
+                        self.concurrency == JobConcurrency.REJECT
+                        and self._detached_task
+                        and not self._detached_task.done()
+                    ):
+                        return self._detached_task
+
+                    await self._handle_concurrency_control(job_group, job)
+                    try:
+                        if not await self._handle_throttling(group_name):
+                            return None  # Job was throttled, exit early
+
+                        self._detached_task = self.sys_create_task(
+                            self._run_detached(job_group, job, cleanup, execute())
+                        )
+                        detached = True
+                        return self._detached_task
+                    finally:
+                        if not detached:
+                            self._release_concurrency_control(job_group, job)
+
                 # Handle execution limits using context manager
                 async with self._concurrency_control(job_group, job):
                     if not await self._handle_throttling(group_name):
                         return None  # Job was throttled, exit early
 
-                    # Execute Job
-                    with job.start():
-                        try:
-                            self.set_last_call(datetime.now(), group_name)
-                            if self._rate_limited_calls is not None:
-                                self.add_rate_limited_call(
-                                    self.last_call(group_name), group_name
-                                )
+                    return await execute()
 
-                            return await method(obj, *args, **kwargs)
-
-                        # If a method has a conditional JobCondition, they must check it in the method
-                        # These should be handled like normal JobConditions as much as possible
-                        except JobConditionException as err:
-                            return self._handle_job_condition_exception(err)
-                        except HassioError as err:
-                            job.capture_error(err)
-                            raise err
-                        except Exception as err:
-                            _LOGGER.exception("Unhandled exception: %s", err)
-                            job.capture_error()
-                            await async_capture_exception(err)
-                            raise JobException from err
-
-            # Jobs that weren't started are always cleaned up. Also clean up done jobs if required
+            # Jobs that weren't started are always cleaned up. Also clean up done jobs if required.
+            # A detached job cleans up after itself once its task completes.
             finally:
-                if (
-                    job.done is None
-                    or _job_override__cleanup
-                    or _job_override__cleanup is None
-                    and self.cleanup
-                ):
+                if not detached and (job.done is None or cleanup):
                     self.sys_jobs.remove_job(job)
 
         return wrapper
@@ -485,6 +524,21 @@ class Job(CoreSysAttributes):
             raise JobConditionException(
                 f"'{method_name}' blocked from execution, mounting not supported on system"
             )
+
+    async def _run_detached(
+        self,
+        job_group: JobGroup | None,
+        job: SupervisorJob,
+        cleanup: bool,
+        execute: Coroutine[Any, Any, Any],
+    ) -> Any:
+        """Run a detached job, then release its concurrency lock and clean up."""
+        try:
+            return await execute
+        finally:
+            self._release_concurrency_control(job_group, job)
+            if job.done is None or cleanup:
+                self.sys_jobs.remove_job(job)
 
     def _release_concurrency_control(
         self, job_group: JobGroup | None, job: SupervisorJob

--- a/tests/jobs/test_job_decorator.py
+++ b/tests/jobs/test_job_decorator.py
@@ -1766,3 +1766,44 @@ async def test_detach_throttle_concurrent_calls(coresys: CoreSys):
     assert (first is None) != (second is None)
     await (first or second)
     assert test.calls == 1
+
+
+async def test_detach_cancelled_task_releases_lock(coresys: CoreSys):
+    """Test cancelling a detached task right away still releases lock and job."""
+
+    class TestClass:
+        """Test class."""
+
+        def __init__(self, coresys: CoreSys):
+            """Initialize the test class."""
+            self.coresys = coresys
+            self.calls = 0
+
+        @Job(
+            name="test_detach_cancelled_task_releases_lock_execute",
+            concurrency=JobConcurrency.REJECT,
+            on_condition=JobException,
+            detach=True,
+        )
+        async def execute(self) -> None:
+            """Execute the class method."""
+            self.calls += 1
+            await asyncio.Event().wait()
+
+    test = TestClass(coresys)
+    first = await test.execute()
+    assert first is not None
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+    assert coresys.jobs.jobs == []
+
+    second = await test.execute()
+    assert second is not None
+    assert second is not first
+    assert test.calls == 2
+    second.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await second
+    assert coresys.jobs.jobs == []

--- a/tests/jobs/test_job_decorator.py
+++ b/tests/jobs/test_job_decorator.py
@@ -1526,3 +1526,186 @@ async def test_progress_syncing(coresys: CoreSys):
     execute_event.set()
     await task
     assert job.done
+
+
+async def test_detach_runs_method_in_task(coresys: CoreSys):
+    """Test a detached job returns a task and cleans up after it completes."""
+
+    class TestClass:
+        """Test class."""
+
+        def __init__(self, coresys: CoreSys):
+            """Initialize the test class."""
+            self.coresys = coresys
+            self.started = asyncio.Event()
+            self.finish = asyncio.Event()
+
+        @Job(name="test_detach_runs_method_in_task_execute", detach=True)
+        async def execute(self) -> str:
+            """Execute the class method."""
+            self.started.set()
+            await self.finish.wait()
+            return "done"
+
+    test = TestClass(coresys)
+    task = await test.execute()
+    assert isinstance(task, asyncio.Task)
+    assert not task.done()
+
+    await test.started.wait()
+    assert [job.name for job in coresys.jobs.jobs] == [
+        "test_detach_runs_method_in_task_execute"
+    ]
+
+    test.finish.set()
+    assert await task == "done"
+    assert coresys.jobs.jobs == []
+
+
+async def test_detach_refused_by_condition(coresys: CoreSys):
+    """Test a detached job returns None when a condition refuses it."""
+
+    class TestClass:
+        """Test class."""
+
+        def __init__(self, coresys: CoreSys):
+            """Initialize the test class."""
+            self.coresys = coresys
+            self.calls = 0
+
+        @Job(
+            name="test_detach_refused_by_condition_execute",
+            conditions=[JobCondition.HEALTHY],
+            detach=True,
+        )
+        async def execute(self) -> None:
+            """Execute the class method."""
+            self.calls += 1
+
+        @Job(
+            name="test_detach_refused_by_condition_raise",
+            conditions=[JobCondition.HEALTHY],
+            on_condition=JobException,
+            detach=True,
+        )
+        async def execute_raise(self) -> None:
+            """Execute the class method."""
+            self.calls += 1
+
+    test = TestClass(coresys)
+    coresys.resolution.add_unhealthy_reason(UnhealthyReason.DOCKER)
+
+    assert await test.execute() is None
+    with pytest.raises(JobException):
+        await test.execute_raise()
+
+    await asyncio.sleep(0)
+    assert test.calls == 0
+    assert coresys.jobs.jobs == []
+
+
+async def test_detach_throttled(coresys: CoreSys):
+    """Test a throttled detached job returns None without starting a task."""
+
+    class TestClass:
+        """Test class."""
+
+        def __init__(self, coresys: CoreSys):
+            """Initialize the test class."""
+            self.coresys = coresys
+            self.calls = 0
+
+        @Job(
+            name="test_detach_throttled_execute",
+            throttle=JobThrottle.THROTTLE,
+            throttle_period=timedelta(hours=1),
+            detach=True,
+        )
+        async def execute(self) -> None:
+            """Execute the class method."""
+            self.calls += 1
+
+    test = TestClass(coresys)
+    task = await test.execute()
+    assert task is not None
+    await task
+    assert test.calls == 1
+
+    assert await test.execute() is None
+    await asyncio.sleep(0)
+    assert test.calls == 1
+    assert coresys.jobs.jobs == []
+
+
+async def test_detach_reject_returns_running_task(coresys: CoreSys):
+    """Test a detached REJECT job returns the running task instead of raising."""
+
+    class TestClass:
+        """Test class."""
+
+        def __init__(self, coresys: CoreSys):
+            """Initialize the test class."""
+            self.coresys = coresys
+            self.finish = asyncio.Event()
+            self.calls = 0
+
+        @Job(
+            name="test_detach_reject_returns_running_task_execute",
+            concurrency=JobConcurrency.REJECT,
+            on_condition=JobException,
+            detach=True,
+        )
+        async def execute(self) -> None:
+            """Execute the class method."""
+            self.calls += 1
+            await self.finish.wait()
+
+    test = TestClass(coresys)
+    first = await test.execute()
+    assert first is not None
+    assert await test.execute() is first
+    await asyncio.sleep(0)
+    assert test.calls == 1
+
+    test.finish.set()
+    await first
+
+    second = await test.execute()
+    assert second is not None
+    assert second is not first
+    await second
+    assert test.calls == 2
+    assert coresys.jobs.jobs == []
+
+
+async def test_detach_error_propagates_to_task(coresys: CoreSys):
+    """Test an error in a detached job is raised when awaiting its task."""
+
+    class TestClass:
+        """Test class."""
+
+        def __init__(self, coresys: CoreSys):
+            """Initialize the test class."""
+            self.coresys = coresys
+
+        @Job(name="test_detach_error_propagates_to_task_execute", detach=True)
+        async def execute(self) -> None:
+            """Execute the class method."""
+            raise HassioError("boom")
+
+    test = TestClass(coresys)
+    task = await test.execute()
+    assert task is not None
+    with pytest.raises(HassioError):
+        await task
+    assert coresys.jobs.jobs == []
+
+
+def test_detach_rejects_group_concurrency():
+    """Test detach cannot be combined with group concurrency."""
+    with pytest.raises(RuntimeError, match="cannot combine detach"):
+        Job(
+            name="test_detach_rejects_group_concurrency",
+            concurrency=JobConcurrency.GROUP_REJECT,
+            detach=True,
+        )

--- a/tests/jobs/test_job_decorator.py
+++ b/tests/jobs/test_job_decorator.py
@@ -1709,3 +1709,60 @@ def test_detach_rejects_group_concurrency():
             concurrency=JobConcurrency.GROUP_REJECT,
             detach=True,
         )
+
+
+async def test_detach_from_within_job_starts_root_job(coresys: CoreSys):
+    """Test a detached job called from inside another job runs as a root job."""
+
+    class TestClass:
+        """Test class."""
+
+        def __init__(self, coresys: CoreSys):
+            """Initialize the test class."""
+            self.coresys = coresys
+            self.parent_id: str | None = "unset"
+
+        @Job(name="test_detach_from_within_job_starts_root_job_outer")
+        async def outer(self) -> asyncio.Task | None:
+            """Call the detached job from within a job."""
+            return await self.inner()
+
+        @Job(name="test_detach_from_within_job_starts_root_job_inner", detach=True)
+        async def inner(self) -> None:
+            """Record the parent of the detached job."""
+            self.parent_id = coresys.jobs.current.parent_id
+
+    test = TestClass(coresys)
+    task = await test.outer()
+    assert task is not None
+    await task
+    assert test.parent_id is None
+    assert coresys.jobs.jobs == []
+
+
+async def test_detach_throttle_concurrent_calls(coresys: CoreSys):
+    """Test concurrent calls to a throttled detached job start only one task."""
+
+    class TestClass:
+        """Test class."""
+
+        def __init__(self, coresys: CoreSys):
+            """Initialize the test class."""
+            self.coresys = coresys
+            self.calls = 0
+
+        @Job(
+            name="test_detach_throttle_concurrent_calls_execute",
+            throttle=JobThrottle.THROTTLE,
+            throttle_period=timedelta(hours=1),
+            detach=True,
+        )
+        async def execute(self) -> None:
+            """Execute the class method."""
+            self.calls += 1
+
+    test = TestClass(coresys)
+    first, second = await asyncio.gather(test.execute(), test.execute())
+    assert (first is None) != (second is None)
+    await (first or second)
+    assert test.calls == 1

--- a/tests/jobs/test_job_decorator.py
+++ b/tests/jobs/test_job_decorator.py
@@ -1807,3 +1807,31 @@ async def test_detach_cancelled_task_releases_lock(coresys: CoreSys):
     with pytest.raises(asyncio.CancelledError):
         await second
     assert coresys.jobs.jobs == []
+
+
+async def test_detach_drops_finished_task_reference(coresys: CoreSys):
+    """Test the decorator does not keep a finished detached task alive."""
+
+    class TestClass:
+        """Test class."""
+
+        job = Job(name="test_detach_drops_finished_task_reference_execute", detach=True)
+
+        def __init__(self, coresys: CoreSys):
+            """Initialize the test class."""
+            self.coresys = coresys
+
+        @job
+        async def execute(self) -> None:
+            """Execute the class method."""
+            raise HassioError("boom")
+
+    test = TestClass(coresys)
+    task = await test.execute()
+    assert task is not None
+    with pytest.raises(HassioError):
+        await task
+
+    await asyncio.sleep(0)
+    # pylint: disable-next=protected-access
+    assert TestClass.job._detached_task is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a `detach=True` option to the `Job` decorator. A detached job awaits its conditions, concurrency control and throttling exactly as before, but then runs the method in a separate task and returns that task to the caller. A refused job returns `None`, or raises `on_condition` when configured. With `REJECT` concurrency, a call while the job is running returns the running task instead of raising. The task releases the concurrency lock and cleans up the job record when it completes. Group concurrency is not supported in this mode and is rejected at decoration time.

This gives callers a definitive answer on whether a long running job was started, without awaiting its completion. The Supervisor auto update in https://github.com/home-assistant/supervisor/pull/7201 needs exactly that: a backup restore that requires a newer Supervisor has to know whether the update actually started before it tells the caller to retry later, and the update itself stops the Supervisor, so it cannot be awaited from within an API request. Today the only way to get that answer is to eagerly start the wrapped call as a task and inspect its `done()` state, which silently depends on none of the job conditions suspending before the refusal. With `detach=True` the auto update becomes `if task := await self.auto_update_supervisor(): raise UpdateInProgress` and the hand-rolled task tracking on `Supervisor` goes away.

The shared method body is factored into a local `execute()` coroutine used by both modes, so the non-detached path behaves as before. The `execute()` coroutine is only created after throttling has passed, so a refused call leaves no unawaited coroutine behind.

Tests cover: the task is returned and the job record is cleaned up after completion, refusal by a condition both with and without `on_condition`, throttling, `REJECT` returning the running task and starting a new one after it finishes, an error in the body surfacing when the task is awaited, and the group concurrency guard.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/supervisor/pull/7201
- Link to documentation pull request:
- Link to cli pull request:
- Link to client library pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format supervisor tests`)
- [x] Tests have been added to verify that the new code works.

If API endpoints or add-on configuration are added/changed:

- [ ] Documentation added/updated for [developers.home-assistant.io][docs-repository]
- [ ] [CLI][cli-repository] updated (if necessary)
- [ ] [Client library][client-library-repository] updated (if necessary)

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[docs-repository]: https://github.com/home-assistant/developers.home-assistant
[cli-repository]: https://github.com/home-assistant/cli
[client-library-repository]: https://github.com/home-assistant-libs/python-supervisor-client/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
